### PR TITLE
LFS-139: As a user, I can browse existing questionnaires, forms, or subjects

### DIFF
--- a/modules/data-entry/src/main/frontend/package.json
+++ b/modules/data-entry/src/main/frontend/package.json
@@ -39,6 +39,7 @@
     "@material-ui/icons": "^4.4.3",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
+    "moment": "^2.24.0",
     "classnames": "^2.2.6"
   }
 }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -1,0 +1,54 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+import React from "react";
+import LiveTable from "./LiveTable.jsx";
+
+export default function Forms(props) {
+  const columns = [
+    {
+      "key": "jcr:uuid",
+      "label": "Identifier",
+      "format": "string",
+      "link": "entry",
+    },
+    {
+      "key": "questionnaire",
+      "label": "Questionnaire",
+      "format": "string",
+    },
+    {
+      "key": "subject",
+      "label": "Subject",
+      "format": "string",
+    },
+    {
+      "key": "jcr:createdBy",
+      "label": "Created by",
+      "format": "string",
+    },
+    {
+      "key": "jcr:created",
+      "label": "Created on",
+      "format": "date:YYYY-MM-DD HH:mm",
+    },
+  ]
+  return (
+    <LiveTable columns={columns} />
+  );
+}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -140,6 +140,9 @@ export default function LiveTable(props) {
 
     // Handle display formatting
     if (column.format && column.format.startsWith('date')) {
+      // The format can be either just "date", in which case a default date format is used, or "date:FORMAT".
+      // Cutting after the fifth char means that either we skip "date:" and read the format,
+      // or we just get the empty string and use the default format.
       let format = column.format.substring(5) || 'YYYY-MM-dd';
       content = _formatDate(content, format);
     }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -1,0 +1,234 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React, { useState } from "react";
+import { Paper, Table, TableHead, TableBody, TableFooter, TableRow, TableCell, TablePagination } from "@material-ui/core";
+import moment from "moment";
+
+// Convert a date into the given format string
+// If the date is invalid (usually because it is missing), return ""
+let _formatDate = (date, formatString) => {
+  let dateObj = moment(date);
+  if (dateObj.isValid()) {
+    return dateObj.format(formatString)
+  }
+  return "";
+};
+
+export default function LiveTable(props) {
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // Define the component's state
+
+  const { customUrl, columns, classes } = props;
+  const [tableData, setTableData] = useState();
+  const [paginationData, setPaginationData] = useState(
+    {
+      "offset": 0,
+      "limit": 50,
+      "displayed": 0,
+      "total": -1,
+      "page": 0,
+    }
+  );
+  const [fetchStatus, setFetchStatus] = useState(
+    {
+      "currentRequestNumber": -1,
+      "currentFetch": false,
+      "fetchError": false,
+    }
+  );
+  // The base URL to fetch from.
+  // This can either be a custom URL provided in props,
+  // or an URL obtained from the current location by extracting the last path segment and appending .paginate
+  // Later, the query string of this URL base will be updated with the pagination details.
+  const urlBase = (
+    customUrl ?
+      new URL(customUrl, window.location.origin)
+    :
+      new URL(window.location.pathname.substring(window.location.pathname.lastIndexOf("/")) + ".paginate", window.location.origin)
+  );
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // Define the component's behavior
+
+  let fetchData = (newPage) => {
+    if (fetchStatus.currentFetch) {
+      // TODO: abort previous request
+    }
+
+    let url = new URL(urlBase);
+    url.searchParams.set("offset", newPage.offset);
+    url.searchParams.set("limit", newPage.limit || paginationData.limit);
+    url.searchParams.set("req", ++fetchStatus.currentRequestNumber);
+    let currentFetch = fetch(url);
+    setFetchStatus(Object.assign(fetchStatus, {
+      "currentFetch": currentFetch,
+      "fetchError": false,
+    }));
+    currentFetch.then((response) => response.ok ? response.json() : Promise.reject(response)).then(handleResponse).catch(handleError);
+    // TODO: update the displayed URL with pagination details, so that we can share/reload at the same page
+  };
+
+  let handleResponse = (json) => {
+    if (+json.req !== fetchStatus.currentRequestNumber) {
+    console.log("Different: ", json.req, fetchStatus.currentRequestNumber);
+      // This is the response for an older request. Discard it, wait for the right one.
+      return;
+    }
+    setTableData(json.rows);
+    setPaginationData(
+      {
+        "offset": json.offset,
+        "limit": json.limit,
+        "displayed": json.returnedrows,
+        "total": json.totalrows,
+        "page": Math.floor(json.offset / json.limit),
+      }
+    );
+  };
+
+  let handleError = (response) => {
+    setTableData();
+    setFetchStatus(Object.assign(fetchStatus, {
+      "currentFetch": false,
+      "fetchError": (response.statusText ? response.statusText : response),
+    }));
+  };
+
+  let makeRow = (entry) => {
+    return (
+      <TableRow key={entry[0]}>
+        { columns ?
+          (
+            columns.map((column, index) => makeCell(entry, column, index))
+          )
+        :
+          (
+            <TableCell><a href={entry[0]}>{entry[1].title}</a></TableCell>
+          )
+        }
+      </TableRow>
+    );
+  };
+
+  let makeCell = (entry, column, index) => {
+    let content = entry[1][column.key];
+    let target = false;
+
+    // Handle links
+    if (column.link === 'entry') {
+      target = entry[0];
+    } else if (column.link === 'value') {
+      target = content;
+    }
+
+    // Handle display formatting
+    if (column.format && column.format.startsWith('date')) {
+      let format = column.format.substring(5) || 'YYYY-MM-dd';
+      content = _formatDate(content, format);
+    }
+
+    // Render the cell
+    return <TableCell key={index}>{ target ? (<a href={target}>{content}</a>) : ( content )}</TableCell>
+  };
+
+  let handleChangePage = (event, page) => {
+    // TODO: Clicking twice on prev page makes two requests for the same "previous" page.
+    // Expected behavior is one of:
+    // - disable the buttons while waiting for the new page, so only one click is possible
+    // - or abort the first request and request the two-behind previous page
+    // The second behavior seems more intuitive, but it needs to store two states:
+    // - the currently displayed page
+    // - the expected page
+    // TODO: Change the code to behave better
+    fetchData({
+      "offset" : page * paginationData.limit,
+    });
+  };
+
+  let handleChangeRowsPerPage = (event) => {
+    const newPageSize = +event.target.value;
+    fetchData({
+      "offset": Math.floor(paginationData.offset / newPageSize) * newPageSize,
+      "limit": newPageSize,
+    });
+  };
+
+  // Initialize the component: if there's no data loaded yet, fetch the first page
+
+  if (fetchStatus.currentRequestNumber == -1) {
+    fetchData(paginationData);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // The rendering code
+
+  return (
+    // We wrap everything in a Paper for a nice separation, as a Table has no background or border of its own.
+    <Paper>
+      {/*
+      // stickyHeader doesn't really work right now, since the Paper just extends all the way down to fit the table.
+      // The whole UI needs to be redesigned so that we can set a maximum height to the Paper,
+      // which would make the table scroll internally.
+      // <Table stickyHeader>
+      */}
+      <Table>
+        {/* TODO: Also add pagination controls at the top? Or maybe the UI redesign mentioned above will fix the problem. */}
+        <TableHead>
+          {/* TODO: Move the whole header in a separate, smarter component that can do filtering and sorting. */}
+          <TableRow>
+          { columns ?
+            (
+              columns.map((column, index) => <TableCell key={index}>{column.label}</TableCell>)
+            )
+          :
+            (
+              <TableCell>Name</TableCell>
+            )
+          }
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          { tableData ?
+            ( Object.entries(tableData).map(makeRow) )
+            :
+            ( <TableRow><TableCell>Please wait...</TableCell></TableRow> )
+            /* TODO: Better progress bar, add some Suspense */
+          }
+        </TableBody>
+      </Table>
+      {/*
+      // The pagination is outside the table itself to support internal scrolling of the table.
+      // The element used by TablePagination by default is TableCell, but since it is not in a TableRow, we have to override this to be a <div>.
+      */}
+      { tableData && (
+          <TablePagination
+            component="div"
+            rowsPerPageOptions={[10, 50, 100, 1000]}
+            count={paginationData.total}
+            rowsPerPage={paginationData.limit}
+            page={paginationData.page}
+            onChangePage={handleChangePage}
+            onChangeRowsPerPage={handleChangeRowsPerPage}
+          />
+        )
+      }
+    </Paper>
+  );
+}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
@@ -1,0 +1,44 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+import React from "react";
+import LiveTable from "./LiveTable.jsx";
+
+export default function Questionnaires(props) {
+  const columns = [
+    {
+      "key": "title",
+      "label": "Title",
+      "format": "string",
+      "link": "entry",
+    },
+    {
+      "key": "jcr:createdBy",
+      "label": "Created by",
+      "format": "string",
+    },
+    {
+      "key": "jcr:created",
+      "label": "Created on",
+      "format": "date:YYYY-MM-DD HH:mm",
+    },
+  ]
+  return (
+    <LiveTable columns={columns} />
+  );
+}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
@@ -1,0 +1,44 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+import React from "react";
+import LiveTable from "./LiveTable.jsx";
+
+export default function Subjects(props) {
+  const columns = [
+    {
+      "key": "identifier",
+      "label": "Identifier",
+      "format": "string",
+      "link": "entry",
+    },
+    {
+      "key": "jcr:createdBy",
+      "label": "Created by",
+      "format": "string",
+    },
+    {
+      "key": "jcr:created",
+      "label": "Created on",
+      "format": "date:YYYY-MM-DD HH:mm",
+    },
+  ]
+  return (
+    <LiveTable columns={columns} />
+  );
+}

--- a/modules/data-entry/src/main/frontend/webpack.config.js
+++ b/modules/data-entry/src/main/frontend/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = {
     [module_name + 'showQuery']: './src/dataQuery/query.js',
     [module_name + 'LiveTable']: './src/dataHomepage/LiveTable.jsx',
     [module_name + 'Questionnaires']: './src/dataHomepage/Questionnaires.jsx',
+    [module_name + 'Subjects']: './src/dataHomepage/Subjects.jsx',
   },
   plugins: [
     new CleanWebpackPlugin(),

--- a/modules/data-entry/src/main/frontend/webpack.config.js
+++ b/modules/data-entry/src/main/frontend/webpack.config.js
@@ -38,6 +38,7 @@ module.exports = {
   },
   externals: [
     {
+      "moment": "moment",
       "react": "React",
       "react-dom": "ReactDOM",
       "lodash": "lodash",

--- a/modules/data-entry/src/main/frontend/webpack.config.js
+++ b/modules/data-entry/src/main/frontend/webpack.config.js
@@ -7,7 +7,8 @@ module.exports = {
   mode: 'development',
   entry: {
     [module_name + 'redirect']: './src/dataQuery/redirect.js',
-    [module_name + 'showQuery']: './src/dataQuery/query.js'
+    [module_name + 'showQuery']: './src/dataQuery/query.js',
+    [module_name + 'LiveTable']: './src/dataHomepage/LiveTable.jsx',
   },
   plugins: [
     new CleanWebpackPlugin(),
@@ -30,7 +31,6 @@ module.exports = {
   output: {
     path: __dirname + '/dist/SLING-INF/content/libs/lfs/resources/',
     publicPath: '/',
-    library: 'dataQuery',
     filename: '[name].[contenthash].js'
   },
   externals: [

--- a/modules/data-entry/src/main/frontend/webpack.config.js
+++ b/modules/data-entry/src/main/frontend/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
     [module_name + 'redirect']: './src/dataQuery/redirect.js',
     [module_name + 'showQuery']: './src/dataQuery/query.js',
     [module_name + 'LiveTable']: './src/dataHomepage/LiveTable.jsx',
+    [module_name + 'Questionnaires']: './src/dataHomepage/Questionnaires.jsx',
   },
   plugins: [
     new CleanWebpackPlugin(),

--- a/modules/data-entry/src/main/frontend/webpack.config.js
+++ b/modules/data-entry/src/main/frontend/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
     [module_name + 'LiveTable']: './src/dataHomepage/LiveTable.jsx',
     [module_name + 'Questionnaires']: './src/dataHomepage/Questionnaires.jsx',
     [module_name + 'Subjects']: './src/dataHomepage/Subjects.jsx',
+    [module_name + 'Forms']: './src/dataHomepage/Forms.jsx',
   },
   plugins: [
     new CleanWebpackPlugin(),

--- a/modules/data-entry/src/main/resources/SLING-INF/content/Extensions.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/Extensions.json
@@ -1,0 +1,42 @@
+{
+    "jcr:primaryType": "sling:Folder",
+    "Questionnaires": {
+        "jcr:primaryType": "lfs:Extension",
+        "lfs:extensionPointId": "lfs/coreUI/sidebar/entry",
+        "lfs:targetURL": "Questionnaires",
+        "lfs:extensionName": "Questionnaires",
+        "lfs:icon": "asset:lfs-homepage.dashboardIcon.js",
+        "lfs:extensionRenderURL": "asset:lfs-dataentry.Questionnaires.js",
+        "jcr:content": {
+            "jcr:primaryType": "nt:resource",
+            "jcr:data": "",
+            "jcr:mimeType": "text/html"
+        }
+    },
+    "Subjects": {
+        "jcr:primaryType": "lfs:Extension",
+        "lfs:extensionPointId": "lfs/coreUI/sidebar/entry",
+        "lfs:targetURL": "Subjects",
+        "lfs:extensionName": "Subjects",
+        "lfs:icon": "asset:lfs-homepage.dashboardIcon.js",
+        "lfs:extensionRenderURL": "asset:lfs-dataentry.Subjects.js",
+        "jcr:content": {
+            "jcr:primaryType": "nt:resource",
+            "jcr:data": "",
+            "jcr:mimeType": "text/html"
+        }
+    },
+    "Forms": {
+        "jcr:primaryType": "lfs:Extension",
+        "lfs:extensionPointId": "lfs/coreUI/sidebar/entry",
+        "lfs:targetURL": "Forms",
+        "lfs:extensionName": "Forms",
+        "lfs:icon": "asset:lfs-homepage.dashboardIcon.js",
+        "lfs:extensionRenderURL": "asset:lfs-dataentry.Forms.js",
+        "jcr:content": {
+            "jcr:primaryType": "nt:resource",
+            "jcr:data": "",
+            "jcr:mimeType": "text/html"
+        }
+    }
+}


### PR DESCRIPTION
A basic LiveTable is displayed on all these pages. Things that need future work:

- sorting and filtering on columns
- make the footer with the pagination always visible
- display the subject and questionnaire labels instead of raw identifiers in the Forms table
- add pages for actually seeing a form/subject/questionnaire, right now the links just go to a HtmlRenderer dumped page
- move the LiveTable in the commons module, to be reusable by other code
- right now the LiveTable code is copied in each of the homepages, make it externally reusable (make all of the commons module a js always available?)

There are TODOs in the code for future improvements.