### PR TITLE
LFS-60: Turn off npm install when using -Pquick

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -670,15 +670,18 @@
               <groupId>com.github.eirslett</groupId>
               <artifactId>frontend-maven-plugin</artifactId>
               <version>1.7.6</version>
+                <!-- Do not run npm or webpack -->
               <executions>
-                <!-- Do not run node or npm-->
                 <execution>
                   <id>install node and npm</id>
                   <phase>none</phase>
                 </execution>
-                <!-- Do not run npm install -->
                 <execution>
                   <id>npm install</id>
+                  <phase>none</phase>
+                </execution>
+                <execution>
+                  <id>webpack</id>
                   <phase>none</phase>
                 </execution>
               </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -664,6 +664,7 @@
       <!-- Use this ( mvn install -Pskip-webpack ) when trying to get a quicker test build, without (re)installing any node dependencies. -->
       <id>skip-webpack</id>
       <properties>
+        <skip.installyarn>true</skip.installyarn>
         <skip.yarn>true</skip.yarn>
         <skip.webpack>true</skip.webpack>
       </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -661,8 +661,8 @@
     </profile>
 
     <profile>
-      <!-- Use this ( mvn install -Pskip-npm ) when trying to get a quicker test build, without (re)installing any node dependencies. -->
-      <id>skip-npm</id>
+      <!-- Use this ( mvn install -Pskip-webpack ) when trying to get a quicker test build, without (re)installing any node dependencies. -->
+      <id>skip-webpack</id>
       <build>
         <pluginManagement>
           <plugins>
@@ -673,11 +673,11 @@
                 <!-- Do not run npm or webpack -->
               <executions>
                 <execution>
-                  <id>install node and npm</id>
+                  <id>install node and yarn</id>
                   <phase>none</phase>
                 </execution>
                 <execution>
-                  <id>npm install</id>
+                  <id>yarn install</id>
                   <phase>none</phase>
                 </execution>
                 <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -658,26 +658,33 @@
         <license.skip>true</license.skip>
         <dependencyCheck.skip>true</dependencyCheck.skip>
       </properties>
+    </profile>
+
+    <profile>
+      <!-- Use this ( mvn install -Pskip-npm ) when trying to get a quicker test build, without (re)installing any node dependencies. -->
+      <id>skip-npm</id>
       <build>
-        <plugins>
-          <plugin>
-            <groupId>com.github.eirslett</groupId>
-            <artifactId>frontend-maven-plugin</artifactId>
-            <version>1.7.6</version>
-            <executions>
-              <!-- Do not run node or npm-->
-              <execution>
-                <id>install node and npm</id>
-                <phase>none</phase>
-              </execution>
-              <!-- Do not run npm install -->
-              <execution>
-                <id>npm install</id>
-                <phase>none</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>com.github.eirslett</groupId>
+              <artifactId>frontend-maven-plugin</artifactId>
+              <version>1.7.6</version>
+              <executions>
+                <!-- Do not run node or npm-->
+                <execution>
+                  <id>install node and npm</id>
+                  <phase>none</phase>
+                </execution>
+                <!-- Do not run npm install -->
+                <execution>
+                  <id>npm install</id>
+                  <phase>none</phase>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
       </build>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -663,32 +663,10 @@
     <profile>
       <!-- Use this ( mvn install -Pskip-webpack ) when trying to get a quicker test build, without (re)installing any node dependencies. -->
       <id>skip-webpack</id>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>com.github.eirslett</groupId>
-              <artifactId>frontend-maven-plugin</artifactId>
-              <version>1.7.6</version>
-                <!-- Do not run npm or webpack -->
-              <executions>
-                <execution>
-                  <id>install node and yarn</id>
-                  <phase>none</phase>
-                </execution>
-                <execution>
-                  <id>yarn install</id>
-                  <phase>none</phase>
-                </execution>
-                <execution>
-                  <id>webpack</id>
-                  <phase>none</phase>
-                </execution>
-              </executions>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
+      <properties>
+        <skip.yarn>true</skip.yarn>
+        <skip.webpack>true</skip.webpack>
+      </properties>
     </profile>
 
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -658,6 +658,27 @@
         <license.skip>true</license.skip>
         <dependencyCheck.skip>true</dependencyCheck.skip>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <version>1.7.6</version>
+            <executions>
+              <!-- Do not run node or npm-->
+              <execution>
+                <id>install node and npm</id>
+                <phase>none</phase>
+              </execution>
+              <!-- Do not run npm install -->
+              <execution>
+                <id>npm install</id>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>


### PR DESCRIPTION
When running -Pquick, `npm install` is no longer run. This may cause issues if someone adds npm dependencies but tries to use -Pquick.