### PR TITLE
Fix LFS-259 bug.

### DIFF
--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
@@ -153,7 +153,7 @@ public class QueryBuilder implements Use
         }
 
         // Escape sequence taken from https://jackrabbit.apache.org/archive/wiki/JCR/EncodingAndEscaping_115513396.html
-        return input.replaceAll("([\\Q+-&|!(){}[]^\"~*?:\\/\\E])", "\\$1").replaceAll("'", "''");
+        return input.replaceAll("([\\Q+-&|!(){}[]^\"~*?:\\/\\E])", "\\\\$1").replaceAll("'", "''");
     }
 
     /**


### PR DESCRIPTION
Special characters are now properly escaped instead of being replaced with `$1`.
For example, before this bug fix, `-` would be transformed to `$1` but now it is transformed to `\-`.

Please note that the fixed method `fullTextEscape(query)` is used by the method `fullTextSearch(query)` which queries using JCR-SQL2. It is currently unknown if these changes will break the functionality of `fullTextSearch(query)` but given that `fullTextEscape(query)` did not match its specifications, it was modified to do so thus allowing it to be used in XPATH queries for searching forms.