### PR TITLE
LFS-78: Write a React component for rendering an ExtensionPoint

### DIFF
--- a/modules/ui-extension/pom.xml
+++ b/modules/ui-extension/pom.xml
@@ -32,6 +32,11 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>com.github.eirslett</groupId>
+        <artifactId>frontend-maven-plugin</artifactId>
+      </plugin>
+
       <!-- This is an OSGi bundle -->
       <plugin>
         <groupId>org.apache.felix</groupId>
@@ -39,6 +44,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
+            <Include-Resource>src/main/frontend/dist/,{maven-resources}</Include-Resource>
             <!-- Initial content to be loaded on bundle installation -->
             <Sling-Initial-Content>SLING-INF/content</Sling-Initial-Content>
             <Sling-Nodetypes>SLING-INF/nodetypes/extension.cnd</Sling-Nodetypes>

--- a/modules/ui-extension/src/main/frontend/package.json
+++ b/modules/ui-extension/src/main/frontend/package.json
@@ -35,10 +35,6 @@
     "webpack-cli": "^3.3.2"
   },
   "dependencies": {
-    "formik": "^1.5.7",
-    "formik-material-fields": "0.0.4",
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0",
-    "yup": "^0.27.0"
+    "react": "^16.9.0"
   }
 }

--- a/modules/ui-extension/src/main/frontend/package.json
+++ b/modules/ui-extension/src/main/frontend/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "lfs-uiextension",
+  "version": "0.1.0",
+  "description": "LFS UI extensions library",
+  "author": "SickKids",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ccmbioinfo/lfs.git",
+    "directory": "modules/login/src/main/frontend"
+  },
+  "babel": {
+    "presets": [
+      "@babel/preset-env",
+      "@babel/preset-react"
+    ],
+    "plugins": [
+      [
+        "@babel/plugin-proposal-class-properties"
+      ]
+    ]
+  },
+  "devDependencies": {
+    "@babel/core": "^7.4.5",
+    "@babel/plugin-proposal-class-properties": "^7.4.4",
+    "@babel/preset-env": "^7.4.5",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^8.0.6",
+    "clean-webpack-plugin": "3.0.0",
+    "eslint": "^5.16.0",
+    "eslint-plugin-auto-import": "^0.1.0",
+    "eslint-plugin-react": "^7.13.0",
+    "webpack": "^4.33.0",
+    "webpack-assets-manifest": "3.1.1",
+    "webpack-cli": "^3.3.2"
+  },
+  "dependencies": {
+    "formik": "^1.5.7",
+    "formik-material-fields": "0.0.4",
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0",
+    "yup": "^0.27.0"
+  }
+}

--- a/modules/ui-extension/src/main/frontend/src/uiextension/extensionPoint.jsx
+++ b/modules/ui-extension/src/main/frontend/src/uiextension/extensionPoint.jsx
@@ -19,11 +19,24 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 
+// Component that allows the user to insert an extension from the given URL.
+//
+// Required props:
+//  path: Location of the extension to insert. This must correspond to a .js or .html file
+//  on this server.
+// Optional props:
+//  id: string ID to give to the containing <div /> element
+//
+// Sample usage:
+// <ExtensionPoint
+//    path="/testRig.js"
+//    />
 function ExtensionPoint(props) {
   const { path, id } = props;
   const [ renderedResponse, setRenderedResponse ] = useState();
   const [ initialized, setInitialized ] = useState(false);
 
+  // Fetch the extension, called once on load
   let fetchExtension = (url) => {
     setInitialized(true);
     const parsedURL = new URL(url, window.location.origin);
@@ -35,6 +48,7 @@ function ExtensionPoint(props) {
     }
   }
 
+  // Determine if content at the URL is safe to include
   let isSafe = (url) => {
     return (
       // The origins must match
@@ -43,6 +57,7 @@ function ExtensionPoint(props) {
       )
   }
 
+  // Parse the content from the given Response object
   let handleResponse = (response) => {
     if (!response.ok) {
       return Promise.reject(`Fetching ExtensionPoint ${path} failed with response ${response.status}`);
@@ -91,7 +106,8 @@ function ExtensionPoint(props) {
 }
 
 ExtensionPoint.propTypes = {
-    path: PropTypes.string.isRequired
+    path: PropTypes.string.isRequired,
+    id: PropTypes.string
 };
 
 export default ExtensionPoint;

--- a/modules/ui-extension/src/main/frontend/src/uiextension/extensionPoint.jsx
+++ b/modules/ui-extension/src/main/frontend/src/uiextension/extensionPoint.jsx
@@ -1,0 +1,79 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+
+function ExtensionPoint(props) {
+  const [ renderedResponse, setRenderedResponse ] = useState();
+  const [ initialized, setInitialized ] = useState(false);
+
+  let fetchExtension = (url) => {
+    setInitialized(true);
+    fetch(url)
+      .then(handleResponse)
+      .then((text) => {setRenderedResponse({__html: text})})
+      .catch(handleError);
+  }
+
+  let handleResponse = (response) => {
+    if (!response.ok) {
+      return Promise.reject(`Fetching ExtensionPoint ${props.path} failed with response ${response.status}`);
+    }
+
+    // Check the headers to determine how to handle this respnse
+    let contentType = response.headers.get('Content-Type');
+
+    // Truncate the ';charset=utf-8'
+    const sepPos = contentType.indexOf(";");
+    if (sepPos >= 0) {
+      contentType = contentType.substr(0, sepPos)
+    }
+
+    // Determine what to do depending on the value of the output
+    if (contentType === 'application/json') {
+      // jsonp
+      // FIXME: Implement
+      return(eval(response.text()));
+    } else if (contentType === 'text/html') {
+      // html -- include it inline
+      return(response.text());
+    } else {
+      // FIXME: What if we don't understand what we're given?
+    }
+  }
+
+  let handleError = (error) => {
+    console.error(error);
+  }
+
+  if (!initialized) {
+    fetchExtension(props.path);
+  }
+
+
+  return(
+    <div dangerouslySetInnerHTML={renderedResponse}/>
+  );
+}
+
+ExtensionPoint.propTypes = {
+    path: PropTypes.string.isRequired
+};
+
+export default ExtensionPoint;

--- a/modules/ui-extension/src/main/frontend/src/uiextension/extensionPoint.jsx
+++ b/modules/ui-extension/src/main/frontend/src/uiextension/extensionPoint.jsx
@@ -42,7 +42,7 @@ function ExtensionPoint(props) {
     setInitialized(true);
 
     // From the extension point path, locate the URL of the ExtensionPoint
-    const uixpFinder = new URL(`${UIXP_FINDER_URL}?path=${url}`, window.location.origin);
+    const uixpFinder = new URL(`${UIXP_FINDER_URL}?uixp=${url}`, window.location.origin);
     fetch(uixpFinder)
       .then(grabUIXP)
       .then(handleResponse)
@@ -73,7 +73,7 @@ function ExtensionPoint(props) {
     // Truncate the ';charset=utf-8'
     const sepPos = contentType.indexOf(";");
     if (sepPos >= 0) {
-      contentType = contentType.substr(0, sepPos)
+      contentType = contentType.substring(0, sepPos)
     }
 
     // Determine what to do depending on the value of the output

--- a/modules/ui-extension/src/main/frontend/src/uiextension/extensionPoint.jsx
+++ b/modules/ui-extension/src/main/frontend/src/uiextension/extensionPoint.jsx
@@ -92,7 +92,7 @@ function ExtensionPoint(props) {
     } else if (contentType === 'text/html') {
       // html -- include it inline
       return(response.text().then((text) => {
-        setRenderedResponse(text);
+        setRenderedResponse((<div dangerouslySetInnerHTML={{__html: text}}/>));
       }));
     } else {
       // Reject any other content type

--- a/modules/ui-extension/src/main/frontend/webpack.config.js
+++ b/modules/ui-extension/src/main/frontend/webpack.config.js
@@ -5,8 +5,7 @@ module_name = require("./package.json").name + ".";
 module.exports = {
   mode: 'development',
   entry: {
-    [module_name + 'extensionPoint']: './src/uiextension/extensionPoint.jsx',
-    [module_name + 'testRig']: './src/uiextension/testRig.jsx',
+    [module_name + 'extensionPoint']: './src/uiextension/extensionPoint.jsx'
   },
   plugins: [
     new CleanWebpackPlugin(),

--- a/modules/ui-extension/src/main/frontend/webpack.config.js
+++ b/modules/ui-extension/src/main/frontend/webpack.config.js
@@ -5,8 +5,7 @@ module_name = require("./package.json").name + ".";
 module.exports = {
   mode: 'development',
   entry: {
-    [module_name + 'extensionPoint']: './src/uiextension/extensionPoint.jsx',
-    [module_name + 'testRig']: './src/uiextension/testRig.jsx'
+    [module_name + 'extensionPoint']: './src/uiextension/extensionPoint.jsx'
   },
   plugins: [
     new CleanWebpackPlugin(),

--- a/modules/ui-extension/src/main/frontend/webpack.config.js
+++ b/modules/ui-extension/src/main/frontend/webpack.config.js
@@ -1,0 +1,45 @@
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const WebpackAssetsManifest = require('webpack-assets-manifest');
+module_name = require("./package.json").name + ".";
+
+module.exports = {
+  mode: 'development',
+  entry: {
+    [module_name + 'extensionPoint']: './src/uiextension/extensionPoint.jsx',
+    [module_name + 'testRig']: './src/uiextension/testRig.jsx'
+  },
+  plugins: [
+    new CleanWebpackPlugin(),
+    new WebpackAssetsManifest({
+      output: "assets.json"
+    })
+  ],
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+        use: ['babel-loader']
+      }
+    ]
+  },
+  resolve: {
+    extensions: ['*', '.js', '.jsx']
+  },
+  output: {
+    path: __dirname + '/dist/SLING-INF/content/libs/lfs/resources/',
+    publicPath: '/',
+    filename: '[name].js',
+  },
+  externals: [
+    {
+      "react": "React",
+      "react-dom": "ReactDOM",
+      "formik": "Formik",
+      "lodash": "lodash",
+      "prop-types": "PropTypes",
+      "jss": "jss",
+      "@material-ui/core": "window['MaterialUI']"
+    }
+  ]
+};

--- a/modules/ui-extension/src/main/frontend/webpack.config.js
+++ b/modules/ui-extension/src/main/frontend/webpack.config.js
@@ -28,7 +28,7 @@ module.exports = {
   output: {
     path: __dirname + '/dist/SLING-INF/content/libs/lfs/resources/',
     publicPath: '/',
-    filename: '[name].js',
+    filename: '[name].[contenthash].js',
   },
   externals: [
     {

--- a/modules/ui-extension/src/main/frontend/webpack.config.js
+++ b/modules/ui-extension/src/main/frontend/webpack.config.js
@@ -5,7 +5,8 @@ module_name = require("./package.json").name + ".";
 module.exports = {
   mode: 'development',
   entry: {
-    [module_name + 'extensionPoint']: './src/uiextension/extensionPoint.jsx'
+    [module_name + 'extensionPoint']: './src/uiextension/extensionPoint.jsx',
+    [module_name + 'testRig']: './src/uiextension/testRig.jsx',
   },
   plugins: [
     new CleanWebpackPlugin(),

--- a/modules/ui-extension/src/main/provisioning/model.txt
+++ b/modules/ui-extension/src/main/provisioning/model.txt
@@ -28,3 +28,12 @@
     org.apache.sling/org.apache.sling.api/2.18.4
     javax.json/javax.json-api/1.1.4
     javax.jcr/jcr/2.0
+
+[:repoinit]
+    # Extension point finder
+    create path (lfs:ExtensionPointFinder) /uixp
+
+    # Allow all users to read from the extension point finder and one of the nodes
+    set ACL for everyone
+        allow   jcr:read    on /uixp
+    end

--- a/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/Extension/null.GET.esp
+++ b/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/Extension/null.GET.esp
@@ -18,7 +18,7 @@
 --%><%
 if (currentNode.hasNode('jcr:content') && currentNode.getNode('jcr:content').getPrimaryItem() != '') {
   // This extension defines custom display code in its jcr:content
-  response.setContentType('text/plain');
+  response.setContentType(currentNode.getNode('jcr:content').getProperty("jcr:mimeType").getString());
   out.print(currentNode.getNode('jcr:content').getPrimaryItem());
 } else {
   // No content, include the JSON displayer for this resource.

--- a/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPoint/null.GET.esp
+++ b/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPoint/null.GET.esp
@@ -18,7 +18,7 @@
 --%><%
 if (currentNode.hasNode('jcr:content') && currentNode.getNode('jcr:content').getPrimaryItem() != '') {
   // This extension defines custom display code in its jcr:content
-  response.setContentType('text/plain');
+  response.setContentType(currentNode.getNode('jcr:content').getProperty("jcr:mimeType").getString());
   out.print(currentNode.getNode('jcr:content').getPrimaryItem());
 } else {
   // No content, just include all the extensions for this point

--- a/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/extensionQuery.js
+++ b/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/extensionQuery.js
@@ -33,6 +33,6 @@ use(function(){
     }
   
     return {
-      uixp: nodePaths
+      uixp: nodePaths[0]
     };
   });

--- a/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/extensionQuery.js
+++ b/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/extensionQuery.js
@@ -29,6 +29,11 @@ use(function(){
     query.bindValue("path", currentSession.getValueFactory().createValue(uixp));
     var queryResults = query.execute().getNodes();
 
+    // If no results were found, throw an exception
+    if (!queryResults.hasNext()) {
+      throw("No UIXP found at " + uixp);
+    }
+
     // Dump the first result into our return statement
     return {
       uixp: queryResults.hasNext() ? queryResults.next().getPath() : ""

--- a/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/extensionQuery.js
+++ b/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/extensionQuery.js
@@ -18,25 +18,19 @@
 //
 // Locate all visible lfs:dataEntry nodes
 use(function(){
-    var path = request.getRequestParameter("path");
-    if (!path) {
+    var uixp = request.getRequestParameter("uixp");
+    if (!uixp) {
         return {'uixp': ''};
     }
-    path = path.getString();
+    uixp = uixp.getString();
     var queryManager = currentSession.getWorkspace().getQueryManager();
     var q = "select * from [lfs:ExtensionPoint] as n WHERE n.'lfs:extensionPointId' = $path and ISDESCENDANTNODE(n, '/apps/lfs/ExtensionPoints/')";
     var query = queryManager.createQuery(q, "JCR-SQL2");
-    query.bindValue("path", currentSession.getValueFactory().createValue(path));
+    query.bindValue("path", currentSession.getValueFactory().createValue(uixp));
     var queryResults = query.execute().getNodes();
   
-    // Dump our iterator into a list of strings
-    var nodePaths = [];
-    while (queryResults.hasNext()) {
-      var resource = queryResults.next();
-      nodePaths.push(resource.getPath());
-    }
-  
+    // Dump the first result into our return statement
     return {
-      uixp: nodePaths[0]
+      uixp: queryResults.next().getPath()
     };
   });

--- a/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/extensionQuery.js
+++ b/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/extensionQuery.js
@@ -39,4 +39,3 @@ use(function(){
       uixp: queryResults.hasNext() ? queryResults.next().getPath() : ""
     };
   });
-  

--- a/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/extensionQuery.js
+++ b/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/extensionQuery.js
@@ -18,7 +18,11 @@
 //
 // Locate all visible lfs:dataEntry nodes
 use(function(){
-    var path = request.getRequestParameter("path").getString();
+    var path = request.getRequestParameter("path");
+    if (!path) {
+        return {'uixp': ''};
+    }
+    path = path.getString();
     var query = resolver.findResources("select * from [lfs:ExtensionPoint] as n WHERE n.'lfs:extensionPointId' = '"+path+"'`", "JCR-SQL2");
   
     // Dump our iterator into a list of strings

--- a/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/extensionQuery.js
+++ b/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/extensionQuery.js
@@ -1,0 +1,34 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+// Locate all visible lfs:dataEntry nodes
+use(function(){
+    var path = request.getRequestParameter("path").getString();
+    var query = resolver.findResources("select * from [lfs:ExtensionPoint] as n WHERE n.'lfs:extensionPointId' = '"+path+"'`", "JCR-SQL2");
+  
+    // Dump our iterator into a list of strings
+    var nodePaths = [];
+    while (query.hasNext()) {
+      var resource = query.next();
+      nodePaths.push(resource.getPath());
+    }
+  
+    return {
+      uixp: nodePaths
+    };
+  });

--- a/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/extensionQuery.js
+++ b/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/extensionQuery.js
@@ -23,12 +23,16 @@ use(function(){
         return {'uixp': ''};
     }
     path = path.getString();
-    var query = resolver.findResources("select * from [lfs:ExtensionPoint] as n WHERE n.'lfs:extensionPointId' = '"+path+"'`", "JCR-SQL2");
+    var queryManager = currentSession.getWorkspace().getQueryManager();
+    var q = "select * from [lfs:ExtensionPoint] as n WHERE n.'lfs:extensionPointId' = $path and ISDESCENDANTNODE(n, '/apps/lfs/ExtensionPoints/')";
+    var query = queryManager.createQuery(q, "JCR-SQL2");
+    query.bindValue("path", currentSession.getValueFactory().createValue(path));
+    var queryResults = query.execute().getNodes();
   
     // Dump our iterator into a list of strings
     var nodePaths = [];
-    while (query.hasNext()) {
-      var resource = query.next();
+    while (queryResults.hasNext()) {
+      var resource = queryResults.next();
       nodePaths.push(resource.getPath());
     }
   

--- a/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/extensionQuery.js
+++ b/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/extensionQuery.js
@@ -28,9 +28,10 @@ use(function(){
     var query = queryManager.createQuery(q, "JCR-SQL2");
     query.bindValue("path", currentSession.getValueFactory().createValue(uixp));
     var queryResults = query.execute().getNodes();
-  
+
     // Dump the first result into our return statement
     return {
-      uixp: queryResults.next().getPath()
+      uixp: queryResults.hasNext() ? queryResults.next().getPath() : ""
     };
   });
+  

--- a/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/null.GET.esp
+++ b/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/null.GET.esp
@@ -1,0 +1,22 @@
+<%--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+--%><%
+// No content, just include all the extensions for this point
+response.setContentType('application/json');
+sling.include(resource + '.resolved');
+%>

--- a/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/resolved.html
+++ b/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/resolved.html
@@ -1,0 +1,22 @@
+<!--/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+*/-->
+<!--/* Display all available extensionPoint nodes */-->
+<sly data-sly-use.query="extensionQuery.js">
+  ${query.uixp @ context='unsafe'}
+</sly>

--- a/modules/ui-extension/src/main/resources/SLING-INF/nodetypes/extension.cnd
+++ b/modules/ui-extension/src/main/resources/SLING-INF/nodetypes/extension.cnd
@@ -91,3 +91,23 @@
   // And any other properties
   - * (undefined) multiple
   - * (undefined)
+
+//-----------------------------------------------------------------------------
+//
+// A UIXP Finder locates extension points based on their ID
+//
+//-----------------------------------------------------------------------------
+[lfs:ExtensionPointFinder] > sling:Resource
+
+  // Attributes
+
+  // We can use extension points in a query.
+  query
+
+  // Properties
+
+  // Hardcode the resource type.
+  - sling:resourceType (STRING) = "lfs/ExtensionPointFinder" mandatory autocreated protected
+
+  // Hardcode the resource supertype: each UIXP is a resource.
+  - sling:resourceSuperType (STRING) = "lfs/Resource" mandatory autocreated protected


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/LFS-78)

Test rig in `LFS-78-test`.

Allows us to point at a `lfs:extensionPointId` and add the content from there, e.g:
```
{ /* Succeeds at evaluating a .js extension point */}
      <ExtensionPoint
        path="lfs/TestUI/JS"
        />
      { /* Succeeds at rendering a .html extension point */}
      <ExtensionPoint
        path="lfs/TestUI/HTML"
        />
      { /* Succeeds at evaluating a .json extension point */}
      <ExtensionPoint
        path="lfs/coreUI/sidebar/entry"
        callback={(test) => {console.log(test); setJsonData(JSON.stringify(test));}}
        />
```
(note that `lfs/TestUI/JS` and `lfs/TestUI/HTML` are `lfs:ExtensionPoint`s only available in the test rig, for now).

Other notes:
- The `ContentType` from accessing an `lfs:ExtensionPoint` or `lfs:Extension` node has been changed from assuming `text/plain` to instead be the `jcr:mimeType` property in the content node.
- A new URL, `/uixp`, has been added to find UIXPs. To use it, supply `?path=<PATH>` where `<PATH>` is the `lfs:extensionPointId` of the extension to find.