### PR TITLE
LFS-200: Search bar across all entities

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -42,7 +42,7 @@ function Forms(props) {
     setFetchStatus(true);
     fetch('/query?query=' + encodeURIComponent(`select * from [lfs:Questionnaire] as n WHERE n.'jcr:uuid'='${id}'`))
       .then((response) => response.ok ? response.json() : Promise.reject(response))
-      .then((json) => {setTitle(json[0]["title"]); setQuestionnairePath(json[0]["@path"])});
+      .then((json) => {setTitle(json["rows"][0]["title"]); setQuestionnairePath(json["rows"][0]["@path"])});
   }
 
   let customUrl = undefined;

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -29,7 +29,7 @@ function Forms(props) {
 
   const entry = /Forms\/(.+)/.exec(location.pathname);
   if (entry) {
-    return <Form id={entry[1]}/>;
+    return <Form id={entry[1]} key={location.pathname}/>;
   }
 
   const [ title, setTitle ] = useState("Forms");

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -66,7 +66,7 @@ function NewFormDialog(props) {
       // Send a fetch request to determine the questionnaires available
       fetch('/query?query=' + encodeURIComponent('select * from [lfs:Questionnaire]'))
         .then((response) => response.ok ? response.json() : Promise.reject(response))
-        .then((json) => {setQuestionnaires(json)})
+        .then((json) => {setQuestionnaires(json["rows"])})
         .catch(parseErrorResponse)
         .finally(() => {setFetching(false)});
       setFetching(true);

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
@@ -24,7 +24,7 @@ export default function Questionnaires(props) {
   const { match, location } = props;
   const entry = /Questionnaires\/(.+)/.exec(location.pathname);
   if (entry) {
-    return <Questionnaire id={entry[1]}/>;
+    return <Questionnaire id={entry[1]} key={location.pathname}/>;
   }
   const columns = [
     {

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -73,7 +73,7 @@ function UserDashboard(props) {
     // Fetch the questionnaires
     fetch("/query?query=select * from [lfs:Questionnaire]")
       .then((response) => response.ok ? response.json() : Promise.reject(response))
-      .then(setQuestionnaires);
+      .then((response) => setQuestionnaires(response["rows"]));
   }
 
   // If no forms can be obtained, we do not want to keep on re-obtaining questionnaires

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -172,7 +172,7 @@ function Form (props) {
   }
 
   return (
-    <form action={data["@path"]} method="POST" onSubmit={saveData} onChange={()=>setLastSaveStatus(undefined)}>
+    <form action={data["@path"]} method="POST" onSubmit={saveData} onChange={()=>setLastSaveStatus(undefined)} key={id}>
       <Grid container direction="column" spacing={4} alignItems="stretch" justify="space-between" wrap="nowrap">
         <Grid item>
           {

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
@@ -19,12 +19,14 @@ package ca.sickkids.ccm.lfs;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.Iterator;
 
 import javax.jcr.RepositoryException;
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
 import javax.script.Bindings;
 
 import org.apache.commons.lang3.StringUtils;
@@ -54,6 +56,9 @@ public class QueryBuilder implements Use
 
     private SlingHttpServletRequest request;
 
+    /* Whether or not the input should be escaped, if it is used in a contains() call. */
+    private boolean shouldEscape;
+
     @Override
     public void init(Bindings bindings)
     {
@@ -65,19 +70,30 @@ public class QueryBuilder implements Use
             final String luceneQuery = this.request.getParameter("lucene");
             final String fullTextQuery = this.request.getParameter("fulltext");
             final String quickQuery = this.request.getParameter("quick");
+            final String doNotEscape = this.request.getParameter("doNotEscapeQuery");
+            final long limit = getLongValueOrDefault(this.request.getParameter("limit"), 10);
+            final long offset = getLongValueOrDefault(this.request.getParameter("offset"), 0);
+            this.shouldEscape = StringUtils.isBlank(doNotEscape) || !("true".equals(doNotEscape));
 
             // Try to use a JCR-SQL2 query first
+            Iterator<Resource> results;
             if (StringUtils.isNotBlank(jcrQuery)) {
-                this.content = queryJCR(this.urlDecode(jcrQuery));
+                results = queryJCR(this.urlDecode(jcrQuery));
             } else if (StringUtils.isNotBlank(luceneQuery)) {
-                this.content = queryLucene(this.urlDecode(luceneQuery));
+                results = queryLucene(this.urlDecode(luceneQuery));
             } else if (StringUtils.isNotBlank(fullTextQuery)) {
-                this.content = fullTextSearch(this.urlDecode(fullTextQuery));
+                results = fullTextSearch(this.urlDecode(fullTextQuery));
             } else if (StringUtils.isNotBlank(quickQuery)) {
-                this.content = quickSearch(this.urlDecode(quickQuery));
+                results = quickSearch(this.urlDecode(quickQuery));
             } else {
-                this.content = Json.createArrayBuilder().build().toString();
+                results = Collections.emptyIterator();
             }
+
+            // output the results into our content
+            JsonObjectBuilder builder = Json.createObjectBuilder();
+            long[] metadata = this.addNodes(builder, results, offset, limit);
+            this.addSummary(builder, this.request, metadata);
+            this.content = builder.build().toString();
         } catch (Exception e) {
             this.content = "Unknown error: " + e.fillInStackTrace();
         }
@@ -101,7 +117,7 @@ public class QueryBuilder implements Use
      * @param query a lucene query
      * @return the content matching the query
      */
-    private String queryLucene(String query) throws RepositoryException
+    private Iterator<Resource> queryLucene(String query) throws RepositoryException
     {
         // Wrap our lucene query in JCR-SQL2 syntax for the resource resolver to understand
         return queryJCR(
@@ -116,11 +132,28 @@ public class QueryBuilder implements Use
      *
      * @return the content matching the query
      */
-    private String fullTextSearch(String query) throws RepositoryException
+    private Iterator<Resource> fullTextSearch(String query) throws RepositoryException
     {
         // Wrap our full-text query in JCR-SQL2 syntax for the resource resolver to understand
         return queryJCR(
-            String.format("select n.* from [nt:base] as n where contains(*, '%s')", query.replace("'", "''")));
+            String.format("select n.* from [nt:base] as n where contains(*, '%s')", this.fullTextEscape(query)));
+    }
+
+    /**
+     * Escapes the input query if this.shouldEscape is true.
+     *
+     * @param input text to escape
+     *
+     * @return an escaped version of the input
+     */
+    private String fullTextEscape(String input)
+    {
+        if (!this.shouldEscape) {
+            return input;
+        }
+
+        // Escape sequence taken from https://jackrabbit.apache.org/archive/wiki/JCR/EncodingAndEscaping_115513396.html
+        return input.replaceAll("([\\Q+-&|!(){}[]^\"~*?:\\/\\E])", "\\$1").replaceAll("'", "''");
     }
 
     /**
@@ -132,7 +165,7 @@ public class QueryBuilder implements Use
      *
      * @return the content matching the query
      */
-    private String quickSearch(String query) throws RepositoryException
+    private Iterator<Resource> quickSearch(String query) throws RepositoryException
     {
         final String[] toSearch = {"lfs:Form", "lfs:Subject", "lfs:Questionnaire"};
         final StringBuilder oakQuery = new StringBuilder();
@@ -140,9 +173,9 @@ public class QueryBuilder implements Use
         for (int i = 0; i < toSearch.length; i++) {
             oakQuery.append(
                 String.format(
-                    "select n.* from [%s] as n where contains(*, '%s')",
+                    "select n.* from [%s] as n where contains(*, '*%s*')",
                     toSearch[i],
-                    query.replace("'", "''")
+                    this.fullTextEscape(query)
                 )
             );
 
@@ -162,16 +195,96 @@ public class QueryBuilder implements Use
      * @param query a JCR-SQL2 query
      * @return the content matching the query
      */
-    private String queryJCR(String query) throws RepositoryException
+    private Iterator<Resource> queryJCR(String query) throws RepositoryException
     {
-        Iterator<Resource> results = this.resourceResolver.findResources(query, "JCR-SQL2");
-        JsonArrayBuilder builder = Json.createArrayBuilder();
-        while (results.hasNext())
-        {
-            Resource result = results.next();
-            builder.add(result.adaptTo(JsonObject.class));
+        return this.resourceResolver.findResources(query, "JCR-SQL2");
+    }
+
+    /**
+     * Write metadata about the request and response. This includes the number of returned and total matching nodes, and
+     * copying some request parameters.
+     *
+     * @param jsonGen the JSON generator where the results should be serialized
+     * @param request the current request
+     * @param offset the requested offset, may be the default value of {0}
+     * @param limit the requested limit, may be the default value of {10}
+     * @param returnedNodes the number of matching nodes included in the response, may be {@code 0} if no nodes were
+     *            returned
+     * @param totalMatchingNodes the total number of accessible nodes matching the request, may be {@code 0} if no nodes
+     *            match the filters, or the current user cannot access the nodes
+     */
+    private void addSummary(final JsonObjectBuilder jsonGen, final SlingHttpServletRequest request, final long[] limits)
+    {
+        String req = request.getParameter("req");
+        if (StringUtils.isBlank(req)) {
+            req = "";
         }
-        return builder.build().toString();
+        jsonGen.add("req", req);
+        jsonGen.add("offset", limits[0]);
+        jsonGen.add("limit", limits[1]);
+        jsonGen.add("returnedrows", limits[2]);
+        jsonGen.add("totalrows", limits[3]);
+    }
+
+    /**
+     * Write the contents of the input nodes, subject to the an offset and a limit.
+     *
+     * @param jsonGen the JSON object generator where the results should be serialized
+     * @param nodes an iterator over the nodes to serialize, which will be consumed
+     * @param offset the requested offset, may be the default value of {0}
+     * @param limit the requested limit, may be the default value of {10}
+     * @return an array of size 4, giving the [0]: offset, [1]: limit, [2]: results, [3]: total matches
+     */
+    private long[] addNodes(final JsonObjectBuilder jsonGen, final Iterator<Resource> nodes,
+        final long offset, final long limit)
+    {
+        final long[] counts = new long[4];
+        counts[0] = offset;
+        counts[1] = limit;
+        counts[2] = 0;
+        counts[3] = 0;
+
+        long offsetCounter = offset < 0 ? 0 : offset;
+        long limitCounter = limit < 0 ? 0 : limit;
+
+        final JsonArrayBuilder builder = Json.createArrayBuilder();
+
+        while (nodes.hasNext()) {
+            Resource n = nodes.next();
+            // Skip results up to the offset provided
+            if (offsetCounter > 0) {
+                --offsetCounter;
+            // Count up to our limit
+            } else if (limitCounter > 0) {
+                builder.add(n.adaptTo(JsonObject.class));
+                --limitCounter;
+                ++counts[2];
+            }
+            // Count the total number of results
+            ++counts[3];
+        }
+
+        jsonGen.add("rows", builder.build());
+
+        return counts;
+    }
+
+    /**
+     * Use the value given (usually from a request.getParameter()) or use a default value.
+     *
+     * @param stringValue the value to use if provided
+     * @param defaultValue the value to use if stringValue is not given
+     * @return Either stringValue, if provided, or defaultValue
+     */
+    private long getLongValueOrDefault(final String stringValue, final long defaultValue)
+    {
+        long value = defaultValue;
+        try {
+            value = Long.parseLong(stringValue);
+        } catch (NumberFormatException exception) {
+            value = defaultValue;
+        }
+        return value;
     }
 
     /**

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/AdminNavbarLinks.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/AdminNavbarLinks.jsx
@@ -33,6 +33,7 @@ class HeaderLinks extends React.Component {
         <SearchBar
           invertColors={!expand}
           closeSidebar={expand ? undefined : closeSidebar}
+          className={expand ? undefined : classes.buttonLink}
           />
         {/* Log out */}
         <IconButton

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/AdminNavbarLinks.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/AdminNavbarLinks.jsx
@@ -11,12 +11,9 @@
 */
 import React from "react";
 // @material-ui/core components
-import { withStyles } from "@material-ui/core";
-import { Hidden } from "@material-ui/core";
+import { Button, Hidden, IconButton, withStyles } from "@material-ui/core";
 // @material-ui/icons
 import ExitToApp from "@material-ui/icons/ExitToApp";
-// core components
-import { Button } from "MaterialDashboardReact";
 
 import SearchBar from "./SearchBar.jsx";
 import headerLinksStyle from "./headerLinksStyle.jsx";
@@ -34,12 +31,9 @@ class HeaderLinks extends React.Component {
       <div>
         <SearchBar />
         {/* Log out */}
-        <Button
-          color={expand ? "transparent" : "white"}
-          justIcon={expand}
-          simple={!(expand)}
+        <IconButton
           aria-label="Log out"
-          className={classes.buttonLink + " " + classes.logout}
+          className={classes.buttonLink + " " + classes.logout + " " + expand || classes.linkText}
           href="/system/sling/logout"
           title="Log out"
         >
@@ -47,7 +41,7 @@ class HeaderLinks extends React.Component {
           <Hidden mdUp implementation="css">
             <p className={classes.linkText}>Log out</p>
           </Hidden>
-        </Button>
+        </IconButton>
       </div>
     );
   }

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/AdminNavbarLinks.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/AdminNavbarLinks.jsx
@@ -9,6 +9,7 @@
 =========================================================
 * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 */
+import PropTypes from "prop-types";
 import React from "react";
 // @material-ui/core components
 import { Button, Hidden, IconButton, withStyles } from "@material-ui/core";
@@ -20,7 +21,7 @@ import headerLinksStyle from "./headerLinksStyle.jsx";
 
 class HeaderLinks extends React.Component {
   render() {
-    const { classes } = this.props;
+    const { classes, closeSidebar } = this.props;
 
     // When the screen is larger than "MdUp" size, we alter some menu items
     // so that they show up white in the sidebar (rather than black on the
@@ -29,7 +30,10 @@ class HeaderLinks extends React.Component {
 
     return (
       <div>
-        <SearchBar />
+        <SearchBar
+          invertColors={!expand}
+          closeSidebar={expand ? undefined : closeSidebar}
+          />
         {/* Log out */}
         <IconButton
           aria-label="Log out"
@@ -45,6 +49,10 @@ class HeaderLinks extends React.Component {
       </div>
     );
   }
+}
+
+HeaderLinks.propTypes = {
+  closeSidebar: PropTypes.func
 }
 
 export default withStyles(headerLinksStyle, {withTheme: true})(HeaderLinks);

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/AdminNavbarLinks.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/AdminNavbarLinks.jsx
@@ -18,6 +18,7 @@ import ExitToApp from "@material-ui/icons/ExitToApp";
 // core components
 import { Button } from "MaterialDashboardReact";
 
+import SearchBar from "./SearchBar.jsx";
 import headerLinksStyle from "./headerLinksStyle.jsx";
 
 class HeaderLinks extends React.Component {
@@ -31,13 +32,14 @@ class HeaderLinks extends React.Component {
 
     return (
       <div>
+        <SearchBar />
         {/* Log out */}
         <Button
           color={expand ? "transparent" : "white"}
           justIcon={expand}
           simple={!(expand)}
           aria-label="Log out"
-          className={classes.buttonLink}
+          className={classes.buttonLink + " " + classes.logout}
           href="/system/sling/logout"
           title="Log out"
         >

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/Navbar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/Navbar.jsx
@@ -14,12 +14,11 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 // @material-ui/core components
 import { withStyles } from "@material-ui/core";
-import { AppBar, Toolbar, IconButton, Hidden } from "@material-ui/core";
+import { AppBar, Button, Toolbar, IconButton, Hidden } from "@material-ui/core";
 // @material-ui/icons
 import Menu from "@material-ui/icons/Menu";
 // core components
 import AdminNavbarLinks from "./AdminNavbarLinks.jsx";
-import { Button } from "MaterialDashboardReact";
 
 import headerStyle from "./headerStyle.jsx";
 

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/Navbar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/Navbar.jsx
@@ -50,7 +50,7 @@ function Header({ ...props }) {
         </div>
         {/* While the screen is wide enough, display the navbar at the topright */}
         <Hidden smDown implementation="css">
-          <AdminNavbarLinks />
+          <AdminNavbarLinks closeSidebar={props.handleDrawerToggle} />
         </Hidden>
         {/* While the screen is too narrow, display the mini sidebar control */}
         <Hidden mdUp implementation="css">

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
@@ -1,0 +1,78 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+import React, { useState } from "react";
+
+import { IconButton, Input, withStyles, InputAdornment } from "@material-ui/core";
+import Search from "@material-ui/icons/Search";
+import HeaderStyle from "./headerStyle.jsx";
+
+const QUERY_URL = "/query?native=";
+
+function SearchBar(props) {
+  const { classes } = props;
+  const [ search, setSearch ] = useState("");
+  const [ timer, setTimer ] = useState();
+  const [ error, setError ] = useState();
+
+  let changeSearch = (query) => {
+    // Reset the timer if it exists
+    if (timer !== null) {
+      clearTimeout(timer);
+    }
+
+    setTimer(setTimeout(runQuery, 500));
+    setSearch(query);
+  }
+
+  let runQuery = () => {
+    let new_url = QUERY_URL + encodeURIComponent(
+      "select * from [lfs:Form] WHERE native('lucene', " + search.replace(/['\\]/g, "\\$1") + ")");
+    fetch(new_url)
+      .then(response => response.ok ? response.json() : Promise.reject(response))
+      .then(displayResults)
+      .catch(handleError)
+  }
+
+  let displayResults = (json) => {
+    // Parse out the top 5 and display in popper?
+  }
+
+  let handleError = (response) => {
+    setError(response)
+  }
+
+  return(
+    <Input
+      type="text"
+      placeholder="Search"
+      value={search}
+      onChange={(event) => changeSearch(event.target.value)}
+      endAdornment={
+        <InputAdornment position="end">
+          <IconButton>
+            <Search />
+          </IconButton>
+        </InputAdornment>
+      }
+      className={classes.search}
+      />
+  );
+}
+
+export default withStyles(HeaderStyle)(SearchBar);

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
@@ -28,7 +28,7 @@ const QUERY_URL = "/query";
 const MAX_RESULTS = 5;
 
 function SearchBar(props) {
-  const { classes, closeSidebar, invertColors } = props;
+  const { classes, className, closeSidebar, invertColors } = props;
   const [ search, setSearch ] = useState("");
   const [ results, setResults ] = useState([]);
   const [ popperOpen, setPopperOpen ] = useState(false);
@@ -114,7 +114,11 @@ function SearchBar(props) {
             </IconButton>
           </InputAdornment>
         }
-        className={classes.search + " " + (invertColors ? classes.invertedColors : "")}
+        className={
+          classes.search
+          + " " + (invertColors ? classes.invertedColors : "")
+          + " " + (className ? className : "")
+        }
         inputRef={input}
         />
       {/* Suggestions list using Popper */}

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
@@ -87,8 +87,6 @@ function SearchBar(props) {
   let displayResults = (json) => {
     // Ignore this result if the request ID does not match our last request
     if (json["req"] != requestID) {
-      console.log(requestID);
-      console.log(json["req"]);
       return;
     }
 

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
@@ -38,6 +38,7 @@ function SearchBar(props) {
   let input = React.useRef();
   let suggestionMenu = React.useRef();
 
+  // Callback to update the value of the search bar. Sends off a delayed fulltext request
   let changeSearch = (query) => {
     // Reset the timer if it exists
     if (timer !== null) {
@@ -55,6 +56,7 @@ function SearchBar(props) {
     setError(false);
   }
 
+  // Runs a fulltext request
   let runQuery = (query) => {
     let new_url = new URL(QUERY_URL, window.location.origin);
     new_url.searchParams.set("quick", encodeURIComponent(query));
@@ -64,6 +66,7 @@ function SearchBar(props) {
       .catch(handleError)
   }
 
+  // Callback to store the results of the top results, or to display 'No results'
   let displayResults = (json) => {
     // Parse out the top 5 and display in popper
     if (json.length >= MAX_RESULTS) {
@@ -79,13 +82,13 @@ function SearchBar(props) {
     }
   }
 
+  // Error handling
   let handleError = (response) => {
     setError(response);
-    console.log(response);
   }
 
+  // Attempt a few different methods of getting the name of an element from <code>/query?quick</code>
   let getElementName = (element) => {
-    // Attempt a few different methods of getting the name
     return element["name"] || element["title"] || element["jcr:uuid"];
   }
 

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
@@ -99,30 +99,31 @@ function SearchBar(props) {
   }
 
   const categoryToAvatar = {
-    ["lfs:Form"]: <ListItemAvatar>
-        <Avatar className={classes.searchResultFormIcon + " " + classes.searchResultAvatar}>
-          <DescriptionIcon />
-        </Avatar>
-      </ListItemAvatar>,
-    ["lfs:Questionnaire"]: <ListItemAvatar>
-        <Avatar className={classes.searchResultQuestionnaireIcon + " " + classes.searchResultAvatar}>
-          <AssignmentIcon />
-        </Avatar>
-      </ListItemAvatar>,
-    ["lfs:Subject"]: <ListItemAvatar>
-        <Avatar className={classes.searchResultSubjectIcon + " " + classes.searchResultAvatar}>
-          <AssignmentIndIcon />
-        </Avatar>
-      </ListItemAvatar>
+    ["lfs:Form"]: <Avatar className={classes.searchResultFormIcon + " " + classes.searchResultAvatar}>
+        <DescriptionIcon />
+      </Avatar>,
+    ["lfs:Questionnaire"]: <Avatar className={classes.searchResultQuestionnaireIcon + " " + classes.searchResultAvatar}>
+        <AssignmentIcon />
+      </Avatar>,
+    ["lfs:Subject"]: <Avatar className={classes.searchResultSubjectIcon + " " + classes.searchResultAvatar}>
+        <AssignmentIndIcon />
+      </Avatar>
   }
 
+  // Get a user friendly version of the icon
   let getCategoryIcon = (element) => (
-    categoryToAvatar[element["jcr:primaryType"]] || " "
+    categoryToAvatar[element["jcr:primaryType"]] ?
+      <ListItemAvatar>{categoryToAvatar[element["jcr:primaryType"]]}</ListItemAvatar>
+      : " "
   );
 
   // Get a user friendly version of the category
   let getFriendlyCategory = (element) => {
-    return (element["jcr:primaryType"] && element["jcr:primaryType"].replace(/lfs:/,""));
+    const friendlyType = element["jcr:primaryType"] && element["jcr:primaryType"].replace(/lfs:/,"");
+    /* Prepend the questionnaire title, if this has it */
+    return (element["questionnaire"] ? element["questionnaire"]["title"] + " " + friendlyType
+    /* Otherwise just use the user-friendly element name */
+      : friendlyType);
   }
 
   // Attempt a few different methods of getting the name of an element from <code>/query?quick</code>

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
@@ -59,7 +59,7 @@ function SearchBar(props) {
   // Runs a fulltext request
   let runQuery = (query) => {
     let new_url = new URL(QUERY_URL, window.location.origin);
-    new_url.searchParams.set("quick", encodeURIComponent(query));
+    new_url.searchParams.set("quick", encodeURIComponent("*" + query + "*"));
     fetch(new_url)
       .then(response => response.ok ? response.json() : Promise.reject(response))
       .then(displayResults)

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
@@ -17,7 +17,8 @@
 //  under the License.
 //
 import classNames from "classnames";
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
+import { withRouter } from "react-router-dom";
 
 import { ClickAwayListener, Grow, IconButton, Input, InputAdornment, ListItemText, MenuItem, MenuList, Paper, Popper, withStyles } from "@material-ui/core";
 import Search from "@material-ui/icons/Search";
@@ -48,7 +49,7 @@ function SearchBar(props) {
 
   let runQuery = (query) => {
     let new_url = new URL(QUERY_URL, window.location.origin);
-    new_url.searchParams.set("fulltext", encodeURIComponent(query));
+    new_url.searchParams.set("quick", encodeURIComponent(query));
     console.log(query);
     fetch(new_url)
       .then(response => response.ok ? response.json() : Promise.reject(response))
@@ -74,7 +75,7 @@ function SearchBar(props) {
 
   let getElementName = (element) => {
     // Attempt a few different methods of getting the name
-    return element["name"] || element["title"] || element["identifier"] || element["@path"];
+    return element["name"] || element["title"] || element["jcr:uuid"];
   }
 
   return(
@@ -107,19 +108,6 @@ function SearchBar(props) {
         placement = "bottom-start"
         keepMounted
         container={document.querySelector('#main-panel')}
-        modifiers={{
-          flip: {
-            enabled: true
-          },
-          preventOverflow: {
-            enabled: true,
-            boundariesElement: 'window',
-            escapeWithReference: true,
-          },
-          hide: {
-            enabled: true
-          }
-        }}
         >
         {({ TransitionProps }) => (
           <Grow
@@ -137,12 +125,14 @@ function SearchBar(props) {
                       className={classes.dropdownItem}
                       key={element["@path"]}
                       onClick={(e) => {
-                        //????
+                        // Redirect
+                        props.history.push("/content.html" + element["@path"]);
                         }}
                       >
                         <ListItemText
                           primary={getElementName(element)}
                           secondary={element["jcr:primaryType"]}
+                          className={classes.dropdownItem}
                           />
                     </MenuItem>
                   ))}
@@ -156,4 +146,4 @@ function SearchBar(props) {
   );
 }
 
-export default withStyles(HeaderStyle)(SearchBar);
+export default withStyles(HeaderStyle)(withRouter(SearchBar));

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
@@ -17,8 +17,9 @@
 //  under the License.
 //
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React, { useState } from "react";
-import { withRouter } from "react-router-dom";
+import { Redirect, withRouter } from "react-router-dom";
 
 import { ClickAwayListener, Grow, IconButton, Input, InputAdornment, ListItemText, MenuItem, MenuList, Paper, Popper, withStyles } from "@material-ui/core";
 import Search from "@material-ui/icons/Search";
@@ -28,7 +29,7 @@ const QUERY_URL = "/query";
 const MAX_RESULTS = 5;
 
 function SearchBar(props) {
-  const { classes } = props;
+  const { classes, closeSidebar, invertColors } = props;
   const [ search, setSearch ] = useState("");
   const [ results, setResults ] = useState([]);
   const [ popperOpen, setPopperOpen ] = useState(false);
@@ -50,7 +51,6 @@ function SearchBar(props) {
   let runQuery = (query) => {
     let new_url = new URL(QUERY_URL, window.location.origin);
     new_url.searchParams.set("quick", encodeURIComponent(query));
-    console.log(query);
     fetch(new_url)
       .then(response => response.ok ? response.json() : Promise.reject(response))
       .then(displayResults)
@@ -61,10 +61,8 @@ function SearchBar(props) {
     // Parse out the top 5 and display in popper?
     if (json.length >= MAX_RESULTS) {
       setResults(json.slice(0, MAX_RESULTS));
-      console.log(json.slice(0, MAX_RESULTS));
     } else {
       setResults(json);
-      console.log(json);
     }
     setPopperOpen(true);
   }
@@ -87,12 +85,12 @@ function SearchBar(props) {
         onChange={(event) => changeSearch(event.target.value)}
         endAdornment={
           <InputAdornment position="end">
-            <IconButton>
+            <IconButton className={invertColors ? classes.invertedColors : ""}>
               <Search />
             </IconButton>
           </InputAdornment>
         }
-        className={classes.search}
+        className={classes.search + " " + (invertColors ? classes.invertedColors : "")}
         inputRef={input}
         />
       {/* Suggestions list using Popper */}
@@ -103,7 +101,7 @@ function SearchBar(props) {
         className={
           classNames({ [classes.popperClose]: !open })
           + " " + classes.popperNav
-          + " " + classes.popperListOnTop
+          + " " + classes.aboveBackground
         }
         placement = "bottom-start"
         keepMounted
@@ -127,6 +125,8 @@ function SearchBar(props) {
                       onClick={(e) => {
                         // Redirect
                         props.history.push("/content.html" + element["@path"]);
+                        closeSidebar && closeSidebar();
+                        setPopperOpen(false);
                         }}
                       >
                         <ListItemText
@@ -144,6 +144,10 @@ function SearchBar(props) {
       </Popper>
     </React.Fragment>
   );
+}
+
+SearchBar.propTypes = {
+  invertColors: PropTypes.bool
 }
 
 export default withStyles(HeaderStyle)(withRouter(SearchBar));

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/headerLinksStyle.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/headerLinksStyle.jsx
@@ -30,6 +30,7 @@ const headerLinksStyle = theme => ({
       display: "flex",
       margin: "10px 15px 0",
       width: "-webkit-fill-available",
+      color: whiteColor,
       "& svg": {
         width: "24px",
         height: "30px",

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/headerLinksStyle.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/headerLinksStyle.jsx
@@ -49,6 +49,9 @@ const headerLinksStyle = theme => ({
         width: "100%"
       }
     }
+  },
+  logout: {
+    marginTop: "0px"
   }
 });
 

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/headerStyle.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/headerStyle.jsx
@@ -102,6 +102,12 @@ const headerStyle = theme => ({
   suggestions: {
     // Unsure, but this should probably be a constant size, not spacing dependent
     maxWidth: theme.spacing(32)
+  },
+  invertedColors: {
+    color: whiteColor
+  },
+  aboveBackground: {
+    zIndex: "1301"
   }
 });
 

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/headerStyle.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/headerStyle.jsx
@@ -95,6 +95,13 @@ const headerStyle = theme => ({
   },
   search: {
     marginTop: theme.spacing(1)
+  },
+  dropdownItem: {
+    whiteSpace: "normal"
+  },
+  suggestions: {
+    // Unsure, but this should probably be a constant size, not spacing dependent
+    maxWidth: theme.spacing(32)
   }
 });
 

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/headerStyle.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/headerStyle.jsx
@@ -100,8 +100,10 @@ const headerStyle = theme => ({
     whiteSpace: "normal"
   },
   suggestions: {
-    // Unsure, but this should probably be a constant size, not spacing dependent
-    maxWidth: theme.spacing(32)
+    width: theme.spacing(32)
+  },
+  suggestionContainer: {
+    minHeight: "10px"
   },
   invertedColors: {
     color: whiteColor

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/headerStyle.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/headerStyle.jsx
@@ -110,6 +110,18 @@ const headerStyle = theme => ({
   },
   aboveBackground: {
     zIndex: "1301"
+  },
+  searchResultAvatar: {
+    color: "white",
+  },
+  searchResultFormIcon: {
+    backgroundColor: "cornflowerblue"
+  },
+  searchResultQuestionnaireIcon: {
+    backgroundColor: "limegreen"
+  },
+  searchResultSubjectIcon: {
+    backgroundColor: "orange"
   }
 });
 

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/headerStyle.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/headerStyle.jsx
@@ -92,6 +92,9 @@ const headerStyle = theme => ({
     backgroundColor: "rgba(" + hexToRgb(grayColor[6]) + ", 0.3)",
     borderRadius: "15px",
     width: theme.spacing(32)
+  },
+  search: {
+    marginTop: theme.spacing(1)
   }
 });
 

--- a/modules/homepage/src/main/frontend/src/themePage/Sidebar/sidebar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Sidebar/sidebar.jsx
@@ -132,7 +132,7 @@ const Sidebar = ({ ...props }) => {
         >
           {brand}
           <div className={classes.sidebarWrapper}>
-            <AdminNavbarLinks />
+            <AdminNavbarLinks closeSidebar={props.handleDrawerToggle}/>
             {links}
             {adminLinks}
           </div>

--- a/modules/homepage/src/main/frontend/webpack.config.js
+++ b/modules/homepage/src/main/frontend/webpack.config.js
@@ -44,8 +44,7 @@ module.exports = {
       "lodash": "lodash",
       "prop-types": "PropTypes",
       "jss": "jss",
-      "@material-ui/core": "MaterialUI",
-      "MaterialDashboardReact": "window['MaterialDashboard']['lfs-material-dashboard.all']"
+      "@material-ui/core": "MaterialUI"
     }
   ]
 };


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/LFS-200).

The new search bar at the top right.

This PR also introduces a few other changes:
1) Changing URLs from one form/questionnaire to another through the React Router did not work due to the lack of a key on `Forms.jsx`
2) `/query` can be given a `lucene` or `quick` parameter for a lucene query or basic fulltext search
3) MaterialDashboardReact dependency has been removed from Homepage, which means that we can remove it entirely now (possibly in another commit)

