### PR TITLE
LFS-313: Section descriptions should not be inline with the section name

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -66,13 +66,13 @@ function Section(props) {
   const headerVariant = (depth > MAX_HEADING_LEVEL - MIN_HEADING_LEVEL ? "body1" : ("h" + (depth+MIN_HEADING_LEVEL)));
   const titleEl = sectionDefinition["label"] &&
     ((idx, uuid) =>
-      <Typography variant={headerVariant} style={{display: "inline"}} className={uuid == selectedUUID ? classes.highlightedTitle: undefined}>
+      <Typography variant={headerVariant} className={uuid == selectedUUID ? classes.highlightedTitle: undefined}>
         {createTitle(sectionDefinition["label"], idx)}
       </Typography>
     );
   const descEl = sectionDefinition["description"] &&
     (idx =>
-      <Typography variant="caption" color="textSecondary">
+      <Typography variant="caption" color="textSecondary" display="block">
         {sectionDefinition["description"]}
       </Typography>
     );


### PR DESCRIPTION
Before:
<img width="416" alt="before" src="https://user-images.githubusercontent.com/88663/73877645-08fdda00-4827-11ea-868d-370d369bc765.png">
After:
<img width="416" alt="after" src="https://user-images.githubusercontent.com/88663/73877669-14e99c00-4827-11ea-8f32-de325dd888d0.png">
