### PR TITLE
JS size reduction

### DIFF
--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/AdminNavbarLinks.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/AdminNavbarLinks.jsx
@@ -15,7 +15,10 @@ import classNames from "classnames";
 import { withStyles } from "@material-ui/core";
 import { MenuItem, MenuList, Grow, Paper, ClickAwayListener, Hidden, Popper } from "@material-ui/core";
 // @material-ui/icons
-import { Person, Notifications, Search, ExitToApp } from "@material-ui/icons";
+import Person from "@material-ui/icons/Person";
+import Notifications from "@material-ui/icons/Notifications";
+import Search from "@material-ui/icons/Search";
+import ExitToApp from "@material-ui/icons/ExitToApp";
 // core components
 import {Button, CustomInput} from "MaterialDashboardReact";
 

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/Navbar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/Navbar.jsx
@@ -16,7 +16,7 @@ import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core";
 import { AppBar, Toolbar, IconButton, Hidden } from "@material-ui/core";
 // @material-ui/icons
-import { Menu } from "@material-ui/icons";
+import Menu from "@material-ui/icons/Menu";
 // core components
 import AdminNavbarLinks from "./AdminNavbarLinks.jsx";
 import { Button } from "MaterialDashboardReact";

--- a/modules/homepage/src/main/frontend/src/themePage/routes.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/routes.jsx
@@ -16,7 +16,12 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import { AccountBox, Assignment, Dashboard, Pets, Settings, Subtitles } from '@material-ui/icons';
+import AccountBox from '@material-ui/icons/AccountBox';
+import Assignment from '@material-ui/icons/Assignment';
+import Dashboard from '@material-ui/icons/Dashboard';
+import Pets from '@material-ui/icons/Pets';
+import Settings from '@material-ui/icons/Settings';
+import Subtitles from '@material-ui/icons/Subtitles';
 
 import DashboardPage from "./Dashboard/dashboard.jsx";
 

--- a/modules/material-dashboard/src/main/frontend/src/MaterialDashboardReact/CustomInput/CustomInput.jsx
+++ b/modules/material-dashboard/src/main/frontend/src/MaterialDashboardReact/CustomInput/CustomInput.jsx
@@ -16,7 +16,8 @@ import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core";
 import { FormControl, InputLabel, Input } from "@material-ui/core";
 // @material-ui/icons
-import { Clear, Check } from "@material-ui/icons";
+import Clear from "@material-ui/icons/Clear";
+import Check from "@material-ui/icons/Check";
 // core components
 import customInputStyle from "./customInputStyle.jsx";
 

--- a/modules/thesaurus/src/main/frontend/src/query/browse.jsx
+++ b/modules/thesaurus/src/main/frontend/src/query/browse.jsx
@@ -19,7 +19,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 // @material-ui/core
-import { withStyles } from "@material-ui/core/styles";
+import { withStyles } from "@material-ui/core";
 import { Dialog, DialogContent, DialogTitle, Typography } from '@material-ui/core';
 // material-dashboard-react
 import { Button } from "MaterialDashboardReact";

--- a/modules/thesaurus/src/main/frontend/src/query/browseListChild.jsx
+++ b/modules/thesaurus/src/main/frontend/src/query/browseListChild.jsx
@@ -19,7 +19,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 // @material-ui/core
-import { withStyles } from "@material-ui/core/styles";
+import { withStyles } from "@material-ui/core";
 import { CircularProgress, Typography } from '@material-ui/core';
 // material-dashboard-react
 import { Button } from "MaterialDashboardReact";

--- a/modules/thesaurus/src/main/frontend/src/query/query.jsx
+++ b/modules/thesaurus/src/main/frontend/src/query/query.jsx
@@ -20,7 +20,7 @@ import classNames from "classnames";
 import React from "react";
 import PropTypes from "prop-types";
 // @material-ui/core
-import { withStyles } from "@material-ui/core/styles";
+import { withStyles } from "@material-ui/core";
 import { ClickAwayListener, Grow, InputAdornment, LinearProgress, MenuItem, MenuList, Paper, Popper, Snackbar, SnackbarContent, Typography } from "@material-ui/core"
 // MaterialDashboardReact
 import { Button, Card, CardHeader, CardBody, CustomInput, QueryStyle } from "MaterialDashboardReact";

--- a/modules/thesaurus/src/main/frontend/src/selector/selectEntry.jsx
+++ b/modules/thesaurus/src/main/frontend/src/selector/selectEntry.jsx
@@ -20,7 +20,7 @@ import React from "react";
 import PropTypes from "prop-types";
 // @material-ui/core
 import { Checkbox, FormControlLabel, IconButton, ListItem, withStyles, Typography, Radio } from "@material-ui/core"
-import { Close } from "@material-ui/icons"
+import Close from "@material-ui/icons/Close"
 import SelectorStyle from "./selectorStyle.jsx"
 
 // Child element that will be inserted to the target DOM


### PR DESCRIPTION
- `withStyles` should be imported from `@material-ui/core`, since the behavior is the same
- icons should be imported individually, since otherwise all of the icons are included in the transpiled JS file, which makes every JS file that uses icons 11Mb