### PR TITLE
Build updates

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -60,9 +60,26 @@
         <artifactId>slingstart-maven-plugin</artifactId>
         <configuration>
           <setFeatureVersions>false</setFeatureVersions>
-          <createWebapp>true</createWebapp>
         </configuration>
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <!-- During the release we also want to generate the war file for server deployment -->
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>slingstart-maven-plugin</artifactId>
+            <configuration>
+              <createWebapp>true</createWebapp>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -58,10 +58,8 @@
       <plugin>
         <groupId>org.apache.sling</groupId>
         <artifactId>slingstart-maven-plugin</artifactId>
-        <version>1.8.2</version>
-        <!-- This allows us to use the "slingstart" packaging type -->
-        <extensions>true</extensions>
         <configuration>
+          <setFeatureVersions>false</setFeatureVersions>
           <createWebapp>true</createWebapp>
         </configuration>
       </plugin>

--- a/distribution/src/main/provisioning/01-boot.txt
+++ b/distribution/src/main/provisioning/01-boot.txt
@@ -30,9 +30,6 @@
     repository.home=${sling.home}/repository
     localIndexDir=${sling.home}/repository/index
 
-[variables]
-    slf4j.version=1.7.26
-
 [artifacts]
     org.apache.sling/org.apache.sling.javax.activation/0.1.0
     org.apache.geronimo.specs/geronimo-annotation_1.3_spec/1.1

--- a/distribution/src/main/provisioning/02-oak.txt
+++ b/distribution/src/main/provisioning/02-oak.txt
@@ -20,9 +20,6 @@
 # This is the OAK feature, the actual JCR implementation used for storing data.
 [feature name=oak]
 
-[variables]
-    oak.version=1.8.8
-
 # JAAS (Java Authentication and Authorization Service) integration into Apache Felix
 [artifacts startLevel=10]
     org.apache.felix/org.apache.felix.jaas/1.0.2

--- a/distribution/src/main/provisioning/10-sling-base.txt
+++ b/distribution/src/main/provisioning/10-sling-base.txt
@@ -19,9 +19,6 @@
 # The main modules for Apache Sling
 [feature name=sling]
 
-[variables]
-    jackrabbit.version=2.16.3
-
 # The Sling framework
 [artifacts]
     org.apache.sling/org.apache.sling.adapter/2.1.10

--- a/modules/data-entry/pom.xml
+++ b/modules/data-entry/pom.xml
@@ -77,8 +77,6 @@
       <plugin>
         <groupId>org.apache.sling</groupId>
         <artifactId>slingstart-maven-plugin</artifactId>
-        <version>1.8.2</version>
-        <extensions>true</extensions>
         <executions>
           <execution>
             <id>attach-prov-model</id>
@@ -89,7 +87,6 @@
           </execution>
         </executions>
         <configuration>
-          <setFeatureVersions>true</setFeatureVersions>
           <attach>
             <type>jar</type>
           </attach>

--- a/modules/data-entry/pom.xml
+++ b/modules/data-entry/pom.xml
@@ -87,8 +87,10 @@
           </execution>
         </executions>
         <configuration>
+          <!-- This will automatically add an [artifacts] entry with the jar produced by this module in the provisioning file -->
           <attach>
             <type>jar</type>
+            <startLevel>10</startLevel>
           </attach>
         </configuration>
       </plugin>

--- a/modules/data-entry/pom.xml
+++ b/modules/data-entry/pom.xml
@@ -32,34 +32,6 @@
 
   <build>
     <plugins>
-      <!-- Compile the React code -->
-      <plugin>
-        <groupId>com.github.eirslett</groupId>
-        <artifactId>frontend-maven-plugin</artifactId>
-        <version>1.7.6</version>
-        <executions>
-          <!-- Installs NodeJS and NPM locally -->
-          <execution>
-            <id>install node and npm</id>
-            <goals>
-              <goal>install-node-and-npm</goal>
-            </goals>
-            <phase>initialize</phase>
-          </execution>
-          <!-- Brings in the dependencies using npm -->
-          <execution>
-            <id>npm install</id>
-            <goals>
-              <goal>npm</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <nodeVersion>v12.2.0</nodeVersion>
-          <workingDirectory>src/main/frontend</workingDirectory>
-        </configuration>
-      </plugin>
-
       <!-- This is an OSGi bundle -->
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/modules/homepage/pom.xml
+++ b/modules/homepage/pom.xml
@@ -91,8 +91,6 @@
       <plugin>
         <groupId>org.apache.sling</groupId>
         <artifactId>slingstart-maven-plugin</artifactId>
-        <version>1.8.2</version>
-        <extensions>true</extensions>
         <executions>
           <execution>
             <id>attach-prov-model</id>
@@ -103,7 +101,6 @@
           </execution>
         </executions>
         <configuration>
-          <setFeatureVersions>true</setFeatureVersions>
           <attach>
             <type>jar</type>
           </attach>

--- a/modules/homepage/pom.xml
+++ b/modules/homepage/pom.xml
@@ -36,38 +36,6 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>1.7.6</version>
-        <executions>
-          <!-- Installs NodeJS and NPM locally -->
-          <execution>
-            <id>install node and npm</id>
-            <goals>
-              <goal>install-node-and-npm</goal>
-            </goals>
-            <phase>initialize</phase>
-          </execution>
-          <!-- Brings in the dependencies using npm -->
-          <execution>
-            <id>npm install</id>
-            <goals>
-              <goal>npm</goal>
-            </goals>
-          </execution>
-          <!-- Runs webpack to compile the JS source code -->
-          <execution>
-            <id>webpack</id>
-            <goals>
-              <goal>webpack</goal>
-            </goals>
-            <configuration>
-              <outputdir>${project.build.directory}/classes/SLING-INF/content/apps/lfs/</outputdir>
-            </configuration>
-          </execution>
-        </executions>
-        <configuration>
-          <nodeVersion>v12.2.0</nodeVersion>
-          <workingDirectory>src/main/frontend</workingDirectory>
-        </configuration>
       </plugin>
 
       <!-- This is an OSGi bundle -->

--- a/modules/homepage/pom.xml
+++ b/modules/homepage/pom.xml
@@ -101,8 +101,10 @@
           </execution>
         </executions>
         <configuration>
+          <!-- This will automatically add an [artifacts] entry with the jar produced by this module in the provisioning file -->
           <attach>
             <type>jar</type>
+            <startLevel>5</startLevel>
           </attach>
         </configuration>
       </plugin>

--- a/modules/startup-customization/src/main/resources/custom_index.html
+++ b/modules/startup-customization/src/main/resources/custom_index.html
@@ -19,10 +19,10 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Agnodice is starting up...</title>
+    <title>LFS is starting up...</title>
     <meta http-equiv="refresh" content="5">
   </head>
   <body>
-    <h1>Agnodice is starting up, please wait</h1>
+    <h1>LFS is starting up, please wait</h1>
   </body>
 </html>

--- a/pom.xml
+++ b/pom.xml
@@ -492,6 +492,40 @@
             <target>1.8</target>
           </configuration>
         </plugin>
+        <!-- Compile the React code -->
+        <plugin>
+          <groupId>com.github.eirslett</groupId>
+          <artifactId>frontend-maven-plugin</artifactId>
+          <version>1.7.6</version>
+          <executions>
+            <!-- Installs NodeJS and NPM locally -->
+            <execution>
+              <id>install node and npm</id>
+              <goals>
+                <goal>install-node-and-npm</goal>
+              </goals>
+              <phase>initialize</phase>
+            </execution>
+            <!-- Brings in the dependencies using npm -->
+            <execution>
+              <id>npm install</id>
+              <goals>
+                <goal>npm</goal>
+              </goals>
+            </execution>
+            <!-- Runs webpack to compile the JS source code -->
+            <execution>
+              <id>webpack</id>
+              <goals>
+                <goal>webpack</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <nodeVersion>v12.2.0</nodeVersion>
+            <workingDirectory>src/main/frontend</workingDirectory>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -676,6 +676,36 @@
         </plugins>
       </build>
     </profile>
+
+    <!--
+        Use this profile to install the built module automatically during development.
+        Requires a running instance.
+        By default it connects to http://localhost:8080 with admin:admin.
+        To specify a different password, use `-Dsling.password=newPassword`
+        To specify a different URL, use `-Dsling.url=https://lfs.server:8443/system/console` (the URL must end with `/system/console` to work properly)
+    -->
+    <profile>
+      <id>autoInstallBundle</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>maven-sling-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>install-bundle</id>
+                <goals>
+                  <goal>install</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -418,6 +418,18 @@
         </plugin>
 
         <plugin>
+          <groupId>org.apache.sling</groupId>
+          <artifactId>slingstart-maven-plugin</artifactId>
+          <!-- Lock down plugin version for build reproducibility -->
+          <version>1.8.2</version>
+          <!-- This allows us to use the "slingstart" and "slingfeature" packaging type -->
+          <extensions>true</extensions>
+          <configuration>
+            <setFeatureVersions>true</setFeatureVersions>
+          </configuration>
+        </plugin>
+
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
           <!-- Lock down plugin version for build reproducibility -->

--- a/pom.xml
+++ b/pom.xml
@@ -734,6 +734,7 @@
           <plugin>
             <groupId>org.apache.sling</groupId>
             <artifactId>maven-sling-plugin</artifactId>
+            <version>2.4.0</version>
             <executions>
               <execution>
                 <id>install-bundle</id>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,9 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>1.7.26</slf4j.version>
+    <jackrabbit.version>2.16.3</jackrabbit.version>
+    <oak.version>1.8.8</oak.version>
+
     <enforcer.skip>false</enforcer.skip>
     <checkstyle.skip>false</checkstyle.skip>
     <license.skip>false</license.skip>
@@ -425,7 +428,10 @@
           <!-- This allows us to use the "slingstart" and "slingfeature" packaging type -->
           <extensions>true</extensions>
           <configuration>
+            <!-- Add the current project version into the provisioning files -->
             <setFeatureVersions>true</setFeatureVersions>
+            <!-- Allows using the maven properties defined above as variables in the provisioning files -->
+            <usePomVariables>true</usePomVariables>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
- centralized maven plugin configurations to reduce copy/paste
- the war distribution is only built during releases, to speed up the dev build
- added support for deploying just one module in a running instance

The last one is nice, it means that you can keep a running instance and only build and deploy one module with `mvn install -PautoInstallBundle` and optionally `-Pquick` for an even faster build.