### PR TITLE
LFS-282: Searching of nested answers (not just direct children); LFS-254: As a user, I can see how my query matched each resource in the quick search results

### DIFF
--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
@@ -225,11 +225,11 @@ public class QueryBuilder implements Use
             Resource thisResource = foundResources.next();
             Resource thisParent = thisResource;
             String[] resourceValues = thisResource.getValueMap().get("value", String[].class);
+            String resourceValue = getMatchingFromArray(resourceValues, query);
             while (thisParent != null && !"lfs/Form".equals(thisParent.getResourceType())) {
                 thisParent = thisParent.getParent();
             }
-            if (thisParent != null) {
-                String resourceValue = getMatchingFromArray(resourceValues, query);
+            if (thisParent != null && resourceValue != null) {
                 int matchIndex = resourceValue.toLowerCase().indexOf(query.toLowerCase());
                 String matchBefore = resourceValue.substring(0, matchIndex);
                 if (matchBefore.length() > this.MAX_CONTEXT_MATCH) {

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
@@ -53,6 +53,8 @@ import org.apache.sling.scripting.sightly.pojo.Use;
  */
 public class QueryBuilder implements Use
 {
+    private final int maxContextMatch = 8;
+
     private String content;
 
     private ResourceResolver resourceResolver;
@@ -220,8 +222,16 @@ public class QueryBuilder implements Use
             {
                 int matchIndex = resourcevalue.toLowerCase().indexOf(query.toLowerCase());
                 String matchBefore = resourcevalue.substring(0, matchIndex);
+                if (matchBefore.length() > this.maxContextMatch) {
+                    matchBefore = "..." + matchBefore.substring(
+                        matchBefore.length() - this.maxContextMatch, matchBefore.length()
+                    );
+                }
                 String matchText = resourcevalue.substring(matchIndex, matchIndex + query.length());
                 String matchAfter = resourcevalue.substring(matchIndex + query.length());
+                if (matchAfter.length() > this.maxContextMatch) {
+                    matchAfter = matchAfter.substring(0, this.maxContextMatch) + "...";
+                }
                 String matchType = getQuestion(thisResource);
                 String[] queryMatch = {
                     matchType,

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
@@ -159,7 +159,7 @@ public class QueryBuilder implements Use
         }
 
         // Escape sequence taken from https://jackrabbit.apache.org/archive/wiki/JCR/EncodingAndEscaping_115513396.html
-        return input.replaceAll("([\\Q+-&|!(){}[]^\"~*?:\\/\\E])", "\\\\$1").replaceAll("'", "''");
+        return input.replaceAll("([\\Q+-&|!(){}[]^\"~*?:\\_%/\\E])", "\\\\$1").replaceAll("'", "''");
     }
 
     /**
@@ -211,9 +211,9 @@ public class QueryBuilder implements Use
         ArrayList<Resource> outputList = new ArrayList<Resource>();
 
         final StringBuilder xpathQuery = new StringBuilder();
-        xpathQuery.append("/jcr:root/Forms//*[jcr:like(fn:lower-case(@value),\"%");
+        xpathQuery.append("/jcr:root/Forms//*[jcr:like(fn:lower-case(@value),'%");
         xpathQuery.append(this.fullTextEscape(query.toLowerCase()));
-        xpathQuery.append("%\"");
+        xpathQuery.append("%'");
         xpathQuery.append(" )]");
 
         Iterator<Resource> foundResources = queryXPATH(xpathQuery.toString());

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
@@ -171,8 +171,7 @@ public class QueryBuilder implements Use
     private String getQuestion(Resource res) throws ItemNotFoundException, RepositoryException
     {
         String questionNodeId = res.getValueMap().get("question", "");
-        if (!"".equals(questionNodeId))
-        {
+        if (!"".equals(questionNodeId)) {
             Node questionNode = res.adaptTo(Node.class).getSession().getNodeByIdentifier(questionNodeId);
             return questionNode.getProperty("text").getValue().toString();
         }
@@ -190,10 +189,8 @@ public class QueryBuilder implements Use
      */
     private String getMatchingFromArray(String[] arr, String str)
     {
-        for (int i = 0; i < arr.length; i++)
-        {
-            if (arr[i].toLowerCase().indexOf(str.toLowerCase()) > -1)
-            {
+        for (int i = 0; i < arr.length; i++) {
+            if (arr[i].toLowerCase().indexOf(str.toLowerCase()) > -1) {
                 return arr[i];
             }
         }
@@ -224,16 +221,14 @@ public class QueryBuilder implements Use
         * For each Resource in foundResources, move up the tree until
         * we find an ancestor node of type `lfs:Form`
         */
-        while (foundResources.hasNext())
-        {
+        while (foundResources.hasNext()) {
             Resource thisResource = foundResources.next();
             Resource thisParent = thisResource;
             String[] resourceValues = thisResource.getValueMap().get("value", String[].class);
             while (thisParent != null && !"lfs/Form".equals(thisParent.getResourceType())) {
                 thisParent = thisParent.getParent();
             }
-            if (thisParent != null)
-            {
+            if (thisParent != null) {
                 String resourceValue = getMatchingFromArray(resourceValues, query);
                 int matchIndex = resourceValue.toLowerCase().indexOf(query.toLowerCase());
                 String matchBefore = resourceValue.substring(0, matchIndex);
@@ -255,8 +250,7 @@ public class QueryBuilder implements Use
                     matchAfter
                 };
                 Node thisParentNode = thisParent.adaptTo(Node.class);
-                if (!thisParentNode.hasProperty("queryMatch"))
-                {
+                if (!thisParentNode.hasProperty("queryMatch")) {
                     thisParentNode.setProperty("queryMatch", queryMatch);
                     outputList.add(thisParent);
                 }

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
@@ -228,22 +228,22 @@ public class QueryBuilder implements Use
         {
             Resource thisResource = foundResources.next();
             Resource thisParent = thisResource;
-            String[] resourcevalues = thisResource.getValueMap().get("value", String[].class);
+            String[] resourceValues = thisResource.getValueMap().get("value", String[].class);
             while (thisParent != null && !"lfs/Form".equals(thisParent.getResourceType())) {
                 thisParent = thisParent.getParent();
             }
             if (thisParent != null)
             {
-                String resourcevalue = getMatchingFromArray(resourcevalues, query);
-                int matchIndex = resourcevalue.toLowerCase().indexOf(query.toLowerCase());
-                String matchBefore = resourcevalue.substring(0, matchIndex);
+                String resourceValue = getMatchingFromArray(resourceValues, query);
+                int matchIndex = resourceValue.toLowerCase().indexOf(query.toLowerCase());
+                String matchBefore = resourceValue.substring(0, matchIndex);
                 if (matchBefore.length() > this.MAX_CONTEXT_MATCH) {
                     matchBefore = "..." + matchBefore.substring(
                         matchBefore.length() - this.MAX_CONTEXT_MATCH, matchBefore.length()
                     );
                 }
-                String matchText = resourcevalue.substring(matchIndex, matchIndex + query.length());
-                String matchAfter = resourcevalue.substring(matchIndex + query.length());
+                String matchText = resourceValue.substring(matchIndex, matchIndex + query.length());
+                String matchAfter = resourceValue.substring(matchIndex + query.length());
                 if (matchAfter.length() > this.MAX_CONTEXT_MATCH) {
                     matchAfter = matchAfter.substring(0, this.MAX_CONTEXT_MATCH) + "...";
                 }

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
@@ -172,12 +172,15 @@ public class QueryBuilder implements Use
      */
     private String getQuestion(Resource res) throws ItemNotFoundException, RepositoryException
     {
-        String questionNodeId = res.getValueMap().get("question", "");
-        if (!"".equals(questionNodeId)) {
-            Node questionNode = res.adaptTo(Node.class).getSession().getNodeByIdentifier(questionNodeId);
-            return questionNode.getProperty("text").getValue().toString();
+        try {
+            Node questionNode = res.adaptTo(Node.class).getProperty("question").getNode();
+            if (questionNode != null) {
+                return questionNode.getProperty("text").getString();
+            }
+        } catch (RepositoryException ex) {
+            return null;
         }
-        return "";
+        return null;
     }
 
     /**
@@ -245,6 +248,9 @@ public class QueryBuilder implements Use
                     matchAfter = matchAfter.substring(0, this.MAX_CONTEXT_MATCH) + "...";
                 }
                 String matchType = getQuestion(thisResource);
+                if (matchType == null) {
+                    continue;
+                }
                 String[] queryMatch = {
                     matchType,
                     matchBefore,

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
@@ -170,7 +170,7 @@ public class QueryBuilder implements Use
      * @param res the JCR Resource corresponding to an answer
      * @return the question string corresponding to the passed answer
      */
-    private String getQuestion(Resource res) throws ItemNotFoundException, RepositoryException
+    private String getQuestion(Resource res) throws ItemNotFoundException
     {
         try {
             Node questionNode = res.adaptTo(Node.class).getProperty("question").getNode();

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
@@ -56,6 +56,8 @@ public class QueryBuilder implements Use
 
     private static final int MAX_CONTEXT_MATCH = 8;
 
+    private static final String LFS_QUERY_MATCH_KEY = "lfs:queryMatch";
+
     private String content;
 
     private ResourceResolver resourceResolver;
@@ -250,8 +252,8 @@ public class QueryBuilder implements Use
                     matchAfter
                 };
                 Node thisParentNode = thisParent.adaptTo(Node.class);
-                if (!thisParentNode.hasProperty("queryMatch")) {
-                    thisParentNode.setProperty("queryMatch", queryMatch);
+                if (!thisParentNode.hasProperty(LFS_QUERY_MATCH_KEY)) {
+                    thisParentNode.setProperty(LFS_QUERY_MATCH_KEY, queryMatch);
                     outputList.add(thisParent);
                 }
             }

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
@@ -37,8 +37,6 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.scripting.sightly.pojo.Use;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A HTL Use-API that can run a JCR query and output the results as JSON. The query to execute is taken from the request
@@ -55,8 +53,6 @@ import org.slf4j.LoggerFactory;
  */
 public class QueryBuilder implements Use
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(QueryBuilder.class);
-
     private String content;
 
     private ResourceResolver resourceResolver;
@@ -227,7 +223,6 @@ public class QueryBuilder implements Use
                 String matchText = resourcevalue.substring(matchIndex, matchIndex + query.length());
                 String matchAfter = resourcevalue.substring(matchIndex + query.length());
                 String matchType = getQuestion(thisResource);
-                LOGGER.info("Found matchType: {}", matchType);
                 String[] queryMatch = {
                     matchType,
                     matchBefore,

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
@@ -54,7 +54,7 @@ import org.apache.sling.scripting.sightly.pojo.Use;
 public class QueryBuilder implements Use
 {
 
-    private final int maxContextMatch = 8;
+    private static final int MAX_CONTEXT_MATCH = 8;
 
     private String content;
 
@@ -244,15 +244,15 @@ public class QueryBuilder implements Use
                 String resourcevalue = getMatchingFromArray(resourcevalues, query);
                 int matchIndex = resourcevalue.toLowerCase().indexOf(query.toLowerCase());
                 String matchBefore = resourcevalue.substring(0, matchIndex);
-                if (matchBefore.length() > this.maxContextMatch) {
+                if (matchBefore.length() > this.MAX_CONTEXT_MATCH) {
                     matchBefore = "..." + matchBefore.substring(
-                        matchBefore.length() - this.maxContextMatch, matchBefore.length()
+                        matchBefore.length() - this.MAX_CONTEXT_MATCH, matchBefore.length()
                     );
                 }
                 String matchText = resourcevalue.substring(matchIndex, matchIndex + query.length());
                 String matchAfter = resourcevalue.substring(matchIndex + query.length());
-                if (matchAfter.length() > this.maxContextMatch) {
-                    matchAfter = matchAfter.substring(0, this.maxContextMatch) + "...";
+                if (matchAfter.length() > this.MAX_CONTEXT_MATCH) {
+                    matchAfter = matchAfter.substring(0, this.MAX_CONTEXT_MATCH) + "...";
                 }
                 String matchType = getQuestion(thisResource);
                 String[] queryMatch = {

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
@@ -229,14 +229,7 @@ public class QueryBuilder implements Use
             Resource thisResource = foundResources.next();
             Resource thisParent = thisResource;
             String[] resourcevalues = thisResource.getValueMap().get("value", String[].class);
-            while (true)
-            {
-                if (thisParent == null)
-                {
-                    break;
-                } else if ("lfs/Form".equals(thisParent.getResourceType())) {
-                    break;
-                }
+            while (thisParent != null && !"lfs/Form".equals(thisParent.getResourceType())) {
                 thisParent = thisParent.getParent();
             }
             if (thisParent != null)

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
@@ -30,6 +30,7 @@ import HeaderStyle from "./headerStyle.jsx";
 
 const QUERY_URL = "/query";
 const MAX_RESULTS = 5;
+const LFS_QUERY_MATCH_KEY = "lfs:queryMatch";
 
 function SearchBar(props) {
   const { classes, className, closeSidebar, invertColors, doNotEscapeQuery } = props;
@@ -257,13 +258,13 @@ function SearchBar(props) {
                             </Typography>
                             {getElementName(element)}
                           </div>)}
-                          secondary={("queryMatch" in element) ? (<React.Fragment>
-                            {getElementQueryMatchKey(element["queryMatch"])}
-                            {getElementQueryMatchBefore(element["queryMatch"])}
+                          secondary={(LFS_QUERY_MATCH_KEY in element) ? (<React.Fragment>
+                            {getElementQueryMatchKey(element[LFS_QUERY_MATCH_KEY])}
+                            {getElementQueryMatchBefore(element[LFS_QUERY_MATCH_KEY])}
                             <span className={classes.highlightedText}>
-                              {getElementQueryMatchText(element["queryMatch"])}
+                              {getElementQueryMatchText(element[LFS_QUERY_MATCH_KEY])}
                             </span>
-                            {getElementQueryMatchAfter(element["queryMatch"])}
+                            {getElementQueryMatchAfter(element[LFS_QUERY_MATCH_KEY])}
                           </React.Fragment>) : undefined}
                           className={classes.dropdownItem}
                           />

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
@@ -111,12 +111,12 @@ function SearchBar(props) {
   function QuickSearchResultHeader(props) {
     const {resultData} = props;
     return resultData && (
-      <React.Fragment>
+      <div>
         <Typography variant="body2" color="textSecondary">
           {(resultData.questionnaire?.title?.concat(' ') || '') + (resultData["jcr:primaryType"]?.replace(/lfs:/,"") || '')}
         </Typography>
         {resultData.subject?.identifier || resultData["jcr:uuid"] || ''}
-      </React.Fragment>
+      </div>
     ) || null
   }
 
@@ -135,6 +135,8 @@ function SearchBar(props) {
   }
 
   // Display a quick search result
+  // If it's a resource, show avatar, category, and title
+  // Otherwise, if it's a generic entry, simply display the name
   function QuickSearchResult(props) {
     const {resultData} = props;
     return resultData["jcr:primaryType"] && (
@@ -146,6 +148,11 @@ function SearchBar(props) {
           className={classes.dropdownItem}
         />
       </React.Fragment>
+    ) || (
+       <ListItemText
+          primary={resultData.name || ''}
+          className={classes.dropdownItem}
+        />
     ) || null
   }
 

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
@@ -30,6 +30,7 @@ import HeaderStyle from "./headerStyle.jsx";
 
 const QUERY_URL = "/query";
 const MAX_RESULTS = 5;
+const MAX_CONTEXT_MATCH = 8;
 
 function SearchBar(props) {
   const { classes, className, closeSidebar, invertColors, doNotEscapeQuery } = props;
@@ -147,6 +148,32 @@ function SearchBar(props) {
       || element["jcr:uuid"];
   }
 
+  let getElementQueryMatchKey = (element) => {
+    return element[0] + " = ";
+  }
+
+  let getElementQueryMatchBefore = (element) => {
+    if (element[1].length <= MAX_CONTEXT_MATCH) {
+      return element[1];
+    }
+    else {
+      return "..." + element[1].slice(-1 * MAX_CONTEXT_MATCH);
+    }
+  }
+
+  let getElementQueryMatchText = (element) => {
+    return element[2];
+  }
+
+  let getElementQueryMatchAfter = (element) => {
+    if (element[3].length <= MAX_CONTEXT_MATCH) {
+      return element[3];
+    }
+    else {
+      return element[3].slice(0, MAX_CONTEXT_MATCH) + "...";
+    }
+  }
+
   return(
     <React.Fragment>
       <Input
@@ -241,6 +268,14 @@ function SearchBar(props) {
                             </Typography>
                             {getElementName(element)}
                           </div>)}
+                          secondary={("queryMatch" in element) ? (<React.Fragment>
+                            {getElementQueryMatchKey(element["queryMatch"])}
+                            {getElementQueryMatchBefore(element["queryMatch"])}
+                            <span className={classes.highlightedText}>
+                              {getElementQueryMatchText(element["queryMatch"])}
+                            </span>
+                            {getElementQueryMatchAfter(element["queryMatch"])}
+                          </React.Fragment>) : undefined}
                           className={classes.dropdownItem}
                           />
                     </MenuItem>

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
@@ -148,20 +148,17 @@ function SearchBar(props) {
       || element["jcr:uuid"];
   }
 
-  let getElementQueryMatchKey = (element) => {
-    return element[0] + " = ";
-  }
-
-  let getElementQueryMatchBefore = (element) => {
-    return element[1];
-  }
-
-  let getElementQueryMatchText = (element) => {
-    return element[2];
-  }
-
-  let getElementQueryMatchAfter = (element) => {
-    return element[3];
+  function QuickSearchMatch(props) {
+    const {matchData} = props;
+    return matchData && (
+      <React.Fragment>
+        <span className={classes.queryMatchKey}>{matchData[0]}</span>
+        <span className={classes.queryMatchSeparator}>: </span>
+        <span className={classes.queryMatchBefore}>{matchData[1]}</span>
+        <span className={classes.highlightedText}>{matchData[2]}</span>
+        <span className={classes.queryMatchAfter}>{matchData[3]}</span>
+      </React.Fragment>
+    ) || null
   }
 
   return(
@@ -258,14 +255,7 @@ function SearchBar(props) {
                             </Typography>
                             {getElementName(element)}
                           </div>)}
-                          secondary={(LFS_QUERY_MATCH_KEY in element) ? (<React.Fragment>
-                            {getElementQueryMatchKey(element[LFS_QUERY_MATCH_KEY])}
-                            {getElementQueryMatchBefore(element[LFS_QUERY_MATCH_KEY])}
-                            <span className={classes.highlightedText}>
-                              {getElementQueryMatchText(element[LFS_QUERY_MATCH_KEY])}
-                            </span>
-                            {getElementQueryMatchAfter(element[LFS_QUERY_MATCH_KEY])}
-                          </React.Fragment>) : undefined}
+                          secondary={(<QuickSearchMatch matchData={element[LFS_QUERY_MATCH_KEY]} />)}
                           className={classes.dropdownItem}
                           />
                     </MenuItem>

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
@@ -22,15 +22,12 @@ import { withRouter } from "react-router-dom";
 
 import { ClickAwayListener, Grow, IconButton, Input, InputAdornment, ListItemText, MenuItem, ListItemAvatar, Avatar}  from "@material-ui/core";
 import { MenuList, Paper, Popper, Typography, withStyles } from "@material-ui/core";
-import AssignmentIcon from "@material-ui/icons/Assignment";
 import DescriptionIcon from "@material-ui/icons/Description";
-import AssignmentIndIcon from "@material-ui/icons/AssignmentInd";
 import Search from "@material-ui/icons/Search";
 import HeaderStyle from "./headerStyle.jsx";
 
 const QUERY_URL = "/query";
 const MAX_RESULTS = 5;
-const LFS_QUERY_MATCH_KEY = "lfs:queryMatch";
 
 function SearchBar(props) {
   const { classes, className, closeSidebar, invertColors, doNotEscapeQuery } = props;
@@ -76,16 +73,16 @@ function SearchBar(props) {
     doNotEscapeQuery && new_url.searchParams.set("doNotEscapeQuery", "true");
     new_url.searchParams.set("limit", MAX_RESULTS);
     new_url.searchParams.set("req", requestID);
-    // In the closure generated, displayResults will look for req_id, instead of requestID+1
+    // In the closure generated, postprocessResults will look for req_id, instead of requestID+1
     setRequestID(requestID+1);
     fetch(new_url)
       .then(response => response.ok ? response.json() : Promise.reject(response))
-      .then(displayResults)
+      .then(postprocessResults)
       .catch(handleError);
   }
 
   // Callback to store the results of the top results, or to display 'No results'
-  let displayResults = (json) => {
+  let postprocessResults = (json) => {
     // Ignore this result if the request ID does not match our last request
     if (json["req"] != requestID) {
       return;
@@ -108,46 +105,22 @@ function SearchBar(props) {
     setError(response);
   }
 
-  const categoryToAvatar = {
-    ["lfs:Form"]: <Avatar className={classes.searchResultFormIcon + " " + classes.searchResultAvatar}>
-        <DescriptionIcon />
-      </Avatar>,
-    ["lfs:Questionnaire"]: <Avatar className={classes.searchResultQuestionnaireIcon + " " + classes.searchResultAvatar}>
-        <AssignmentIcon />
-      </Avatar>,
-    ["lfs:Subject"]: <Avatar className={classes.searchResultSubjectIcon + " " + classes.searchResultAvatar}>
-        <AssignmentIndIcon />
-      </Avatar>
+  // Generate a human-readable info about the resource (form) matching the query:
+  // * questionnaire title (if available) and result type, followed by
+  // * the form's subject name (if available) or the resource's uuid
+  function QuickSearchResultHeader(props) {
+    const {resultData} = props;
+    return resultData && (
+      <React.Fragment>
+        <Typography variant="body2" color="textSecondary">
+          {(resultData.questionnaire?.title?.concat(' ') || '') + (resultData["jcr:primaryType"]?.replace(/lfs:/,"") || '')}
+        </Typography>
+        {resultData.subject?.identifier || resultData["jcr:uuid"] || ''}
+      </React.Fragment>
+    ) || null
   }
 
-  // Get a user friendly version of the icon
-  let getCategoryIcon = (element) => (
-    categoryToAvatar[element["jcr:primaryType"]] ?
-      <ListItemAvatar>{categoryToAvatar[element["jcr:primaryType"]]}</ListItemAvatar>
-      : " "
-  );
-
-  // Get a user friendly version of the category
-  let getFriendlyCategory = (element) => {
-    const friendlyType = element["jcr:primaryType"] && element["jcr:primaryType"].replace(/lfs:/,"");
-    /* Prepend the questionnaire title, if this has it */
-    return (element["questionnaire"] ? element["questionnaire"]["title"] + " " + friendlyType
-    /* Otherwise just use the user-friendly element name */
-      : friendlyType);
-  }
-
-  // Attempt a few different methods of getting the name of an element from <code>/query?quick</code>
-  let getElementName = (element) => {
-    /* Form data: grab the subject name */
-    return (element["subject"] && element["subject"]["identifier"])
-      /* Questionnaire: grab the title */
-      || element["name"] || element["title"]
-      /* Subject: grab the subject ID */
-      || element["identifier"]
-      /* Could not find any of the above: return the uuid */
-      || element["jcr:uuid"];
-  }
-
+  // Display how the query matched the result
   function QuickSearchMatch(props) {
     const {matchData} = props;
     return matchData && (
@@ -157,6 +130,21 @@ function SearchBar(props) {
         <span className={classes.queryMatchBefore}>{matchData[1]}</span>
         <span className={classes.highlightedText}>{matchData[2]}</span>
         <span className={classes.queryMatchAfter}>{matchData[3]}</span>
+      </React.Fragment>
+    ) || null
+  }
+
+  // Display a quick search result
+  function QuickSearchResult(props) {
+    const {resultData} = props;
+    return resultData["jcr:primaryType"] && (
+      <React.Fragment>
+        <ListItemAvatar><Avatar className={classes.searchResultAvatar}><DescriptionIcon /></Avatar></ListItemAvatar>
+        <ListItemText
+          primary={(<QuickSearchResultHeader resultData={resultData} />)}
+          secondary={(<QuickSearchMatch matchData={resultData["lfs:queryMatch"]} />)}
+          className={classes.dropdownItem}
+        />
       </React.Fragment>
     ) || null
   }
@@ -231,33 +219,22 @@ function SearchBar(props) {
                         primaryTypographyProps={{color: "error"}}
                         />
                     </MenuItem>
-                  : results.map( (element) => (
+                  : results.map( (result) => (
                     /* Results if no errors occurred */
                     <MenuItem
                       className={classes.dropdownItem}
-                      key={element["@path"]}
-                      disabled={element["disabled"]}
+                      key={result["@path"]}
+                      disabled={result["disabled"]}
                       onClick={(e) => {
                         // Redirect using React-router
-                        if (element["@path"]) {
-                          props.history.push("/content.html" + element["@path"]);
+                        if (result["@path"]) {
+                          props.history.push("/content.html" + result["@path"]);
                           closeSidebar && closeSidebar();
                           setPopperOpen(false);
                         }
                         }}
                       >
-                        {getCategoryIcon(element)}
-                        {/* for now, nothing in the secondary until we get the suggest() API working */}
-                        <ListItemText
-                          primary={(<div>
-                            <Typography variant="body2" color="textSecondary">
-                              {getFriendlyCategory(element)}
-                            </Typography>
-                            {getElementName(element)}
-                          </div>)}
-                          secondary={(<QuickSearchMatch matchData={element[LFS_QUERY_MATCH_KEY]} />)}
-                          className={classes.dropdownItem}
-                          />
+                      <QuickSearchResult resultData={result} />
                     </MenuItem>
                   ))}
                 </MenuList>

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
@@ -30,7 +30,6 @@ import HeaderStyle from "./headerStyle.jsx";
 
 const QUERY_URL = "/query";
 const MAX_RESULTS = 5;
-const MAX_CONTEXT_MATCH = 8;
 
 function SearchBar(props) {
   const { classes, className, closeSidebar, invertColors, doNotEscapeQuery } = props;
@@ -153,12 +152,7 @@ function SearchBar(props) {
   }
 
   let getElementQueryMatchBefore = (element) => {
-    if (element[1].length <= MAX_CONTEXT_MATCH) {
-      return element[1];
-    }
-    else {
-      return "..." + element[1].slice(-1 * MAX_CONTEXT_MATCH);
-    }
+    return element[1];
   }
 
   let getElementQueryMatchText = (element) => {
@@ -166,12 +160,7 @@ function SearchBar(props) {
   }
 
   let getElementQueryMatchAfter = (element) => {
-    if (element[3].length <= MAX_CONTEXT_MATCH) {
-      return element[3];
-    }
-    else {
-      return element[3].slice(0, MAX_CONTEXT_MATCH) + "...";
-    }
+    return element[3];
   }
 
   return(

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/headerStyle.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/headerStyle.jsx
@@ -123,6 +123,15 @@ const headerStyle = theme => ({
   searchResultSubjectIcon: {
     backgroundColor: "orange"
   },
+  queryMatchKey : {
+    fontStyle: "italic"
+  },
+  queryMatchSeparator: {
+  },
+  queryMatchBefore: {
+  },
+  queryMatchAfter: {
+  },
   highlightedText: {
     fontWeight: "bold",
     backgroundColor: theme.palette.warning.light,

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/headerStyle.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/headerStyle.jsx
@@ -122,6 +122,12 @@ const headerStyle = theme => ({
   },
   searchResultSubjectIcon: {
     backgroundColor: "orange"
+  },
+  highlightedText: {
+    fontWeight: "bold",
+    backgroundColor: theme.palette.warning.light,
+    padding: "1px 2px",
+    borderRadius: "4px"
   }
 });
 

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/headerStyle.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/headerStyle.jsx
@@ -112,16 +112,8 @@ const headerStyle = theme => ({
     zIndex: "1301"
   },
   searchResultAvatar: {
-    color: "white",
-  },
-  searchResultFormIcon: {
-    backgroundColor: "cornflowerblue"
-  },
-  searchResultQuestionnaireIcon: {
-    backgroundColor: "limegreen"
-  },
-  searchResultSubjectIcon: {
-    backgroundColor: "orange"
+    color: theme.palette.getContrastText(theme.palette.info.main),
+    backgroundColor: theme.palette.info.main,
   },
   queryMatchKey : {
     fontStyle: "italic"


### PR DESCRIPTION
This PR re-implements the `quickSearch()` method so that *XPATH* is used instead of *JCR-SQL2*. The *XPATH* query is written so that not only direct children of the form but also nested answers are searched. This PR also takes front-end code from the *LFS-254* PR, specifically for highlighting the matching text substring for a matching answer.

This PR implements everything required by *LFS-254* except for ensuring that it is the *first* matching answer that is displayed in the auto-suggest results - this has been moved to a new sprint. Due to the large overlap in functionality between this PR and *LFS-254*, merging this PR will not allow for *LFS-254* to be merged over-top.