### PR TITLE
LFS-241: Add support for questionnaire sections

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -27,14 +27,16 @@ export const VALUE_POS = 1;
 // Holds answers and automatically generates hidden inputs
 // for form submission
 function Answer (props) {
-  let { answers, answerNodeType, valueType, questionDefinition, existingAnswer } = props;
-  let [answerPath] = useState((existingAnswer && existingAnswer[0]) || uuidv4());
+  let { answers, answerNodeType, existingAnswer, path, questionDefinition, valueType } = props;
+  let [ answerID ] = useState((existingAnswer && existingAnswer[0]) || uuidv4());
+  let answerPath = path + "/" + answerID;
+
   return (
     <React.Fragment>
-      <input type="hidden" name={`./${answerPath}/jcr:primaryType`} value={answerNodeType}></input>
-      <input type="hidden" name={`./${answerPath}/question`} value={questionDefinition['jcr:uuid']}></input>
-      <input type="hidden" name={`./${answerPath}/question@TypeHint`} value="Reference"></input>
-      <input type="hidden" name={`./${answerPath}/value@TypeHint`} value={valueType}></input>
+      <input type="hidden" name={`${answerPath}/jcr:primaryType`} value={answerNodeType}></input>
+      <input type="hidden" name={`${answerPath}/question`} value={questionDefinition['jcr:uuid']}></input>
+      <input type="hidden" name={`${answerPath}/question@TypeHint`} value="Reference"></input>
+      <input type="hidden" name={`${answerPath}/value@TypeHint`} value={valueType}></input>
       {answers.map( (element, index) => {
         return (
           <input type="hidden" name={`./${answerPath}/value`} key={element[VALUE_POS] === undefined ? index : element[VALUE_POS]} value={element[VALUE_POS]}></input>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx
@@ -188,6 +188,7 @@ function DateQuestion(props) {
         existingAnswer={existingAnswer}
         answerNodeType="lfs:DateAnswer"
         valueType="Date"
+        {...rest}
         />
       <TextField
         type={textFieldType}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -169,7 +169,7 @@ function Form (props) {
         {
           Object.entries(data.questionnaire)
             .filter(([key, value]) => value['jcr:primaryType'] == 'lfs:Question' || value['jcr:primaryType'] == 'lfs:Section')
-            .map(([key, questionDefinition]) => FormEntry(questionDefinition, data, key))
+            .map(([key, questionDefinition]) => FormEntry(questionDefinition, ".", 0, data, key))
         }
       </Grid>
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -30,6 +30,7 @@ import {
 
 import QuestionnaireStyle from "./QuestionnaireStyle";
 import FormEntry, { ENTRY_TYPES } from "./FormEntry";
+import { CONTAINER_PROPS } from "./Section";
 
 // TODO Once components from the login module can be imported, open the login Dialog in-page instead of opening a popup window
 
@@ -148,7 +149,7 @@ function Form (props) {
 
   return (
     <form action={data["@path"]} method="POST" onSubmit={saveData} onChange={()=>setLastSaveStatus(undefined)} key={id}>
-      <Grid container direction="column" spacing={4} alignItems="stretch" justify="space-between" wrap="nowrap">
+      <Grid container {...CONTAINER_PROPS} >
         <Grid item>
           {
             data && data.questionnaire && data.questionnaire.title ?

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -28,7 +28,7 @@ import {
   withStyles
 } from "@material-ui/core";
 
-import QuestionnaireStyle, { CONTAINER_PROPS } from "./QuestionnaireStyle";
+import QuestionnaireStyle, { FORM_ENTRY_CONTAINER_PROPS } from "./QuestionnaireStyle";
 import FormEntry, { ENTRY_TYPES } from "./FormEntry";
 
 // TODO Once components from the login module can be imported, open the login Dialog in-page instead of opening a popup window
@@ -148,7 +148,7 @@ function Form (props) {
 
   return (
     <form action={data["@path"]} method="POST" onSubmit={saveData} onChange={()=>setLastSaveStatus(undefined)} key={id}>
-      <Grid container {...CONTAINER_PROPS} >
+      <Grid container {...FORM_ENTRY_CONTAINER_PROPS} >
         <Grid item>
           {
             data && data.questionnaire && data.questionnaire.title ?

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -28,9 +28,8 @@ import {
   withStyles
 } from "@material-ui/core";
 
-import QuestionnaireStyle from "./QuestionnaireStyle";
+import QuestionnaireStyle, { CONTAINER_PROPS } from "./QuestionnaireStyle";
 import FormEntry, { ENTRY_TYPES } from "./FormEntry";
-import { CONTAINER_PROPS } from "./Section";
 
 // TODO Once components from the login module can be imported, open the login Dialog in-page instead of opening a popup window
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -29,7 +29,7 @@ import {
 } from "@material-ui/core";
 
 import QuestionnaireStyle from "./QuestionnaireStyle";
-import FormEntry from "./FormEntry";
+import FormEntry, { ENTRY_TYPES } from "./FormEntry";
 
 // TODO Once components from the login module can be imported, open the login Dialog in-page instead of opening a popup window
 
@@ -168,7 +168,7 @@ function Form (props) {
         </Grid>
         {
           Object.entries(data.questionnaire)
-            .filter(([key, value]) => value['jcr:primaryType'] == 'lfs:Question' || value['jcr:primaryType'] == 'lfs:Section')
+            .filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType']))
             .map(([key, questionDefinition]) => FormEntry(questionDefinition, ".", 0, data, key))
         }
       </Grid>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -169,7 +169,7 @@ function Form (props) {
         {
           Object.entries(data.questionnaire)
             .filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType']))
-            .map(([key, questionDefinition]) => FormEntry(questionDefinition, ".", 0, data, key))
+            .map(([key, entryDefinition]) => FormEntry(entryDefinition, ".", 0, data, key))
         }
       </Grid>
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -94,12 +94,22 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key) => {
   );
 }
 
-export default function FormEntry(questionDefinition, path, depth, existingAnswers, key) {
+/**
+ * Display a question or section from the questionnaire, along with its answer(s).
+ *
+ * @param {Object} entryDefinition the definition for this entry JSON
+ * @param {string} path the path to the parent of the entry
+ * @param {int} depth the section nesting depth
+ * @param {Object} existingAnswers form data that may include answers already submitted for this component
+ * @param {string} key the node name of the section definition JCR node
+ * @returns a React component that renders the section
+ */
+export default function FormEntry(entryDefinition, path, depth, existingAnswers, key) {
   // TODO: As before, I'm writing something that's basically an if statement
   // this should instead be via a componentManager
-  if (QUESTION_TYPES.includes(questionDefinition["jcr:primaryType"])) {
-      return displayQuestion(questionDefinition, path, existingAnswers, key);
-  } else if (SECTION_TYPES.includes(questionDefinition["jcr:primaryType"])) {
-      return displaySection(questionDefinition, path, depth, existingAnswers, key);
+  if (QUESTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
+      return displayQuestion(entryDefinition, path, existingAnswers, key);
+  } else if (SECTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
+      return displaySection(entryDefinition, path, depth, existingAnswers, key);
   }
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -34,7 +34,7 @@ import TextQuestion from "./TextQuestion";
 import VocabularyQuestion from "./VocabularyQuestion";
 
 const QUESTION_TYPES = ["lfs:Question"];
-const SECTION_TYPES = ["lfs:Section", "lfs:SectionLink"];
+const SECTION_TYPES = ["lfs:Section"];
 export const ENTRY_TYPES = QUESTION_TYPES.concat(SECTION_TYPES);
 
 /**
@@ -75,13 +75,6 @@ let displayQuestion = (questionDefinition, path, existingAnswer, key) => {
  * @returns a React component that renders the section
  */
 let displaySection = (sectionDefinition, path, depth, existingAnswer, key) => {
-  // Parse through SectionLink nodes to find our Section node
-  // We expect sectionDefinition to have been passed from the Resource to JSON adapter factory,
-  // which prevents infinite loops
-  while (sectionDefinition && sectionDefinition["jcr:primaryType"] == "lfs:SectionLink") {
-    sectionDefinition = sectionDefinition["ref"];
-  }
-
   // Catch an invalid section
   if (!sectionDefinition || sectionDefinition["jcr:primaryType"] != "lfs:Section") {
     console.log("Error: an invalid section was passed to displaySection:");
@@ -92,7 +85,7 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key) => {
   // Find the existing AnswerSection for this section, if available
   const existingQuestionAnswer = existingAnswer && Object.entries(existingAnswer)
     .find(([key, value]) => value["sling:resourceType"] == "lfs/AnswerSection"
-      && value["question"]["jcr:uuid"] === sectionDefinition["jcr:uuid"]);
+      && value["section"]["jcr:uuid"] === sectionDefinition["jcr:uuid"]);
 
   return (
     <Section

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -41,6 +41,7 @@ export const ENTRY_TYPES = QUESTION_TYPES.concat(SECTION_TYPES);
  * Method responsible for displaying a question from the questionnaire, along with its answer(s).
  *
  * @param {Object} questionDefinition the question definition JSON
+ * @param {string} path the path to the parent of the question
  * @param {Object} existingAnswer form data that may include answers already submitted for this component
  * @param {string} key the node name of the question definition JCR node
  * @returns a React component that renders the question
@@ -67,6 +68,8 @@ let displayQuestion = (questionDefinition, path, existingAnswer, key) => {
  * TODO: Somehow pass the conditional state upwards from here
  *
  * @param {Object} sectionDefinition the section definition JSON
+ * @param {string} path the path to the parent of the section
+ * @param {int} depth the section nesting depth
  * @param {Object} existingAnswer form data that may include answers already submitted for this component
  * @param {string} key the node name of the section definition JCR node
  * @returns a React component that renders the section

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -41,13 +41,21 @@ import VocabularyQuestion from "./VocabularyQuestion";
  * @param {string} key the node name of the question definition JCR node
  * @returns a React component that renders the question
  */
-let displayQuestion = (questionDefinition, existingAnswer, key) => {
+let displayQuestion = (questionDefinition, path, existingAnswer, key) => {
   const existingQuestionAnswer = existingAnswer && Object.entries(existingAnswer)
     .find(([key, value]) => value["sling:resourceSuperType"] == "lfs/Answer"
       && value["question"]["jcr:uuid"] === questionDefinition["jcr:uuid"]);
   // This variable must start with an upper case letter so that React treats it as a component
   const QuestionDisplay = AnswerComponentManager.getAnswerComponent(questionDefinition);
-  return <Grid item key={key}><QuestionDisplay key={key} questionDefinition={questionDefinition} existingAnswer={existingQuestionAnswer} /></Grid>;
+  return (
+    <Grid item key={key} className={"questionContainer"}>
+      <QuestionDisplay
+        key={key}
+        questionDefinition={questionDefinition}
+        existingAnswer={existingQuestionAnswer}
+        path={path} />
+    </Grid>
+  );
 };
 
 /**
@@ -59,7 +67,7 @@ let displayQuestion = (questionDefinition, existingAnswer, key) => {
  * @param {string} key the node name of the section definition JCR node
  * @returns a React component that renders the section
  */
-let displaySection = (sectionDefinition, existingAnswer, key) => {
+let displaySection = (sectionDefinition, path, depth, existingAnswer, key) => {
   // Parse through SectionLink nodes to find our Section node
   // TODO: What if a sectionRef loop is present?
   while (sectionDefinition && sectionDefinition["sling:resourceType"] == "sectionLink") {
@@ -68,15 +76,23 @@ let displaySection = (sectionDefinition, existingAnswer, key) => {
   const existingQuestionAnswer = existingAnswer && Object.entries(existingAnswer)
     .find(([key, value]) => value["sling:resourceType"] == "lfs/AnswerSection"
       && value["question"]["jcr:uuid"] === sectionDefinition["jcr:uuid"]);
-  return <Section key={key} sectionDefinition={sectionDefinition} existingAnswer={existingQuestionAnswer} />;
+  return (
+    <Section
+      key={key}
+      depth={depth}
+      sectionDefinition={sectionDefinition}
+      existingAnswer={existingQuestionAnswer}
+      path={path}
+      />
+  );
 }
 
-export default function FormEntry(questionDefinition, existingAnswers, key) {
+export default function FormEntry(questionDefinition, path, depth, existingAnswers, key) {
   // TODO: As before, I'm writing something that's basically an if statement
   // this should instead be via a componentManager
   if (questionDefinition["jcr:primaryType"] == "lfs:Question") {
-      return displayQuestion(questionDefinition, existingAnswers, key);
+      return displayQuestion(questionDefinition, path, existingAnswers, key);
   } else if (questionDefinition["jcr:primaryType"] == "lfs:Section") {
-      return displaySection(questionDefinition, existingAnswers, key);
+      return displaySection(questionDefinition, path, depth, existingAnswers, key);
   }
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -37,6 +37,7 @@ import VocabularyQuestion from "./VocabularyQuestion";
  * Method responsible for displaying a question from the questionnaire, along with its answer(s).
  *
  * @param {Object} questionDefinition the question definition JSON
+ * @param {Object} existingAnswer form data that may include answers already submitted for this component
  * @param {string} key the node name of the question definition JCR node
  * @returns a React component that renders the question
  */
@@ -54,6 +55,7 @@ let displayQuestion = (questionDefinition, existingAnswer, key) => {
  * TODO: Somehow pass the conditional state upwards from here
  *
  * @param {Object} sectionDefinition the section definition JSON
+ * @param {Object} existingAnswer form data that may include answers already submitted for this component
  * @param {string} key the node name of the section definition JCR node
  * @returns a React component that renders the section
  */

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -81,9 +81,6 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key) => {
   while (sectionDefinition && sectionDefinition["jcr:primaryType"] == "lfs:SectionLink") {
     sectionDefinition = sectionDefinition["ref"];
   }
-  const existingQuestionAnswer = existingAnswer && Object.entries(existingAnswer)
-    .find(([key, value]) => value["sling:resourceType"] == "lfs/AnswerSection"
-      && value["question"]["jcr:uuid"] === sectionDefinition["jcr:uuid"]);
 
   // Catch an invalid section
   if (!sectionDefinition || sectionDefinition["jcr:primaryType"] != "lfs:Section") {
@@ -91,6 +88,11 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key) => {
     console.log(sectionDefinition);
     return(<React.Fragment></React.Fragment>);
   }
+
+  // Find the existing AnswerSection for this section, if available
+  const existingQuestionAnswer = existingAnswer && Object.entries(existingAnswer)
+    .find(([key, value]) => value["sling:resourceType"] == "lfs/AnswerSection"
+      && value["question"]["jcr:uuid"] === sectionDefinition["jcr:uuid"]);
 
   return (
     <Section

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -33,6 +33,10 @@ import PedigreeQuestion from "./PedigreeQuestion";
 import TextQuestion from "./TextQuestion";
 import VocabularyQuestion from "./VocabularyQuestion";
 
+const QUESTION_TYPES = ["lfs:Question"];
+const SECTION_TYPES = ["lfs:Section", "lfs:SectionLink"];
+export const ENTRY_TYPES = QUESTION_TYPES.concat(SECTION_TYPES);
+
 /**
  * Method responsible for displaying a question from the questionnaire, along with its answer(s).
  *
@@ -90,9 +94,9 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key) => {
 export default function FormEntry(questionDefinition, path, depth, existingAnswers, key) {
   // TODO: As before, I'm writing something that's basically an if statement
   // this should instead be via a componentManager
-  if (questionDefinition["jcr:primaryType"] == "lfs:Question") {
+  if (QUESTION_TYPES.includes(questionDefinition["jcr:primaryType"])) {
       return displayQuestion(questionDefinition, path, existingAnswers, key);
-  } else if (questionDefinition["jcr:primaryType"] == "lfs:Section") {
+  } else if (SECTION_TYPES.includes(questionDefinition["jcr:primaryType"])) {
       return displaySection(questionDefinition, path, depth, existingAnswers, key);
   }
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -1,0 +1,80 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React from "react";
+
+import { Grid } from "@material-ui/core";
+
+import AnswerComponentManager from "./AnswerComponentManager";
+import Section from "./Section";
+
+// FIXME In order for the questions to be registered, they need to be loaded, and the only way to do that at the moment is to explicitly invoke them here. Find a way to automatically load all question types, possibly using self-declaration in a node, like the assets, or even by filtering through assets.
+
+import BooleanQuestion from "./BooleanQuestion";
+import DateQuestion from "./DateQuestion";
+import NumberQuestion from "./NumberQuestion";
+import PedigreeQuestion from "./PedigreeQuestion";
+import TextQuestion from "./TextQuestion";
+import VocabularyQuestion from "./VocabularyQuestion";
+
+/**
+ * Method responsible for displaying a question from the questionnaire, along with its answer(s).
+ *
+ * @param {Object} questionDefinition the question definition JSON
+ * @param {string} key the node name of the question definition JCR node
+ * @returns a React component that renders the question
+ */
+let displayQuestion = (questionDefinition, existingAnswer, key) => {
+  const existingQuestionAnswer = existingAnswer && Object.entries(existingAnswer)
+    .find(([key, value]) => value["sling:resourceSuperType"] == "lfs/Answer"
+      && value["question"]["jcr:uuid"] === questionDefinition["jcr:uuid"]);
+  // This variable must start with an upper case letter so that React treats it as a component
+  const QuestionDisplay = AnswerComponentManager.getAnswerComponent(questionDefinition);
+  return <Grid item key={key}><QuestionDisplay key={key} questionDefinition={questionDefinition} existingAnswer={existingQuestionAnswer} /></Grid>;
+};
+
+/**
+ * Method responsible for displaying a section from the questionnaire, along with its answer(s).
+ * TODO: Somehow pass the conditional state upwards from here
+ *
+ * @param {Object} sectionDefinition the section definition JSON
+ * @param {string} key the node name of the section definition JCR node
+ * @returns a React component that renders the section
+ */
+let displaySection = (sectionDefinition, existingAnswer, key) => {
+  // Parse through SectionLink nodes to find our Section node
+  // TODO: What if a sectionRef loop is present?
+  while (sectionDefinition && sectionDefinition["sling:resourceType"] == "sectionLink") {
+    sectionDefinition = sectionDefinition["ref"];
+  }
+  const existingQuestionAnswer = existingAnswer && Object.entries(existingAnswer)
+    .find(([key, value]) => value["sling:resourceType"] == "lfs/AnswerSection"
+      && value["question"]["jcr:uuid"] === sectionDefinition["jcr:uuid"]);
+  return <Section key={key} sectionDefinition={sectionDefinition} existingAnswer={existingQuestionAnswer} />;
+}
+
+export default function FormEntry(questionDefinition, existingAnswers, key) {
+  // TODO: As before, I'm writing something that's basically an if statement
+  // this should instead be via a componentManager
+  if (questionDefinition["jcr:primaryType"] == "lfs:Question") {
+      return displayQuestion(questionDefinition, existingAnswers, key);
+  } else if (questionDefinition["jcr:primaryType"] == "lfs:Section") {
+      return displaySection(questionDefinition, existingAnswers, key);
+  }
+}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -76,13 +76,22 @@ let displayQuestion = (questionDefinition, path, existingAnswer, key) => {
  */
 let displaySection = (sectionDefinition, path, depth, existingAnswer, key) => {
   // Parse through SectionLink nodes to find our Section node
-  // TODO: What if a sectionRef loop is present?
-  while (sectionDefinition && sectionDefinition["sling:resourceType"] == "sectionLink") {
+  // We expect sectionDefinition to have been passed from the Resource to JSON adapter factory,
+  // which prevents infinite loops
+  while (sectionDefinition && sectionDefinition["jcr:primaryType"] == "lfs:SectionLink") {
     sectionDefinition = sectionDefinition["ref"];
   }
   const existingQuestionAnswer = existingAnswer && Object.entries(existingAnswer)
     .find(([key, value]) => value["sling:resourceType"] == "lfs/AnswerSection"
       && value["question"]["jcr:uuid"] === sectionDefinition["jcr:uuid"]);
+
+  // Catch an invalid section
+  if (!sectionDefinition || sectionDefinition["jcr:primaryType"] != "lfs:Section") {
+    console.log("Error: an invalid section was passed to displaySection:");
+    console.log(sectionDefinition);
+    return(<React.Fragment></React.Fragment>);
+  }
+
   return (
     <Section
       key={key}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -96,7 +96,7 @@ const questionnaireStyle = theme => ({
         marginLeft: "-50%",
         marginTop: "-50%"
     },
-    paddedSection: {
+    labeledSection: {
         marginTop: theme.spacing(2),
         // Select only questions that occur immediately after padded sections,
         // and add a large margin before them

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -110,4 +110,14 @@ const questionnaireStyle = theme => ({
     }
 });
 
+
+// Props used in grid containers for displaying Form entries
+export const CONTAINER_PROPS = {
+    direction: "column",
+    spacing: 4,
+    alignItems: "stretch",
+    justify: "space-between",
+    wrap: "nowrap"
+  };
+
 export default questionnaireStyle;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -95,6 +95,18 @@ const questionnaireStyle = theme => ({
         left: '50%',
         marginLeft: "-50%",
         marginTop: "-50%"
+    },
+    paddedSection: {
+        marginTop: theme.spacing(2),
+        // Select only questions that occur immediately after padded sections,
+        // and add a large margin before them
+        "& +.questionContainer": {
+            marginTop: theme.spacing(4),
+        }
+    },
+    sectionHeader: {
+        paddingBottom: "0 !important",
+        marginBottom: theme.spacing(-1)
     }
 });
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -112,7 +112,7 @@ const questionnaireStyle = theme => ({
 
 
 // Props used in grid containers for displaying Form entries
-export const CONTAINER_PROPS = {
+export const FORM_ENTRY_CONTAINER_PROPS = {
     direction: "column",
     spacing: 4,
     alignItems: "stretch",

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -25,6 +25,20 @@ import uuidv4 from "uuid/v4";
 import FormEntry, { ENTRY_TYPES } from "./FormEntry";
 import QuestionnaireStyle from "./QuestionnaireStyle";
 
+
+// Props used in Section grid containers
+export const CONTAINER_PROPS = {
+  direction: "column",
+  spacing: 4,
+  alignItems: "stretch",
+  justify: "space-between",
+  wrap: "nowrap"
+};
+
+// The heading levels that @material-ui supports
+const MAX_HEADING_LEVEL = 6;
+const MIN_HEADING_LEVEL = 3;
+
 /**
  * Component that consists of a few sections, and optionally has some criteria to its display
  *
@@ -40,7 +54,7 @@ function Section(props) {
   const { classes, depth, existingAnswer, path, sectionDefinition } = props;
   const [sectionID] = useState((existingAnswer && existingAnswer[0]) || uuidv4());
   const sectionPath = path + "/" + sectionID;
-  const headerVariant = (depth > 3 ? "body1" : ("h" + (depth+3)));
+  const headerVariant = (depth > MAX_HEADING_LEVEL - MIN_HEADING_LEVEL ? "body1" : ("h" + (depth+MIN_HEADING_LEVEL)));
 
   const titleEl = sectionDefinition["label"] && <Typography variant={headerVariant}>{sectionDefinition["label"]} </Typography>;
   const descEl = sectionDefinition["description"] && <Typography variant="overline">{sectionDefinition["description"]} </Typography>
@@ -52,7 +66,7 @@ function Section(props) {
       <input type="hidden" name={`${sectionPath}/question`} value={sectionDefinition['jcr:uuid']}></input>
       <input type="hidden" name={`${sectionPath}/question@TypeHint`} value="Reference"></input>
 
-      <Grid container direction="column" spacing={4} alignItems="stretch" justify="space-between" wrap="nowrap">
+      <Grid container {...CONTAINER_PROPS}>
         {hasPadding &&
           <Grid item className={classes.sectionHeader}>
             {titleEl}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -17,8 +17,9 @@
 //  under the License.
 //
 
-import React from "react";
-import { Grid, Typography } from "@material-ui/core";
+import React, { useState } from "react";
+import { Grid, Typography, withStyles } from "@material-ui/core";
+import uuidv4 from "uuid/v4";
 
 import FormEntry from "./FormEntry";
 import QuestionnaireStyle from "./QuestionnaireStyle";
@@ -26,6 +27,8 @@ import QuestionnaireStyle from "./QuestionnaireStyle";
 /// Component that consists of a few sections, and optionally has some criteria to its display
 function Section(props) {
   const { classes, depth, existingAnswer, path, sectionDefinition } = props;
+  const [sectionID] = useState((existingAnswer && existingAnswer[0]) || uuidv4());
+  const sectionPath = path + "/" + sectionID;
   const headerVariant = (depth > 3 ? "body1" : ("h" + (depth+3)));
 
   const titleEl = sectionDefinition["label"] && <Typography variant={headerVariant}>{sectionDefinition["label"]} </Typography>;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -1,0 +1,91 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React, { useState } from "react";
+import { Grid, withStyles } from "@material-ui/core";
+
+import AnswerComponentManager from "./AnswerComponentManager";
+import QuestionnaireStyle from "./QuestionnaireStyle";
+
+/// Component that consists of a few sections, and optionally has some criteria to its display
+function Section(props) {
+  const { classes, existingAnswer, sectionDefinition } = props;
+  const [ error, setError ] = useState();
+
+  // I need to move the AnswerComponentManager renderer outside of Form so it can be accessed here instead of this
+
+  /**
+   * Method responsible for displaying a question from the questionnaire, along with its answer(s).
+   *
+   * @param {Object} questionDefinition the question definition JSON
+   * @param {string} key the node name of the question definition JCR node
+   * @returns a React component that renders the question
+   */
+  let displayQuestion = (questionDefinition, key) => {
+    const existingQuestionAnswer = existingAnswer && Object.entries(existingAnswer)
+      .find(([key, value]) => value["sling:resourceSuperType"] == "lfs/Answer"
+        && value["question"]["jcr:uuid"] === questionDefinition["jcr:uuid"]);
+    // This variable must start with an upper case letter so that React treats it as a component
+    const QuestionDisplay = AnswerComponentManager.getAnswerComponent(questionDefinition);
+    return <QuestionDisplay key={key} questionDefinition={questionDefinition} existingAnswer={existingQuestionAnswer} />;
+  };
+
+  /**
+   * Method responsible for displaying a section from the questionnaire, along with its answer(s).
+   * TODO: Somehow pass the conditional state upwards from here
+   *
+   * @param {Object} sectionDefinition the section definition JSON
+   * @param {string} key the node name of the section definition JCR node
+   * @returns a React component that renders the section
+   */
+  let displaySection = (sectionDefinition, key) => {
+    // Parse through SectionLink nodes to find our Section node
+    // TODO: What if a sectionRef loop is present?
+    while (sectionDefinition && sectionDefinition["sling:resourceType"] == "sectionLink") {
+      sectionDefinition = sectionDefinition["ref"];
+    }
+    const existingQuestionAnswer = existingAnswer && Object.entries(existingAnswer)
+      .find(([key, value]) => value["sling:resourceType"] == "lfs/AnswerSection"
+        && value["question"]["jcr:uuid"] === sectionDefinition["jcr:uuid"]);
+    return <Section key={key} sectionDefinition={sectionDefinition} existingAnswer={existingQuestionAnswer} />;
+  }
+
+  // TODO: As before, I'm writing something that's basically an if statement
+  // this should instead be via a componentManager
+  // This code is likely reuseable for the Section component as well
+  let display = (definition, key) => {
+    if (definition["jcr:primaryType"] == "lfs:Question") {
+      return displayQuestion(definition, key);
+    } else if (definition["jcr:primaryType"] == "lfs:Section") {
+      return displaySection(definition, key);
+    }
+  }
+
+  return (
+    <React.Fragment>
+    {
+      Object.entries(sectionDefinition)
+        .filter(([key, value]) => value['jcr:primaryType'] == 'lfs:Question' || value['jcr:primaryType'] == 'lfs:Section')
+        .map(([key, definition]) => <Grid item key={key}>{display(definition, key)}</Grid>)
+    }
+    </React.Fragment>
+  );
+}
+
+export default withStyles(QuestionnaireStyle)(Section);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -17,75 +17,23 @@
 //  under the License.
 //
 
-import React, { useState } from "react";
-import { Grid, withStyles } from "@material-ui/core";
+import React from "react";
 
-import AnswerComponentManager from "./AnswerComponentManager";
-import QuestionnaireStyle from "./QuestionnaireStyle";
+import FormEntry from "./FormEntry";
 
 /// Component that consists of a few sections, and optionally has some criteria to its display
 function Section(props) {
-  const { classes, existingAnswer, sectionDefinition } = props;
-  const [ error, setError ] = useState();
-
-  // I need to move the AnswerComponentManager renderer outside of Form so it can be accessed here instead of this
-
-  /**
-   * Method responsible for displaying a question from the questionnaire, along with its answer(s).
-   *
-   * @param {Object} questionDefinition the question definition JSON
-   * @param {string} key the node name of the question definition JCR node
-   * @returns a React component that renders the question
-   */
-  let displayQuestion = (questionDefinition, key) => {
-    const existingQuestionAnswer = existingAnswer && Object.entries(existingAnswer)
-      .find(([key, value]) => value["sling:resourceSuperType"] == "lfs/Answer"
-        && value["question"]["jcr:uuid"] === questionDefinition["jcr:uuid"]);
-    // This variable must start with an upper case letter so that React treats it as a component
-    const QuestionDisplay = AnswerComponentManager.getAnswerComponent(questionDefinition);
-    return <QuestionDisplay key={key} questionDefinition={questionDefinition} existingAnswer={existingQuestionAnswer} />;
-  };
-
-  /**
-   * Method responsible for displaying a section from the questionnaire, along with its answer(s).
-   * TODO: Somehow pass the conditional state upwards from here
-   *
-   * @param {Object} sectionDefinition the section definition JSON
-   * @param {string} key the node name of the section definition JCR node
-   * @returns a React component that renders the section
-   */
-  let displaySection = (sectionDefinition, key) => {
-    // Parse through SectionLink nodes to find our Section node
-    // TODO: What if a sectionRef loop is present?
-    while (sectionDefinition && sectionDefinition["sling:resourceType"] == "sectionLink") {
-      sectionDefinition = sectionDefinition["ref"];
-    }
-    const existingQuestionAnswer = existingAnswer && Object.entries(existingAnswer)
-      .find(([key, value]) => value["sling:resourceType"] == "lfs/AnswerSection"
-        && value["question"]["jcr:uuid"] === sectionDefinition["jcr:uuid"]);
-    return <Section key={key} sectionDefinition={sectionDefinition} existingAnswer={existingQuestionAnswer} />;
-  }
-
-  // TODO: As before, I'm writing something that's basically an if statement
-  // this should instead be via a componentManager
-  // This code is likely reuseable for the Section component as well
-  let display = (definition, key) => {
-    if (definition["jcr:primaryType"] == "lfs:Question") {
-      return displayQuestion(definition, key);
-    } else if (definition["jcr:primaryType"] == "lfs:Section") {
-      return displaySection(definition, key);
-    }
-  }
+  const { existingAnswer, sectionDefinition } = props;
 
   return (
     <React.Fragment>
     {
       Object.entries(sectionDefinition)
         .filter(([key, value]) => value['jcr:primaryType'] == 'lfs:Question' || value['jcr:primaryType'] == 'lfs:Section')
-        .map(([key, definition]) => <Grid item key={key}>{display(definition, key)}</Grid>)
+        .map(([key, definition]) => FormEntry(definition, existingAnswer, key))
     }
     </React.Fragment>
   );
 }
 
-export default withStyles(QuestionnaireStyle)(Section);
+export default Section;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -57,7 +57,7 @@ function Section(props) {
   const headerVariant = (depth > MAX_HEADING_LEVEL - MIN_HEADING_LEVEL ? "body1" : ("h" + (depth+MIN_HEADING_LEVEL)));
 
   const titleEl = sectionDefinition["label"] && <Typography variant={headerVariant}>{sectionDefinition["label"]} </Typography>;
-  const descEl = sectionDefinition["description"] && <Typography variant="overline">{sectionDefinition["description"]} </Typography>
+  const descEl = sectionDefinition["description"] && <Typography variant="caption" color="textSecondary">{sectionDefinition["description"]} </Typography>
   const hasPadding = titleEl || descEl;
 
   return (

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -23,7 +23,7 @@ import { Grid, Typography, withStyles } from "@material-ui/core";
 import uuidv4 from "uuid/v4";
 
 import FormEntry, { ENTRY_TYPES } from "./FormEntry";
-import QuestionnaireStyle, { CONTAINER_PROPS } from "./QuestionnaireStyle";
+import QuestionnaireStyle, { FORM_ENTRY_CONTAINER_PROPS } from "./QuestionnaireStyle";
 
 // The heading levels that @material-ui supports
 const MAX_HEADING_LEVEL = 6;
@@ -56,7 +56,7 @@ function Section(props) {
       <input type="hidden" name={`${sectionPath}/question`} value={sectionDefinition['jcr:uuid']}></input>
       <input type="hidden" name={`${sectionPath}/question@TypeHint`} value="Reference"></input>
 
-      <Grid container {...CONTAINER_PROPS}>
+      <Grid container {...FORM_ENTRY_CONTAINER_PROPS}>
         {hasPadding &&
           <Grid item className={classes.sectionHeader}>
             {titleEl}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -23,17 +23,7 @@ import { Grid, Typography, withStyles } from "@material-ui/core";
 import uuidv4 from "uuid/v4";
 
 import FormEntry, { ENTRY_TYPES } from "./FormEntry";
-import QuestionnaireStyle from "./QuestionnaireStyle";
-
-
-// Props used in Section grid containers
-export const CONTAINER_PROPS = {
-  direction: "column",
-  spacing: 4,
-  alignItems: "stretch",
-  justify: "space-between",
-  wrap: "nowrap"
-};
+import QuestionnaireStyle, { CONTAINER_PROPS } from "./QuestionnaireStyle";
 
 // The heading levels that @material-ui supports
 const MAX_HEADING_LEVEL = 6;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -21,28 +21,37 @@ import React from "react";
 import { Grid, Typography } from "@material-ui/core";
 
 import FormEntry from "./FormEntry";
+import QuestionnaireStyle from "./QuestionnaireStyle";
 
 /// Component that consists of a few sections, and optionally has some criteria to its display
 function Section(props) {
-  const { existingAnswer, sectionDefinition } = props;
+  const { classes, depth, existingAnswer, path, sectionDefinition } = props;
+  const headerVariant = (depth > 3 ? "body1" : ("h" + (depth+3)));
 
-  const titleEl = sectionDefinition["label"] && <Typography variant="h3">{sectionDefinition["label"]} </Typography>;
+  const titleEl = sectionDefinition["label"] && <Typography variant={headerVariant}>{sectionDefinition["label"]} </Typography>;
   const descEl = sectionDefinition["description"] && <Typography variant="overline">{sectionDefinition["description"]} </Typography>
+  const hasPadding = titleEl || descEl;
 
   return (
-    <React.Fragment>
-      {(titleEl || descEl) &&
-        <Grid item>
-          {titleEl}
-          {descEl}
-        </Grid>
-      }
-      {Object.entries(sectionDefinition)
-        .filter(([key, value]) => value['jcr:primaryType'] == 'lfs:Question' || value['jcr:primaryType'] == 'lfs:Section')
-        .map(([key, definition]) => FormEntry(definition, existingAnswer, key))
-      }
-    </React.Fragment>
+    <Grid item className={hasPadding && classes.paddedSection}>
+      <input type="hidden" name={`${sectionPath}/jcr:primaryType`} value={"lfs:AnswerSection"}></input>
+      <input type="hidden" name={`${sectionPath}/question`} value={sectionDefinition['jcr:uuid']}></input>
+      <input type="hidden" name={`${sectionPath}/question@TypeHint`} value="Reference"></input>
+
+      <Grid container direction="column" spacing={4} alignItems="stretch" justify="space-between" wrap="nowrap">
+        {hasPadding &&
+          <Grid item className={classes.sectionHeader}>
+            {titleEl}
+            {descEl}
+          </Grid>
+        }
+        {Object.entries(sectionDefinition)
+          .filter(([key, value]) => value['jcr:primaryType'] == 'lfs:Question' || value['jcr:primaryType'] == 'lfs:Section')
+          .map(([key, definition]) => FormEntry(definition, sectionPath, depth+1, existingAnswer && existingAnswer[1], key))
+        }
+      </Grid>
+    </Grid>
   );
 }
 
-export default Section;
+export default withStyles(QuestionnaireStyle)(Section);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -18,13 +18,24 @@
 //
 
 import React, { useState } from "react";
+import PropTypes from "prop-types";
 import { Grid, Typography, withStyles } from "@material-ui/core";
 import uuidv4 from "uuid/v4";
 
 import FormEntry, { ENTRY_TYPES } from "./FormEntry";
 import QuestionnaireStyle from "./QuestionnaireStyle";
 
-/// Component that consists of a few sections, and optionally has some criteria to its display
+/**
+ * Component that consists of a few sections, and optionally has some criteria to its display
+ *
+ * @example
+ * <Section depth={1} path="." sectionDefinition={{label: "Section"}} />
+ *
+ * @param {int} depth the section nesting depth
+ * @param {Object} existingAnswer form data that may include answers already submitted for this component
+ * @param {string} path the path to the parent of the question
+ * @param {Object} sectionDefinition the section definition JSON
+ */
 function Section(props) {
   const { classes, depth, existingAnswer, path, sectionDefinition } = props;
   const [sectionID] = useState((existingAnswer && existingAnswer[0]) || uuidv4());
@@ -55,6 +66,17 @@ function Section(props) {
       </Grid>
     </Grid>
   );
+}
+
+Section.propTypes = {
+  classes: PropTypes.object.isRequired,
+  depth: PropTypes.number.isRequired,
+  existingAnswer: PropTypes.object,
+  path: PropTypes.string.isRequired,
+  sectionDefinition: PropTypes.shape({
+    label: PropTypes.string,
+    description: PropTypes.string,
+  }).isRequired,
 }
 
 export default withStyles(QuestionnaireStyle)(Section);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -18,6 +18,7 @@
 //
 
 import React from "react";
+import { Grid, Typography } from "@material-ui/core";
 
 import FormEntry from "./FormEntry";
 
@@ -25,13 +26,21 @@ import FormEntry from "./FormEntry";
 function Section(props) {
   const { existingAnswer, sectionDefinition } = props;
 
+  const titleEl = sectionDefinition["label"] && <Typography variant="h3">{sectionDefinition["label"]} </Typography>;
+  const descEl = sectionDefinition["description"] && <Typography variant="overline">{sectionDefinition["description"]} </Typography>
+
   return (
     <React.Fragment>
-    {
-      Object.entries(sectionDefinition)
+      {(titleEl || descEl) &&
+        <Grid item>
+          {titleEl}
+          {descEl}
+        </Grid>
+      }
+      {Object.entries(sectionDefinition)
         .filter(([key, value]) => value['jcr:primaryType'] == 'lfs:Question' || value['jcr:primaryType'] == 'lfs:Section')
         .map(([key, definition]) => FormEntry(definition, existingAnswer, key))
-    }
+      }
     </React.Fragment>
   );
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -30,7 +30,8 @@ const MAX_HEADING_LEVEL = 6;
 const MIN_HEADING_LEVEL = 3;
 
 /**
- * Component that consists of a few sections, and optionally has some criteria to its display
+ * Component responsible for displaying a (sub)section of a questionnaire, consisting of a title, a description,
+ * a list of questions and/or subsections, and may have some conditions to its display.
  *
  * @example
  * <Section depth={1} path="." sectionDefinition={{label: "Section"}} />
@@ -48,16 +49,16 @@ function Section(props) {
 
   const titleEl = sectionDefinition["label"] && <Typography variant={headerVariant}>{sectionDefinition["label"]} </Typography>;
   const descEl = sectionDefinition["description"] && <Typography variant="caption" color="textSecondary">{sectionDefinition["description"]} </Typography>
-  const hasPadding = titleEl || descEl;
+  const hasHeader = titleEl || descEl;
 
   return (
-    <Grid item className={hasPadding && classes.paddedSection}>
+    <Grid item className={hasHeader && classes.labeledSection}>
       <input type="hidden" name={`${sectionPath}/jcr:primaryType`} value={"lfs:AnswerSection"}></input>
-      <input type="hidden" name={`${sectionPath}/question`} value={sectionDefinition['jcr:uuid']}></input>
-      <input type="hidden" name={`${sectionPath}/question@TypeHint`} value="Reference"></input>
+      <input type="hidden" name={`${sectionPath}/section`} value={sectionDefinition['jcr:uuid']}></input>
+      <input type="hidden" name={`${sectionPath}/section@TypeHint`} value="Reference"></input>
 
       <Grid container {...FORM_ENTRY_CONTAINER_PROPS}>
-        {hasPadding &&
+        {hasHeader &&
           <Grid item className={classes.sectionHeader}>
             {titleEl}
             {descEl}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -76,7 +76,7 @@ function Section(props) {
 Section.propTypes = {
   classes: PropTypes.object.isRequired,
   depth: PropTypes.number.isRequired,
-  existingAnswer: PropTypes.object,
+  existingAnswer: PropTypes.array,
   path: PropTypes.string.isRequired,
   sectionDefinition: PropTypes.shape({
     label: PropTypes.string,

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -21,7 +21,7 @@ import React, { useState } from "react";
 import { Grid, Typography, withStyles } from "@material-ui/core";
 import uuidv4 from "uuid/v4";
 
-import FormEntry from "./FormEntry";
+import FormEntry, { ENTRY_TYPES } from "./FormEntry";
 import QuestionnaireStyle from "./QuestionnaireStyle";
 
 /// Component that consists of a few sections, and optionally has some criteria to its display
@@ -49,7 +49,7 @@ function Section(props) {
           </Grid>
         }
         {Object.entries(sectionDefinition)
-          .filter(([key, value]) => value['jcr:primaryType'] == 'lfs:Question' || value['jcr:primaryType'] == 'lfs:Section')
+          .filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType']))
           .map(([key, definition]) => FormEntry(definition, sectionPath, depth+1, existingAnswer && existingAnswer[1], key))
         }
       </Grid>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -29,7 +29,7 @@ import {
 
 import LiveTable from "../dataHomepage/LiveTable.jsx";
 
-import QuestionnaireStyle, { CONTAINER_PROPS } from "./QuestionnaireStyle";
+import QuestionnaireStyle from "./QuestionnaireStyle";
 
 /**
  * Component that displays a Subject.
@@ -120,7 +120,7 @@ function Subject (props) {
 
   return (
     <div>
-      <Grid container {...CONTAINER_PROPS} >
+      <Grid container direction="column" spacing={4} alignItems="stretch" justify="space-between" wrap="nowrap">
         <Grid item>
           {
             data && data.identifier ?
@@ -145,9 +145,5 @@ function Subject (props) {
     </div>
   );
 };
-
-Subject.PropTypes = {
-  id: PropTypes.string
-}
 
 export default withStyles(QuestionnaireStyle)(Subject);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -29,7 +29,7 @@ import {
 
 import LiveTable from "../dataHomepage/LiveTable.jsx";
 
-import QuestionnaireStyle from "./QuestionnaireStyle";
+import QuestionnaireStyle, { CONTAINER_PROPS } from "./QuestionnaireStyle";
 
 /**
  * Component that displays a Subject.
@@ -120,7 +120,7 @@ function Subject (props) {
 
   return (
     <div>
-      <Grid container direction="column" spacing={4} alignItems="stretch" justify="space-between" wrap="nowrap">
+      <Grid container {...CONTAINER_PROPS} >
         <Grid item>
           {
             data && data.identifier ?
@@ -145,5 +145,9 @@ function Subject (props) {
     </div>
   );
 };
+
+Subject.PropTypes = {
+  id: PropTypes.string
+}
 
 export default withStyles(QuestionnaireStyle)(Subject);

--- a/modules/data-entry/src/main/frontend/src/vocabSelector/select.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabSelector/select.jsx
@@ -295,6 +295,7 @@ function VocabularySelector(props) {
         answerNodeType={'lfs:VocabularyAnswer'}
         questionDefinition={questionDefinition}
         existingAnswer={existingAnswer}
+        {...rest}
       />
     </React.Fragment>
   );

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -260,6 +260,30 @@
   + * (lfs:Question, lfs:Section) = lfs:Question
 
 //-----------------------------------------------------------------------------
+// A section link is a reference to another link that should be inserted here.
+[lfs:SectionLink] > sling:Resource, mix:referenceable
+  // Attributes
+
+  // The list of subsections and questions is orderable.
+  orderable
+  // We can use section links in a query.
+  query
+  // The main sub-item of a section is its reference.
+  primaryitem ref
+
+  // Properties
+
+  // Hardcode the resource type.
+  - sling:resourceType (STRING) = "lfs/SectionLink" mandatory autocreated protected
+
+  // Hardcode the resource supertype: each section link is a resource.
+  - sling:resourceSuperType (STRING) = "lfs/Resource" mandatory autocreated protected
+
+  // An optional reference to another section node, if this node is merely a link to
+  // a section in another questionnaire
+  - ref (reference) mandatory
+
+//-----------------------------------------------------------------------------
 // A questionnaire is a collection of sections and questions.
 [lfs:Questionnaire] > sling:Folder, mix:referenceable, mix:versionable
   // Attributes
@@ -457,6 +481,21 @@
 
   // Hardcode the resource supertype.
   - sling:resourceSuperType (STRING) = "lfs/Answer" mandatory autocreated protected
+
+//-----------------------------------------------------------------------------
+// Section object, which can contain multiple other answers. The "question" element here
+// can be multiple
+[lfs:AnswerSection] > lfs:Answer
+  // Hardcode the resource type.
+  - sling:resourceType (STRING) = "lfs/AnswerSection" mandatory autocreated protected
+
+  // Hardcode the resource supertype.
+  - sling:resourceSuperType (STRING) = "lfs/Answer" mandatory autocreated protected
+
+  // Children
+
+  // The answers recorded in this section.
+  + * (lfs:Answer) = lfs:Answer
 
 //-----------------------------------------------------------------------------
 // Forms: a filled in questionnaire.

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -260,30 +260,6 @@
   + * (lfs:Question, lfs:Section) = lfs:Question
 
 //-----------------------------------------------------------------------------
-// A section link is a reference to another section (e.g. in another Questionnaire)
-// that should be inserted here.
-[lfs:SectionLink] > sling:Resource, mix:referenceable
-  // Attributes
-
-  // The list of subsections and questions is orderable.
-  orderable
-  // We can use section links in a query.
-  query
-  // The main sub-item of a section is its reference.
-  primaryitem ref
-
-  // Properties
-
-  // Hardcode the resource type.
-  - sling:resourceType (STRING) = "lfs/SectionLink" mandatory autocreated protected
-
-  // Hardcode the resource supertype: each section link is a resource.
-  - sling:resourceSuperType (STRING) = "lfs/Resource" mandatory autocreated protected
-
-  // A reference to another section node
-  - ref (path) mandatory
-
-//-----------------------------------------------------------------------------
 // A questionnaire is a collection of sections and questions.
 [lfs:Questionnaire] > sling:Folder, mix:referenceable, mix:versionable
   // Attributes

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -260,7 +260,8 @@
   + * (lfs:Question, lfs:Section) = lfs:Question
 
 //-----------------------------------------------------------------------------
-// A section link is a reference to another link that should be inserted here.
+// A section link is a reference to another section (e.g. in another Questionnaire)
+// that should be inserted here.
 [lfs:SectionLink] > sling:Resource, mix:referenceable
   // Attributes
 
@@ -484,7 +485,7 @@
 
 //-----------------------------------------------------------------------------
 // Section object, which can contain multiple other answers. The "question" element here
-// can be multiple
+// should be the section we're answering
 [lfs:AnswerSection] > lfs:Answer
   // Hardcode the resource type.
   - sling:resourceType (STRING) = "lfs/AnswerSection" mandatory autocreated protected

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -280,9 +280,8 @@
   // Hardcode the resource supertype: each section link is a resource.
   - sling:resourceSuperType (STRING) = "lfs/Resource" mandatory autocreated protected
 
-  // An optional reference to another section node, if this node is merely a link to
-  // a section in another questionnaire
-  - ref (reference) mandatory
+  // A reference to another section node
+  - ref (path) mandatory
 
 //-----------------------------------------------------------------------------
 // A questionnaire is a collection of sections and questions.

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -485,17 +485,35 @@
 //-----------------------------------------------------------------------------
 // Section object, which can contain multiple other answers. The "question" element here
 // should be the section we're answering
-[lfs:AnswerSection] > lfs:Answer
+[lfs:AnswerSection] > sling:Folder
+  // Attributes
+  // The child answers will need to be orderable.
+  orderable
+
+  // We can use answer sections in a query.
+  query
+
+  // The main sub-item of an answer is its section link.
+  primaryitem section
+
   // Hardcode the resource type.
   - sling:resourceType (STRING) = "lfs/AnswerSection" mandatory autocreated protected
 
   // Hardcode the resource supertype.
-  - sling:resourceSuperType (STRING) = "lfs/Answer" mandatory autocreated protected
+  - sling:resourceSuperType (STRING) = "lfs/Resource" mandatory autocreated protected
+
+  // A reference to the section being answered.
+  // Mandatory, every answer section is answering a section.
+  // No full text search, since it's just a non-textual reference.
+  - section (reference) mandatory nofulltext
+
+  // An optional additional identifier for the section being answered, in case of repeatable sections.
+  - sectionInstanceLabel (string)
 
   // Children
 
-  // The answers recorded in this section.
-  + * (lfs:Answer) = lfs:Answer
+  // The answers and other answersections recorded in this section.
+  + * (lfs:Answer, lfs:AnswerSection) = lfs:Answer
 
 //-----------------------------------------------------------------------------
 // Forms: a filled in questionnaire.
@@ -526,8 +544,8 @@
 
   // Children
 
-  // The answers recorded in this form.
-  + * (lfs:Answer)
+  // The answers and answer sections recorded in this form.
+  + * (lfs:Answer, lfs:AnswerSection) = lfs:Answer
 
 //-----------------------------------------------------------------------------
 // The homepage for the Forms space.


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/LFS-241)
**Testing branch**: `LFS-241-test`. Use the Demographics form there for an example of a deeply nested section and a section link.

This branch allows you to define "sections", where questions can be grouped (in later PRs, they will be able to be repeated & conditionally inserted).

New NodeTypes: 
- `lfs:SectionLink`, which defines a link to a section (useful if you wish to repeat a set of questions from a different questionnaire)
- `lfs:AnswerSection`, which groups together answers (useful later, when we need to repeat a section n times and want to keep the answers in a sane order).