### PR TITLE
LFS-242: As an administrator, I can configure sections/questions within a questionnaire to be displayed conditionally based on the answers provided by the user to previous questions within that questionnaire

### DIFF
--- a/modules/data-entry/src/main/frontend/package.json
+++ b/modules/data-entry/src/main/frontend/package.json
@@ -15,14 +15,14 @@
       "@babel/preset-react"
     ],
     "plugins": [
-      [
-        "@babel/plugin-proposal-class-properties"
-      ]
+      "@babel/plugin-proposal-class-properties",
+      "@babel/plugin-proposal-optional-chaining"
     ]
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",
     "@babel/plugin-proposal-class-properties": "^7.4.4",
+    "@babel/plugin-proposal-optional-chaining": "^7.8.3",
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
     "babel-loader": "^8.0.6",

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -17,9 +17,11 @@
 //  under the License.
 //
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import uuidv4 from "uuid/v4";
+
+import { useFormWriterContext } from "./FormContext";
 
 export const LABEL_POS = 0;
 export const VALUE_POS = 1;
@@ -27,9 +29,18 @@ export const VALUE_POS = 1;
 // Holds answers and automatically generates hidden inputs
 // for form submission
 function Answer (props) {
-  let { answers, answerNodeType, existingAnswer, path, questionDefinition, valueType } = props;
+  let { answers, answerNodeType, existingAnswer, path, questionName, questionDefinition, valueType } = props;
   let [ answerID ] = useState((existingAnswer && existingAnswer[0]) || uuidv4());
   let answerPath = path + "/" + answerID;
+  // Hooks must be pulled from the top level, so this cannot be moved to inside the useEffect()
+  const changeFormContext = useFormWriterContext();
+
+  // When the answers change, we inform the FormContext
+  useEffect(() => {
+    if (answers && answers.length > 0) {
+      changeFormContext((oldContext) => ({...oldContext, [questionName]: answers}));
+    }
+  }, [answers]);
 
   return (
     <React.Fragment>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Conditional.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Conditional.jsx
@@ -19,30 +19,50 @@
 
 import { VALUE_POS } from "./Answer";
 
+/**
+ * Determines whether or not the conditional is satisfied.
+ * @param {STRING} operand_a The first operand to compare
+ * @param {STRING} comparator The operator to use as a comparison
+ * @param {STRING} operand_b The second operand to compare (if necessary)
+ */
 export function isConditionalSatisfied(operand_a, comparator, operand_b) {
-    if (comparator == "=") {
-        return operand_a == operand_b;
-    } else if (comparator == "<") {
-        return operand_a < operand_b;
-    } else if (comparator == ">") {
-        return operand_a > operand_b;
-    } else if (comparator == "<>") {
-        return operand_a !== operand_b;
-    } else if (comparator == "is empty") {
-        return operand_a == null || operand_a == undefined;
-    } else if (comparator == "is not empty") {
-        return operand_a != null && operand_a != undefined;
-    }
+  if (comparator == "=") {
+    return operand_a == operand_b;
+  } else if (comparator == "<") {
+    return operand_a < operand_b;
+  } else if (comparator == ">") {
+    return operand_a > operand_b;
+  } else if (comparator == "<>") {
+    return operand_a !== operand_b;
+  } else if (comparator == "is empty") {
+    return operand_a == null || operand_a == undefined;
+  } else if (comparator == "is not empty") {
+    return operand_a != null && operand_a != undefined;
+  } else {
+    // Invalid operand
+    throw new Error("Invalid operand specified.")
+  }
 }
 
+/**
+ * Determines if the given lfs:Conditional is true or not.
+ * @param {Object} conditional The lfs:Conditional to assert the truth of
+ * @param {Object} context The React Context from which to pull values
+ */
 export function isConditionalObjSatisfied(conditional, context) {
-    return isConditionalSatisfied(
-        getValue(context, conditional["operandA"], conditional["operandAIsReference"]),
-        conditional["comparator"],
-        getValue(context, conditional["operandB"], conditional["operandBIsReference"])
-        );
+  return isConditionalSatisfied(
+    getValue(context, conditional["operandA"], conditional["operandAIsReference"]),
+    conditional["comparator"],
+    getValue(context, conditional["operandB"], conditional["operandBIsReference"])
+    );
 }
 
+/**
+ * Converts a potential reference into its value from the given context, or returns the id input.
+ * @param {Object} context The React Context from which to pull values
+ * @param {String} id The ID of the field to use, or its raw value
+ * @param {Boolean} isReference Whether or not the input is a reference or not
+ */
 function getValue(context, id, isReference) {
     return (isReference ? (context[id] && context[id][0] && context[id][0][VALUE_POS]) : (id));
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Conditional.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Conditional.jsx
@@ -1,0 +1,48 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import { VALUE_POS } from "./Answer";
+
+export function isConditionalSatisfied(operand_a, comparator, operand_b) {
+    if (comparator == "=") {
+        return operand_a == operand_b;
+    } else if (comparator == "<") {
+        return operand_a < operand_b;
+    } else if (comparator == ">") {
+        return operand_a > operand_b;
+    } else if (comparator == "<>") {
+        return operand_a !== operand_b;
+    } else if (comparator == "is empty") {
+        return operand_a == null || operand_a == undefined;
+    } else if (comparator == "is not empty") {
+        return operand_a != null && operand_a != undefined;
+    }
+}
+
+export function isConditionalObjSatisfied(conditional, context) {
+    return isConditionalSatisfied(
+        getValue(context, conditional["operandA"], conditional["operandAIsReference"]),
+        conditional["comparator"],
+        getValue(context, conditional["operandB"], conditional["operandBIsReference"])
+        );
+}
+
+function getValue(context, id, isReference) {
+    return (isReference ? (context[id] && context[id][0] && context[id][0][VALUE_POS]) : (id));
+}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalComponentManager.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalComponentManager.jsx
@@ -1,0 +1,59 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+let _registeredComponents = [];
+let _registeredConditionalTypes = [];
+
+// This is a utility class which helps the Section component decide how each to handle conditions on its display.
+export default class ConditionalComponentManager {
+  /**
+   * Registers a new conditional handler. This method is only supposed to be called by each conditional handler.
+   * @param {Function} component A function which can be called to determine how well suited the registered component can handle a given conditional object.
+   *     The function receives the JSON of a conditional, and returns a tuple (array with 2 items), the actual function that can handle the conditional, and the confidence that it is the right handler.
+   *     The confidence is a number between 0 and 100, with a bigger number indicating more confidence. The registered component with the highest confidence will be used to handle the conditional.
+   * @param {Array} conditionalTypes The jcr:primaryTypes that denote that an object is a valid conditional.
+   */
+  static registerConditionComponent(component, conditionalTypes) {
+    _registeredComponents.push(component);
+    _registeredConditionalTypes = _registeredConditionalTypes.concat(conditionalTypes);
+  }
+
+  /**
+   * Returns whether or not the given property a valid conditional.
+   * @param {Object} property The JSON of a potential condition definition
+   * @returns Whether or not the given property is a valid conditional
+   */
+  static isValidConditional(property) {
+    return _registeredConditionalTypes.includes(property["jcr:primaryType"]);
+  }
+
+  /**
+   * Determines whether the given condition is truthy or not, by querying each registered conditional component.
+   * @param {Object} conditionDefinition The full JSON of the condition definition, as obtained from JCR
+   * @param {Object} context The React Context to evaluate the condition within, usually given by a FormContext
+   * @returns Whether or not the given conditional is truthy
+   */
+  static evaluateCondition(conditionDefinition, context) {
+    return (_registeredComponents
+      .map(component => (component)(conditionDefinition))
+      .filter(handler => handler)
+      .reduce(([chosenDisplayer, maxPriority], [displayer, priority]) => priority > maxPriority ? [displayer, priority] : [chosenDisplayer, maxPriority]))[0]
+      (conditionDefinition, context);
+  }
+}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalGroup.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalGroup.jsx
@@ -18,6 +18,7 @@
 //
 
 import ConditionalComponentManager from "./ConditionalComponentManager";
+
 /**
  * Determines if an lfs:ConditionalGroup object is truthy or not.
  * @param {Object} conditional The lfs:ConditionalGroup object to evaluate the truthiness of

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalGroup.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalGroup.jsx
@@ -1,0 +1,42 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import ConditionalComponentManager from "./ConditionalComponentManager";
+/**
+ * Determines if an lfs:ConditionalGroup object is truthy or not.
+ * @param {Object} conditional The lfs:ConditionalGroup object to evaluate the truthiness of
+ * @param {Object} context The React Context from which to pull values
+ */
+export function isConditionalGroupSatisfied(conditional, context) {
+  let conditionalChildren = Object.values(conditional)
+    .filter((child) => ConditionalComponentManager.isValidConditional(child));
+  if (conditional["requireAll"]) {
+    return conditionalChildren.every( (child) => ConditionalComponentManager.evaluateCondition(child, context) );
+  } else {
+    return conditionalChildren.some( (child) => ConditionalComponentManager.evaluateCondition(child, context) );
+  }
+}
+
+const HANDLED_TYPES = ["lfs:ConditionalGroup", "lfs:Section"];
+
+ConditionalComponentManager.registerConditionComponent((conditionDefinition) => {
+  if (HANDLED_TYPES.includes(conditionDefinition["jcr:primaryType"])) {
+    return [isConditionalGroupSatisfied, 50];
+  }
+}, HANDLED_TYPES);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
@@ -20,29 +20,28 @@
 import { VALUE_POS } from "./Answer";
 import ConditionalComponentManager from "./ConditionalComponentManager";
 
+// A mapping from operands to conditionals
+const COMPARE_MAP = {
+  "=": (a, b) => (a == b),
+  "<": (a, b) => (a < b),
+  ">": (a, b) => (a > b),
+  "<>": (a, b) => (a !== b),
+  "is empty": (a) => (a == null || a == undefined),
+  "is not empty": (a) => (a != null && a != undefined)
+}
+
 /**
  * Determines whether or not the conditional is satisfied.
- * @param {STRING} operandA The first operand to compare
  * @param {STRING} comparator The operator to use as a comparison
- * @param {STRING} operandB The second operand to compare (if necessary)
+ * @param {STRING...} operands Any number of operands used for the comparison
  */
-export function isConditionalSatisfied(operandA, comparator, operandB) {
-  if (comparator == "=") {
-    return operandA == operandB;
-  } else if (comparator == "<") {
-    return operandA < operandB;
-  } else if (comparator == ">") {
-    return operandA > operandB;
-  } else if (comparator == "<>") {
-    return operandA !== operandB;
-  } else if (comparator == "is empty") {
-    return operandA == null || operandA == undefined;
-  } else if (comparator == "is not empty") {
-    return operandA != null && operandA != undefined;
-  } else {
+export function isConditionalSatisfied(comparator, ...operands) {
+  if (!(comparator in COMPARE_MAP)) {
     // Invalid operand
     throw new Error("Invalid operand specified.")
   }
+
+  return COMPARE_MAP[comparator]?.apply(null, operands);
 }
 
 /**
@@ -67,7 +66,7 @@ export function isConditionalObjSatisfied(conditional, context) {
 
   return firstCondition( (valueA) => {
     return secondCondition( (valueB) => {
-      return isConditionalSatisfied(valueA, conditional["comparator"], valueB);
+      return isConditionalSatisfied(conditional["comparator"], valueA, valueB);
     })
   })
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -30,6 +30,7 @@ import {
 
 import QuestionnaireStyle, { FORM_ENTRY_CONTAINER_PROPS } from "./QuestionnaireStyle";
 import FormEntry, { ENTRY_TYPES } from "./FormEntry";
+import { FormProvider } from "./FormContext";
 
 // TODO Once components from the login module can be imported, open the login Dialog in-page instead of opening a popup window
 
@@ -166,11 +167,13 @@ function Form (props) {
             : ""
           }
         </Grid>
-        {
-          Object.entries(data.questionnaire)
-            .filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType']))
-            .map(([key, entryDefinition]) => FormEntry(entryDefinition, ".", 0, data, key))
-        }
+        <FormProvider>
+          {
+            Object.entries(data.questionnaire)
+              .filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType']))
+              .map(([key, entryDefinition]) => FormEntry(entryDefinition, ".", 0, data, key))
+          }
+        </FormProvider>
       </Grid>
 
       <Button

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormContext.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormContext.jsx
@@ -26,6 +26,8 @@ const FormWriterContext = React.createContext();
 
 /**
  * A context provider for a form, which contains answers and a way to set them
+ * @param {Object} props the props to pass onwards to the child, generally its children
+ * @returns {Object} a React component with the form provider
  */
 export function FormProvider(props) {
   const [answers, setAnswers] = React.useState(DEFAULT_STATE);
@@ -38,8 +40,9 @@ export function FormProvider(props) {
 }
 
 /**
- * Read from the context of the parent form.
- * This will throw an error if it is not within a FormProvider
+ * Obtain the context reader of the parent form.
+ * @returns {Object} a React context of values from the parent form
+ * @throws an error if it is not within a FormProvider
  */
 export function useFormReaderContext() {
   const context = React.useContext(FormReaderContext);
@@ -52,8 +55,9 @@ export function useFormReaderContext() {
 }
 
 /**
- * Write to the context of the parent form.
- * This will throw an error if it is not within a FormProvider
+ * Obtain a writer to the context of the parent form.
+ * @returns {Object} a React context of values from the parent form
+ * @throws an error if it is not within a FormProvider
  */
 export function useFormWriterContext() {
   const context = React.useContext(FormWriterContext);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormContext.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormContext.jsx
@@ -1,0 +1,66 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React from "react";
+
+const DEFAULT_STATE = {};
+
+const FormReaderContext = React.createContext(DEFAULT_STATE);
+const FormWriterContext = React.createContext();
+
+/**
+ * A context provider for a form, which contains answers and a way to set them
+ */
+export function FormProvider(props) {
+  const [answers, setAnswers] = React.useState(DEFAULT_STATE);
+
+  return (
+    <FormReaderContext.Provider value={answers}>
+      <FormWriterContext.Provider value={setAnswers} {...props}/>
+    </FormReaderContext.Provider>
+    );
+}
+
+/**
+ * Read from the context of the parent form.
+ * This will throw an error if it is not within a FormProvider
+ */
+export function useFormReaderContext() {
+  const context = React.useContext(FormReaderContext);
+
+  if (context == undefined) {
+    throw new Error("useFormReaderContext must be used within a FormProvider")
+  }
+
+  return context;
+}
+
+/**
+ * Write to the context of the parent form.
+ * This will throw an error if it is not within a FormProvider
+ */
+export function useFormWriterContext() {
+  const context = React.useContext(FormWriterContext);
+
+  if (context == undefined) {
+    throw new Error("useFormWriterContext must be used within a FormProvider")
+  }
+
+  return context;
+}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -55,10 +55,11 @@ let displayQuestion = (questionDefinition, path, existingAnswer, key) => {
   return (
     <Grid item key={key} className={"questionContainer"}>
       <QuestionDisplay
-        key={key}
         questionDefinition={questionDefinition}
         existingAnswer={existingQuestionAnswer}
-        path={path} />
+        path={path}
+        questionName={key}
+        />
     </Grid>
   );
 };
@@ -86,6 +87,8 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key) => {
   const existingQuestionAnswer = existingAnswer && Object.entries(existingAnswer)
     .find(([key, value]) => value["sling:resourceType"] == "lfs/AnswerSection"
       && value["section"]["jcr:uuid"] === sectionDefinition["jcr:uuid"]);
+
+  // Locate all
 
   return (
     <Section

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -88,8 +88,6 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key) => {
     .find(([key, value]) => value["sling:resourceType"] == "lfs/AnswerSection"
       && value["section"]["jcr:uuid"] === sectionDefinition["jcr:uuid"]);
 
-  // Locate all
-
   return (
     <Section
       key={key}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -107,6 +107,9 @@ const questionnaireStyle = theme => ({
     sectionHeader: {
         paddingBottom: "0 !important",
         marginBottom: theme.spacing(-1)
+    },
+    collapsedSection: {
+        padding: "0 !important"
     }
 });
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -52,7 +52,6 @@ function Section(props) {
   const [sectionID] = useState((existingAnswer && existingAnswer[0]) || uuidv4());
   const sectionPath = path + "/" + sectionID;
   const headerVariant = (depth > MAX_HEADING_LEVEL - MIN_HEADING_LEVEL ? "body1" : ("h" + (depth+MIN_HEADING_LEVEL)));
-  // Hooks must be pulled from the top level, so this cannot be moved to inside the useEffect()
   const formContext = useFormReaderContext();
 
   const titleEl = sectionDefinition["label"] && <Typography variant={headerVariant}>{sectionDefinition["label"]} </Typography>;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -22,7 +22,7 @@ import PropTypes from "prop-types";
 import { Collapse, Grid, Typography, withStyles } from "@material-ui/core";
 import uuidv4 from "uuid/v4";
 
-import { isConditionalObjSatisfied } from "./Conditional";
+import { isConditionalGroupSatisfied } from "./Conditional";
 import FormEntry, { ENTRY_TYPES } from "./FormEntry";
 import { useFormReaderContext } from "./FormContext";
 import QuestionnaireStyle, { FORM_ENTRY_CONTAINER_PROPS } from "./QuestionnaireStyle";
@@ -56,11 +56,9 @@ function Section(props) {
   const hasHeader = titleEl || descEl;
 
   // Determine if we have any conditionals in our definition that would cause us to be hidden
-  const displayed = Object.entries(sectionDefinition)
-      // Grab all of the conditionals from our definition
-      .filter(([_, value]) => value['jcr:primaryType'] === "lfs:Conditional")
-      // Ensure they are all satisfied
-      .every(([_, value]) => isConditionalObjSatisfied(value, formContext));
+  const displayed = isConditionalGroupSatisfied(
+    sectionDefinition,
+    formContext);
 
   return useCallback(<Collapse
     in={displayed}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -22,10 +22,14 @@ import PropTypes from "prop-types";
 import { Collapse, Grid, Typography, withStyles } from "@material-ui/core";
 import uuidv4 from "uuid/v4";
 
-import { isConditionalGroupSatisfied } from "./Conditional";
+import ConditionalComponentManager from "./ConditionalComponentManager";
 import FormEntry, { ENTRY_TYPES } from "./FormEntry";
 import { useFormReaderContext } from "./FormContext";
 import QuestionnaireStyle, { FORM_ENTRY_CONTAINER_PROPS } from "./QuestionnaireStyle";
+
+// FIXME In order for the conditionals to be registered, they need to be loaded, and the only way to do that at the moment is to explicitly invoke them here. Find a way to automatically load all conditional types, possibly using self-declaration in a node, like the assets, or even by filtering through assets.
+import ConditionalGroup from "./ConditionalGroup";
+import ConditionalSingle from "./ConditionalSingle";
 
 // The heading levels that @material-ui supports
 const MAX_HEADING_LEVEL = 6;
@@ -56,7 +60,7 @@ function Section(props) {
   const hasHeader = titleEl || descEl;
 
   // Determine if we have any conditionals in our definition that would cause us to be hidden
-  const displayed = isConditionalGroupSatisfied(
+  const displayed = ConditionalComponentManager.evaluateCondition(
     sectionDefinition,
     formContext);
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 import PropTypes from "prop-types";
 import { Collapse, Grid, Typography, withStyles } from "@material-ui/core";
 import uuidv4 from "uuid/v4";
@@ -62,7 +62,7 @@ function Section(props) {
       // Ensure they are all satisfied
       .every(([_, value]) => isConditionalObjSatisfied(value, formContext));
 
-  return <Collapse
+  return useCallback(<Collapse
     in={displayed}
     component={Grid}
     item
@@ -84,7 +84,7 @@ function Section(props) {
         .map(([key, definition]) => FormEntry(definition, sectionPath, depth+1, existingAnswer && existingAnswer[1], key))
       }
     </Grid>
-  </Collapse>
+  </Collapse>, [displayed]);
 }
 
 Section.propTypes = {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -63,10 +63,14 @@ function Section(props) {
     sectionDefinition,
     formContext);
 
+  // mountOnEnter and unmountOnExit force the inputs and children to be outside of the DOM during form submission
+  // if it is not currently visible
   return useCallback(<Collapse
     in={displayed}
     component={Grid}
     item
+    mountOnEnter
+    unmountOnExit
     className={(hasHeader ? classes.labeledSection : "") + " " + (displayed ? "" : classes.collapsedSection)}
     >
     <input type="hidden" name={`${sectionPath}/jcr:primaryType`} value={"lfs:AnswerSection"}></input>

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -228,7 +228,39 @@
   // Children
 
   // The questions and sub-sections that make up this section.
-  + * (lfs:Question, lfs:Section) = lfs:Question
+  // The conditions to display this section may also be listed as children
+  + * (lfs:Question, lfs:Section, lfs:Conditional) = lfs:Question
+
+//-----------------------------------------------------------------------------
+// A conditional is a condition that can be imposed on e.g. the display of a section
+[lfs:Conditional] > sling:Resource
+  // Attributes
+
+  // Conditionals are queryable
+  query
+
+  // Properties
+
+  // Hardcode the resource type.
+  - sling:resourceType (STRING) = "lfs/Conditional" mandatory autocreated protected
+
+  // Hardcode the resource supertype: each section link is a resource.
+  - sling:resourceSuperType (STRING) = "lfs/Resource" mandatory autocreated protected
+
+  // A conditional always has at least one operand.
+  - operandA (STRING) mandatory
+
+  // The first operand may either be a value or a reference to a value
+  - operandAIsReference (BOOLEAN) = false mandatory autocreated
+
+  // A conditional always has exactly one comparator
+  - comparator (STRING) mandatory
+
+  // A conditional may optionally have a second operand.
+  - operandB (STRING)
+
+  // The second operand may also either be a value or a reference to a value
+  - operandBIsReference (BOOLEAN) = false mandatory autocreated
 
 //-----------------------------------------------------------------------------
 // A questionnaire is a collection of sections and questions.

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -229,11 +229,13 @@
 
   // The questions and sub-sections that make up this section.
   // The conditions to display this section may also be listed as children
-  + * (lfs:Question, lfs:Section, lfs:Conditional) = lfs:Question
+  + * (lfs:Question, lfs:Section, lfs:Conditional, lfs:ConditionalGroup) = lfs:Question
 
 //-----------------------------------------------------------------------------
-// A conditional is a condition that can be imposed on e.g. the display of a section
-[lfs:Conditional] > sling:Resource
+// A conditional group is a set of conditions that can be imposed on e.g. the display of a section.
+// The conditions are listed as children of this, and may be turned from an OR to an AND via the
+// `requireAll` property.
+[lfs:ConditionalGroup] > sling:Resource
   // Attributes
 
   // Conditionals are queryable
@@ -247,20 +249,67 @@
   // Hardcode the resource supertype: each section link is a resource.
   - sling:resourceSuperType (STRING) = "lfs/Resource" mandatory autocreated protected
 
-  // A conditional always has at least one operand.
-  - operandA (STRING) mandatory
+  // This conditional may contain any number of conditionals or conditional groups
+  + * (lfs:ConditionalGroup, lfs:Conditional) = lfs:Question
 
-  // The first operand may either be a value or a reference to a value
-  - operandAIsReference (BOOLEAN) = false mandatory autocreated
+//-----------------------------------------------------------------------------
+// A conditional is a condition that can be imposed on e.g. the display of a section.
+[lfs:Conditional] > sling:Resource
+  // Attributes
+
+  // Conditionals are queryable
+  query
+  // Our children are orderable, and may be executable in a specific order
+  orderable
+
+  // Properties
+
+  // Hardcode the resource type.
+  - sling:resourceType (STRING) = "lfs/Conditional" mandatory autocreated protected
+
+  // Hardcode the resource supertype: each section link is a resource.
+  - sling:resourceSuperType (STRING) = "lfs/Resource" mandatory autocreated protected
+
+  // A conditional will always have a child node called operandA of type ConditionalValue
+  + operandA (lfs:ConditionalValue) mandatory
 
   // A conditional always has exactly one comparator
   - comparator (STRING) mandatory
 
-  // A conditional may optionally have a second operand.
-  - operandB (STRING)
+  // A second child operandB may be specified, but leaving it as the default is OK if the comparator is singular
+  + operandB (lfs:ConditionalValue) = lfs:ConditionalValue autocreated
 
-  // The second operand may also either be a value or a reference to a value
-  - operandBIsReference (BOOLEAN) = false mandatory autocreated
+//-----------------------------------------------------------------------------
+// A conditional value is either a value or a method of getting a value.
+[lfs:ConditionalValue] > sling:Resource
+  // Attributes
+
+  // We don't have children, but let's assume children might need to be ordered in the future.
+  orderable
+  // The main sub-item of an answer is its value.
+  primaryitem value
+  // Conditional values are queryable
+  query
+
+  // Properties
+
+  // Hardcode the resource type.
+  - sling:resourceType (STRING) = "lfs/ConditionalValue" mandatory autocreated protected
+
+  // Hardcode the resource supertype: each value is a resource.
+  - sling:resourceSuperType (STRING) = "lfs/Resource" mandatory autocreated protected
+
+  // The value which may be a reference to a field or a value (or multiple values)
+  - value (STRING) multiple
+
+  // Whether or not this value is a reference or not
+  - isReference (BOOLEAN)
+
+  // Require that the parent conditional checks every value (for a multi-valued field)
+  // Otherwise it will return true if at least one value fits
+  - requireAll (BOOLEAN) = false mandatory autocreated
+
+  // We don't define any subchildren.
 
 //-----------------------------------------------------------------------------
 // A questionnaire is a collection of sections and questions.

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -303,7 +303,7 @@
   - value (STRING) multiple
 
   // Whether or not this value is a reference or not
-  - isReference (BOOLEAN)
+  - isReference (BOOLEAN) = false autocreated
 
   // Require that the parent conditional checks every value (for a multi-valued field)
   // Otherwise it will return true if at least one value fits


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/LFS-242).

**Testing branch**: `LFS-242-test`. In demographics:
- one of the sections will only appear if `patient_id` is set to 5.
- one of the sections will only appear If `patient_id` is 6 OR if the family is set to 'test'
- one of the sections will only appear if `patient_id` is 6 AND if the family is set to 'test'

This commit enables the concept of conditional sections, where a value will only appear if other values defined elsewhere in the form meets some criteria.