### PR TITLE
LFS-231: Console warning about synchronous XMLHttpRequest on the main thread

### DIFF
--- a/modules/homepage/src/main/frontend/src/themePage/index.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/index.jsx
@@ -20,7 +20,7 @@ import PropTypes from 'prop-types';
 import React, { Suspense } from "react";
 import ReactDOM from "react-dom";
 import Sidebar from "./Sidebar/sidebar"
-import sidebarRoutes, { loadRemoteComponents, loadRemoteIcons, contentNodes } from './routes';
+import sidebarRoutes, { loadRemoteComponents, loadRemoteIcons, loadContentNodes } from './routes';
 import { withStyles } from '@material-ui/core';
 import { Redirect, Router, Route, Switch } from "react-router-dom";
 import { createBrowserHistory } from "history";
@@ -84,7 +84,8 @@ class Main extends React.Component {
 
   componentDidMount() {
     window.addEventListener("resize", this.autoCloseMobileMenus);
-    loadRemoteComponents(contentNodes)
+    loadContentNodes()
+    .then(loadRemoteComponents)
     .then(loadRemoteIcons)
     .then(this._buildSidebar)
     .catch(function(err) {

--- a/modules/homepage/src/main/resources/SLING-INF/content/libs/lfs/Homepage/html.GET.html
+++ b/modules/homepage/src/main/resources/SLING-INF/content/libs/lfs/Homepage/html.GET.html
@@ -19,11 +19,26 @@
 <sly data-sly-resource="${@selectors='header'}"/>
     <script>
       // Redirect to /login if the user is not logged in
-      if (window.Sling.getSessionInfo() === null || window.Sling.getSessionInfo().userID === 'anonymous') {
+      // Since the default window.Sling.getSessionInfo() throws an async warning, we fetch it ourselves
+      var url = window.Sling.baseurl+"/system/sling/info.sessionInfo.json";
+      fetch(url)
+      .then(function(response) {
+        if (response.ok) {
+          return response.json();
+        } else {
+          throw new Error();
+        }
+      })
+      .then(function(json) {
+        if (json.userID === 'anonymous') {
+          throw new Error();
+        }
+      })
+      .catch(function() {
         // Provide the `resource` to redirect to after successful login
         var relativeLocation = window.location.toString().substring(window.location.origin.length);
         window.location = "/login.html" + ((relativeLocation.length > 1) ? ("?resource=" + encodeURIComponent(relativeLocation)) : "");
-      }
+      });
     </script>
     <div id="main-container"></div>
     <sly data-sly-use.assets="/libs/lfs/resources/assets">

--- a/modules/homepage/src/main/resources/SLING-INF/content/libs/lfs/Homepage/html.GET.html
+++ b/modules/homepage/src/main/resources/SLING-INF/content/libs/lfs/Homepage/html.GET.html
@@ -20,7 +20,7 @@
     <script>
       // Redirect to /login if the user is not logged in
       // Since the default window.Sling.getSessionInfo() throws an async warning, we fetch it ourselves
-      var url = window.Sling.baseurl+"/system/sling/info.sessionInfo.json";
+      var url = window.Sling.baseurl + "/system/sling/info.sessionInfo.json";
       fetch(url)
       .then(function(response) {
         if (response.ok) {
@@ -37,7 +37,7 @@
       .catch(function() {
         // Provide the `resource` to redirect to after successful login
         var relativeLocation = window.location.toString().substring(window.location.origin.length);
-        window.location = "/login.html" + ((relativeLocation.length > 1) ? ("?resource=" + encodeURIComponent(relativeLocation)) : "");
+        window.location = window.Sling.baseurl + "/login.html" + ((relativeLocation.length > 1) ? ("?resource=" + encodeURIComponent(relativeLocation)) : "");
       });
     </script>
     <div id="main-container"></div>


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/LFS-231)

To test, load any page of LFS and check the console for warnings. The only one remaining should be the `@material-ui/styles` one.

This PR also includes a refactor of `homepage/.../routes.jsx`, which was previously using `XMLHttpRequest`. In the interest of making our codebase a little more consistent, I've switched it all to use `.fetch` calls.