### PR TITLE
LFS-5: HTL sources should be validated during build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -413,7 +413,7 @@
           </executions>
           <configuration>
             <failOnWarnings>true</failOnWarnings>
-            <sourceDirectory>src</sourceDirectory>
+            <sourceDirectory>src/main/resources/</sourceDirectory>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
Only our sources should be validated, not npm dependencies