### PR TITLE
LFS-283: The form's save button is slightly shifted to the right

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -80,7 +80,6 @@ const questionnaireStyle = theme => ({
         marginTop: theme.spacing(2),
         bottom: theme.spacing(1),
         float: "right"
-
     },
     newFormButtonWrapper: {
         margin: theme.spacing(1),

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -76,10 +76,11 @@ const questionnaireStyle = theme => ({
         height: "100%"
     },
     saveButton: {
-        position: "fixed",
-        top: 'auto',
+        position: "sticky",
+        marginTop: theme.spacing(2),
         bottom: theme.spacing(1),
-        right: theme.spacing(6.5)
+        float: "right"
+
     },
     newFormButtonWrapper: {
         margin: theme.spacing(1),


### PR DESCRIPTION
Nicer fix using "sticky" positioning which allows the button to scroll up with its container when positioned at the bottom of the container.

Upon reviewing the request, please evaluate if the support for sticky can be considered satisfactory: https://caniuse.com/#feat=css-sticky