### PR TITLE
LFS-237: Setup the LFS container to support clustering

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,30 @@ To enable developer mode, also add `--env DEV=true -p 5005:5005` to the `docker 
 
 To enable debug mode, also add `--env DEBUG=true` to the `docker run` command. Note that the application will not start until a debugger is actually attached to the process on port 5005.
 
-`docker run -d -p 8080:8080 -p 5005:5005 --env DEV=true --env DEBUG=true --name lfs-debug lfs/lfs`
+`docker run --network lfsbridge -d -p 8080:8080 -p 5005:5005 --env DEV=true --env DEBUG=true --name lfs-debug lfs/lfs`
+
+### Running a Docker Cluster of Multiple LFS Instances
+
+Similar to the *Running with Docker* example, before the LFS Docker
+container can be started, an isolated network providing MongoDB must be
+established. To do so:
+
+```bash
+docker network create lfsbridge
+docker run --rm --network lfsbridge --name mongo -d mongo
+```
+
+Now, start the initial LFS Docker container:
+
+```bash
+docker run --rm --network lfsbridge -d -p 8080:8080 -e INITIAL_SLING_NODE=true lfs/lfs
+```
+
+Start all subsequent LFS containers:
+
+```bash
+docker run --rm --network lfsbridge -d -p 8081:8080 lfs/lfs
+docker run --rm --network lfsbridge -d -p 8082:8080 lfs/lfs
+docker run --rm --network lfsbridge -d -p 8083:8080 lfs/lfs
+...
+```

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ To specify a different URL, use `-Dsling.url=https://lfs.server:8443/system/cons
 `mvn install -PintegrationTests` to run integration tests
 
 ## Run:
-`java -jar distribution/target/lfs-*.jar` => the app will run at `http://localhost:8080` (default port)
+`java -jar distribution/target/lfs-*.jar -Dsling.run.modes=initial_sling_node` => the app will run at `http://localhost:8080` (default port)
 
-`java -jar distribution/target/lfs-*.jar -p PORT` to run at a different port
+`java -jar distribution/target/lfs-*.jar -p PORT -Dsling.run.modes=initial_sling_node` to run at a different port
 
-`java -jar distribution/target/lfs-*.jar -Dsling.run.modes=dev` to include the content browser (Composum), accessible at `http://localhost:8080/bin/browser.html`
+`java -jar distribution/target/lfs-*.jar -Dsling.run.modes=initial_sling_node,dev` to include the content browser (Composum), accessible at `http://localhost:8080/bin/browser.html`
 
 ## Running with Docker
 If Docker is installed, then the build will also create a new image named `lfs/lfs:latest`. You can run this image (for testing) with:

--- a/distribution/Dockerfile
+++ b/distribution/Dockerfile
@@ -41,4 +41,4 @@ EXPOSE 8080
 EXPOSE 5005
 
 # This is the default command executed when starting the container
-ENTRYPOINT java ${DEBUG:+ -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005} -jar ${project.artifactId}-${project.version}.jar ${DEV:+-Dsling.run.modes=dev}
+ENTRYPOINT java -Dsling.run.modes=${INITIAL_SLING_NODE:+initial_sling_node,}oak_mongo${DEV:+,dev} ${DEBUG:+ -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005} -jar ${project.artifactId}-${project.version}.jar

--- a/modules/ldap-support/src/main/provisioning/25-external-authentication.txt
+++ b/modules/ldap-support/src/main/provisioning/25-external-authentication.txt
@@ -30,7 +30,7 @@
     org.apache.jackrabbit/oak-auth-external/${oak.version}
 
 # Configuration for authentication and authorization
-[configurations]
+[configurations runModes=initial_sling_node]
   # ExternalLoginModuleFactory will be automatically picked up by JAAS
   # This configures the ExternalLoginModule created by the factory
   org.apache.jackrabbit.oak.spi.security.authentication.external.impl.ExternalLoginModuleFactory

--- a/modules/ldap-support/src/main/provisioning/60-ldap-connection.txt
+++ b/modules/ldap-support/src/main/provisioning/60-ldap-connection.txt
@@ -31,7 +31,7 @@
 
 # The actual configuration for the LDAP connection.
 # See the README file in this module for details about editing the configuration.
-[configurations]
+[configurations runModes=initial_sling_node]
   org.apache.jackrabbit.oak.security.authentication.ldap.impl.LdapIdentityProvider
     bind.dn="${lfs.ldap.dn}"
     bind.password="${lfs.ldap.password}"

--- a/modules/login/src/main/provisioning/model.txt
+++ b/modules/login/src/main/provisioning/model.txt
@@ -28,6 +28,6 @@
     end
 
 #This configures the default login page for the sling form based authentication handler
-[configurations]
+[configurations runModes=initial_sling_node]
     org.apache.sling.auth.form.FormAuthenticationHandler
         form.login.form="/login"


### PR DESCRIPTION
Make `[configurations]` sections conditional upon the `runMode` so that we can launch one instance with `INITIAL_SLING_NODE` set to `true` and the others without this environment variable so that we may have multiple instances of LFS (Sling) with the same MongoDB backend (and thus the same clinical data) so as to improve scalability