### PR TITLE
LFS-171: Clean up the side menu

### DIFF
--- a/modules/data-entry/src/main/resources/SLING-INF/content/Extensions.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/Extensions.json
@@ -7,6 +7,7 @@
         "lfs:extensionName": "Questionnaires",
         "lfs:icon": "asset:lfs-dataentry.questionnairesIcon.js",
         "lfs:extensionRenderURL": "asset:lfs-dataentry.Questionnaires.js",
+        "lfs:defaultOrder": 91,
         "jcr:content": {
             "jcr:primaryType": "nt:resource",
             "jcr:data": "",
@@ -20,6 +21,7 @@
         "lfs:extensionName": "Subjects",
         "lfs:icon": "asset:lfs-dataentry.subjectsIcon.js",
         "lfs:extensionRenderURL": "asset:lfs-dataentry.Subjects.js",
+        "lfs:defaultOrder": 1,
         "jcr:content": {
             "jcr:primaryType": "nt:resource",
             "jcr:data": "",
@@ -33,6 +35,7 @@
         "lfs:extensionName": "Forms",
         "lfs:icon": "asset:lfs-dataentry.formsIcon.js",
         "lfs:extensionRenderURL": "asset:lfs-dataentry.Forms.js",
+        "lfs:defaultOrder": 92,
         "jcr:content": {
             "jcr:primaryType": "nt:resource",
             "jcr:data": "",

--- a/modules/data-entry/src/main/resources/SLING-INF/content/Extensions.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/Extensions.json
@@ -35,7 +35,7 @@
         "lfs:extensionName": "Forms",
         "lfs:icon": "asset:lfs-dataentry.formsIcon.js",
         "lfs:extensionRenderURL": "asset:lfs-dataentry.Forms.js",
-        "lfs:defaultOrder": 92,
+        "lfs:defaultOrder": 2,
         "jcr:content": {
             "jcr:primaryType": "nt:resource",
             "jcr:data": "",

--- a/modules/homepage/src/main/frontend/src/themePage/Sidebar/sidebar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Sidebar/sidebar.jsx
@@ -31,14 +31,62 @@ const Sidebar = ({ ...props }) => {
   var links = (
     <List className={classes.list}>
       {routes.map((prop, key) => {
-        var adminButton = " ";
         var listItemClasses;
 
         // Generate a list of class names for each item in the sidebar
         // We colour two links in: the currently active
         // link, and the administration link
-        if (prop.path === "/admin.html") {
-          adminButton = classes.adminButton + " ";
+        if (prop.isAdmin) {
+          // Don't put non-admin links in here
+          return;
+        }
+        listItemClasses = classNames({
+          [" " + classes[color]]: activeRoute(prop.layout + prop.path)
+        });
+        const whiteFontClasses = classNames({
+          [" " + classes.whiteFont]: activeRoute(prop.layout + prop.path)
+        });
+
+        // Handle prop.icon being either a class or the name of an icon class
+        // NavLink allows us to set styles iff the link's URL matches the current URL
+        return (
+          <NavLink
+            to={prop.layout + prop.path}
+            className={classes.item}
+            activeClassName="active"
+            key={key}
+          >
+            <ListItem button className={classes.itemLink + listItemClasses}>
+              <prop.icon
+                  className={classNames(classes.itemIcon, whiteFontClasses)}
+                />
+              <ListItemText
+                primary={prop.name}
+                className={classNames(classes.itemText, whiteFontClasses)}
+                disableTypography={true}
+              />
+            </ListItem>
+          </NavLink>
+        );
+      })}
+    </List>
+  );
+
+  var adminLinks = (
+    <List className={classes.adminSidebar}>
+      {routes.map((prop, key) => {
+        var blueButton = " ";
+        var listItemClasses;
+
+        // Generate a list of class names for each item in the sidebar
+        // We colour two links in: the currently active
+        // link, and the administration link
+        if (!prop.isAdmin) {
+          // Don't put non-admin links in here
+          return;
+        } else if (prop.path === "/admin.html") {
+          // The admin page button is blue
+          blueButton = classes.adminButton + " ";
           listItemClasses = classNames({
             [" " + classes[color]]: true
           });
@@ -56,7 +104,7 @@ const Sidebar = ({ ...props }) => {
         return (
           <NavLink
             to={prop.layout + prop.path}
-            className={adminButton + classes.item}
+            className={blueButton + classes.item}
             activeClassName="active"
             key={key}
           >
@@ -110,6 +158,7 @@ const Sidebar = ({ ...props }) => {
           <div className={classes.sidebarWrapper}>
             <AdminNavbarLinks />
             {links}
+            {adminLinks}
           </div>
           {image !== undefined ? (
             <div
@@ -128,7 +177,10 @@ const Sidebar = ({ ...props }) => {
           classes={{paper: classes.drawerPaper}}
         >
           {brand}
-          <div className={classes.sidebarWrapper}>{links}</div>
+          <div className={classes.sidebarWrapper}>
+            {links}
+            {adminLinks}
+          </div>
           {image !== undefined ? (
             <div
               className={classes.background}

--- a/modules/homepage/src/main/frontend/src/themePage/Sidebar/sidebar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Sidebar/sidebar.jsx
@@ -30,11 +30,10 @@ const Sidebar = ({ ...props }) => {
   // Generate NavLinks and ListItems from the given route prop
   // activeStyle is true for anything that should look "active" (e.g. the admin link, the current page)
   function generateListItem(prop, key, activeStyle) {
-    var listItemClasses, whiteFontClasses;
-    listItemClasses = classNames({
+    const listBackground = classNames({
       [" " + classes[color]]: activeStyle
     });
-    whiteFontClasses = classNames({
+    const listItemFont = classNames({
       [" " + classes.whiteFont]: activeStyle
     });
 
@@ -45,13 +44,13 @@ const Sidebar = ({ ...props }) => {
         activeClassName="active"
         key={key}
       >
-        <ListItem button className={classes.itemLink + listItemClasses}>
+        <ListItem button className={classes.itemLink + listBackground}>
           <prop.icon
-              className={classNames(classes.itemIcon, whiteFontClasses)}
+              className={classNames(classes.itemIcon, listItemFont)}
             />
           <ListItemText
             primary={prop.name}
-            className={classNames(classes.itemText, whiteFontClasses)}
+            className={classNames(classes.itemText, listItemFont)}
             disableTypography={true}
           />
         </ListItem>

--- a/modules/homepage/src/main/frontend/src/themePage/Sidebar/sidebar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Sidebar/sidebar.jsx
@@ -27,99 +27,59 @@ const Sidebar = ({ ...props }) => {
   }
   const { classes, color, logoImage, image, logoText, routes } = props;
 
+  // Generate NavLinks and ListItems from the given route prop
+  // activeStyle is true for anything that should look "active" (e.g. the admin link, the current page)
+  function generateListItem(prop, key, activeStyle) {
+    var listItemClasses, whiteFontClasses;
+    listItemClasses = classNames({
+      [" " + classes[color]]: activeStyle
+    });
+    whiteFontClasses = classNames({
+      [" " + classes.whiteFont]: activeStyle
+    });
+
+    return (
+      <NavLink
+        to={prop.layout + prop.path}
+        className={classes.item}
+        activeClassName="active"
+        key={key}
+      >
+        <ListItem button className={classes.itemLink + listItemClasses}>
+          <prop.icon
+              className={classNames(classes.itemIcon, whiteFontClasses)}
+            />
+          <ListItemText
+            primary={prop.name}
+            className={classNames(classes.itemText, whiteFontClasses)}
+            disableTypography={true}
+          />
+        </ListItem>
+      </NavLink>
+    );
+  }
+
   // Links
   var links = (
     <List className={classes.list}>
-      {routes.map((prop, key) => {
-        var listItemClasses;
-
-        // Generate a list of class names for each item in the sidebar
-        // We colour two links in: the currently active
-        // link, and the administration link
-        if (prop.isAdmin) {
-          // Don't put non-admin links in here
-          return;
-        }
-        listItemClasses = classNames({
-          [" " + classes[color]]: activeRoute(prop.layout + prop.path)
-        });
-        const whiteFontClasses = classNames({
-          [" " + classes.whiteFont]: activeRoute(prop.layout + prop.path)
-        });
-
-        // Handle prop.icon being either a class or the name of an icon class
-        // NavLink allows us to set styles iff the link's URL matches the current URL
-        return (
-          <NavLink
-            to={prop.layout + prop.path}
-            className={classes.item}
-            activeClassName="active"
-            key={key}
-          >
-            <ListItem button className={classes.itemLink + listItemClasses}>
-              <prop.icon
-                  className={classNames(classes.itemIcon, whiteFontClasses)}
-                />
-              <ListItemText
-                primary={prop.name}
-                className={classNames(classes.itemText, whiteFontClasses)}
-                disableTypography={true}
-              />
-            </ListItem>
-          </NavLink>
-        );
+      {routes.filter((prop, key) => {
+        // Only use non-admin links
+        return !prop.isAdmin;
+      }).map((prop, key) => {
+        return(generateListItem(prop, key, activeRoute(prop.layout + prop.path)));
       })}
     </List>
   );
 
   var adminLinks = (
     <List className={classes.adminSidebar}>
-      {routes.map((prop, key) => {
-        var blueButton = " ";
-        var listItemClasses;
-
-        // Generate a list of class names for each item in the sidebar
-        // We colour two links in: the currently active
-        // link, and the administration link
-        if (!prop.isAdmin) {
-          // Don't put non-admin links in here
-          return;
-        } else if (prop.path === "/admin.html") {
-          // The admin page button is blue
-          blueButton = classes.adminButton + " ";
-          listItemClasses = classNames({
-            [" " + classes[color]]: true
-          });
-        } else {
-          listItemClasses = classNames({
-            [" " + classes[color]]: activeRoute(prop.layout + prop.path)
-          });
-        }
-        const whiteFontClasses = classNames({
-          [" " + classes.whiteFont]: activeRoute(prop.layout + prop.path)
-        });
-
-        // Handle prop.icon being either a class or the name of an icon class
-        // NavLink allows us to set styles iff the link's URL matches the current URL
-        return (
-          <NavLink
-            to={prop.layout + prop.path}
-            className={blueButton + classes.item}
-            activeClassName="active"
-            key={key}
-          >
-            <ListItem button className={classes.itemLink + listItemClasses}>
-              <prop.icon
-                  className={classNames(classes.itemIcon, whiteFontClasses)}
-                />
-              <ListItemText
-                primary={prop.name}
-                className={classNames(classes.itemText, whiteFontClasses)}
-                disableTypography={true}
-              />
-            </ListItem>
-          </NavLink>
-        );
+      {routes.filter((prop, key) => {
+        // Only use admin links
+        return prop.isAdmin;
+      }).map((prop, key) => {
+        // To make it stand out, the admin link is also active
+        const isActive = prop.path === "/admin.html" || activeRoute(prop.layout + prop.path);
+        return(generateListItem(prop, key, isActive));
       })}
     </List>
   );

--- a/modules/homepage/src/main/frontend/src/themePage/Sidebar/sidebarStyle.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Sidebar/sidebarStyle.jsx
@@ -282,6 +282,8 @@ import {
       overflowScrolling: "touch"
     },
     adminButton: {
+    },
+    adminSidebar: {
       [theme.breakpoints.up("md")]: {
         position: "absolute",
         width: "100%",

--- a/modules/homepage/src/main/frontend/src/themePage/index.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/index.jsx
@@ -58,8 +58,15 @@ class Main extends React.Component {
     window.removeEventListener("resize", this.autoCloseMobileMenus);
   }
 
+  // Determine if the given defaultOrder makes the associated link an admin link (i.e. defaultOrder is in the 90s)
+  // FIXME: Admin links should ideally be in a separate extension target
+  _isAdministrativeButton(order) {
+    return Math.floor(order % 100 / 90);
+  }
+
   _buildSidebar = (uixData) => {
     var routes = sidebarRoutes.slice();
+    uixData.sort((firstEl, secondEl) => {return firstEl.order - secondEl.order;});
     for (var id in uixData) {
       var uixDatum = uixData[id];
       routes.push({
@@ -67,6 +74,7 @@ class Main extends React.Component {
         name: uixDatum.name,
         icon: uixDatum.icon,
         component: uixDatum.reactComponent,
+        isAdmin: this._isAdministrativeButton(uixDatum.order),
         rtlName: "rtl:test",
         layout: "/content.html"
       });

--- a/modules/homepage/src/main/frontend/src/themePage/routes.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/routes.jsx
@@ -74,7 +74,8 @@ var loadRemoteComponent = function(component) {
         reactComponent: null,
         path: "/" + component["lfs:targetURL"],
         name: component["lfs:extensionName"],
-        iconUrl: component["lfs:icon"]
+        iconUrl: component["lfs:icon"],
+        order: component["lfs:defaultOrder"]
       });
     }
 
@@ -86,7 +87,8 @@ var loadRemoteComponent = function(component) {
           reactComponent: returnVal.default,
           path: "/" + component["lfs:targetURL"],
           name: component["lfs:extensionName"],
-          iconUrl: component["lfs:icon"]
+          iconUrl: component["lfs:icon"],
+          order: component["lfs:defaultOrder"]
         });
       } else {
         return reject();

--- a/modules/homepage/src/main/frontend/src/themePage/routes.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/routes.jsx
@@ -16,58 +16,8 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import AccountBox from '@material-ui/icons/AccountBox';
-import Assignment from '@material-ui/icons/Assignment';
-import Dashboard from '@material-ui/icons/Dashboard';
-import Pets from '@material-ui/icons/Pets';
-import Settings from '@material-ui/icons/Settings';
-import Subtitles from '@material-ui/icons/Subtitles';
-
-import DashboardPage from "./Dashboard/dashboard.jsx";
 
 var sidebarRoutes = [
-    {
-      path: "/dashboard.html",
-      name: "Dashboard",
-      icon: Dashboard,
-      component: DashboardPage,
-      layout: "/content.html"
-    },
-    {
-      path: "/view.html",
-      name: "Patients",
-      icon: Assignment,
-      component: "",
-      layout: "/content.html"
-    },
-    {
-      path: "/modelorganisms.html",
-      name: "Model Organisms",
-      icon: Pets,
-      component: "",
-      layout: "/content.html"
-    },
-    {
-      path: "/variants.html",
-      name: "Variants",
-      icon: Subtitles,
-      component: "",
-      layout: "/content.html"
-    },
-    {
-      path: "/userpage.html",
-      name: "User Profile",
-      icon: AccountBox,
-      component: "",
-      layout: "/content.html"
-    },
-    {
-      path: "/admin.html",
-      name: "Administration",
-      icon: Settings,
-      component: "",
-      layout: "/content.html"
-    },
 ];
 
 const ASSET_PREFIX="asset:";
@@ -117,6 +67,16 @@ var loadRemoteComponent = function(component) {
   return new Promise(function(resolve, reject) {
     var request = new XMLHttpRequest();
     var url = parseAssetURL(component['lfs:extensionRenderURL']);
+
+    // If the URL is empty, return an empty page
+    if (url === "") {
+      return resolve({
+        reactComponent: null,
+        path: "/" + component["lfs:targetURL"],
+        name: component["lfs:extensionName"],
+        iconUrl: component["lfs:icon"]
+      });
+    }
 
     request.onload = function() {
       if(request.status >= 200 && request.status < 400) {

--- a/modules/homepage/src/main/frontend/webpack.config.js
+++ b/modules/homepage/src/main/frontend/webpack.config.js
@@ -8,7 +8,10 @@ module.exports = {
   entry: {
     [module_name + 'themeindex']: './src/themePage/index.jsx',
     [module_name + 'dashboard']: './src/themePage/Dashboard/dashboard.jsx',
-    [module_name + 'dashboardIcon']: '@material-ui/icons/Dashboard.js'
+    [module_name + 'dashboardIcon']: '@material-ui/icons/Dashboard.js',
+    [module_name + 'modelOrganismsIcon']: '@material-ui/icons/Pets.js',
+    [module_name + 'variantsIcon']: '@material-ui/icons/Subtitles.js',
+    [module_name + 'adminIcon']: '@material-ui/icons/Settings.js'
   },
   plugins: [
     new CleanWebpackPlugin(),

--- a/modules/homepage/src/main/resources/SLING-INF/content/Extensions.json
+++ b/modules/homepage/src/main/resources/SLING-INF/content/Extensions.json
@@ -1,0 +1,55 @@
+{
+    "jcr:primaryType": "sling:Folder",
+    "Dashboard": {
+        "jcr:primaryType": "lfs:Extension",
+        "lfs:extensionPointId": "lfs/coreUI/sidebar/entry",
+        "lfs:extensionName": "Dashboard",
+        "lfs:icon": "asset:lfs-homepage.dashboardIcon.js",
+        "lfs:extensionRenderURL": "asset:lfs-homepage.dashboard.js",
+        "lfs:targetURL": "dashboard",
+        "jcr:content": {
+            "jcr:primaryType": "nt:resource",
+            "jcr:data": "test",
+            "jcr:mimeType": "text/html"
+        }
+    },
+    "Administration": {
+        "jcr:primaryType": "lfs:Extension",
+        "lfs:extensionPointId": "lfs/coreUI/sidebar/entry",
+        "lfs:extensionName": "Administration",
+        "lfs:icon": "asset:lfs-homepage.adminIcon.js",
+        "lfs:extensionRenderURL": "asset:lfs-homepage.dashboard.js",
+        "lfs:targetURL": "admin.html",
+        "jcr:content": {
+            "jcr:primaryType": "nt:resource",
+            "jcr:data": "test",
+            "jcr:mimeType": "text/html"
+        }
+    },
+    "Model Organisms": {
+        "jcr:primaryType": "lfs:Extension",
+        "lfs:extensionPointId": "lfs/coreUI/sidebar/entry",
+        "lfs:extensionName": "Model Organisms",
+        "lfs:icon": "asset:lfs-homepage.modelOrganismsIcon.js",
+        "lfs:extensionRenderURL": "",
+        "lfs:targetURL": "modelorganisms",
+        "jcr:content": {
+            "jcr:primaryType": "nt:resource",
+            "jcr:data": "test",
+            "jcr:mimeType": "text/html"
+        }
+    },
+    "Variants": {
+        "jcr:primaryType": "lfs:Extension",
+        "lfs:extensionPointId": "lfs/coreUI/sidebar/entry",
+        "lfs:extensionName": "Model Organisms",
+        "lfs:icon": "asset:lfs-homepage.variantsIcon.js",
+        "lfs:extensionRenderURL": "",
+        "lfs:targetURL": "variants",
+        "jcr:content": {
+            "jcr:primaryType": "nt:resource",
+            "jcr:data": "test",
+            "jcr:mimeType": "text/html"
+        }
+    }
+}

--- a/modules/homepage/src/main/resources/SLING-INF/content/Extensions.json
+++ b/modules/homepage/src/main/resources/SLING-INF/content/Extensions.json
@@ -35,7 +35,7 @@
         "lfs:icon": "asset:lfs-dataentry.subjectsIcon.js",
         "lfs:extensionRenderURL": "",
         "lfs:targetURL": "tumours",
-        "lfs:defaultOrder": 2,
+        "lfs:defaultOrder": 5,
         "jcr:content": {
             "jcr:primaryType": "nt:resource",
             "jcr:data": "test",
@@ -49,7 +49,7 @@
         "lfs:icon": "asset:lfs-dataentry.subjectsIcon.js",
         "lfs:extensionRenderURL": "",
         "lfs:targetURL": "treatments",
-        "lfs:defaultOrder": 3,
+        "lfs:defaultOrder": 10,
         "jcr:content": {
             "jcr:primaryType": "nt:resource",
             "jcr:data": "test",
@@ -63,7 +63,7 @@
         "lfs:icon": "asset:lfs-homepage.modelOrganismsIcon.js",
         "lfs:extensionRenderURL": "",
         "lfs:targetURL": "modelorganisms",
-        "lfs:defaultOrder": 4,
+        "lfs:defaultOrder": 15,
         "jcr:content": {
             "jcr:primaryType": "nt:resource",
             "jcr:data": "test",
@@ -77,7 +77,7 @@
         "lfs:icon": "asset:lfs-homepage.variantsIcon.js",
         "lfs:extensionRenderURL": "",
         "lfs:targetURL": "variants",
-        "lfs:defaultOrder": 5,
+        "lfs:defaultOrder": 20,
         "jcr:content": {
             "jcr:primaryType": "nt:resource",
             "jcr:data": "test",

--- a/modules/homepage/src/main/resources/SLING-INF/content/Extensions.json
+++ b/modules/homepage/src/main/resources/SLING-INF/content/Extensions.json
@@ -7,6 +7,7 @@
         "lfs:icon": "asset:lfs-homepage.dashboardIcon.js",
         "lfs:extensionRenderURL": "asset:lfs-homepage.dashboard.js",
         "lfs:targetURL": "dashboard",
+        "lfs:defaultOrder": 0,
         "jcr:content": {
             "jcr:primaryType": "nt:resource",
             "jcr:data": "test",
@@ -20,6 +21,35 @@
         "lfs:icon": "asset:lfs-homepage.adminIcon.js",
         "lfs:extensionRenderURL": "asset:lfs-homepage.dashboard.js",
         "lfs:targetURL": "admin.html",
+        "lfs:defaultOrder": 90,
+        "jcr:content": {
+            "jcr:primaryType": "nt:resource",
+            "jcr:data": "test",
+            "jcr:mimeType": "text/html"
+        }
+    },
+    "Tumours": {
+        "jcr:primaryType": "lfs:Extension",
+        "lfs:extensionPointId": "lfs/coreUI/sidebar/entry",
+        "lfs:extensionName": "Tumours",
+        "lfs:icon": "asset:lfs-dataentry.subjectsIcon.js",
+        "lfs:extensionRenderURL": "",
+        "lfs:targetURL": "tumours",
+        "lfs:defaultOrder": 2,
+        "jcr:content": {
+            "jcr:primaryType": "nt:resource",
+            "jcr:data": "test",
+            "jcr:mimeType": "text/html"
+        }
+    },
+    "Treatments": {
+        "jcr:primaryType": "lfs:Extension",
+        "lfs:extensionPointId": "lfs/coreUI/sidebar/entry",
+        "lfs:extensionName": "Treatments",
+        "lfs:icon": "asset:lfs-dataentry.subjectsIcon.js",
+        "lfs:extensionRenderURL": "",
+        "lfs:targetURL": "treatments",
+        "lfs:defaultOrder": 3,
         "jcr:content": {
             "jcr:primaryType": "nt:resource",
             "jcr:data": "test",
@@ -33,6 +63,7 @@
         "lfs:icon": "asset:lfs-homepage.modelOrganismsIcon.js",
         "lfs:extensionRenderURL": "",
         "lfs:targetURL": "modelorganisms",
+        "lfs:defaultOrder": 4,
         "jcr:content": {
             "jcr:primaryType": "nt:resource",
             "jcr:data": "test",
@@ -42,10 +73,11 @@
     "Variants": {
         "jcr:primaryType": "lfs:Extension",
         "lfs:extensionPointId": "lfs/coreUI/sidebar/entry",
-        "lfs:extensionName": "Model Organisms",
+        "lfs:extensionName": "Variants",
         "lfs:icon": "asset:lfs-homepage.variantsIcon.js",
         "lfs:extensionRenderURL": "",
         "lfs:targetURL": "variants",
+        "lfs:defaultOrder": 5,
         "jcr:content": {
             "jcr:primaryType": "nt:resource",
             "jcr:data": "test",

--- a/modules/vocabularies/src/main/resources/SLING-INF/content/Extensions.json
+++ b/modules/vocabularies/src/main/resources/SLING-INF/content/Extensions.json
@@ -7,6 +7,7 @@
     "lfs:icon": "asset:lfs-vocabularies.vocabulariesIcon.js",
     "lfs:extensionRenderURL": "asset:lfs-vocabularies.admin-page.js",
     "lfs:targetURL": "admin/vocabularies",
+    "lfs:defaultOrder": 94,
     "jcr:content": {
       "jcr:primaryType": "nt:resource",
       "jcr:data": "test",


### PR DESCRIPTION
Unsure where to put the Forms link currently, so I stuck it under administration. This will be a draft PR until we figure out where to stick it.

Main changes here are the usage of defaultOrder to determine where in the sidebar things should be displayed, and the removal of the hardcoded routes. As a FIXME, a `defaultOrder` with a tens digit of '9' (e.g. 90, 91, etc.) will be treated as an admin link and moved to the bottom.