### PR TITLE
LFS-80: Add cache busting for the frontend code

### DIFF
--- a/modules/commons/src/main/frontend/package.json
+++ b/modules/commons/src/main/frontend/package.json
@@ -26,10 +26,12 @@
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
     "babel-loader": "^8.0.6",
+    "clean-webpack-plugin": "3.0.0",
     "eslint": "^5.16.0",
     "eslint-plugin-auto-import": "^0.1.0",
     "eslint-plugin-react": "^7.13.0",
     "webpack": "^4.33.0",
+    "webpack-assets-manifest": "3.1.1",
     "webpack-cli": "^3.3.2"
   },
   "dependencies": {

--- a/modules/commons/src/main/frontend/src/header.js
+++ b/modules/commons/src/main/frontend/src/header.js
@@ -72,9 +72,9 @@ class GlobalHeader extends React.Component {
   componentDidMount () {
     if (!this.state.loggedIn && !window.location.pathname.startsWith('/login')) {
       // Determine the location of the loginDialogue script
-      var loginLib = window.Sling.getContent("/libs/lfs/resources/login.json", 1, "");
+      var assets = window.Sling.getContent("/libs/lfs/resources/assets.json", 1, "");
       const script = document.createElement("script");
-      script.src = "/libs/lfs/resources/" + loginLib["loginDialogue.js"];
+      script.src = "/libs/lfs/resources/" + assets["loginDialogue.js"];
       document.body.appendChild(script);
     }
   }

--- a/modules/commons/src/main/frontend/src/header.js
+++ b/modules/commons/src/main/frontend/src/header.js
@@ -71,8 +71,10 @@ class GlobalHeader extends React.Component {
 
   componentDidMount () {
     if (!this.state.loggedIn && !window.location.pathname.startsWith('/login')) {
+      // Determine the location of the loginDialogue script
+      var loginLib = window.Sling.getContent("/libs/lfs/resources/login.json", 1, "");
       const script = document.createElement("script");
-      script.src = "/libs/lfs/resources/loginDialogue.js";
+      script.src = "/libs/lfs/resources/" + loginLib["loginDialogue.js"];
       document.body.appendChild(script);
     }
   }

--- a/modules/commons/src/main/frontend/src/header.js
+++ b/modules/commons/src/main/frontend/src/header.js
@@ -74,7 +74,7 @@ class GlobalHeader extends React.Component {
       // Determine the location of the loginDialogue script
       var assets = window.Sling.getContent("/libs/lfs/resources/assets.json", 1, "");
       const script = document.createElement("script");
-      script.src = "/libs/lfs/resources/" + assets["loginDialogue.js"];
+      script.src = "/libs/lfs/resources/" + assets["lfs-login.loginDialogue.js"];
       document.body.appendChild(script);
     }
   }

--- a/modules/commons/src/main/frontend/webpack.config.js
+++ b/modules/commons/src/main/frontend/webpack.config.js
@@ -1,13 +1,13 @@
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 
-module_name = require("./package.json").name;
+module_name = require("./package.json").name + ".";
 
 module.exports = {
   mode: 'development',
   entry: {
-    footer: './src/footer.js',
-    header: './src/header.js'
+    [module_name + 'footer']: './src/footer.js',
+    [module_name + 'header']: './src/header.js'
   },
   plugins: [
     new CleanWebpackPlugin(),
@@ -30,7 +30,7 @@ module.exports = {
   output: {
     path: __dirname + '/dist/SLING-INF/content/libs/lfs/resources/',
     publicPath: '/',
-    filename: module_name + '.[name].[contenthash].js'
+    filename: '[name].[contenthash].js'
   },
   externals: [
     {

--- a/modules/commons/src/main/frontend/webpack.config.js
+++ b/modules/commons/src/main/frontend/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
   plugins: [
     new CleanWebpackPlugin(),
     new WebpackAssetsManifest({
-      output: "commons.json"
+      output: "assets.json"
     })
   ],
   module: {

--- a/modules/commons/src/main/frontend/webpack.config.js
+++ b/modules/commons/src/main/frontend/webpack.config.js
@@ -1,6 +1,8 @@
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 
+module_name = require("./package.json").name;
+
 module.exports = {
   mode: 'development',
   entry: {
@@ -28,7 +30,7 @@ module.exports = {
   output: {
     path: __dirname + '/dist/SLING-INF/content/libs/lfs/resources/',
     publicPath: '/',
-    filename: '[name].[contenthash].js'
+    filename: module_name + '.[name].[contenthash].js'
   },
   externals: [
     {

--- a/modules/commons/src/main/frontend/webpack.config.js
+++ b/modules/commons/src/main/frontend/webpack.config.js
@@ -1,9 +1,18 @@
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const WebpackAssetsManifest = require('webpack-assets-manifest');
+
 module.exports = {
   mode: 'development',
   entry: {
     footer: './src/footer.js',
     header: './src/header.js'
   },
+  plugins: [
+    new CleanWebpackPlugin(),
+    new WebpackAssetsManifest({
+      output: "commons.json"
+    })
+  ],
   module: {
     rules: [
       {
@@ -19,7 +28,7 @@ module.exports = {
   output: {
     path: __dirname + '/dist/SLING-INF/content/libs/lfs/resources/',
     publicPath: '/',
-    filename: '[name].js'
+    filename: '[name].[contenthash].js'
   },
   externals: [
     {

--- a/modules/commons/src/main/resources/SLING-INF/content/libs/lfs/Resource/footer.html
+++ b/modules/commons/src/main/resources/SLING-INF/content/libs/lfs/Resource/footer.html
@@ -18,7 +18,7 @@
 */-->
     <div id="footer-container"></div>
     <sly data-sly-use.assets="/libs/lfs/resources/assets">
-      <script src="/libs/lfs/resources/${assets['footer.js']}"></script>
+      <script src="/libs/lfs/resources/${assets['lfs-commons.footer.js']}"></script>
     </sly>
   </body>
 </html>

--- a/modules/commons/src/main/resources/SLING-INF/content/libs/lfs/Resource/footer.html
+++ b/modules/commons/src/main/resources/SLING-INF/content/libs/lfs/Resource/footer.html
@@ -17,6 +17,8 @@
   under the License.
 */-->
     <div id="footer-container"></div>
-    <script src="/libs/lfs/resources/footer.js"></script>
+    <sly data-sly-use.commonslib="/libs/lfs/resources/commons">
+      <script src="/libs/lfs/resources/${commonslib['footer.js']}"></script>
+    </sly>
   </body>
 </html>

--- a/modules/commons/src/main/resources/SLING-INF/content/libs/lfs/Resource/footer.html
+++ b/modules/commons/src/main/resources/SLING-INF/content/libs/lfs/Resource/footer.html
@@ -17,8 +17,8 @@
   under the License.
 */-->
     <div id="footer-container"></div>
-    <sly data-sly-use.commonslib="/libs/lfs/resources/commons">
-      <script src="/libs/lfs/resources/${commonslib['footer.js']}"></script>
+    <sly data-sly-use.assets="/libs/lfs/resources/assets">
+      <script src="/libs/lfs/resources/${assets['footer.js']}"></script>
     </sly>
   </body>
 </html>

--- a/modules/commons/src/main/resources/SLING-INF/content/libs/lfs/Resource/header.html
+++ b/modules/commons/src/main/resources/SLING-INF/content/libs/lfs/Resource/header.html
@@ -34,4 +34,6 @@
   </head>
   <body>
     <div id="header-container"></div>
-    <script src="/libs/lfs/resources/header.js"></script>
+    <sly data-sly-use.commonslib="/libs/lfs/resources/commons">
+      <script src="/libs/lfs/resources/${commonslib['header.js']}"></script>
+    </sly>

--- a/modules/commons/src/main/resources/SLING-INF/content/libs/lfs/Resource/header.html
+++ b/modules/commons/src/main/resources/SLING-INF/content/libs/lfs/Resource/header.html
@@ -34,6 +34,6 @@
   </head>
   <body>
     <div id="header-container"></div>
-    <sly data-sly-use.commonslib="/libs/lfs/resources/commons">
-      <script src="/libs/lfs/resources/${commonslib['header.js']}"></script>
+    <sly data-sly-use.assets="/libs/lfs/resources/assets">
+      <script src="/libs/lfs/resources/${assets['header.js']}"></script>
     </sly>

--- a/modules/commons/src/main/resources/SLING-INF/content/libs/lfs/Resource/header.html
+++ b/modules/commons/src/main/resources/SLING-INF/content/libs/lfs/Resource/header.html
@@ -35,5 +35,5 @@
   <body>
     <div id="header-container"></div>
     <sly data-sly-use.assets="/libs/lfs/resources/assets">
-      <script src="/libs/lfs/resources/${assets['header.js']}"></script>
+      <script src="/libs/lfs/resources/${assets['lfs-commons.header.js']}"></script>
     </sly>

--- a/modules/data-entry/src/main/frontend/package.json
+++ b/modules/data-entry/src/main/frontend/package.json
@@ -26,10 +26,12 @@
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
     "babel-loader": "^8.0.6",
+    "clean-webpack-plugin": "3.0.0",
     "eslint": "^5.16.0",
     "eslint-plugin-auto-import": "^0.1.0",
     "eslint-plugin-react": "^7.13.0",
     "webpack": "^4.33.0",
+    "webpack-assets-manifest": "3.1.1",
     "webpack-cli": "^3.3.2"
   },
   "dependencies": {

--- a/modules/data-entry/src/main/frontend/webpack.config.js
+++ b/modules/data-entry/src/main/frontend/webpack.config.js
@@ -1,13 +1,13 @@
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 
-module_name = require("./package.json").name;
+module_name = require("./package.json").name + ".";
 
 module.exports = {
   mode: 'development',
   entry: {
-    redirect: './src/dataQuery/redirect.js',
-    showQuery: './src/dataQuery/query.js'
+    [module_name + 'redirect']: './src/dataQuery/redirect.js',
+    [module_name + 'showQuery']: './src/dataQuery/query.js'
   },
   plugins: [
     new CleanWebpackPlugin(),
@@ -31,7 +31,7 @@ module.exports = {
     path: __dirname + '/dist/SLING-INF/content/libs/lfs/resources/',
     publicPath: '/',
     library: 'dataQuery',
-    filename: module_name + '.[name].[contenthash].js'
+    filename: '[name].[contenthash].js'
   },
   externals: [
     {

--- a/modules/data-entry/src/main/frontend/webpack.config.js
+++ b/modules/data-entry/src/main/frontend/webpack.config.js
@@ -1,6 +1,8 @@
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 
+module_name = require("./package.json").name;
+
 module.exports = {
   mode: 'development',
   entry: {
@@ -29,7 +31,7 @@ module.exports = {
     path: __dirname + '/dist/SLING-INF/content/libs/lfs/resources/',
     publicPath: '/',
     library: 'dataQuery',
-    filename: '[name].[contenthash].js'
+    filename: module_name + '.[name].[contenthash].js'
   },
   externals: [
     {

--- a/modules/data-entry/src/main/frontend/webpack.config.js
+++ b/modules/data-entry/src/main/frontend/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
   plugins: [
     new CleanWebpackPlugin(),
     new WebpackAssetsManifest({
-      output: "data-entry.json"
+      output: "assets.json"
     })
   ],
   module: {

--- a/modules/data-entry/src/main/frontend/webpack.config.js
+++ b/modules/data-entry/src/main/frontend/webpack.config.js
@@ -1,9 +1,18 @@
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const WebpackAssetsManifest = require('webpack-assets-manifest');
+
 module.exports = {
   mode: 'development',
   entry: {
     redirect: './src/dataQuery/redirect.js',
     showQuery: './src/dataQuery/query.js'
   },
+  plugins: [
+    new CleanWebpackPlugin(),
+    new WebpackAssetsManifest({
+      output: "data-entry.json"
+    })
+  ],
   module: {
     rules: [
       {
@@ -20,7 +29,7 @@ module.exports = {
     path: __dirname + '/dist/SLING-INF/content/libs/lfs/resources/',
     publicPath: '/',
     library: 'dataQuery',
-    filename: '[name].js'
+    filename: '[name].[contenthash].js'
   },
   externals: [
     {

--- a/modules/data-entry/src/main/resources/SLING-INF/content/libs/lfs/dataEntryViewer/html.GET.html
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/libs/lfs/dataEntryViewer/html.GET.html
@@ -33,10 +33,12 @@
         </form>
 
         <!-- Use React to prettify page -->
-        <script src="/libs/lfs/resources/showQuery.js"></script>
+        <sly data-sly-use.dataentrylib="/libs/lfs/resources/data-entry">
+        <script src="/libs/lfs/resources/${dataentrylib['showQuery.js']}"></script>
 
         <!-- Call our library after React to prevent the Module from failing to export -->
-        <script src="/libs/lfs/resources/redirect.js"></script>
+        <script src="/libs/lfs/resources/${dataentrylib['redirect.js']}"></script>
+        </sly>
 
         <!-- iframe to silence submitForm submission -->
         <IFRAME style="display:none" name="hidden-form"></IFRAME>

--- a/modules/data-entry/src/main/resources/SLING-INF/content/libs/lfs/dataEntryViewer/html.GET.html
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/libs/lfs/dataEntryViewer/html.GET.html
@@ -33,11 +33,11 @@
         </form>
 
         <!-- Use React to prettify page -->
-        <sly data-sly-use.dataentrylib="/libs/lfs/resources/data-entry">
-        <script src="/libs/lfs/resources/${dataentrylib['showQuery.js']}"></script>
+        <sly data-sly-use.assets="/libs/lfs/resources/assets">
+        <script src="/libs/lfs/resources/${assets['showQuery.js']}"></script>
 
         <!-- Call our library after React to prevent the Module from failing to export -->
-        <script src="/libs/lfs/resources/${dataentrylib['redirect.js']}"></script>
+        <script src="/libs/lfs/resources/${assets['redirect.js']}"></script>
         </sly>
 
         <!-- iframe to silence submitForm submission -->

--- a/modules/data-entry/src/main/resources/SLING-INF/content/libs/lfs/dataEntryViewer/html.GET.html
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/libs/lfs/dataEntryViewer/html.GET.html
@@ -34,10 +34,10 @@
 
         <!-- Use React to prettify page -->
         <sly data-sly-use.assets="/libs/lfs/resources/assets">
-        <script src="/libs/lfs/resources/${assets['showQuery.js']}"></script>
+        <script src="/libs/lfs/resources/${assets['lfs-dataentry.showQuery.js']}"></script>
 
         <!-- Call our library after React to prevent the Module from failing to export -->
-        <script src="/libs/lfs/resources/${assets['redirect.js']}"></script>
+        <script src="/libs/lfs/resources/${assets['lfs-dataentry.redirect.js']}"></script>
         </sly>
 
         <!-- iframe to silence submitForm submission -->

--- a/modules/homepage/src/main/frontend/package.json
+++ b/modules/homepage/src/main/frontend/package.json
@@ -26,10 +26,12 @@
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
     "babel-loader": "^8.0.6",
+    "clean-webpack-plugin": "3.0.0",
     "eslint": "^5.16.0",
     "eslint-plugin-auto-import": "^0.1.0",
     "eslint-plugin-react": "^7.13.0",
     "webpack": "^4.33.0",
+    "webpack-assets-manifest": "3.1.1",
     "webpack-cli": "^3.3.2"
   },
   "dependencies": {

--- a/modules/homepage/src/main/frontend/webpack.config.js
+++ b/modules/homepage/src/main/frontend/webpack.config.js
@@ -1,6 +1,8 @@
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 
+module_name = require("./package.json").name;
+
 module.exports = {
   mode: 'development',
   entry: {
@@ -27,7 +29,7 @@ module.exports = {
   output: {
     path: __dirname + '/dist/SLING-INF/content/libs/lfs/resources/',
     publicPath: '/',
-    filename: '[name].[contenthash].js'
+    filename: module_name + '.[name].[contenthash].js'
   },
   externals: [
     {

--- a/modules/homepage/src/main/frontend/webpack.config.js
+++ b/modules/homepage/src/main/frontend/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
   plugins: [
     new CleanWebpackPlugin(),
     new WebpackAssetsManifest({
-      output: "homepage.json"
+      output: "assets.json"
     })
   ],
   module: {

--- a/modules/homepage/src/main/frontend/webpack.config.js
+++ b/modules/homepage/src/main/frontend/webpack.config.js
@@ -1,8 +1,17 @@
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const WebpackAssetsManifest = require('webpack-assets-manifest');
+
 module.exports = {
   mode: 'development',
   entry: {
     themeindex: './src/themePage/index.jsx'
   },
+  plugins: [
+    new CleanWebpackPlugin(),
+    new WebpackAssetsManifest({
+      output: "homepage.json"
+    })
+  ],
   module: {
     rules: [
       {
@@ -18,7 +27,7 @@ module.exports = {
   output: {
     path: __dirname + '/dist/SLING-INF/content/libs/lfs/resources/',
     publicPath: '/',
-    filename: '[name].js'
+    filename: '[name].[contenthash].js'
   },
   externals: [
     {

--- a/modules/homepage/src/main/frontend/webpack.config.js
+++ b/modules/homepage/src/main/frontend/webpack.config.js
@@ -1,12 +1,12 @@
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 
-module_name = require("./package.json").name;
+module_name = require("./package.json").name + ".";
 
 module.exports = {
   mode: 'development',
   entry: {
-    themeindex: './src/themePage/index.jsx'
+    [module_name + 'themeindex']: './src/themePage/index.jsx'
   },
   plugins: [
     new CleanWebpackPlugin(),
@@ -29,7 +29,7 @@ module.exports = {
   output: {
     path: __dirname + '/dist/SLING-INF/content/libs/lfs/resources/',
     publicPath: '/',
-    filename: module_name + '.[name].[contenthash].js'
+    filename: '[name].[contenthash].js'
   },
   externals: [
     {

--- a/modules/homepage/src/main/resources/SLING-INF/content/libs/lfs/Homepage/html.GET.esp
+++ b/modules/homepage/src/main/resources/SLING-INF/content/libs/lfs/Homepage/html.GET.esp
@@ -23,7 +23,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>${properties.title}</title>
+    <title><%= currentNode.title %></title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <script crossorigin src="https://unpkg.com/prop-types@15.6.2/prop-types.js"></script>
     <script crossorigin src="https://unpkg.com/jss@9.8.7/dist/jss.js"></script>
@@ -43,6 +43,6 @@
       }
     </script>
     <div id="main-container"></div>
-    <script src="/libs/lfs/resources/themeindex.js"></script>
+    <script src="/libs/lfs/resources/<%=resolver.getResource("/libs/lfs/resources/homepage").properties["themeindex.js"] %>"></script>
   </body>
 </html>

--- a/modules/homepage/src/main/resources/SLING-INF/content/libs/lfs/Homepage/html.GET.html
+++ b/modules/homepage/src/main/resources/SLING-INF/content/libs/lfs/Homepage/html.GET.html
@@ -44,7 +44,7 @@
     </script>
     <div id="main-container"></div>
     <sly data-sly-use.assets="/libs/lfs/resources/assets">
-      <script src="/libs/lfs/resources/${assets['themeindex.js']}"></script>
+      <script src="/libs/lfs/resources/${assets['lfs-homepage.themeindex.js']}"></script>
     </sly>
   </body>
 </html>

--- a/modules/homepage/src/main/resources/SLING-INF/content/libs/lfs/Homepage/html.GET.html
+++ b/modules/homepage/src/main/resources/SLING-INF/content/libs/lfs/Homepage/html.GET.html
@@ -43,8 +43,8 @@
       }
     </script>
     <div id="main-container"></div>
-    <sly data-sly-use.homepagelib="/libs/lfs/resources/homepage">
-      <script src="/libs/lfs/resources/${homepagelib['themeindex.js']}"></script>
+    <sly data-sly-use.assets="/libs/lfs/resources/assets">
+      <script src="/libs/lfs/resources/${assets['themeindex.js']}"></script>
     </sly>
   </body>
 </html>

--- a/modules/homepage/src/main/resources/SLING-INF/content/libs/lfs/Homepage/html.GET.html
+++ b/modules/homepage/src/main/resources/SLING-INF/content/libs/lfs/Homepage/html.GET.html
@@ -23,7 +23,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title><%= currentNode.title %></title>
+    <title>${properties.title}</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <script crossorigin src="https://unpkg.com/prop-types@15.6.2/prop-types.js"></script>
     <script crossorigin src="https://unpkg.com/jss@9.8.7/dist/jss.js"></script>
@@ -43,6 +43,8 @@
       }
     </script>
     <div id="main-container"></div>
-    <script src="/libs/lfs/resources/<%=resolver.getResource("/libs/lfs/resources/homepage").properties["themeindex.js"] %>"></script>
+    <sly data-sly-use.homepagelib="/libs/lfs/resources/homepage">
+      <script src="/libs/lfs/resources/${homepagelib['themeindex.js']}"></script>
+    </sly>
   </body>
 </html>

--- a/modules/login/src/main/frontend/package.json
+++ b/modules/login/src/main/frontend/package.json
@@ -26,10 +26,12 @@
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
     "babel-loader": "^8.0.6",
+    "clean-webpack-plugin": "3.0.0",
     "eslint": "^5.16.0",
     "eslint-plugin-auto-import": "^0.1.0",
     "eslint-plugin-react": "^7.13.0",
     "webpack": "^4.33.0",
+    "webpack-assets-manifest": "3.1.1",
     "webpack-cli": "^3.3.2"
   },
   "dependencies": {

--- a/modules/login/src/main/frontend/webpack.config.js
+++ b/modules/login/src/main/frontend/webpack.config.js
@@ -1,9 +1,18 @@
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const WebpackAssetsManifest = require('webpack-assets-manifest');
+
 module.exports = {
   mode: 'development',
   entry: {
     login: './src/login/loginMain.js',
     loginDialogue: './src/login/loginDialogue.js'
   },
+  plugins: [
+    new CleanWebpackPlugin(),
+    new WebpackAssetsManifest({
+      output: "login.json"
+    })
+  ],
   module: {
     rules: [
       {
@@ -19,7 +28,7 @@ module.exports = {
   output: {
     path: __dirname + '/dist/SLING-INF/content/libs/lfs/resources/',
     publicPath: '/',
-    filename: '[name].js'
+    filename: '[name].[contenthash].js'
   },
   externals: [
     {

--- a/modules/login/src/main/frontend/webpack.config.js
+++ b/modules/login/src/main/frontend/webpack.config.js
@@ -1,6 +1,8 @@
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 
+module_name = require("./package.json").name;
+
 module.exports = {
   mode: 'development',
   entry: {
@@ -28,7 +30,7 @@ module.exports = {
   output: {
     path: __dirname + '/dist/SLING-INF/content/libs/lfs/resources/',
     publicPath: '/',
-    filename: '[name].[contenthash].js'
+    filename: module_name + '.[name].[contenthash].js'
   },
   externals: [
     {

--- a/modules/login/src/main/frontend/webpack.config.js
+++ b/modules/login/src/main/frontend/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
   plugins: [
     new CleanWebpackPlugin(),
     new WebpackAssetsManifest({
-      output: "login.json"
+      output: "assets.json"
     })
   ],
   module: {

--- a/modules/login/src/main/frontend/webpack.config.js
+++ b/modules/login/src/main/frontend/webpack.config.js
@@ -1,13 +1,13 @@
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 
-module_name = require("./package.json").name;
+module_name = require("./package.json").name + ".";
 
 module.exports = {
   mode: 'development',
   entry: {
-    login: './src/login/loginMain.js',
-    loginDialogue: './src/login/loginDialogue.js'
+    [module_name + 'login']: './src/login/loginMain.js',
+    [module_name + 'loginDialogue']: './src/login/loginDialogue.js'
   },
   plugins: [
     new CleanWebpackPlugin(),
@@ -30,7 +30,7 @@ module.exports = {
   output: {
     path: __dirname + '/dist/SLING-INF/content/libs/lfs/resources/',
     publicPath: '/',
-    filename: module_name + '.[name].[contenthash].js'
+    filename: '[name].[contenthash].js'
   },
   externals: [
     {

--- a/modules/login/src/main/resources/SLING-INF/content/libs/lfs/login/html.html
+++ b/modules/login/src/main/resources/SLING-INF/content/libs/lfs/login/html.html
@@ -35,7 +35,7 @@
   <body>
     <div id="main-login-container"></div>
     <sly data-sly-use.assets="/libs/lfs/resources/assets">
-      <script src="/libs/lfs/resources/${assets['login.js']}"></script>
+      <script src="/libs/lfs/resources/${assets['lfs-login.login.js']}"></script>
     </sly>
   </body>
 </html>

--- a/modules/login/src/main/resources/SLING-INF/content/libs/lfs/login/html.html
+++ b/modules/login/src/main/resources/SLING-INF/content/libs/lfs/login/html.html
@@ -34,6 +34,8 @@
   </head>
   <body>
     <div id="main-login-container"></div>
-    <script src="/libs/lfs/resources/login.js"></script>
+    <sly data-sly-use.loginlib="/libs/lfs/resources/login">
+      <script src="/libs/lfs/resources/${loginlib['login.js']}"></script>
+    </sly>
   </body>
 </html>

--- a/modules/login/src/main/resources/SLING-INF/content/libs/lfs/login/html.html
+++ b/modules/login/src/main/resources/SLING-INF/content/libs/lfs/login/html.html
@@ -34,8 +34,8 @@
   </head>
   <body>
     <div id="main-login-container"></div>
-    <sly data-sly-use.loginlib="/libs/lfs/resources/login">
-      <script src="/libs/lfs/resources/${loginlib['login.js']}"></script>
+    <sly data-sly-use.assets="/libs/lfs/resources/assets">
+      <script src="/libs/lfs/resources/${assets['login.js']}"></script>
     </sly>
   </body>
 </html>


### PR DESCRIPTION
This is achieved in three parts:
1) Using the [WebpackAssetsManifest](https://github.com/webdeveric/webpack-assets-manifest) plugin to generate a .json file telling the server where to find the entry points, e.g.:
`{"jcr:primaryType":"sling:Folder","jcr:createdBy":"admin","jcr:created":"Thu Jul 11 2019 15:10:27 GMT-0400","themeindex.js":"themeindex.202e3c3516601f18eb8f.js"}`
2) Switching the homepage from html.GET.html to html.GET.esp to parse out the location of the script.
3) Using [WebpackCleanupPlugin](https://www.npmjs.com/package/webpack-cleanup-plugin) to clean up the webpack folder between compiles, for organization's sake. 

This is all based on suggestions by @sdumitriu through [this Medium article](https://medium.com/@jsilvax/introducing-webpack-into-an-existing-java-based-web-app-ff53f14d37ec).