### PR TITLE
LFS-320: Add support for notes on answers

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -21,6 +21,7 @@ import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import uuidv4 from "uuid/v4";
 
+import Comment from "./Comment";
 import { useFormWriterContext } from "./FormContext";
 
 export const LABEL_POS = 0;
@@ -29,7 +30,8 @@ export const VALUE_POS = 1;
 // Holds answers and automatically generates hidden inputs
 // for form submission
 function Answer (props) {
-  let { answers, answerNodeType, existingAnswer, path, questionName, questionDefinition, valueType } = props;
+  let { answers, answerNodeType, existingAnswer, path, questionName, questionDefinition, valueType, onChangeComment } = props;
+  let { enableComments } = { ...props, ...questionDefinition };
   let [ answerID ] = useState((existingAnswer && existingAnswer[0]) || uuidv4());
   let answerPath = path + "/" + answerID;
   // Hooks must be pulled from the top level, so this cannot be moved to inside the useEffect()
@@ -61,6 +63,12 @@ function Answer (props) {
       :
         <input type="hidden" name={`${answerPath}/value@Delete`} value="0"></input>
       }
+      {enableComments &&
+        <Comment
+          existingAnswer={existingAnswer}
+          answerPath={answerPath}
+          onChangeComment={onChangeComment}
+          />}
     </React.Fragment>
     );
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -21,7 +21,7 @@ import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import uuidv4 from "uuid/v4";
 
-import Comment from "./Comment";
+import Note from "./Note";
 import { useFormWriterContext } from "./FormContext";
 
 export const LABEL_POS = 0;
@@ -30,8 +30,8 @@ export const VALUE_POS = 1;
 // Holds answers and automatically generates hidden inputs
 // for form submission
 function Answer (props) {
-  let { answers, answerNodeType, existingAnswer, path, questionName, questionDefinition, valueType, onChangeComment } = props;
-  let { enableComments } = { ...props, ...questionDefinition };
+  let { answers, answerNodeType, existingAnswer, path, questionName, questionDefinition, valueType, onChangeNote } = props;
+  let { enableNotes } = { ...props, ...questionDefinition };
   let [ answerID ] = useState((existingAnswer && existingAnswer[0]) || uuidv4());
   let answerPath = path + "/" + answerID;
   // Hooks must be pulled from the top level, so this cannot be moved to inside the useEffect()
@@ -63,11 +63,11 @@ function Answer (props) {
       :
         <input type="hidden" name={`${answerPath}/value@Delete`} value="0"></input>
       }
-      {enableComments &&
-        <Comment
+      {enableNotes &&
+        <Note
           existingAnswer={existingAnswer}
           answerPath={answerPath}
-          onChangeComment={onChangeComment}
+          onChangeNote={onChangeNote}
           />}
     </React.Fragment>
     );

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Comment.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Comment.jsx
@@ -30,14 +30,14 @@ import QuestionnaireStyle from "./QuestionnaireStyle";
 function Comment (props) {
   const { answerPath, existingAnswer, classes, onChangeComment } = {...props};
   let [ comment, setComment ] = useState((existingAnswer?.[1]?.comment));
-  let [ visible, setVisible ] = useState(Boolean(existingAnswer));
+  let [ visible, setVisible ] = useState(Boolean(comment));
 
   let changeComment = (event) => {
     onChangeComment && onChangeComment(event.target.value);
     setComment(event.target.value);
   }
 
-  const commentIsEmpty = comment == null;
+  const commentIsEmpty = comment == null || comment == "";
 
   return (<React.Fragment>
     <div className = {classes.showCommentsContainer}>
@@ -76,7 +76,9 @@ function Comment (props) {
         placeholder = "Please place any additional comments here."
         />
     </Collapse>
-    <input type="hidden" name={`${answerPath}/comment`} value={comment} />
+    {commentIsEmpty ?
+      <input type="hidden" name={`${answerPath}/comment@Delete`} value="0" />
+      : <input type="hidden" name={`${answerPath}/comment`} value={comment} />}
   </React.Fragment>);
 }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Comment.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Comment.jsx
@@ -46,7 +46,7 @@ function Comment (props) {
         >
         <Button
           color = "default"
-          className = {classes.showCommentsButton}
+          className = {classes.toggleCommentsButton}
           onClick = {() => {
             setVisible(!visible);
           }}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Comment.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Comment.jsx
@@ -21,6 +21,7 @@ import React, {useState} from "react";
 import PropTypes from "prop-types";
 
 import { Button, Collapse, TextField, Tooltip, withStyles } from "@material-ui/core";
+import AddIcon from "@material-ui/icons/Add";
 import UnfoldMore from "@material-ui/icons/UnfoldMore";
 import UnfoldLess from "@material-ui/icons/UnfoldLess";
 
@@ -36,21 +37,28 @@ function Comment (props) {
     setComment(event.target.value);
   }
 
+  const commentIsEmpty = comment == null;
+
   return (<React.Fragment>
     <div className = {classes.showCommentsContainer}>
-      <Button
-        color = "default"
-        onClick = {() => {
-          setVisible(!visible);
-        }}
-        startIcon = {visible ?
-          <UnfoldLess fontSize="small" />
-          : <UnfoldMore fontSize="small" />
-        }
-        disableFocusRipple
+      <Tooltip
+        title = {visible ? "Hide notes" : (commentIsEmpty ? "Add notes" : "Show notes")}
         >
-        {visible ? "Hide additional comments" : "Show additional comments"}
-      </Button>
+        <Button
+          color = "default"
+          className = {classes.showCommentsButton}
+          onClick = {() => {
+            setVisible(!visible);
+          }}
+          startIcon = {visible ?
+            <UnfoldLess fontSize="small" />
+            : (commentIsEmpty ? <AddIcon fontSize="small" /> : <UnfoldMore fontSize="small" />)
+          }
+          disableFocusRipple
+          >
+          Notes
+        </Button>
+      </Tooltip>
     </div>
     <Collapse
       in={visible}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Comment.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Comment.jsx
@@ -1,0 +1,75 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React, {useState} from "react";
+import PropTypes from "prop-types";
+
+import { Button, Collapse, TextField, Tooltip, withStyles } from "@material-ui/core";
+import UnfoldMore from "@material-ui/icons/UnfoldMore";
+import UnfoldLess from "@material-ui/icons/UnfoldLess";
+
+import QuestionnaireStyle from "./QuestionnaireStyle";
+
+function Comment (props) {
+  const { answerPath, existingAnswer, classes, onChangeComment } = {...props};
+  let [ comment, setComment ] = useState((existingAnswer?.[1]?.comment));
+  let [ visible, setVisible ] = useState(Boolean(existingAnswer));
+
+  let changeComment = (event) => {
+    onChangeComment && onChangeComment(event.target.value);
+    setComment(event.target.value);
+  }
+
+  return (<React.Fragment>
+    <div className = {classes.showCommentsContainer}>
+      <Button
+        color = "default"
+        onClick = {() => {
+          setVisible(!visible);
+        }}
+        startIcon = {visible ?
+          <UnfoldLess fontSize="small" />
+          : <UnfoldMore fontSize="small" />
+        }
+        disableFocusRipple
+        >
+        {visible ? "Hide additional comments" : "Show additional comments"}
+      </Button>
+    </div>
+    <Collapse
+      in={visible}
+      >
+      <TextField
+        value = {comment}
+        onChange = {changeComment}
+        variant = "outlined"
+        multiline
+        rows = "4"
+        className = {classes.commentSection}
+        InputProps = {{
+          className: classes.textField
+        }}
+        placeholder = "Please place any additional comments here."
+        />
+    </Collapse>
+    <input type="hidden" name={`${answerPath}/comment`} value={comment} />
+  </React.Fragment>);
+}
+
+export default withStyles(QuestionnaireStyle)(Comment);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx
@@ -182,14 +182,6 @@ function DateQuestion(props) {
       {...rest}
       >
       {error && <Typography color='error'>{errorText}</Typography>}
-      <Answer
-        answers={outputAnswers}
-        questionDefinition={props.questionDefinition}
-        existingAnswer={existingAnswer}
-        answerNodeType="lfs:DateAnswer"
-        valueType="Date"
-        {...rest}
-        />
       <TextField
         type={textFieldType}
         className={classes.textField + " " + classes.answerField}
@@ -241,6 +233,14 @@ function DateQuestion(props) {
         />
       </React.Fragment>
       }
+      <Answer
+        answers={outputAnswers}
+        questionDefinition={props.questionDefinition}
+        existingAnswer={existingAnswer}
+        answerNodeType="lfs:DateAnswer"
+        valueType="Date"
+        {...rest}
+        />
     </Question>);
 }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -203,22 +203,17 @@ function MultipleChoice(props) {
   if (isBare) {
     return(
       <React.Fragment>
+        {ghostInput}
         <Answer
           answers={answers}
           existingAnswer={existingAnswer}
           {...rest}
           />
-        {ghostInput}
       </React.Fragment>
     )
   } else if (isRadio) {
     return (
       <React.Fragment>
-        <Answer
-          answers={answers}
-          existingAnswer={existingAnswer}
-          {...rest}
-          />
         <RadioGroup
           aria-label="selection"
           name="selection"
@@ -254,21 +249,26 @@ function MultipleChoice(props) {
         </RadioGroup>
         {ghostInput}
         {warning}
-      </React.Fragment>
-    );
-  } else {
-    return (
-      <React.Fragment>
         <Answer
           answers={answers}
           existingAnswer={existingAnswer}
           {...rest}
           />
+      </React.Fragment>
+    );
+  } else {
+    return (
+      <React.Fragment>
         <List className={classes.checkboxList}>
           {generateDefaultOptions(options, selection, disabled, isRadio, selectNonGhostOption, removeOption)}
         </List>
         {ghostInput}
         {warning}
+        <Answer
+          answers={answers}
+          existingAnswer={existingAnswer}
+          {...rest}
+          />
       </React.Fragment>
     )
   }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Note.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Note.jsx
@@ -27,32 +27,32 @@ import UnfoldLess from "@material-ui/icons/UnfoldLess";
 
 import QuestionnaireStyle from "./QuestionnaireStyle";
 
-function Comment (props) {
-  const { answerPath, existingAnswer, classes, onChangeComment } = {...props};
-  let [ comment, setComment ] = useState((existingAnswer?.[1]?.comment));
-  let [ visible, setVisible ] = useState(Boolean(comment));
+function Note (props) {
+  const { answerPath, existingAnswer, classes, onChangeNote } = {...props};
+  let [ note, setNote ] = useState((existingAnswer?.[1]?.note));
+  let [ visible, setVisible ] = useState(Boolean(note));
 
-  let changeComment = (event) => {
-    onChangeComment && onChangeComment(event.target.value);
-    setComment(event.target.value);
+  let changeNote = (event) => {
+    onChangeNote && onChangeNote(event.target.value);
+    setNote(event.target.value);
   }
 
-  const commentIsEmpty = comment == null || comment == "";
+  const noteIsEmpty = note == null || note == "";
 
   return (<React.Fragment>
-    <div className = {classes.showCommentsContainer}>
+    <div className = {classes.toggleNotesContainer}>
       <Tooltip
-        title = {visible ? "Hide notes" : (commentIsEmpty ? "Add notes" : "Show notes")}
+        title = {visible ? "Hide notes" : (noteIsEmpty ? "Add notes" : "Show notes")}
         >
         <Button
           color = "default"
-          className = {classes.toggleCommentsButton}
+          className = {classes.toggleNotesButton}
           onClick = {() => {
             setVisible(!visible);
           }}
           startIcon = {visible ?
             <UnfoldLess fontSize="small" />
-            : (commentIsEmpty ? <AddIcon fontSize="small" /> : <UnfoldMore fontSize="small" />)
+            : (noteIsEmpty ? <AddIcon fontSize="small" /> : <UnfoldMore fontSize="small" />)
           }
           disableFocusRipple
           >
@@ -64,22 +64,22 @@ function Comment (props) {
       in={visible}
       >
       <TextField
-        value = {comment}
-        onChange = {changeComment}
+        value = {note}
+        onChange = {changeNote}
         variant = "outlined"
         multiline
         rows = "4"
-        className = {classes.commentSection}
+        className = {classes.noteSection}
         InputProps = {{
           className: classes.textField
         }}
-        placeholder = "Please place any additional comments here."
+        placeholder = "Please place any additional notes here."
         />
     </Collapse>
-    {commentIsEmpty ?
-      <input type="hidden" name={`${answerPath}/comment@Delete`} value="0" />
-      : <input type="hidden" name={`${answerPath}/comment`} value={comment} />}
+    {noteIsEmpty ?
+      <input type="hidden" name={`${answerPath}/note@Delete`} value="0" />
+      : <input type="hidden" name={`${answerPath}/note`} value={note} />}
   </React.Fragment>);
 }
 
-export default withStyles(QuestionnaireStyle)(Comment);
+export default withStyles(QuestionnaireStyle)(Note);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Note.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Note.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, {useState} from "react";
+import React, { useState, useRef } from "react";
 import PropTypes from "prop-types";
 
 import { Button, Collapse, TextField, Tooltip, withStyles } from "@material-ui/core";
@@ -31,10 +31,15 @@ function Note (props) {
   const { answerPath, existingAnswer, classes, onChangeNote } = {...props};
   let [ note, setNote ] = useState((existingAnswer?.[1]?.note));
   let [ visible, setVisible ] = useState(Boolean(note));
+  let inputRef = useRef();
 
   let changeNote = (event) => {
     onChangeNote && onChangeNote(event.target.value);
     setNote(event.target.value);
+  }
+
+  let focusInput = () => {
+    inputRef.current.focus();
   }
 
   const noteIsEmpty = note == null || note == "";
@@ -54,14 +59,14 @@ function Note (props) {
             <UnfoldLess fontSize="small" />
             : (noteIsEmpty ? <AddIcon fontSize="small" /> : <UnfoldMore fontSize="small" />)
           }
-          disableFocusRipple
           >
           Notes
         </Button>
       </Tooltip>
     </div>
     <Collapse
-      in={visible}
+      in = {visible}
+      onEntered = {focusInput}
       >
       <TextField
         value = {note}
@@ -74,6 +79,7 @@ function Note (props) {
           className: classes.textField
         }}
         placeholder = "Please place any additional notes here."
+        inputRef = {inputRef}
         />
     </Collapse>
     {noteIsEmpty ?

--- a/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
@@ -160,6 +160,7 @@ function NumberQuestion(props) {
   return (
     <Question
       text={text}
+      existingAnswer={existingAnswer}
       {...rest}
       >
       {error && <Typography color='error'>{errorText}</Typography>}
@@ -179,13 +180,6 @@ function NumberQuestion(props) {
         /> :
       /* Otherwise just use a single text field */
       <React.Fragment>
-        <Answer
-          answers={answers}
-          existingAnswer={existingAnswer}
-          answerNodeType={answerNodeType}
-          valueType={valueType}
-          {...rest}
-          />
         <TextField
           className={classes.textField + " " + classes.answerField}
           onChange={(event) => {
@@ -196,6 +190,13 @@ function NumberQuestion(props) {
           value={input}
           InputProps={muiInputProps}
           />
+          <Answer
+            answers={answers}
+            existingAnswer={existingAnswer}
+            answerNodeType={answerNodeType}
+            valueType={valueType}
+            {...rest}
+            />
       </React.Fragment>
         }
       {isRange &&

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -173,6 +173,9 @@ const questionnaireStyle = theme => ({
     showCommentsContainer: {
         padding: theme.spacing(1, 0, 1, 2)
     },
+    showCommentsButton: {
+        textTransform: "none"
+    },
     commentSection: {
         display: "block",
         marginLeft: theme.spacing(6)

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -169,6 +169,13 @@ const questionnaireStyle = theme => ({
     },
     highlightedTitle: {
         color: theme.palette.primary.light,
+    },
+    showCommentsContainer: {
+        padding: theme.spacing(1, 0, 1, 2)
+    },
+    commentSection: {
+        display: "block",
+        marginLeft: theme.spacing(6)
     }
 });
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -173,7 +173,7 @@ const questionnaireStyle = theme => ({
     showCommentsContainer: {
         padding: theme.spacing(1, 0, 1, 2)
     },
-    showCommentsButton: {
+    toggleCommentsButton: {
         textTransform: "none"
     },
     commentSection: {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -170,13 +170,13 @@ const questionnaireStyle = theme => ({
     highlightedTitle: {
         color: theme.palette.primary.light,
     },
-    showCommentsContainer: {
+    toggleNotesContainer: {
         padding: theme.spacing(1, 0, 1, 2)
     },
-    toggleCommentsButton: {
+    toggleNotesButton: {
         textTransform: "none"
     },
-    commentSection: {
+    noteSection: {
         display: "block",
         marginLeft: theme.spacing(6)
     }

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -181,6 +181,10 @@
   // If defined, this must be a valid solr query that can be placed in the "fq" field.
   - vocabularyFilter (string)
 
+  // Some questions may be answered with long stories, which may have useful information but should not be stored as-is without curation.
+  // We allow users to place these answers in a Comments section
+  - enableComments (boolean)
+
   // Since not all properties are mandatory, customizing a question requires defining only
   // the properties of interest.
   //
@@ -414,6 +418,10 @@
 
   // The value, undefined yet, must be properly typed by the concrete subtypes.
   - value (undefined)
+
+  // Some questions may have been answered with long stories, which may have useful information.
+  // We allow users to place these answers in a Comment section
+  - comment (string)
 
   // We don't define any subchildren.
 

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -182,8 +182,8 @@
   - vocabularyFilter (string)
 
   // Some questions may be answered with long stories, which may have useful information but should not be stored as-is without curation.
-  // We allow users to place these answers in a Comments section
-  - enableComments (boolean)
+  // We allow users to place these answers in a Notes section
+  - enableNotes (boolean)
 
   // Since not all properties are mandatory, customizing a question requires defining only
   // the properties of interest.
@@ -420,8 +420,8 @@
   - value (undefined)
 
   // Some questions may have been answered with long stories, which may have useful information.
-  // We allow users to place these answers in a Comment section
-  - comment (string)
+  // We allow users to place these answers in a Note section
+  - note (string)
 
   // We don't define any subchildren.
 


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/LFS-320)

**Test branch**: `LFS-320-test` 

**To test**: From the homepage, create a Demographics form. The Family question has comments enabled, which can be added to.

**Additional notes**: This is configurable from the Questionnaire definition and is off by default. All question components that use an `Answer` component will have this (optionally) enabled, and for best-looking results I've moved the `Answer` component to the bottom of every question (it previously was sometimes at the top of the question, and sometimes at the bottom -- its positioning did not previously matter since it had no visible components)