### PR TITLE
LFS-277: Filter out all incomplete forms from the form listings

### DIFF
--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
@@ -121,6 +121,10 @@ public class PaginationServlet extends SlingSafeMethodsServlet
                 )
             );
         }
+        // Only display `INCOMPLETE` forms if we are explicitly checking the status of forms
+        if (!("statusFlags".equals(fieldname))) {
+            query.append(" and not n.'statusFlags'='INCOMPLETE'");
+        }
 
         // Condition on child nodes. See parseFilter for details.
         final String[] filtervalues = request.getParameterValues("filtervalues");


### PR DESCRIPTION
**Please note this PR is branched off of LFS-276, which in turn is branched off of LFS-275, which in turn is branched off of LFS-273** 

This PR modifies the `doGet()` function in `PaginationServlet` so that, unless the `fieldname` parameter is set to `statusFlags`, forms will not be returned if they contain the `INCOMPLETE` status flag.

This is a very simple solution but I believe that it covers all requirements for LFS-277. Please send me your feedback.