### PR TITLE
LFS-114: Searching for child terms in a vocabulary doesn't work

### DIFF
--- a/modules/vocabularies/src/main/resources/SLING-INF/content/oak:index/vocabularyTerms.json
+++ b/modules/vocabularies/src/main/resources/SLING-INF/content/oak:index/vocabularyTerms.json
@@ -40,13 +40,13 @@
                     "useInExcerpt": true
                 },
                 "parents": {
-                    "analyzed": false,
+                    "analyzed": true,
                     "propertyIndex": true,
                     "nodeScopeIndex": false,
                     "useInExcerpt": false
                 },
                 "ancestors": {
-                    "analyzed": false,
+                    "analyzed": true,
                     "propertyIndex": true,
                     "nodeScopeIndex": false,
                     "useInExcerpt": false


### PR DESCRIPTION
Fixed by making all fields analyzed