### PR TITLE
LFS-78: Write a React component for rendering an ExtensionPoint

### DIFF
--- a/modules/ui-extension/pom.xml
+++ b/modules/ui-extension/pom.xml
@@ -32,6 +32,11 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>com.github.eirslett</groupId>
+        <artifactId>frontend-maven-plugin</artifactId>
+      </plugin>
+
       <!-- This is an OSGi bundle -->
       <plugin>
         <groupId>org.apache.felix</groupId>
@@ -39,6 +44,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
+            <Include-Resource>src/main/frontend/dist/,{maven-resources}</Include-Resource>
             <!-- Initial content to be loaded on bundle installation -->
             <Sling-Initial-Content>SLING-INF/content</Sling-Initial-Content>
             <Sling-Nodetypes>SLING-INF/nodetypes/extension.cnd</Sling-Nodetypes>

--- a/modules/ui-extension/src/main/frontend/package.json
+++ b/modules/ui-extension/src/main/frontend/package.json
@@ -35,10 +35,6 @@
     "webpack-cli": "^3.3.2"
   },
   "dependencies": {
-    "formik": "^1.5.7",
-    "formik-material-fields": "0.0.4",
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0",
-    "yup": "^0.27.0"
+    "react": "^16.9.0"
   }
 }

--- a/modules/ui-extension/src/main/frontend/package.json
+++ b/modules/ui-extension/src/main/frontend/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "lfs-uiextension",
+  "version": "0.1.0",
+  "description": "LFS UI extensions library",
+  "author": "SickKids",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ccmbioinfo/lfs.git",
+    "directory": "modules/login/src/main/frontend"
+  },
+  "babel": {
+    "presets": [
+      "@babel/preset-env",
+      "@babel/preset-react"
+    ],
+    "plugins": [
+      [
+        "@babel/plugin-proposal-class-properties"
+      ]
+    ]
+  },
+  "devDependencies": {
+    "@babel/core": "^7.4.5",
+    "@babel/plugin-proposal-class-properties": "^7.4.4",
+    "@babel/preset-env": "^7.4.5",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^8.0.6",
+    "clean-webpack-plugin": "3.0.0",
+    "eslint": "^5.16.0",
+    "eslint-plugin-auto-import": "^0.1.0",
+    "eslint-plugin-react": "^7.13.0",
+    "webpack": "^4.33.0",
+    "webpack-assets-manifest": "3.1.1",
+    "webpack-cli": "^3.3.2"
+  },
+  "dependencies": {
+    "formik": "^1.5.7",
+    "formik-material-fields": "0.0.4",
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0",
+    "yup": "^0.27.0"
+  }
+}

--- a/modules/ui-extension/src/main/frontend/src/uiextension/extensionPoint.jsx
+++ b/modules/ui-extension/src/main/frontend/src/uiextension/extensionPoint.jsx
@@ -19,11 +19,24 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 
+// Component that allows the user to insert an extension from the given URL.
+//
+// Required props:
+//  path: Location of the extension to insert. This must correspond to a .js or .html file
+//  on this server.
+// Optional props:
+//  id: string ID to give to the containing <div /> element
+//
+// Sample usage:
+// <ExtensionPoint
+//    path="/testRig.js"
+//    />
 function ExtensionPoint(props) {
   const { path, id } = props;
   const [ renderedResponse, setRenderedResponse ] = useState();
   const [ initialized, setInitialized ] = useState(false);
 
+  // Fetch the extension, called once on load
   let fetchExtension = (url) => {
     setInitialized(true);
     const parsedURL = new URL(url, window.location.origin);
@@ -35,6 +48,7 @@ function ExtensionPoint(props) {
     }
   }
 
+  // Determine if content at the URL is safe to include
   let isSafe = (url) => {
     return (
       // The origins must match
@@ -43,6 +57,7 @@ function ExtensionPoint(props) {
       )
   }
 
+  // Parse the content from the given Response object
   let handleResponse = (response) => {
     if (!response.ok) {
       return Promise.reject(`Fetching ExtensionPoint ${path} failed with response ${response.status}`);
@@ -91,7 +106,8 @@ function ExtensionPoint(props) {
 }
 
 ExtensionPoint.propTypes = {
-    path: PropTypes.string.isRequired
+    path: PropTypes.string.isRequired,
+    id: PropTypes.string
 };
 
 export default ExtensionPoint;

--- a/modules/ui-extension/src/main/frontend/src/uiextension/extensionPoint.jsx
+++ b/modules/ui-extension/src/main/frontend/src/uiextension/extensionPoint.jsx
@@ -1,0 +1,79 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+
+function ExtensionPoint(props) {
+  const [ renderedResponse, setRenderedResponse ] = useState();
+  const [ initialized, setInitialized ] = useState(false);
+
+  let fetchExtension = (url) => {
+    setInitialized(true);
+    fetch(url)
+      .then(handleResponse)
+      .then((text) => {setRenderedResponse({__html: text})})
+      .catch(handleError);
+  }
+
+  let handleResponse = (response) => {
+    if (!response.ok) {
+      return Promise.reject(`Fetching ExtensionPoint ${props.path} failed with response ${response.status}`);
+    }
+
+    // Check the headers to determine how to handle this respnse
+    let contentType = response.headers.get('Content-Type');
+
+    // Truncate the ';charset=utf-8'
+    const sepPos = contentType.indexOf(";");
+    if (sepPos >= 0) {
+      contentType = contentType.substr(0, sepPos)
+    }
+
+    // Determine what to do depending on the value of the output
+    if (contentType === 'application/json') {
+      // jsonp
+      // FIXME: Implement
+      return(eval(response.text()));
+    } else if (contentType === 'text/html') {
+      // html -- include it inline
+      return(response.text());
+    } else {
+      // FIXME: What if we don't understand what we're given?
+    }
+  }
+
+  let handleError = (error) => {
+    console.error(error);
+  }
+
+  if (!initialized) {
+    fetchExtension(props.path);
+  }
+
+
+  return(
+    <div dangerouslySetInnerHTML={renderedResponse}/>
+  );
+}
+
+ExtensionPoint.propTypes = {
+    path: PropTypes.string.isRequired
+};
+
+export default ExtensionPoint;

--- a/modules/ui-extension/src/main/frontend/webpack.config.js
+++ b/modules/ui-extension/src/main/frontend/webpack.config.js
@@ -5,8 +5,7 @@ module_name = require("./package.json").name + ".";
 module.exports = {
   mode: 'development',
   entry: {
-    [module_name + 'extensionPoint']: './src/uiextension/extensionPoint.jsx',
-    [module_name + 'testRig']: './src/uiextension/testRig.jsx'
+    [module_name + 'extensionPoint']: './src/uiextension/extensionPoint.jsx'
   },
   plugins: [
     new CleanWebpackPlugin(),

--- a/modules/ui-extension/src/main/frontend/webpack.config.js
+++ b/modules/ui-extension/src/main/frontend/webpack.config.js
@@ -1,0 +1,45 @@
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const WebpackAssetsManifest = require('webpack-assets-manifest');
+module_name = require("./package.json").name + ".";
+
+module.exports = {
+  mode: 'development',
+  entry: {
+    [module_name + 'extensionPoint']: './src/uiextension/extensionPoint.jsx',
+    [module_name + 'testRig']: './src/uiextension/testRig.jsx'
+  },
+  plugins: [
+    new CleanWebpackPlugin(),
+    new WebpackAssetsManifest({
+      output: "assets.json"
+    })
+  ],
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+        use: ['babel-loader']
+      }
+    ]
+  },
+  resolve: {
+    extensions: ['*', '.js', '.jsx']
+  },
+  output: {
+    path: __dirname + '/dist/SLING-INF/content/libs/lfs/resources/',
+    publicPath: '/',
+    filename: '[name].js',
+  },
+  externals: [
+    {
+      "react": "React",
+      "react-dom": "ReactDOM",
+      "formik": "Formik",
+      "lodash": "lodash",
+      "prop-types": "PropTypes",
+      "jss": "jss",
+      "@material-ui/core": "window['MaterialUI']"
+    }
+  ]
+};


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/LFS-78)

Test rig in `LFS-78-test`.

Allows us to point at a URL and add the content from there, e.g:
```
<ExtensionPoint
        path="/testRig.js"
        />
```

Draft until I figure out whether or not we should add support for default exports and our cachebusting.