### PR TITLE
LFS-330: Installing multiple vocabularies in OBO format causes subsequent installations to copy data from previous installations

### DIFF
--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/OboParser.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/OboParser.java
@@ -53,7 +53,6 @@ import ca.sickkids.ccm.lfs.vocabularies.spi.VocabularyTermSource;
     service = SourceParser.class,
     scope = ServiceScope.PROTOTYPE,
     name = "SourceParser.OBO")
-@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 public class OboParser implements SourceParser
 {
     /** Marks the start of a new Frame. */


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/LFS-330)

To test: from the sidebar, head to the Vocabularies admin page and install HP, followed by TAXRANK. Querying the entries of TAXRANK via `/Vocabularies/TAXRANK.1.json` will no longer show all of the terms from HP.