### PR TITLE
LFS-324: [Bugfix] Date answers keep going back in time after each save/reload

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx
@@ -99,7 +99,7 @@ function amendMoment(date, format) {
 function DateQuestion(props) {
   let {existingAnswer, type, displayFormat, lowerLimit, upperLimit, classes, ...rest} = props;
   let {text, dateFormat} = {dateFormat: "yyyy-MM-dd", ...props.questionDefinition, ...props};
-  let currentStartValue = existingAnswer && existingAnswer[1].value && Array.of(existingAnswer[1].value).flat()[0] || null;
+  let currentStartValue = existingAnswer && existingAnswer[1].value && Array.of(existingAnswer[1].value).flat()[0].split("T")[0] || null;
   const [selectedDate, changeDate] = useState(amendMoment(moment(currentStartValue), dateFormat));
   // FIXME There's no way to store the end date currently. Maybe add existingAnswer[1].endValue?
   const [selectedEndDate, changeEndDate] = useState(amendMoment(moment(), dateFormat));


### PR DESCRIPTION
The *LFS-324* bug is caused by the `DateQuestion` component reading its set date as UTC time from its *state* and passing this to a *moment.js* object. To remedy this problem, timezone information should be ignored as only dates are important, not times.