### PR TITLE
LFS-369: Notes don't show up in quick searches 

### DIFF
--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
@@ -63,7 +63,7 @@ public class QueryBuilder implements Use
     private static final String LFS_QUERY_MATCH_BEFORE_KEY = "before";
     private static final String LFS_QUERY_MATCH_TEXT_KEY = "text";
     private static final String LFS_QUERY_MATCH_AFTER_KEY = "after";
-    private static final String LFS_QUERY_MATCH_NOTES_KEY = "isNotes";
+    private static final String LFS_QUERY_MATCH_NOTES_KEY = "inNotes";
 
     private String content;
 

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/QueryBuilder.java
@@ -269,7 +269,7 @@ public class QueryBuilder implements Use
             String noteValue = thisResource.getValueMap().get("note", String.class);
 
             // As a fallback for when the query isn't in the value field, attempt to use the note field
-            if (resourceValue == null && StringUtils.containsIgnoreCase(query, noteValue)) {
+            if (resourceValue == null && StringUtils.containsIgnoreCase(noteValue, query)) {
                 resourceValue = noteValue;
             }
 

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
@@ -29,6 +29,14 @@ import HeaderStyle from "./headerStyle.jsx";
 const QUERY_URL = "/query";
 const MAX_RESULTS = 5;
 
+// Location of the quick search result metadata in a node, outlining what needs to be highlighted
+const LFS_QUERY_MATCH_KEY = "lfs:queryMatch";
+// Properties of the quick search result metadata
+const LFS_QUERY_QUESTION_KEY = "Question";
+const LFS_QUERY_MATCH_BEFORE_KEY = "Before";
+const LFS_QUERY_MATCH_TEXT_KEY = "Text";
+const LFS_QUERY_MATCH_AFTER_KEY = "After";
+
 function SearchBar(props) {
   const { classes, className, closeSidebar, invertColors, doNotEscapeQuery } = props;
   const [ search, setSearch ] = useState("");
@@ -126,11 +134,11 @@ function SearchBar(props) {
     const {matchData} = props;
     return matchData && (
       <React.Fragment>
-        <span className={classes.queryMatchKey}>{matchData[0]}</span>
+        <span className={classes.queryMatchKey}>{matchData[LFS_QUERY_QUESTION_KEY]}</span>
         <span className={classes.queryMatchSeparator}>: </span>
-        <span className={classes.queryMatchBefore}>{matchData[1]}</span>
-        <span className={classes.highlightedText}>{matchData[2]}</span>
-        <span className={classes.queryMatchAfter}>{matchData[3]}</span>
+        <span className={classes.queryMatchBefore}>{matchData[LFS_QUERY_MATCH_BEFORE_KEY]}</span>
+        <span className={classes.highlightedText}>{matchData[LFS_QUERY_MATCH_TEXT_KEY]}</span>
+        <span className={classes.queryMatchAfter}>{matchData[LFS_QUERY_MATCH_AFTER_KEY]}</span>
       </React.Fragment>
     ) || null
   }
@@ -145,7 +153,7 @@ function SearchBar(props) {
         <ListItemAvatar><Avatar className={classes.searchResultAvatar}><DescriptionIcon /></Avatar></ListItemAvatar>
         <ListItemText
           primary={(<QuickSearchResultHeader resultData={resultData} />)}
-          secondary={(<QuickSearchMatch matchData={resultData["lfs:queryMatch"]} />)}
+          secondary={(<QuickSearchMatch matchData={resultData[LFS_QUERY_MATCH_KEY]} />)}
           className={classes.dropdownItem}
         />
       </React.Fragment>

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
@@ -98,7 +98,7 @@ function SearchBar(props) {
       return;
     }
 
-    // Parse out the top 5 and display in popper
+    // Show the results, if any
     if (json["rows"].length > 0) {
       setResults(json["rows"]);
     } else {
@@ -244,11 +244,11 @@ function SearchBar(props) {
                         primaryTypographyProps={{color: "error"}}
                         />
                     </MenuItem>
-                  : results.map( (result) => (
+                  : results.map( (result, i) => (
                     /* Results if no errors occurred */
                     <MenuItem
                       className={classes.dropdownItem}
-                      key={result["@path"]}
+                      key={i}
                       disabled={result["disabled"]}
                       onClick={(e) => {
                         // Redirect using React-router

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
@@ -32,10 +32,11 @@ const MAX_RESULTS = 5;
 // Location of the quick search result metadata in a node, outlining what needs to be highlighted
 const LFS_QUERY_MATCH_KEY = "lfs:queryMatch";
 // Properties of the quick search result metadata
-const LFS_QUERY_QUESTION_KEY = "Question";
-const LFS_QUERY_MATCH_BEFORE_KEY = "Before";
-const LFS_QUERY_MATCH_TEXT_KEY = "Text";
-const LFS_QUERY_MATCH_AFTER_KEY = "After";
+const LFS_QUERY_QUESTION_KEY = "question";
+const LFS_QUERY_MATCH_BEFORE_KEY = "before";
+const LFS_QUERY_MATCH_TEXT_KEY = "text";
+const LFS_QUERY_MATCH_AFTER_KEY = "after";
+const LFS_QUERY_MATCH_NOTES_KEY = "isNotes";
 
 function SearchBar(props) {
   const { classes, className, closeSidebar, invertColors, doNotEscapeQuery } = props;
@@ -132,9 +133,11 @@ function SearchBar(props) {
   // Display how the query matched the result
   function QuickSearchMatch(props) {
     const {matchData} = props;
+    // Adjust the question text to reflect the notes, if the match was on the notes
+    let questionText = matchData[LFS_QUERY_QUESTION_KEY] + (matchData[LFS_QUERY_MATCH_NOTES_KEY] ? " / Notes" : "");
     return matchData && (
       <React.Fragment>
-        <span className={classes.queryMatchKey}>{matchData[LFS_QUERY_QUESTION_KEY]}</span>
+        <span className={classes.queryMatchKey}>{questionText}</span>
         <span className={classes.queryMatchSeparator}>: </span>
         <span className={classes.queryMatchBefore}>{matchData[LFS_QUERY_MATCH_BEFORE_KEY]}</span>
         <span className={classes.highlightedText}>{matchData[LFS_QUERY_MATCH_TEXT_KEY]}</span>

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/SearchBar.jsx
@@ -36,7 +36,7 @@ const LFS_QUERY_QUESTION_KEY = "question";
 const LFS_QUERY_MATCH_BEFORE_KEY = "before";
 const LFS_QUERY_MATCH_TEXT_KEY = "text";
 const LFS_QUERY_MATCH_AFTER_KEY = "after";
-const LFS_QUERY_MATCH_NOTES_KEY = "isNotes";
+const LFS_QUERY_MATCH_NOTES_KEY = "inNotes";
 
 function SearchBar(props) {
   const { classes, className, closeSidebar, invertColors, doNotEscapeQuery } = props;


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/LFS-369)

[Review link of just this PR](https://github.com/ccmbioinfo/lfs/pull/176/commits/2721cc9bee4d676d0a0890306bf48336c82bdbcc)

**Test branch**: `LFS-369-test` 

**To test**: From the homepage, create a Demographics form. The Family question has comments enabled, which can be added to. These notes should now be searchable from the quick search bar.

**Additional notes**: This includes a minor refactor of `QueryBuilder.java`, to avoid the cyclomatic complexity and executable statement count checkstyle errors.