### PR TITLE
LFS-203: The system should provide secure access to data

### DIFF
--- a/distribution/src/main/provisioning/01-boot.txt
+++ b/distribution/src/main/provisioning/01-boot.txt
@@ -23,10 +23,24 @@
 
 # additional entries for sling.properties
 # ---------------------------------------
-# oak_tar and oak_mongo run modes are mutually exclusive,
-# and cannot be changed after the first startup
 [settings]
-    sling.run.mode.install.options=oak_tar,oak_mongo|permissions_open,permissions_trusted|forms,noforms
+    # These options can be used to configure the instance.
+    # The vbar `|` character separates groups of options,
+    # while the comma `,` character separates mutually exclusive options from a group.
+    # If one of the options from a group is not specified, then the first one is considered the default and used.
+    # If more than one option is specified at runtime, then only the one appearing earlier in this definition list will be used.
+    # Install options cannot be changed after the first startup, and they don't need to be specified again for subsequent restarts.
+
+    # oak_tar or oak_mongo define which storage backend to use.
+    # For a standalone test instance, the filesystem option oak_tar is quick and easy, since it needs no special setup, but doesn't provide a good enough performance.
+
+    # forms enables the Questionnaires and Forms feature
+
+    # permissions_open lets all authenticated users access all data.
+    # permissions_trusted requires that after self-registration, users must be manually added to the TrustedUsers group by an administrator before they can access data.
+
+    sling.run.mode.install.options=oak_tar,oak_mongo|forms,noforms|permissions_open,permissions_trusted
+
     repository.home=${sling.home}/repository
     localIndexDir=${sling.home}/repository/index
 

--- a/distribution/src/main/provisioning/01-boot.txt
+++ b/distribution/src/main/provisioning/01-boot.txt
@@ -26,7 +26,7 @@
 # oak_tar and oak_mongo run modes are mutually exclusive,
 # and cannot be changed after the first startup
 [settings]
-    sling.run.mode.install.options=oak_tar,oak_mongo
+    sling.run.mode.install.options=oak_tar,oak_mongo|permissions_open,permissions_trusted|forms,noforms
     repository.home=${sling.home}/repository
     localIndexDir=${sling.home}/repository/index
 

--- a/distribution/src/main/provisioning/13-repoinit.txt
+++ b/distribution/src/main/provisioning/13-repoinit.txt
@@ -22,9 +22,9 @@
 
 [artifacts]
     # This can parse a :repoinit section from a provisioning file into POJOs
-    org.apache.sling/org.apache.sling.repoinit.parser/1.2.2
+    org.apache.sling/org.apache.sling.repoinit.parser/1.2.4
     # This performs the instructions parsed from a :repoinit section in JCR
-    org.apache.sling/org.apache.sling.jcr.repoinit/1.1.8
+    org.apache.sling/org.apache.sling.jcr.repoinit/1.1.10
     # This can read provisioning files
     org.apache.sling/org.apache.sling.provisioning.model/1.8.4
 

--- a/distribution/src/main/provisioning/40-startup.txt
+++ b/distribution/src/main/provisioning/40-startup.txt
@@ -27,3 +27,16 @@
   # Allow self-registration
   org.apache.sling.jackrabbit.usermanager.impl.post.CreateUserServlet
     self.registration.enabled=B"true"
+
+  # Authentication requirements
+  org.apache.sling.engine.impl.auth.SlingAuthenticator
+    # Don't allow anonymous access by default
+    auth.annonymous=B"false"
+    # Require access by default on all resources, with a few exceptions
+    sling.auth.requirements=[ \
+      "+/", \
+      "-/login", \
+      "-/libs", \
+      "-/apps", \
+      "-/system", \
+    ]

--- a/modules/commons/src/main/provisioning/model.txt
+++ b/modules/commons/src/main/provisioning/model.txt
@@ -22,7 +22,12 @@
 
 [:repoinit]
     create path (sling:Folder) /libs/lfs
+    create path (sling:Folder) /libs/lfs/resources
+    create path (sling:Folder) /apps/lfs
+    create path (sling:Folder) /Extensions
 
     set ACL for everyone
         allow   jcr:read    on /libs/lfs
+        allow   jcr:read    on /apps/lfs
+        allow   jcr:read    on /Extensions
     end

--- a/modules/data-entry/pom.xml
+++ b/modules/data-entry/pom.xml
@@ -63,13 +63,6 @@
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <!-- This will automatically add an [artifacts] entry with the jar produced by this module in the provisioning file -->
-          <attach>
-            <type>jar</type>
-            <startLevel>10</startLevel>
-          </attach>
-        </configuration>
       </plugin>
 
       <!-- Reconfigure to ignore theme files from material-dashboard-react, as they're under their own license -->

--- a/modules/data-entry/src/main/provisioning/model.txt
+++ b/modules/data-entry/src/main/provisioning/model.txt
@@ -39,7 +39,7 @@
     # Allow all users to read from the database and one of the nodes
     set ACL for everyone
         allow   jcr:read    on /Questionnaires
-        allow   jcr:read    on /Forms
-        allow   jcr:read    on /Subjects
+        allow   jcr:all     on /Forms
+        allow   jcr:all     on /Subjects
         allow   jcr:read    on /query
     end

--- a/modules/data-entry/src/main/provisioning/model.txt
+++ b/modules/data-entry/src/main/provisioning/model.txt
@@ -20,7 +20,7 @@
 # The LFS homepage
 [feature name=lfs-dataentry]
 
-[artifacts]
+[artifacts runModes=forms startLevel=10]
     org.apache.sling/org.apache.sling.scripting.sightly/1.1.2-1.4.0
     org.apache.sling/org.apache.sling.scripting.sightly.runtime/1.1.0-1.4.0
     org.apache.sling/org.apache.sling.api/2.18.4
@@ -28,18 +28,49 @@
     javax.jcr/jcr/2.0
     javax.servlet/javax.servlet-api/3.1.0
     org.apache.commons/commons-csv/1.6
+    ca.sickkids.ccm.lfs/lfs-dataentry
 
-[:repoinit]
-    # Data entry
-    create path (lfs:QuestionnairesHomepage) /Questionnaires
-    create path (lfs:FormsHomepage) /Forms
-    create path (lfs:SubjectsHomepage) /Subjects
-    create path (lfs:dataQuery) /query
+[configurations runModes=forms]
+    org.apache.sling.jcr.repoinit.RepositoryInitializer-forms
+        scripts=["\
+            create path (lfs:dataQuery) /query \
+\
+            # Allow all users to query; the actual results will obey their access rights \
+            set ACL for everyone \
+                allow   jcr:read    on /query \
+            end \
+          "]
 
-    # Allow all users to read from the database and one of the nodes
-    set ACL for everyone
-        allow   jcr:read    on /Questionnaires
-        allow   jcr:all     on /Forms
-        allow   jcr:all     on /Subjects
-        allow   jcr:read    on /query
-    end
+[configurations runModes=forms,permissions_open]
+    org.apache.sling.jcr.repoinit.RepositoryInitializer-forms_open
+        scripts=["\
+            create path (lfs:QuestionnairesHomepage) /Questionnaires \
+            create path (lfs:FormsHomepage) /Forms \
+            create path (lfs:SubjectsHomepage) /Subjects \
+\
+            set ACL on /Forms,/Subjects \
+                allow jcr:all for everyone \
+            end \
+\
+            set ACL on /Questionnaires \
+                allow jcr:read for everyone \
+            end \
+          "]
+
+[configurations runModes=forms,permissions_trusted]
+    org.apache.sling.jcr.repoinit.RepositoryInitializer-forms_trusted
+        scripts=["\
+            create path (lfs:QuestionnairesHomepage) /Questionnaires \
+            create path (lfs:FormsHomepage) /Forms \
+            create path (lfs:SubjectsHomepage) /Subjects \
+\
+            create group TrustedUsers \
+\
+            set ACL on /Forms,/Subjects \
+                allow jcr:all for TrustedUsers \
+            end \
+\
+            set ACL on /Questionnaires \
+                allow jcr:read for TrustedUsers \
+            end \
+          "]

--- a/modules/homepage/src/main/provisioning/model.txt
+++ b/modules/homepage/src/main/provisioning/model.txt
@@ -22,9 +22,7 @@
 
 [:repoinit]
     create path (lfs:Homepage) /content
-    create path (sling:Folder) /libs/lfs/resources
 
     set ACL for everyone
         allow   jcr:read    on /content
-        allow   jcr:read    on /libs/lfs/resources
     end

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <lfs.version>${project.version}</lfs.version>
     <slf4j.version>1.7.26</slf4j.version>
     <jackrabbit.version>2.16.3</jackrabbit.version>
     <oak.version>1.8.8</oak.version>
@@ -473,6 +474,8 @@
             <setFeatureVersions>true</setFeatureVersions>
             <!-- Allows using the maven properties defined above as variables in the provisioning files -->
             <usePomVariables>true</usePomVariables>
+            <!-- Allow defining versions in the POM file -->
+            <usePomDependencies>true</usePomDependencies>
           </configuration>
         </plugin>
 

--- a/tests/src/test/java/ca/sickkids/ccm/lfs/it/HomepageIT.java
+++ b/tests/src/test/java/ca/sickkids/ccm/lfs/it/HomepageIT.java
@@ -44,14 +44,14 @@ public class HomepageIT
     @BeforeClass
     public static void waitForStartup() throws TimeoutException, InterruptedException
     {
-        client = slingInstanceRule.defaultInstance.getClient(SlingClient.class, null, null);
+        client = slingInstanceRule.defaultInstance.getClient(SlingClient.class, "admin", "admin");
 
         Polling p = new Polling()
         {
             @Override
             public Boolean call() throws Exception
             {
-                return HomepageIT.client.doGet("/").getStatusLine().getStatusCode() == SC_OK;
+                return HomepageIT.client.doGet("/login").getStatusLine().getStatusCode() == SC_OK;
             }
 
             @Override
@@ -66,19 +66,19 @@ public class HomepageIT
     }
 
     @Test
-    public void homepageIsDisplayedWhenNotLoggedInAtContextRoot() throws Exception
+    public void homepageIsDisplayedAtContextRoot() throws Exception
     {
         checkHtmlHomepage("/");
     }
 
     @Test
-    public void homepageIsDisplayedWhenNotLoggedInAtSlashContent() throws Exception
+    public void homepageIsDisplayedAtSlashContent() throws Exception
     {
         checkHtmlHomepage("/content");
     }
 
     @Test
-    public void homepageIsDisplayedWhenNotLoggedInAtSlashContentDotHtml() throws Exception
+    public void homepageIsDisplayedAtSlashContentDotHtml() throws Exception
     {
         checkHtmlHomepage("/content.html");
     }


### PR DESCRIPTION
Things to test:
- self-registered accounts can create, view, edit forms
- they cannot create or edit questionnaires
- when starting with `-r permissions_trusted` they can't do the above
- after admin adds a user to the group using http://localhost:8080/bin/users.html/home/groups they get the ability to access data again
- direct access to the data must be tested as well, not just the UI