### PR TITLE
LFS-201: Configure indexing for forms and subjects

### DIFF
--- a/modules/data-entry/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
@@ -4,7 +4,7 @@
     "compatVersion": 2,
     "async": "async",
     "evaluatePathRestrictions": true,
-    "includedPaths": "/Forms",
+    "includedPaths": ["/Forms"],
     "indexRules" : {
         "jcr:primaryType": "nt:unstructured",
         "lfs:Form" : {

--- a/modules/data-entry/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
@@ -1,0 +1,43 @@
+{
+    "jcr:primaryType": "oak:QueryIndexDefinition",
+    "type": "lucene",
+    "compatVersion": 2,
+    "async": "async",
+    "evaluatePathRestrictions": true,
+    "includedPaths": "/Forms",
+    "indexRules" : {
+        "jcr:primaryType": "nt:unstructured",
+        "lfs:Form" : {
+            "jcr:primaryType": "nt:unstructured",
+            "properties": {
+                "jcr:primaryType": "nt:unstructured",
+                "questionnaire": {
+                    "analyzed": false,
+                    "boost": 1,
+                    "nodeScopeIndex": false,
+                    "useInExcerpt": true,
+                    "ordered": true,
+                    "propertyIndex": true
+                },
+                "subject": {
+                    "analyzed": false,
+                    "boost": 1,
+                    "nodeScopeIndex": false,
+                    "useInExcerpt": true,
+                    "ordered": true,
+                    "propertyIndex": true
+                }
+            }
+        }
+    },
+    "aggregates" : {
+        "jcr:primaryType": "nt:unstructured",
+        "lfs:Form" : {
+            "jcr:primaryType": "nt:unstructured",
+            "include0": {
+                "jcr:primaryType": "nt:unstructured",
+                "path": "*"
+            }
+        }
+    }
+}

--- a/modules/data-entry/src/main/resources/SLING-INF/content/oak%3Aindex/subjects.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/oak%3Aindex/subjects.json
@@ -1,0 +1,25 @@
+{
+    "jcr:primaryType": "oak:QueryIndexDefinition",
+    "type": "lucene",
+    "compatVersion": 2,
+    "async": "async",
+    "evaluatePathRestrictions": true,
+    "includedPaths": ["/Subjects"],
+    "indexRules" : {
+        "jcr:primaryType": "nt:unstructured",
+        "lfs:Subject" : {
+            "jcr:primaryType": "nt:unstructured",
+            "properties": {
+                "jcr:primaryType": "nt:unstructured",
+                "identifier": {
+                    "analyzed": false,
+                    "boost": 100,
+                    "nodeScopeIndex": true,
+                    "useInExcerpt": true,
+                    "ordered": true,
+                    "propertyIndex": true
+                }
+            }
+        }
+    }
+}

--- a/modules/vocabularies/src/main/resources/SLING-INF/content/oak%3Aindex/vocabularyTerms.json
+++ b/modules/vocabularies/src/main/resources/SLING-INF/content/oak%3Aindex/vocabularyTerms.json
@@ -4,7 +4,7 @@
     "compatVersion": 2,
     "async": "async",
     "evaluatePathRestrictions": true,
-    "includedPaths": "/Vocabularies",
+    "includedPaths": ["/Vocabularies"],
     "indexRules" : {
         "jcr:primaryType": "nt:unstructured",
         "lfs:VocabularyTerm" : {


### PR DESCRIPTION
To test: create some forms, fill in some of their fields, then in the `bin/browser` search for nodes with queries like the following:

` select * from [lfs:Form] as n where contains (n.*, 'african')`