### PR TITLE
LFS-285: Emptied answers cannot be saved for multi-choice questions

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -36,10 +36,11 @@ function Answer (props) {
       <input type="hidden" name={`${answerPath}/jcr:primaryType`} value={answerNodeType}></input>
       <input type="hidden" name={`${answerPath}/question`} value={questionDefinition['jcr:uuid']}></input>
       <input type="hidden" name={`${answerPath}/question@TypeHint`} value="Reference"></input>
+      <input type="hidden" name={`${answerPath}/value@Delete`} value="0"></input>
       <input type="hidden" name={`${answerPath}/value@TypeHint`} value={valueType}></input>
       {answers.map( (element, index) => {
         return (
-          <input type="hidden" name={`./${answerPath}/value`} key={element[VALUE_POS] === undefined ? index : element[VALUE_POS]} value={element[VALUE_POS]}></input>
+          <input type="hidden" name={`${answerPath}/value`} key={element[VALUE_POS] === undefined ? index : element[VALUE_POS]} value={element[VALUE_POS]}></input>
           );
       })}
     </React.Fragment>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -36,13 +36,20 @@ function Answer (props) {
       <input type="hidden" name={`${answerPath}/jcr:primaryType`} value={answerNodeType}></input>
       <input type="hidden" name={`${answerPath}/question`} value={questionDefinition['jcr:uuid']}></input>
       <input type="hidden" name={`${answerPath}/question@TypeHint`} value="Reference"></input>
-      <input type="hidden" name={`${answerPath}/value@Delete`} value="0"></input>
-      <input type="hidden" name={`${answerPath}/value@TypeHint`} value={valueType}></input>
-      {answers.map( (element, index) => {
-        return (
-          <input type="hidden" name={`${answerPath}/value`} key={element[VALUE_POS] === undefined ? index : element[VALUE_POS]} value={element[VALUE_POS]}></input>
-          );
-      })}
+
+      {/* Add the answers, if any exist, or otherwise delete them */}
+      {(answers && answers.length) ?
+        (<React.Fragment>
+          <input type="hidden" name={`${answerPath}/value@TypeHint`} value={valueType}></input>
+          {answers.map( (element, index) => {
+            return (
+              <input type="hidden" name={`${answerPath}/value`} key={element[VALUE_POS] === undefined ? index : element[VALUE_POS]} value={element[VALUE_POS]}></input>
+              );
+          })}
+        </React.Fragment>)
+      :
+        <input type="hidden" name={`${answerPath}/value@Delete`} value="0"></input>
+      }
     </React.Fragment>
     );
 }


### PR DESCRIPTION
Also fix a minor issue where the `answerPath` of child nodes may have been in the wrong location.

To test, insert anything into a new Demographics form, save it, then delete it and save it again. It should be properly removed.

With help by @sdumitriu , this uses an `@Delete` [hidden input](https://sling.apache.org/documentation/bundles/manipulating-content-the-slingpostservlet-servlets-post.html#delete) to force removal of an empty input.