### PR TITLE
LFS-19: Add generic data entry node type

### DIFF
--- a/modules/data-entry/pom.xml
+++ b/modules/data-entry/pom.xml
@@ -26,9 +26,9 @@
     <version>0.1-SNAPSHOT</version>
   </parent>
 
-  <artifactId>lfs-homepage</artifactId>
+  <artifactId>lfs-dataentry</artifactId>
   <packaging>bundle</packaging>
-  <name>LFS - The homepage</name>
+  <name>LFS - Data entry module</name>
 
   <build>
     <plugins>
@@ -53,16 +53,6 @@
               <goal>npm</goal>
             </goals>
           </execution>
-          <!-- Runs webpack to compile the JS source code -->
-          <execution>
-            <id>webpack</id>
-            <goals>
-              <goal>webpack</goal>
-            </goals>
-            <configuration>
-              <outputdir>${project.build.directory}/classes/SLING-INF/content/apps/lfs/</outputdir>
-            </configuration>
-          </execution>
         </executions>
         <configuration>
           <nodeVersion>v12.2.0</nodeVersion>
@@ -77,13 +67,9 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Include-Resource>src/main/frontend/dist/,{maven-resources}</Include-Resource>
-            <Sling-Nodetypes>SLING-INF/nodetypes/homepage.cnd</Sling-Nodetypes>
-            <!-- Initial content to be loaded on bundle installation -->
+            <Include-Resource>{maven-resources}</Include-Resource>
+            <Sling-Nodetypes>SLING-INF/nodetypes/dataentry.cnd</Sling-Nodetypes>
             <Sling-Initial-Content>
-              SLING-INF/content/content;overwrite:=true;path:=/content;maven:mount:=false,
-              SLING-INF/content/libs/lfs/Homepage;overwrite:=true;path:=/libs/lfs/Homepage;maven:mount:=true,
-              SLING-INF/content/libs/lfs/resources;overwrite:=true;path:=/libs/lfs/resources;maven:mount:=true
             </Sling-Initial-Content>
           </instructions>
         </configuration>

--- a/modules/data-entry/src/main/provisioning/model.txt
+++ b/modules/data-entry/src/main/provisioning/model.txt
@@ -17,14 +17,5 @@
 #  under the License.
 #
 
-# This is the LFS project
-[feature name=lfs]
-
-[variables]
-    lfs.version=0.1-SNAPSHOT
-
-[artifacts]
-    # Customizes the page displayed during startup, before all the bundles are activated
-    ca.sickkids.ccm.lfs/lfs-startup-customization/${lfs.version}
-    ca.sickkids.ccm.lfs/lfs-homepage/${lfs.version}/slingfeature/slingfeature
-    ca.sickkids.ccm.lfs/lfs-dataentry/${lfs.version}/slingfeature/slingfeature
+# The LFS homepage
+[feature name=lfs-dataentry]

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -27,8 +27,8 @@
 //-----------------------------------------------------------------------------
 
 //-----------------------------------------------------------------------------
-// Simple nodetype for identifying the homepage.
-[lfs:Dataentry] > sling:Resource
+// Simple nodetype to store user-entered data.
+[lfs:dataEntry] > sling:Resource
   // Attributes:
   query
 

--- a/modules/homepage/pom.xml
+++ b/modules/homepage/pom.xml
@@ -78,7 +78,7 @@
         <configuration>
           <instructions>
             <Include-Resource>src/main/frontend/dist/,{maven-resources}</Include-Resource>
-            <Sling-Nodetypes>SLING-INF/nodetypes/homepage.cnd</Sling-Nodetypes>
+            <Sling-Nodetypes>SLING-INF/nodetypes/homepage.cnd,SLING-INF/nodetypes/dataentry.cnd</Sling-Nodetypes>
             <!-- Initial content to be loaded on bundle installation -->
             <Sling-Initial-Content>
               SLING-INF/content/content;overwrite:=true;path:=/content;maven:mount:=false,

--- a/modules/homepage/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/homepage/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -1,0 +1,35 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+<sling = 'http://sling.apache.org/jcr/sling/1.0'>
+<lfs = 'https://lfs.ccm.sickkids.ca/'>
+
+//-----------------------------------------------------------------------------
+//
+// Generic data entry type
+//
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+// Simple nodetype for identifying the homepage.
+[lfs:Dataentry] > sling:Resource
+  // Attributes:
+  query
+
+  // We don't define any properties or subchildren

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -33,5 +33,6 @@
   <modules>
     <module>startup-customization</module>
     <module>homepage</module>
+    <module>data-entry</module>
   </modules>
 </project>


### PR DESCRIPTION
Added a generic data entry node type, verifiable through the content browser.

![image](https://user-images.githubusercontent.com/4656440/58185296-d011db00-7c80-11e9-855b-0c5f2db4d921.png)
