### PR TITLE
LFS-273-275: Automatically flag answers/forms based on their values/levels of completion

### DIFF
--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -608,6 +608,8 @@
   // Hardcode the resource supertype: each form is a resource.
   - sling:resourceSuperType (STRING) = "lfs/Resource" mandatory autocreated protected
 
+  - statusFlags (STRING) = "INCOMPLETE" mandatory autocreated
+
   // A reference to the questionnaire being filled in.
   // Mandatory, every form has a questionnaire.
   // No full text search, since it's just a non-textual reference.

--- a/modules/form-completion-status/pom.xml
+++ b/modules/form-completion-status/pom.xml
@@ -66,5 +66,9 @@
       <artifactId>org.osgi.service.component.annotations</artifactId>
       <version>1.4.0</version>
     </dependency>
+    <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -142,6 +142,13 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                     statusFlags.add(STATUS_FLAG_INCOMPLETE);
                 }
                 this.currentNodeBuilder.setProperty(STATUS_FLAGS, statusFlags, Type.STRINGS);
+
+                //Summarize all parents
+                try {
+                    summarizeBuilders(this.currentNodeBuilderPath);
+                } catch (RepositoryException e) {
+                    LOGGER.warn("Could not run summarize()");
+                }
             }
         }
     }
@@ -252,7 +259,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
          * i == 1 --> jcr:root/Forms
          * i == 2 --> jcr:root/Forms/<some form object>
          */
-        for (int i = nodeBuilders.size() - 1; i >= 2; i--) {
+        for (int i = nodeBuilders.size() - 2; i >= 2; i--) {
             summarizeBuilder(nodeBuilders.get(i));
         }
     }

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -42,6 +42,10 @@ import org.apache.sling.api.resource.ResourceResolver;
 public class AnswerCompletionStatusEditor extends DefaultEditor
 {
 
+    private static final String STATUS_FLAGS = "statusFlags";
+    private static final String STATUS_FLAG_INCOMPLETE = "INCOMPLETE";
+    private static final String STATUS_FLAG_INVALID = "INVALID";
+
     // This holds the builder for the current node. The methods called for editing specific properties don't receive the
     // actual parent node of those properties, so we must manually keep track of the current node.
     private final NodeBuilder currentNodeBuilder;
@@ -79,8 +83,8 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
             int numAnswers = iterableLength(nodeAnswers);
             ArrayList<String> statusFlags = new ArrayList<String>();
             if (checkInvalidAnswer(questionNode, numAnswers)) {
-                statusFlags.add("INVALID");
-                statusFlags.add("INCOMPLETE");
+                statusFlags.add(STATUS_FLAG_INVALID);
+                statusFlags.add(STATUS_FLAG_INCOMPLETE);
             } else {
                 /*
                  * We are here because:
@@ -101,7 +105,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                  * Remove INVALID and INCOMPLETE flags if all validation rules pass
                  */
             }
-            this.currentNodeBuilder.setProperty("statusFlags", statusFlags, Type.STRINGS);
+            this.currentNodeBuilder.setProperty(STATUS_FLAGS, statusFlags, Type.STRINGS);
         }
     }
 
@@ -115,10 +119,10 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 ArrayList<String> statusFlags = new ArrayList<String>();
                 //Only add the INVALID,INCOMPLETE flags if the given question requires more than zero answers
                 if (checkInvalidAnswer(questionNode, 0)) {
-                    statusFlags.add("INVALID");
-                    statusFlags.add("INCOMPLETE");
+                    statusFlags.add(STATUS_FLAG_INVALID);
+                    statusFlags.add(STATUS_FLAG_INCOMPLETE);
                 }
-                this.currentNodeBuilder.setProperty("statusFlags", statusFlags, Type.STRINGS);
+                this.currentNodeBuilder.setProperty(STATUS_FLAGS, statusFlags, Type.STRINGS);
             }
         }
     }
@@ -136,9 +140,9 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 ArrayList<String> statusFlags = new ArrayList<String>();
                 //Only add the INCOMPLETE flag if the given question requires more than zero answers
                 if (checkInvalidAnswer(questionNode, 0)) {
-                    statusFlags.add("INCOMPLETE");
+                    statusFlags.add(STATUS_FLAG_INCOMPLETE);
                 }
-                this.currentNodeBuilder.getChildNode(name).setProperty("statusFlags", statusFlags, Type.STRINGS);
+                this.currentNodeBuilder.getChildNode(name).setProperty(STATUS_FLAGS, statusFlags, Type.STRINGS);
             }
         }
         return new AnswerCompletionStatusEditor(this.currentNodeBuilder.getChildNode(name),

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -58,8 +58,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     // is later used for obtaining the constraints on the answers submitted to a question.
     private final ResourceResolver currentResourceResolver;
 
-    private final String currentPath;
-
     private final ArrayList<NodeBuilder> currentNodeBuilderPath;
 
     /**
@@ -67,16 +65,12 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
      *
      * @param nodeBuilder the builder for the current node
      * @param resourceResolver a ResourceResolver object used to obtain answer constraints
-     * @param path the JCR path of this node
      */
-    public AnswerCompletionStatusEditor(ArrayList<NodeBuilder> nodeBuilder, ResourceResolver resourceResolver,
-        String path)
+    public AnswerCompletionStatusEditor(ArrayList<NodeBuilder> nodeBuilder, ResourceResolver resourceResolver)
     {
         this.currentNodeBuilderPath = nodeBuilder;
         this.currentNodeBuilder = nodeBuilder.get(nodeBuilder.size() - 1);
         this.currentResourceResolver = resourceResolver;
-        this.currentPath = path;
-        LOGGER.warn("Constructing AnswerCompletionStatusEditor with path: {}", path);
         LOGGER.warn("this.currentNodeBuilderPath = {}", this.currentNodeBuilderPath);
         /*
         try {
@@ -128,27 +122,10 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
             }
             this.currentNodeBuilder.setProperty(STATUS_FLAGS, statusFlags, Type.STRINGS);
             //Summarize all parents
-            for (int i = this.currentNodeBuilderPath.size() - 1; i >= 0; i--) {
-                String[] sections = this.currentPath.split("/");
-                String subsection = "";
-                //ArrayList<NodeBuilder> subsectionNodeBuilder = new ArrayList<NodeBuilder>();
-                for (int j = 0; j <= i; j++) {
-                    if ("".equals(sections[j])) {
-                        continue;
-                    }
-                    subsection += "/" + sections[j];
-                    //subsectionNodeBuilder.add(this.currentNodeBuilderPath.get(j));
-                }
-                if (!subsection.startsWith("/Forms/")) {
-                    continue;
-                }
-                LOGGER.warn("WILL SUMMARIZE: {}", subsection);
-                LOGGER.warn("OBJECTS...: {}", this.currentNodeBuilderPath.get(i));
-                try {
-                    summarizeBuilders(this.currentNodeBuilderPath);
-                } catch (RepositoryException e) {
-                    LOGGER.warn("Could not run summarize()");
-                }
+            try {
+                summarizeBuilders(this.currentNodeBuilderPath);
+            } catch (RepositoryException e) {
+                LOGGER.warn("Could not run summarize()");
             }
         }
     }
@@ -190,32 +167,24 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 this.currentNodeBuilder.getChildNode(name).setProperty(STATUS_FLAGS, statusFlags, Type.STRINGS);
             }
         }
-        String newNodeName = "";
-        if (!"".equals(name)) {
-            newNodeName = this.currentPath + "/" + name;
-        }
         ArrayList<NodeBuilder> tmpList = new ArrayList<NodeBuilder>();
         for (int i = 0; i < this.currentNodeBuilderPath.size(); i++) {
             tmpList.add(this.currentNodeBuilderPath.get(i));
         }
         tmpList.add(this.currentNodeBuilder.getChildNode(name));
-        return new AnswerCompletionStatusEditor(tmpList, this.currentResourceResolver, newNodeName);
+        return new AnswerCompletionStatusEditor(tmpList, this.currentResourceResolver);
     }
 
     @Override
     public Editor childNodeChanged(String name, NodeState before, NodeState after) throws CommitFailedException
     {
-        LOGGER.warn("[AnswerCompletionStatusEditor] childNodeChanged: {}", name);
-        String newNodeName = "";
-        if (!"".equals(name)) {
-            newNodeName = this.currentPath + "/" + name;
-        }
+        LOGGER.warn("[AnswerStatusFlagEditor] childNodeChanged: {}", name);
         ArrayList<NodeBuilder> tmpList = new ArrayList<NodeBuilder>();
         for (int i = 0; i < this.currentNodeBuilderPath.size(); i++) {
             tmpList.add(this.currentNodeBuilderPath.get(i));
         }
         tmpList.add(this.currentNodeBuilder.getChildNode(name));
-        return new AnswerCompletionStatusEditor(tmpList, this.currentResourceResolver, newNodeName);
+        return new AnswerCompletionStatusEditor(tmpList, this.currentResourceResolver);
     }
 
     /**

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -58,12 +58,17 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     // is later used for obtaining the constraints on the answers submitted to a question.
     private final ResourceResolver currentResourceResolver;
 
+    // This holds a list of NodeBuilders with the first item corresponding to the root of the JCR tree
+    // and the last item corresponding to the current node. By keeping this list, one is capable of
+    // moving up the tree and setting status flags of ancestor nodes based on the status flags of a
+    // descendant node.
     private final ArrayList<NodeBuilder> currentNodeBuilderPath;
 
     /**
      * Simple constructor.
      *
-     * @param nodeBuilder the builder for the current node
+     * @param nodeBuilder an ArrayList of NodeBuilder objects starting from the root of the JCR tree
+     *     and moving down towards the current node.
      * @param resourceResolver a ResourceResolver object used to obtain answer constraints
      */
     public AnswerCompletionStatusEditor(ArrayList<NodeBuilder> nodeBuilder, ResourceResolver resourceResolver)
@@ -72,13 +77,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         this.currentNodeBuilder = nodeBuilder.get(nodeBuilder.size() - 1);
         this.currentResourceResolver = resourceResolver;
         LOGGER.warn("this.currentNodeBuilderPath = {}", this.currentNodeBuilderPath);
-        /*
-        try {
-            summarizeBuilders(this.currentNodeBuilderPath);
-        } catch (RepositoryException e) {
-            LOGGER.warn("Could not run summarize()");
-        }
-        */
     }
 
     // Called when a new property is added
@@ -263,7 +261,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     {
         LOGGER.warn("WORKING WITH: {}", selectedNodeBuilder);
         //Iterate through all children of this node
-        //NodeIterator childNodes = selectedNode.getNodes();
         Iterable<String> childrenNames = selectedNodeBuilder.getChildNodeNames();
         Iterator<String> childrenNamesIter = childrenNames.iterator();
         boolean isInvalid = false;
@@ -287,7 +284,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 }
             }
         }
-        //Set the flags in selectedNode accordingly
+        //Set the flags in selectedNodeBuilder accordingly
         ArrayList<String> statusFlags = new ArrayList<String>();
         if (isInvalid) {
             statusFlags.add(STATUS_FLAG_INVALID);
@@ -296,7 +293,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
             statusFlags.add(STATUS_FLAG_INCOMPLETE);
         }
         //Write these statusFlags to the JCR repo
-        //selectedNode.setProperty(STATUS_FLAGS, statusFlags.toArray(new String[0]));
         selectedNodeBuilder.setProperty(STATUS_FLAGS, statusFlags, Type.STRINGS);
     }
 }

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -76,7 +76,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         this.currentNodeBuilderPath = nodeBuilder;
         this.currentNodeBuilder = nodeBuilder.get(nodeBuilder.size() - 1);
         this.currentResourceResolver = resourceResolver;
-        LOGGER.warn("this.currentNodeBuilderPath = {}", this.currentNodeBuilderPath);
     }
 
     // Called when a new property is added
@@ -166,7 +165,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     @Override
     public Editor childNodeAdded(String name, NodeState after) throws CommitFailedException
     {
-        LOGGER.warn("[AnswerCompletionStatusEditor] childNodeAdded: {}", name);
         Node questionNode = getQuestionNode(this.currentNodeBuilder.getChildNode(name));
         if (questionNode != null) {
             if (this.currentNodeBuilder.getChildNode(name).hasProperty("question")) {
@@ -189,7 +187,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     @Override
     public Editor childNodeChanged(String name, NodeState before, NodeState after) throws CommitFailedException
     {
-        LOGGER.warn("[AnswerStatusFlagEditor] childNodeChanged: {}", name);
         ArrayList<NodeBuilder> tmpList = new ArrayList<NodeBuilder>();
         for (int i = 0; i < this.currentNodeBuilderPath.size(); i++) {
             tmpList.add(this.currentNodeBuilderPath.get(i));
@@ -272,7 +269,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
 
     private void summarizeBuilder(NodeBuilder selectedNodeBuilder) throws RepositoryException
     {
-        LOGGER.warn("WORKING WITH: {}", selectedNodeBuilder);
         //Iterate through all children of this node
         Iterable<String> childrenNames = selectedNodeBuilder.getChildNodeNames();
         Iterator<String> childrenNamesIter = childrenNames.iterator();
@@ -287,7 +283,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 Iterator<String> selectedPropsIter = selectedProps.iterator();
                 while (selectedPropsIter.hasNext()) {
                     String thisStr = selectedPropsIter.next();
-                    LOGGER.warn("...checking for... {}", thisStr);
                     if (STATUS_FLAG_INVALID.equals(thisStr)) {
                         isInvalid = true;
                     }

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -280,10 +280,18 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
 
     private void summarizeBuilders(ArrayList<NodeBuilder> nodeBuilders) throws RepositoryException
     {
-        if (nodeBuilders.size() < 3) {
-            return;
+        /*
+         * i == 0 --> jcr:root
+         * i == 1 --> jcr:root/Forms
+         * i == 2 --> jcr:root/Forms/<some form object>
+         */
+        for (int i = nodeBuilders.size() - 1; i >= 2; i--) {
+            summarizeBuilder(nodeBuilders.get(i));
         }
-        NodeBuilder selectedNodeBuilder = nodeBuilders.get(nodeBuilders.size() - 2);
+    }
+
+    private void summarizeBuilder(NodeBuilder selectedNodeBuilder) throws RepositoryException
+    {
         LOGGER.warn("WORKING WITH: {}", selectedNodeBuilder);
         //Iterate through all children of this node
         //NodeIterator childNodes = selectedNode.getNodes();

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -84,6 +84,12 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     public void propertyAdded(PropertyState after) throws CommitFailedException
     {
         propertyChanged(null, after);
+        //Summarize all parents
+        try {
+            summarizeBuilders(this.currentNodeBuilderPath);
+        } catch (RepositoryException e) {
+            return;
+        }
     }
 
     // Called when the value of an existing property gets changed

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -328,6 +328,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     /**
      * Evaluates the boolean expression {propA} {operator} {propB}.
      */
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
     private boolean evalSectionCondition(PropertyState propA, Property propB, String operator)
         throws RepositoryException, ValueFormatException
     {
@@ -364,6 +365,12 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                     break;
             }
             if ("<>".equals(operator)) {
+                testResult = !testResult;
+            }
+            return testResult;
+        } else if ("is empty".equals(operator) || "is not empty".equals(operator)) {
+            boolean testResult = (propA == null);
+            if ("is not empty".equals(operator)) {
                 testResult = !testResult;
             }
             return testResult;

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -336,18 +336,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
              * Everything else uses ==
              */
             LOGGER.warn("propA is of type {}", propA.getType().toString());
-            /*
-            if (Type.STRING.equals(propA.getType())) {
-                if (propA.getValue(Type.STRING).equals(propB.getValues()[0].getString())) {
-                    return true;
-                }
-            } else {
-                LOGGER.warn("COMPARING WITH == ...");
-                if (propA.getValue(Type.BOOLEAN) == propB.getValues()[0].getBoolean()) {
-                    return true;
-                }
-            }
-            */
             boolean testResult = false;
             switch (propB.getValues()[0].getType()) {
                 case PropertyType.STRING:

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -352,25 +352,21 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         }
     }
 
-    @SuppressWarnings("checkstyle:ReturnCount")
     private int getPropertyStateType(PropertyState ps)
     {
+        int ret = PropertyType.STRING;
         if (Type.LONG.equals(ps.getType())) {
-            return PropertyType.LONG;
+            ret = PropertyType.LONG;
+        } else if (Type.DOUBLE.equals(ps.getType())) {
+            ret = PropertyType.DOUBLE;
+        } else if (Type.DECIMAL.equals(ps.getType())) {
+            ret = PropertyType.DECIMAL;
+        } else if (Type.BOOLEAN.equals(ps.getType())) {
+            ret = PropertyType.BOOLEAN;
+        } else if (Type.DATE.equals(ps.getType())) {
+            ret = PropertyType.DATE;
         }
-        if (Type.DOUBLE.equals(ps.getType())) {
-            return PropertyType.DOUBLE;
-        }
-        if (Type.DECIMAL.equals(ps.getType())) {
-            return PropertyType.DECIMAL;
-        }
-        if (Type.BOOLEAN.equals(ps.getType())) {
-            return PropertyType.BOOLEAN;
-        }
-        if (Type.DATE.equals(ps.getType())) {
-            return PropertyType.DATE;
-        }
-        return PropertyType.STRING;
+        return ret;
     }
 
     private boolean evalSectionEq(PropertyState propA, Value valB)

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -502,11 +502,66 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         return outStr;
     }
 
-    @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:JavaNCSS"})
+    private Object getObjectFromPropertyState(PropertyState ps)
+    {
+        Object ret = null;
+        switch (getPropertyStateType(ps))
+        {
+            case PropertyType.STRING:
+                ret = ps.getValue(Type.STRING);
+                break;
+            case PropertyType.LONG:
+                ret = ps.getValue(Type.LONG);
+                break;
+            case PropertyType.DOUBLE:
+                ret = ps.getValue(Type.DOUBLE);
+                break;
+            case PropertyType.DECIMAL:
+                ret = ps.getValue(Type.DECIMAL);
+                break;
+            case PropertyType.BOOLEAN:
+                ret = ps.getValue(Type.BOOLEAN);
+                break;
+            case PropertyType.DATE:
+                ret = ps.getValue(Type.DATE);
+                break;
+            default:
+                break;
+        }
+        return ret;
+    }
+
+    private Object getObjectFromValue(Value val) throws RepositoryException, ValueFormatException
+    {
+        Object ret = null;
+        switch (val.getType()) {
+            case PropertyType.STRING:
+                ret = val.getString();
+                break;
+            case PropertyType.LONG:
+                ret = val.getLong();
+                break;
+            case PropertyType.DOUBLE:
+                ret = val.getDouble();
+                break;
+            case PropertyType.DECIMAL:
+                ret = val.getDecimal();
+                break;
+            case PropertyType.BOOLEAN:
+                ret = val.getBoolean();
+                break;
+            case PropertyType.DATE:
+                ret = val.getDate();
+                break;
+            default:
+                break;
+        }
+        return ret;
+    }
+
     private Object getOperandValue(final Node operand, final Node sectionNode, final NodeBuilder prevNb)
         throws RepositoryException
     {
-        //TODO: Implement me
         Object returnedValue = null;
         if (operand.getProperty(PROP_IS_REFERENCE).getValue().getBoolean()) {
             String key = operand.getProperty(PROP_VALUE).getValues()[0].getString();
@@ -521,31 +576,8 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 return null;
             }
             final PropertyState operandProp = conditionalFormNode.getProperty(PROP_VALUE);
-            switch (getPropertyStateType(operandProp))
-            {
-                case PropertyType.STRING:
-                    returnedValue = operandProp.getValue(Type.STRING);
-                    break;
-                case PropertyType.LONG:
-                    returnedValue = operandProp.getValue(Type.LONG);
-                    break;
-                case PropertyType.DOUBLE:
-                    returnedValue = operandProp.getValue(Type.DOUBLE);
-                    break;
-                case PropertyType.DECIMAL:
-                    returnedValue = operandProp.getValue(Type.DECIMAL);
-                    break;
-                case PropertyType.BOOLEAN:
-                    returnedValue = operandProp.getValue(Type.BOOLEAN);
-                    break;
-                case PropertyType.DATE:
-                    returnedValue = operandProp.getValue(Type.DATE);
-                    break;
-                default:
-                    break;
-            }
+            returnedValue = getObjectFromPropertyState(operandProp);
         } else {
-            //return operand.getProperty(PROP_VALUE);
             Property nodeProp = operand.getProperty(PROP_VALUE);
             Value nodeVal;
             if (nodeProp.isMultiple()) {
@@ -553,29 +585,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
             } else {
                 nodeVal = nodeProp.getValue();
             }
-            //return nodeVal;
-            switch (nodeVal.getType()) {
-                case PropertyType.STRING:
-                    returnedValue = nodeVal.getString();
-                    break;
-                case PropertyType.LONG:
-                    returnedValue = nodeVal.getLong();
-                    break;
-                case PropertyType.DOUBLE:
-                    returnedValue = nodeVal.getDouble();
-                    break;
-                case PropertyType.DECIMAL:
-                    returnedValue = nodeVal.getDecimal();
-                    break;
-                case PropertyType.BOOLEAN:
-                    returnedValue = nodeVal.getBoolean();
-                    break;
-                case PropertyType.DATE:
-                    returnedValue = nodeVal.getDate();
-                    break;
-                default:
-                    break;
-            }
+            returnedValue = getObjectFromValue(nodeVal);
         }
         return returnedValue;
     }
@@ -612,25 +622,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
             final String comparator = conditionNode.getProperty("comparator").getString();
             final Node operandB = conditionNode.getNode("operandB");
             final Node operandA = conditionNode.getNode("operandA");
-
-            /*
-            String keyA = operandA.getProperty(PROP_VALUE).getValues()[0].getString();
-            // Sanitize
-            keyA = sanitizeNodeName(keyA);
-            // Get the node from the Questionnaire corresponding to keyA
-            final Node sectionNodeParent = sectionNode.getParent();
-            final Node keyANode = sectionNodeParent.getNode(keyA);
-            final String keyANodeUUID = keyANode.getIdentifier();
-            // Get the node from the Form containing the answer to keyANode
-            final NodeBuilder conditionalFormNode = getChildNodeWithQuestion(prevNb, keyANodeUUID);
-            // ...if the answer node does not exist, return false - can't compare to something non-existant
-            if (conditionalFormNode == null) {
-                return false;
-            }
-            final PropertyState comparedProp = conditionalFormNode.getProperty(PROP_VALUE);
-            final Property referenceProp = operandB.getProperty(PROP_VALUE);
-            return evalSectionCondition(comparedProp, referenceProp, comparator);
-            */
 
             final Object valueA = getOperandValue(operandA, sectionNode, prevNb);
             final Object valueB = getOperandValue(operandB, sectionNode, prevNb);

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -299,9 +299,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
          * i == 1 --> jcr:root/Forms
          * i == 2 --> jcr:root/Forms/<some form object>
          */
-        LOGGER.warn("Running summarizeBuilders() on size: {}", nodeBuilders.size());
         for (int i = nodeBuilders.size() - 2; i >= 2; i--) {
-            LOGGER.warn("Running summarizeBuilder() for {}", nodeBuilders.get(i));
             summarizeBuilder(nodeBuilders.get(i), nodeBuilders.get(i - 1));
         }
     }
@@ -327,7 +325,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
             NodeBuilder selectedChild = nb.getChildNode(selectedChildName);
             if (selectedChild.hasProperty("question")) {
                 if (uuid.equals(selectedChild.getProperty("question").getValue(Type.STRING))) {
-                    LOGGER.warn("....found the match!!");
                     return selectedChild;
                 }
             }
@@ -343,7 +340,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
      */
     private Calendar parseDate(final String str)
     {
-        LOGGER.warn("PARSING DATE: {}", str);
         try {
             //SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
             SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd");
@@ -361,26 +357,20 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     private int getPropertyStateType(PropertyState ps)
     {
         if (Type.LONG.equals(ps.getType())) {
-            LOGGER.warn("{} is a PropertyType.LONG", ps.getValue(Type.LONG));
             return PropertyType.LONG;
         }
         if (Type.DOUBLE.equals(ps.getType())) {
-            LOGGER.warn("{} is a PropertyType.DOUBLE", ps.getValue(Type.DOUBLE));
             return PropertyType.DOUBLE;
         }
         if (Type.DECIMAL.equals(ps.getType())) {
-            LOGGER.warn("{} is a PropertyType.DECIMAL", ps.getValue(Type.DECIMAL));
             return PropertyType.DECIMAL;
         }
         if (Type.BOOLEAN.equals(ps.getType())) {
-            LOGGER.warn("{} is a PropertyType.BOOLEAN", ps.getValue(Type.BOOLEAN));
             return PropertyType.BOOLEAN;
         }
         if (Type.DATE.equals(ps.getType())) {
-            LOGGER.warn("{} is a PropertyType.DATE", ps.getValue(Type.DATE));
             return PropertyType.DATE;
         }
-        LOGGER.warn("{} is a PropertyType.STRING", ps.getValue(Type.STRING));
         return PropertyType.STRING;
     }
 
@@ -474,7 +464,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
              * Type.STRING uses .equals()
              * Everything else uses ==
              */
-            LOGGER.warn("propA is of type {}", propA.getType().toString());
             boolean testResult = evalSectionEq(propA, valB);
             if ("<>".equals(operator)) {
                 testResult = !testResult;
@@ -529,12 +518,10 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
             Node operandA = conditionNode.getNode("operandA");
             //TODO: Sanitize?
             String keyA = operandA.getProperty("value").getValues()[0].getString();
-            LOGGER.warn("Value of keyA is {}", keyA);
             //Get the node from the Questionnaire corresponding to keyA
             Node sectionNodeParent = sectionNode.getParent();
             Node keyANode = sectionNodeParent.getNode(keyA);
             String keyANodeUUID = keyANode.getIdentifier();
-            LOGGER.warn("Checking for a match to {}...", keyANodeUUID);
             //Get the node from the Form containg the answer to keyANode
             NodeBuilder conditionalFormNode = getChildNodeWithQuestion(prevNb, keyANodeUUID);
             PropertyState comparedProp = conditionalFormNode.getProperty("value");
@@ -552,7 +539,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         Node sectionNode = getSectionNode(nb);
         if (sectionNode.hasNode("condition")) {
             Node conditionNode = sectionNode.getNode("condition");
-            LOGGER.warn("...The condition node is {}", conditionNode.getIdentifier());
             /*
              * Recursively go through all children of the condition node
              * and determine if this condition node evaluates to True or
@@ -576,14 +562,9 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         boolean isIncomplete = false;
         while (childrenNamesIter.hasNext()) {
             String selectedChildName = childrenNamesIter.next();
-            LOGGER.warn("Checking child ----> {}", selectedChildName);
             NodeBuilder selectedChild = selectedNodeBuilder.getChildNode(selectedChildName);
             if ("lfs:AnswerSection".equals(selectedChild.getProperty("jcr:primaryType").getValue(Type.STRING))) {
-                LOGGER.warn("........ {} is an AnswerSection, we may not need to include it.", selectedChildName);
-                if (getSectionCondition(selectedChild, selectedNodeBuilder)) {
-                    LOGGER.warn(" **** INCLUDE IT! ****");
-                } else {
-                    LOGGER.warn(" **** SKIP IT! ****");
+                if (!getSectionCondition(selectedChild, selectedNodeBuilder)) {
                     continue;
                 }
             }

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -524,7 +524,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         return false;
     }
 
-    @SuppressWarnings("checkstyle:NestedIfDepth")
     private boolean getSectionCondition(NodeBuilder nb, NodeBuilder prevNb)
         throws RepositoryException
     {

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -218,6 +218,12 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         return null;
     }
 
+    /**
+     * Gets the questionnaire section node referenced by the AnswerSection
+     *     NodeBuilder nb.
+     *
+     * @return the section Node object referenced by NodeBuilder nb
+     */
     private Node getSectionNode(NodeBuilder nb)
     {
         try {

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -257,12 +257,11 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         throws RepositoryException
     {
         // Iterate through all children of this node
-        final Iterable<String> childrenNames = selectedNodeBuilder.getChildNodeNames();
-        final Iterator<String> childrenNamesIter = childrenNames.iterator();
+        final Iterator<String> childrenNames = this.currentNodeBuilder.getChildNodeNames().iterator();
         boolean isInvalid = false;
         boolean isIncomplete = false;
-        while (childrenNamesIter.hasNext()) {
-            final String selectedChildName = childrenNamesIter.next();
+        while (childrenNames.hasNext()) {
+            final String selectedChildName = childrenNames.next();
             final NodeBuilder selectedChild = this.currentNodeBuilder.getChildNode(selectedChildName);
             if ("lfs:AnswerSection".equals(selectedChild.getProperty("jcr:primaryType").getValue(Type.STRING))) {
                 final Session resourceSession = this.currentResourceResolver.adaptTo(Session.class);

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -325,6 +325,86 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         return null;
     }
 
+    private int getPropertyStateType(PropertyState ps)
+    {
+        if (Type.LONG.equals(ps.getType())) {
+            return PropertyType.LONG;
+        }
+        if (Type.DOUBLE.equals(ps.getType())) {
+            return PropertyType.DOUBLE;
+        }
+        if (Type.DECIMAL.equals(ps.getType())) {
+            return PropertyType.DECIMAL;
+        }
+        if (Type.BOOLEAN.equals(ps.getType())) {
+            return PropertyType.BOOLEAN;
+        }
+        return PropertyType.STRING;
+    }
+
+    private boolean evalSectionEq(PropertyState propA, Value valB)
+        throws RepositoryException, ValueFormatException
+    {
+        boolean testResult = false;
+        //switch (valB.getType()) {
+        switch (getPropertyStateType(propA)) {
+            case PropertyType.STRING:
+                testResult = propA.getValue(Type.STRING).equals(valB.getString());
+                break;
+            case PropertyType.LONG:
+                testResult = (propA.getValue(Type.LONG) == valB.getLong());
+                break;
+            case PropertyType.DOUBLE:
+                testResult = (propA.getValue(Type.DOUBLE) == valB.getDouble());
+                break;
+            case PropertyType.DECIMAL:
+                testResult = (propA.getValue(Type.DECIMAL) == valB.getDecimal());
+                break;
+            case PropertyType.BOOLEAN:
+                testResult = (propA.getValue(Type.BOOLEAN) == valB.getBoolean());
+                break;
+            default:
+                break;
+        }
+        return testResult;
+    }
+
+    private boolean evalSectionLt(PropertyState propA, Value valB)
+        throws RepositoryException, ValueFormatException
+    {
+        boolean testResult = false;
+        //switch (valB.getType()) {
+        switch (getPropertyStateType(propA)) {
+            case PropertyType.LONG:
+                testResult = (propA.getValue(Type.LONG) < valB.getLong());
+                break;
+            case PropertyType.DOUBLE:
+                testResult = (propA.getValue(Type.DOUBLE) < valB.getDouble());
+                break;
+            default:
+                break;
+        }
+        return testResult;
+    }
+
+    private boolean evalSectionGt(PropertyState propA, Value valB)
+        throws RepositoryException, ValueFormatException
+    {
+        boolean testResult = false;
+        //switch (valB.getType()) {
+        switch (getPropertyStateType(propA)) {
+            case PropertyType.LONG:
+                testResult = (propA.getValue(Type.LONG) > valB.getLong());
+                break;
+            case PropertyType.DOUBLE:
+                testResult = (propA.getValue(Type.DOUBLE) > valB.getDouble());
+                break;
+            default:
+                break;
+        }
+        return testResult;
+    }
+
     /**
      * Evaluates the boolean expression {propA} {operator} {propB}.
      */
@@ -344,26 +424,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
              * Everything else uses ==
              */
             LOGGER.warn("propA is of type {}", propA.getType().toString());
-            boolean testResult = false;
-            switch (valB.getType()) {
-                case PropertyType.STRING:
-                    testResult = propA.getValue(Type.STRING).equals(valB.getString());
-                    break;
-                case PropertyType.LONG:
-                    testResult = (propA.getValue(Type.LONG) == valB.getLong());
-                    break;
-                case PropertyType.DOUBLE:
-                    testResult = (propA.getValue(Type.DOUBLE) == valB.getDouble());
-                    break;
-                case PropertyType.DECIMAL:
-                    testResult = (propA.getValue(Type.DECIMAL) == valB.getDecimal());
-                    break;
-                case PropertyType.BOOLEAN:
-                    testResult = (propA.getValue(Type.BOOLEAN) == valB.getBoolean());
-                    break;
-                default:
-                    break;
-            }
+            boolean testResult = evalSectionEq(propA, valB);
             if ("<>".equals(operator)) {
                 testResult = !testResult;
             }
@@ -374,6 +435,10 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 testResult = !testResult;
             }
             return testResult;
+        } else if ("<".equals(operator)) {
+            return evalSectionLt(propA, valB);
+        } else if (">".equals(operator)) {
+            return evalSectionGt(propA, valB);
         }
         //If we can't evaluate it, assume it to be false
         return false;

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -166,7 +166,8 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 try {
                     summarizeBuilders(this.currentNodeBuilderPath);
                 } catch (RepositoryException e) {
-                    LOGGER.warn("Could not run summarize()");
+                    LOGGER.warn("Could not run summarizeBuilders()");
+                    LOGGER.warn(e.toString());
                 }
             }
         }

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -341,7 +341,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     private Calendar parseDate(final String str)
     {
         try {
-            //SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
             SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd");
             Date date = fmt.parse(str.split("T")[0]);
             Calendar calendar = Calendar.getInstance();
@@ -378,7 +377,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         throws RepositoryException, ValueFormatException
     {
         boolean testResult = false;
-        //switch (valB.getType()) {
         switch (getPropertyStateType(propA)) {
             case PropertyType.STRING:
                 testResult = propA.getValue(Type.STRING).equals(valB.getString());
@@ -408,7 +406,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         throws RepositoryException, ValueFormatException
     {
         boolean testResult = false;
-        //switch (valB.getType()) {
         switch (getPropertyStateType(propA)) {
             case PropertyType.LONG:
                 testResult = (propA.getValue(Type.LONG) < valB.getLong());
@@ -429,7 +426,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         throws RepositoryException, ValueFormatException
     {
         boolean testResult = false;
-        //switch (valB.getType()) {
         switch (getPropertyStateType(propA)) {
             case PropertyType.LONG:
                 testResult = (propA.getValue(Type.LONG) > valB.getLong());

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -24,6 +24,7 @@ import javax.jcr.Property;
 import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.Value;
 import javax.jcr.ValueFormatException;
 
 import org.apache.jackrabbit.oak.api.CommitFailedException;
@@ -330,31 +331,40 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     private boolean evalSectionCondition(PropertyState propA, Property propB, String operator)
         throws RepositoryException, ValueFormatException
     {
-        if ("=".equals(operator)) {
+        Value valB;
+        if (propB.isMultiple()) {
+            valB = propB.getValues()[0];
+        } else {
+            valB = propB.getValue();
+        }
+        if ("=".equals(operator) || "<>".equals(operator)) {
             /*
              * Type.STRING uses .equals()
              * Everything else uses ==
              */
             LOGGER.warn("propA is of type {}", propA.getType().toString());
             boolean testResult = false;
-            switch (propB.getValues()[0].getType()) {
+            switch (valB.getType()) {
                 case PropertyType.STRING:
-                    testResult = propA.getValue(Type.STRING).equals(propB.getValues()[0].getString());
+                    testResult = propA.getValue(Type.STRING).equals(valB.getString());
                     break;
                 case PropertyType.LONG:
-                    testResult = (propA.getValue(Type.LONG) == propB.getValues()[0].getLong());
+                    testResult = (propA.getValue(Type.LONG) == valB.getLong());
                     break;
                 case PropertyType.DOUBLE:
-                    testResult = (propA.getValue(Type.DOUBLE) == propB.getValues()[0].getDouble());
+                    testResult = (propA.getValue(Type.DOUBLE) == valB.getDouble());
                     break;
                 case PropertyType.DECIMAL:
-                    testResult = (propA.getValue(Type.DECIMAL) == propB.getValues()[0].getDecimal());
+                    testResult = (propA.getValue(Type.DECIMAL) == valB.getDecimal());
                     break;
                 case PropertyType.BOOLEAN:
-                    testResult = (propA.getValue(Type.BOOLEAN) == propB.getValues()[0].getBoolean());
+                    testResult = (propA.getValue(Type.BOOLEAN) == valB.getBoolean());
                     break;
                 default:
                     break;
+            }
+            if ("<>".equals(operator)) {
+                testResult = !testResult;
             }
             return testResult;
         }

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -44,9 +44,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * An {@link Editor} that verifies the correctness and completeness of
- * submitted questionnaire answers and sets the INVALID and INCOMPLETE
- * status flags accordingly.
+ * An {@link Editor} that verifies the correctness and completeness of submitted questionnaire answers and sets the
+ * INVALID and INCOMPLETE status flags accordingly.
  *
  * @version $Id$
  */
@@ -56,10 +55,13 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     private static final Logger LOGGER = LoggerFactory.getLogger(AnswerCompletionStatusEditor.class);
 
     private static final String PROP_VALUE = "value";
+
     private static final String PROP_QUESTION = "question";
 
     private static final String STATUS_FLAGS = "statusFlags";
+
     private static final String STATUS_FLAG_INCOMPLETE = "INCOMPLETE";
+
     private static final String STATUS_FLAG_INVALID = "INVALID";
 
     // This holds the builder for the current node. The methods called for editing specific properties don't receive the
@@ -92,28 +94,28 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
 
     // Called when a new property is added
     @Override
-    public void propertyAdded(PropertyState after)
+    public void propertyAdded(final PropertyState after)
         throws CommitFailedException
     {
         propertyChanged(null, after);
-        //Summarize all parents
+        // Summarize all parents
         try {
             summarizeBuilders(this.currentNodeBuilderPath);
-        } catch (RepositoryException e) {
+        } catch (final RepositoryException e) {
             return;
         }
     }
 
     // Called when the value of an existing property gets changed
     @Override
-    public void propertyChanged(PropertyState before, PropertyState after)
+    public void propertyChanged(final PropertyState before, final PropertyState after)
         throws CommitFailedException
     {
-        Node questionNode = getQuestionNode(this.currentNodeBuilder);
+        final Node questionNode = getQuestionNode(this.currentNodeBuilder);
         if (questionNode != null && PROP_VALUE.equals(after.getName())) {
-            Iterable<String> nodeAnswers = after.getValue(Type.STRINGS);
-            int numAnswers = iterableLength(nodeAnswers);
-            List<String> statusFlags = new ArrayList<>();
+            final Iterable<String> nodeAnswers = after.getValue(Type.STRINGS);
+            final int numAnswers = iterableLength(nodeAnswers);
+            final List<String> statusFlags = new ArrayList<>();
             if (checkInvalidAnswer(questionNode, numAnswers)) {
                 statusFlags.add(STATUS_FLAG_INVALID);
                 statusFlags.add(STATUS_FLAG_INCOMPLETE);
@@ -138,10 +140,10 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                  */
             }
             this.currentNodeBuilder.setProperty(STATUS_FLAGS, statusFlags, Type.STRINGS);
-            //Summarize all parents
+            // Summarize all parents
             try {
                 summarizeBuilders(this.currentNodeBuilderPath);
-            } catch (RepositoryException e) {
+            } catch (final RepositoryException e) {
                 LOGGER.warn("Could not run summarize()");
             }
         }
@@ -149,10 +151,10 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
 
     // Called when a property is deleted
     @Override
-    public void propertyDeleted(PropertyState before)
+    public void propertyDeleted(final PropertyState before)
         throws CommitFailedException
     {
-        Node questionNode = getQuestionNode(this.currentNodeBuilder);
+        final Node questionNode = getQuestionNode(this.currentNodeBuilder);
         if (questionNode != null) {
             if (PROP_VALUE.equals(before.getName())) {
                 final List<String> statusFlags = new ArrayList<>();
@@ -163,10 +165,10 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 }
                 this.currentNodeBuilder.setProperty(STATUS_FLAGS, statusFlags, Type.STRINGS);
 
-                //Summarize all parents
+                // Summarize all parents
                 try {
                     summarizeBuilders(this.currentNodeBuilderPath);
-                } catch (RepositoryException e) {
+                } catch (final RepositoryException e) {
                     LOGGER.warn("Could not run summarizeBuilders()");
                     LOGGER.warn(e.toString());
                 }
@@ -179,10 +181,10 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     // DefaultEditor is to stop at the root, so we must override the following two methods in order for the editor to be
     // invoked on non-root nodes.
     @Override
-    public Editor childNodeAdded(String name, NodeState after)
+    public Editor childNodeAdded(final String name, final NodeState after)
         throws CommitFailedException
     {
-        Node questionNode = getQuestionNode(this.currentNodeBuilder.getChildNode(name));
+        final Node questionNode = getQuestionNode(this.currentNodeBuilder.getChildNode(name));
         if (questionNode != null) {
             if (this.currentNodeBuilder.getChildNode(name).hasProperty(PROP_QUESTION)) {
                 final List<String> statusFlags = new ArrayList<>();
@@ -199,7 +201,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     }
 
     @Override
-    public Editor childNodeChanged(String name, NodeState before, NodeState after)
+    public Editor childNodeChanged(final String name, final NodeState before, final NodeState after)
         throws CommitFailedException
     {
         final List<NodeBuilder> tmpList = new ArrayList<>(this.currentNodeBuilderPath);
@@ -208,42 +210,41 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     }
 
     /**
-     * Gets the question node associated with the answer for which this
-     * AnswerCompletionStatusEditor is an editor thereof.
+     * Gets the question node associated with the answer for which this AnswerCompletionStatusEditor is an editor
+     * thereof.
      *
      * @return the question Node object associated with this answer
      */
-    private Node getQuestionNode(NodeBuilder nb)
+    private Node getQuestionNode(final NodeBuilder nb)
     {
         try {
             if (nb.hasProperty(PROP_QUESTION)) {
-                Session resourceSession = this.currentResourceResolver.adaptTo(Session.class);
-                String questionNodeReference = nb.getProperty(PROP_QUESTION).getValue(Type.REFERENCE);
-                Node questionNode = resourceSession.getNodeByIdentifier(questionNodeReference);
+                final Session resourceSession = this.currentResourceResolver.adaptTo(Session.class);
+                final String questionNodeReference = nb.getProperty(PROP_QUESTION).getValue(Type.REFERENCE);
+                final Node questionNode = resourceSession.getNodeByIdentifier(questionNodeReference);
                 return questionNode;
             }
-        } catch (RepositoryException ex) {
+        } catch (final RepositoryException ex) {
             return null;
         }
         return null;
     }
 
     /**
-     * Gets the questionnaire section node referenced by the AnswerSection
-     *     NodeBuilder nb.
+     * Gets the questionnaire section node referenced by the AnswerSection NodeBuilder nb.
      *
      * @return the section Node object referenced by NodeBuilder nb
      */
-    private Node getSectionNode(NodeBuilder nb)
+    private Node getSectionNode(final NodeBuilder nb)
     {
         try {
             if (nb.hasProperty("section")) {
-                Session resourceSession = this.currentResourceResolver.adaptTo(Session.class);
-                String sectionNodeReference = nb.getProperty("section").getValue(Type.REFERENCE);
-                Node sectionNode = resourceSession.getNodeByIdentifier(sectionNodeReference);
+                final Session resourceSession = this.currentResourceResolver.adaptTo(Session.class);
+                final String sectionNodeReference = nb.getProperty("section").getValue(Type.REFERENCE);
+                final Node sectionNode = resourceSession.getNodeByIdentifier(sectionNodeReference);
                 return sectionNode;
             }
-        } catch (RepositoryException ex) {
+        } catch (final RepositoryException ex) {
             return null;
         }
         return null;
@@ -255,12 +256,11 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
      * @param iterable the Iterable object to be counted
      * @return the number of objects in the Iterable
      */
-    private int iterableLength(Iterable iterable)
+    private int iterableLength(final Iterable<?> iterable)
     {
         int len = 0;
-        Iterator iterator = iterable.iterator();
-        while (iterator.hasNext())
-        {
+        final Iterator<?> iterator = iterable.iterator();
+        while (iterator.hasNext()) {
             iterator.next();
             len++;
         }
@@ -273,16 +273,16 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
      * @param questionNode the Node to provide the minAnswers and maxAnswers properties
      * @return true if the number of answers is valid, false if it is not
      */
-    private boolean checkInvalidAnswer(Node questionNode, int numAnswers)
+    private boolean checkInvalidAnswer(final Node questionNode, final int numAnswers)
     {
         try {
-            long minAnswers = questionNode.getProperty("minAnswers").getLong();
-            long maxAnswers = questionNode.getProperty("maxAnswers").getLong();
+            final long minAnswers = questionNode.getProperty("minAnswers").getLong();
+            final long maxAnswers = questionNode.getProperty("maxAnswers").getLong();
             if ((numAnswers < minAnswers && minAnswers != 0) || (numAnswers > maxAnswers && maxAnswers != 0)) {
                 return true;
             }
-        } catch (RepositoryException ex) {
-            //If something goes wrong then we definitely cannot have a valid answer
+        } catch (final RepositoryException ex) {
+            // If something goes wrong then we definitely cannot have a valid answer
             return true;
         }
         return false;
@@ -302,24 +302,21 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     }
 
     /**
-     * Returns the first NodeBuilder with a question value equal to the
-     * String uuid that is a child of the NodeBuilder nb. If no such
-     * child can be found, null is returned
+     * Returns the first NodeBuilder with a question value equal to the String uuid that is a child of the NodeBuilder
+     * nb. If no such child can be found, null is returned
      *
      * @param nb the NodeBuilder to search through its children
-     * @param uuid the UUID String for which the child's question
-     *     property must be equal to
-     * @return the first NodeBuilder with a question value equal to the
-     *     String uuid that is a child of the NodeBuilder nb, or null if
-     *     such node does not exist.
+     * @param uuid the UUID String for which the child's question property must be equal to
+     * @return the first NodeBuilder with a question value equal to the String uuid that is a child of the NodeBuilder
+     *         nb, or null if such node does not exist.
      */
-    private NodeBuilder getChildNodeWithQuestion(NodeBuilder nb, String uuid)
+    private NodeBuilder getChildNodeWithQuestion(final NodeBuilder nb, final String uuid)
     {
-        Iterable<String> childrenNames = nb.getChildNodeNames();
-        Iterator<String> childrenNamesIter = childrenNames.iterator();
+        final Iterable<String> childrenNames = nb.getChildNodeNames();
+        final Iterator<String> childrenNamesIter = childrenNames.iterator();
         while (childrenNamesIter.hasNext()) {
-            String selectedChildName = childrenNamesIter.next();
-            NodeBuilder selectedChild = nb.getChildNode(selectedChildName);
+            final String selectedChildName = childrenNamesIter.next();
+            final NodeBuilder selectedChild = nb.getChildNode(selectedChildName);
             if (selectedChild.hasProperty(PROP_QUESTION)) {
                 if (uuid.equals(selectedChild.getProperty(PROP_QUESTION).getValue(Type.STRING))) {
                     return selectedChild;
@@ -338,18 +335,18 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     private Calendar parseDate(final String str)
     {
         try {
-            SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd");
-            Date date = fmt.parse(str.split("T")[0]);
-            Calendar calendar = Calendar.getInstance();
+            final SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd");
+            final Date date = fmt.parse(str.split("T")[0]);
+            final Calendar calendar = Calendar.getInstance();
             calendar.setTime(date);
             return calendar;
-        } catch (ParseException e) {
+        } catch (final ParseException e) {
             LOGGER.warn("PARSING DATE FAILED");
             return null;
         }
     }
 
-    private int getPropertyStateType(PropertyState ps)
+    private int getPropertyStateType(final PropertyState ps)
     {
         int ret = PropertyType.STRING;
         if (Type.LONG.equals(ps.getType())) {
@@ -366,7 +363,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         return ret;
     }
 
-    private boolean evalSectionEq(PropertyState propA, Value valB)
+    private boolean evalSectionEq(final PropertyState propA, final Value valB)
         throws RepositoryException, ValueFormatException
     {
         boolean testResult = false;
@@ -395,7 +392,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         return testResult;
     }
 
-    private boolean evalSectionLt(PropertyState propA, Value valB)
+    private boolean evalSectionLt(final PropertyState propA, final Value valB)
         throws RepositoryException, ValueFormatException
     {
         boolean testResult = false;
@@ -415,7 +412,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         return testResult;
     }
 
-    private boolean evalSectionGt(PropertyState propA, Value valB)
+    private boolean evalSectionGt(final PropertyState propA, final Value valB)
         throws RepositoryException, ValueFormatException
     {
         boolean testResult = false;
@@ -438,7 +435,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     /**
      * Evaluates the boolean expression {propA} {operator} {propB}.
      */
-    private boolean evalSectionCondition(PropertyState propA, Property propB, String operator)
+    private boolean evalSectionCondition(final PropertyState propA, final Property propB, final String operator)
         throws RepositoryException, ValueFormatException
     {
         Value valB;
@@ -468,17 +465,16 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         } else if (">".equals(operator)) {
             return evalSectionGt(propA, valB);
         }
-        //If we can't evaluate it, assume it to be false
+        // If we can't evaluate it, assume it to be false
         return false;
     }
 
     /*
-     * Read in a string, inStr, and return it with any non-allowed
-     * chars removed.
+     * Read in a string, inStr, and return it with any non-allowed chars removed.
      */
-    private String sanitizeNodeName(String inStr)
+    private String sanitizeNodeName(final String inStr)
     {
-        String inStrLower = inStr.toLowerCase();
+        final String inStrLower = inStr.toLowerCase();
         String outStr = "";
         for (int i = 0; i < inStr.length(); i++) {
             if ("abcdefghijklmnopqrstuvwxyz 0123456789_-".indexOf(inStrLower.charAt(i)) > -1) {
@@ -489,26 +485,26 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     }
 
     /*
-     * Given a "condition" node from the "Questionnaires" and a
-     * "lfs:AnswerSection" node from the "Forms" and a NodeBuilder type
-     * object referring to the parent of the "lfs:AnswerSection" node,
-     * evaluate the boolean expression defined by the descendants of
-     * the "condition" Node.
+     * Given a "condition" node from the "Questionnaires" and a "lfs:AnswerSection" node from the "Forms" and a
+     * NodeBuilder type object referring to the parent of the "lfs:AnswerSection" node, evaluate the boolean expression
+     * defined by the descendants of the "condition" Node.
      */
-    private boolean evaluateConditionNodeRecursive(Node conditionNode, Node sectionNode, NodeBuilder prevNb)
+    private boolean evaluateConditionNodeRecursive(final Node conditionNode, final Node sectionNode,
+        final NodeBuilder prevNb)
         throws RepositoryException
     {
         if ("lfs:ConditionalGroup".equals(conditionNode.getProperty("jcr:primaryType").getString())) {
-            //Is this an OR or an AND
-            boolean requireAll = conditionNode.getProperty("requireAll").getBoolean();
-            //Evaluate recursively
-            Iterator<Node> conditionChildren = conditionNode.getNodes();
+            // Is this an OR or an AND
+            final boolean requireAll = conditionNode.getProperty("requireAll").getBoolean();
+            // Evaluate recursively
+            final Iterator<Node> conditionChildren = conditionNode.getNodes();
             boolean downstreamResult = false;
             if (requireAll) {
                 downstreamResult = true;
             }
             while (conditionChildren.hasNext()) {
-                boolean partialRes = evaluateConditionNodeRecursive(conditionChildren.next(), sectionNode, prevNb);
+                final boolean partialRes =
+                    evaluateConditionNodeRecursive(conditionChildren.next(), sectionNode, prevNb);
                 if (requireAll) {
                     downstreamResult = downstreamResult && partialRes;
                 } else {
@@ -517,36 +513,35 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
             }
             return downstreamResult;
         } else if ("lfs:Conditional".equals(conditionNode.getProperty("jcr:primaryType").getString())) {
-            String comparator = conditionNode.getProperty("comparator").getString();
-            Node operandB = conditionNode.getNode("operandB");
-            Node operandA = conditionNode.getNode("operandA");
+            final String comparator = conditionNode.getProperty("comparator").getString();
+            final Node operandB = conditionNode.getNode("operandB");
+            final Node operandA = conditionNode.getNode("operandA");
             String keyA = operandA.getProperty(PROP_VALUE).getValues()[0].getString();
-            //Sanitize
+            // Sanitize
             keyA = sanitizeNodeName(keyA);
-            //Get the node from the Questionnaire corresponding to keyA
-            Node sectionNodeParent = sectionNode.getParent();
-            Node keyANode = sectionNodeParent.getNode(keyA);
-            String keyANodeUUID = keyANode.getIdentifier();
-            //Get the node from the Form containg the answer to keyANode
-            NodeBuilder conditionalFormNode = getChildNodeWithQuestion(prevNb, keyANodeUUID);
-            PropertyState comparedProp = conditionalFormNode.getProperty(PROP_VALUE);
-            Property referenceProp = operandB.getProperty(PROP_VALUE);
+            // Get the node from the Questionnaire corresponding to keyA
+            final Node sectionNodeParent = sectionNode.getParent();
+            final Node keyANode = sectionNodeParent.getNode(keyA);
+            final String keyANodeUUID = keyANode.getIdentifier();
+            // Get the node from the Form containing the answer to keyANode
+            final NodeBuilder conditionalFormNode = getChildNodeWithQuestion(prevNb, keyANodeUUID);
+            final PropertyState comparedProp = conditionalFormNode.getProperty(PROP_VALUE);
+            final Property referenceProp = operandB.getProperty(PROP_VALUE);
             return evalSectionCondition(comparedProp, referenceProp, comparator);
         }
-        //If all goes wrong
+        // If all goes wrong
         return false;
     }
 
-    private boolean getSectionCondition(NodeBuilder nb, NodeBuilder prevNb)
+    private boolean getSectionCondition(final NodeBuilder nb, final NodeBuilder prevNb)
         throws RepositoryException
     {
-        Node sectionNode = getSectionNode(nb);
+        final Node sectionNode = getSectionNode(nb);
         if (sectionNode.hasNode("condition")) {
-            Node conditionNode = sectionNode.getNode("condition");
+            final Node conditionNode = sectionNode.getNode("condition");
             /*
-             * Recursively go through all children of the condition node
-             * and determine if this condition node evaluates to True or
-             * False.
+             * Recursively go through all children of the condition node and determine if this condition node evaluates
+             * to True or False.
              */
             if (evaluateConditionNodeRecursive(conditionNode, sectionNode, prevNb)) {
                 return true;
@@ -555,28 +550,28 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         return false;
     }
 
-    private void summarizeBuilder(NodeBuilder selectedNodeBuilder, NodeBuilder prevNb)
+    private void summarizeBuilder(final NodeBuilder selectedNodeBuilder, final NodeBuilder prevNb)
         throws RepositoryException
     {
-        //Iterate through all children of this node
-        Iterable<String> childrenNames = selectedNodeBuilder.getChildNodeNames();
-        Iterator<String> childrenNamesIter = childrenNames.iterator();
+        // Iterate through all children of this node
+        final Iterable<String> childrenNames = selectedNodeBuilder.getChildNodeNames();
+        final Iterator<String> childrenNamesIter = childrenNames.iterator();
         boolean isInvalid = false;
         boolean isIncomplete = false;
         while (childrenNamesIter.hasNext()) {
-            String selectedChildName = childrenNamesIter.next();
-            NodeBuilder selectedChild = selectedNodeBuilder.getChildNode(selectedChildName);
+            final String selectedChildName = childrenNamesIter.next();
+            final NodeBuilder selectedChild = selectedNodeBuilder.getChildNode(selectedChildName);
             if ("lfs:AnswerSection".equals(selectedChild.getProperty("jcr:primaryType").getValue(Type.STRING))) {
                 if (!getSectionCondition(selectedChild, selectedNodeBuilder)) {
                     continue;
                 }
             }
-            //Is selectedChild - invalid? , incomplete?
+            // Is selectedChild - invalid? , incomplete?
             if (selectedChild.hasProperty(STATUS_FLAGS)) {
-                Iterable<String> selectedProps = selectedChild.getProperty(STATUS_FLAGS).getValue(Type.STRINGS);
-                Iterator<String> selectedPropsIter = selectedProps.iterator();
+                final Iterable<String> selectedProps = selectedChild.getProperty(STATUS_FLAGS).getValue(Type.STRINGS);
+                final Iterator<String> selectedPropsIter = selectedProps.iterator();
                 while (selectedPropsIter.hasNext()) {
-                    String thisStr = selectedPropsIter.next();
+                    final String thisStr = selectedPropsIter.next();
                     if (STATUS_FLAG_INVALID.equals(thisStr)) {
                         isInvalid = true;
                     }
@@ -594,7 +589,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         if (isIncomplete) {
             statusFlags.add(STATUS_FLAG_INCOMPLETE);
         }
-        //Write these statusFlags to the JCR repo
+        // Write these statusFlags to the JCR repo
         selectedNodeBuilder.setProperty(STATUS_FLAGS, statusFlags, Type.STRINGS);
     }
 }

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -16,22 +16,13 @@
  */
 package ca.sickkids.ccm.lfs.formcompletionstatus;
 
-import java.math.BigDecimal;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
 import javax.jcr.Node;
-import javax.jcr.Property;
-import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
-import javax.jcr.Value;
-import javax.jcr.ValueFormatException;
 
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
@@ -58,8 +49,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     private static final String PROP_VALUE = "value";
 
     private static final String PROP_QUESTION = "question";
-
-    private static final String PROP_IS_REFERENCE = "isReference";
 
     private static final String STATUS_FLAGS = "statusFlags";
 
@@ -233,26 +222,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     }
 
     /**
-     * Gets the questionnaire section node referenced by the AnswerSection NodeBuilder nb.
-     *
-     * @return the section Node object referenced by NodeBuilder nb
-     */
-    private Node getSectionNode(final NodeBuilder nb)
-    {
-        try {
-            if (nb.hasProperty("section")) {
-                final Session resourceSession = this.currentResourceResolver.adaptTo(Session.class);
-                final String sectionNodeReference = nb.getProperty("section").getValue(Type.REFERENCE);
-                final Node sectionNode = resourceSession.getNodeByIdentifier(sectionNodeReference);
-                return sectionNode;
-            }
-        } catch (final RepositoryException ex) {
-            return null;
-        }
-        return null;
-    }
-
-    /**
      * Counts the number of items in an Iterable.
      *
      * @param iterable the Iterable object to be counted
@@ -303,368 +272,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         }
     }
 
-    /**
-     * Returns the first NodeBuilder with a question value equal to the String uuid that is a child of the NodeBuilder
-     * nb. If no such child can be found, null is returned
-     *
-     * @param nb the NodeBuilder to search through its children
-     * @param uuid the UUID String for which the child's question property must be equal to
-     * @return the first NodeBuilder with a question value equal to the String uuid that is a child of the NodeBuilder
-     *         nb, or null if such node does not exist.
-     */
-    private NodeBuilder getChildNodeWithQuestion(final NodeBuilder nb, final String uuid)
-    {
-        final Iterable<String> childrenNames = nb.getChildNodeNames();
-        final Iterator<String> childrenNamesIter = childrenNames.iterator();
-        while (childrenNamesIter.hasNext()) {
-            final String selectedChildName = childrenNamesIter.next();
-            final NodeBuilder selectedChild = nb.getChildNode(selectedChildName);
-            if (selectedChild.hasProperty(PROP_QUESTION)) {
-                if (uuid.equals(selectedChild.getProperty(PROP_QUESTION).getValue(Type.STRING))) {
-                    return selectedChild;
-                }
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Parses a date from the given input string.
-     *
-     * @param str the serialized date to parse
-     * @return the parsed date, or {@code null} if the date cannot be parsed
-     */
-    private Calendar parseDate(final String str)
-    {
-        try {
-            final SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd");
-            final Date date = fmt.parse(str.split("T")[0]);
-            final Calendar calendar = Calendar.getInstance();
-            //calendar.setTimeZone(TimeZone.getTimeZone("GMT"));
-            calendar.setTime(date);
-            //calendar.set(Calendar.HOUR, 0);
-            //calendar.set(Calendar.MINUTE, 0);
-            //calendar.set(Calendar.SECOND, 0);
-            //calendar.set(Calendar.MILLISECOND, 0);
-            return calendar;
-        } catch (final ParseException e) {
-            LOGGER.warn("PARSING DATE FAILED: Invalid date {}", str);
-            return null;
-        }
-    }
-
-    private int getPropertyStateType(final PropertyState ps)
-    {
-        int ret = PropertyType.UNDEFINED;
-        if (Type.STRING.equals(ps.getType())) {
-            ret = PropertyType.STRING;
-        } else if (Type.LONG.equals(ps.getType())) {
-            ret = PropertyType.LONG;
-        } else if (Type.DOUBLE.equals(ps.getType())) {
-            ret = PropertyType.DOUBLE;
-        } else if (Type.DECIMAL.equals(ps.getType())) {
-            ret = PropertyType.DECIMAL;
-        } else if (Type.BOOLEAN.equals(ps.getType())) {
-            ret = PropertyType.BOOLEAN;
-        } else if (Type.DATE.equals(ps.getType())) {
-            ret = PropertyType.DATE;
-        }
-        return ret;
-    }
-
-    private int getPropertyObjectType(final Object obj)
-    {
-        int ret = PropertyType.UNDEFINED;
-        if (obj instanceof String) {
-            ret = PropertyType.STRING;
-        } else if (obj instanceof Long) {
-            ret = PropertyType.LONG;
-        } else if (obj instanceof Double) {
-            ret = PropertyType.DOUBLE;
-        } else if (obj instanceof BigDecimal) {
-            ret = PropertyType.DECIMAL;
-        } else if (obj instanceof Boolean) {
-            ret = PropertyType.BOOLEAN;
-        } else if (obj instanceof Calendar) {
-            ret = PropertyType.DATE;
-        }
-        return ret;
-    }
-
-    private boolean evalSectionEq(final Object propA, final Object propB)
-        throws RepositoryException, ValueFormatException
-    {
-        boolean testResult = false;
-        switch (getPropertyObjectType(propA)) {
-            case PropertyType.STRING:
-                testResult = propA.equals(propB);
-                break;
-            case PropertyType.LONG:
-                testResult = (propA == propB);
-                break;
-            case PropertyType.DOUBLE:
-                testResult = (propA.equals(propB));
-                break;
-            case PropertyType.DECIMAL:
-                testResult = (((BigDecimal) propA).compareTo((BigDecimal) propB) == 0);
-                break;
-            case PropertyType.BOOLEAN:
-                testResult = (propA == propB);
-                break;
-            case PropertyType.DATE:
-                testResult = propA.equals(propB);
-                break;
-            default:
-                break;
-        }
-        return testResult;
-    }
-
-    private boolean evalSectionLt(final Object propA, final Object propB)
-        throws RepositoryException, ValueFormatException
-    {
-        boolean testResult = false;
-        switch (getPropertyObjectType(propA)) {
-            case PropertyType.LONG:
-                testResult = ((long) propA < (long) propB);
-                break;
-            case PropertyType.DOUBLE:
-                testResult = ((double) propA < (double) propB);
-                break;
-            case PropertyType.DATE:
-                testResult = ((Calendar) propA).before((Calendar) propB);
-                break;
-            default:
-                break;
-        }
-        return testResult;
-    }
-
-    private boolean evalSectionGt(final Object propA, final Object propB)
-        throws RepositoryException, ValueFormatException
-    {
-        boolean testResult = false;
-        switch (getPropertyObjectType(propA)) {
-            case PropertyType.LONG:
-                testResult = ((long) propA > (long) propB);
-                break;
-            case PropertyType.DOUBLE:
-                testResult = ((double) propA > (double) propB);
-                break;
-            case PropertyType.DATE:
-                testResult = ((Calendar) propA).after((Calendar) propB);
-                break;
-            default:
-                break;
-        }
-        return testResult;
-    }
-
-    /**
-     * Evaluates the boolean expression {propA} {operator} {propB}.
-     */
-    private boolean evalSectionCondition(final Object propA, final Object propB, final String operator)
-        throws RepositoryException, ValueFormatException
-    {
-        if ("=".equals(operator) || "<>".equals(operator)) {
-            /*
-             * Type.STRING uses .equals()
-             * Everything else uses ==
-             */
-            boolean testResult = evalSectionEq(propA, propB);
-            if ("<>".equals(operator)) {
-                testResult = !testResult;
-            }
-            return testResult;
-        } else if ("is empty".equals(operator) || "is not empty".equals(operator)) {
-            boolean testResult = (propA == null);
-            if ("is not empty".equals(operator)) {
-                testResult = !testResult;
-            }
-            return testResult;
-        } else if ("<".equals(operator)) {
-            return evalSectionLt(propA, propB);
-        } else if (">".equals(operator)) {
-            return evalSectionGt(propA, propB);
-        }
-        // If we can't evaluate it, assume it to be false
-        return false;
-    }
-
-    /*
-     * Read in a string, inStr, and return it with any non-allowed chars removed.
-     */
-    private String sanitizeNodeName(final String inStr)
-    {
-        final String inStrLower = inStr.toLowerCase();
-        String outStr = "";
-        for (int i = 0; i < inStr.length(); i++) {
-            if ("abcdefghijklmnopqrstuvwxyz 0123456789_-".indexOf(inStrLower.charAt(i)) > -1) {
-                outStr += inStr.charAt(i);
-            }
-        }
-        return outStr;
-    }
-
-    private Object getObjectFromPropertyState(PropertyState ps)
-    {
-        Object ret = null;
-        switch (getPropertyStateType(ps))
-        {
-            case PropertyType.STRING:
-                ret = ps.getValue(Type.STRING);
-                break;
-            case PropertyType.LONG:
-                ret = ps.getValue(Type.LONG);
-                break;
-            case PropertyType.DOUBLE:
-                ret = ps.getValue(Type.DOUBLE);
-                break;
-            case PropertyType.DECIMAL:
-                ret = ps.getValue(Type.DECIMAL);
-                break;
-            case PropertyType.BOOLEAN:
-                ret = ps.getValue(Type.BOOLEAN);
-                break;
-            case PropertyType.DATE:
-                ret = parseDate(ps.getValue(Type.DATE));
-                break;
-            default:
-                break;
-        }
-        return ret;
-    }
-
-    private Object getObjectFromValue(Value val) throws RepositoryException, ValueFormatException
-    {
-        Object ret = null;
-        switch (val.getType()) {
-            case PropertyType.STRING:
-                ret = val.getString();
-                break;
-            case PropertyType.LONG:
-                ret = val.getLong();
-                break;
-            case PropertyType.DOUBLE:
-                ret = val.getDouble();
-                break;
-            case PropertyType.DECIMAL:
-                ret = val.getDecimal();
-                break;
-            case PropertyType.BOOLEAN:
-                ret = val.getBoolean();
-                break;
-            case PropertyType.DATE:
-                //Calendar calendar = Calendar.getInstance();
-                //calendar.set(val.getDate().get(Calendar.YEAR),
-                //    val.getDate().get(Calendar.MONTH),
-                //    val.getDate().get(Calendar.DAY_OF_MONTH));
-                //ret = val.getDate();
-                Calendar calendar = parseDate(Integer.toString(val.getDate().get(Calendar.YEAR))
-                    + "-"
-                    + Integer.toString(val.getDate().get(Calendar.MONTH) + 1)
-                    + "-"
-                    + Integer.toString(val.getDate().get(Calendar.DAY_OF_MONTH))
-                    + "T00:00");
-                ret = calendar;
-                break;
-            default:
-                break;
-        }
-        return ret;
-    }
-
-    private Object getOperandValue(final Node operand, final Node sectionNode, final NodeBuilder prevNb)
-        throws RepositoryException
-    {
-        Object returnedValue = null;
-        if (operand.getProperty(PROP_IS_REFERENCE).getValue().getBoolean()) {
-            String key = operand.getProperty(PROP_VALUE).getValues()[0].getString();
-            // Sanitize
-            key = sanitizeNodeName(key);
-            final Node sectionNodeParent = sectionNode.getParent();
-            final Node keyNode = sectionNodeParent.getNode(key);
-            final String keyNodeUUID = keyNode.getIdentifier();
-            // Get the node from the Form containing the answer to keyNode
-            final NodeBuilder conditionalFormNode = getChildNodeWithQuestion(prevNb, keyNodeUUID);
-            if (conditionalFormNode == null) {
-                return null;
-            }
-            final PropertyState operandProp = conditionalFormNode.getProperty(PROP_VALUE);
-            if (operandProp != null) {
-                returnedValue = getObjectFromPropertyState(operandProp);
-            }
-        } else {
-            Property nodeProp = operand.getProperty(PROP_VALUE);
-            Value nodeVal;
-            if (nodeProp.isMultiple()) {
-                nodeVal = nodeProp.getValues()[0];
-            } else {
-                nodeVal = nodeProp.getValue();
-            }
-            returnedValue = getObjectFromValue(nodeVal);
-        }
-        return returnedValue;
-    }
-
-    /*
-     * Given a "condition" node from the "Questionnaires" and a "lfs:AnswerSection" node from the "Forms" and a
-     * NodeBuilder type object referring to the parent of the "lfs:AnswerSection" node, evaluate the boolean expression
-     * defined by the descendants of the "condition" Node.
-     */
-    private boolean evaluateConditionNodeRecursive(final Node conditionNode, final Node sectionNode,
-        final NodeBuilder prevNb)
-        throws RepositoryException
-    {
-        if ("lfs:ConditionalGroup".equals(conditionNode.getProperty("jcr:primaryType").getString())) {
-            // Is this an OR or an AND
-            final boolean requireAll = conditionNode.getProperty("requireAll").getBoolean();
-            // Evaluate recursively
-            final Iterator<Node> conditionChildren = conditionNode.getNodes();
-            boolean downstreamResult = false;
-            if (requireAll) {
-                downstreamResult = true;
-            }
-            while (conditionChildren.hasNext()) {
-                final boolean partialRes =
-                    evaluateConditionNodeRecursive(conditionChildren.next(), sectionNode, prevNb);
-                if (requireAll) {
-                    downstreamResult = downstreamResult && partialRes;
-                } else {
-                    downstreamResult = downstreamResult || partialRes;
-                }
-            }
-            return downstreamResult;
-        } else if ("lfs:Conditional".equals(conditionNode.getProperty("jcr:primaryType").getString())) {
-            final String comparator = conditionNode.getProperty("comparator").getString();
-            final Node operandB = conditionNode.getNode("operandB");
-            final Node operandA = conditionNode.getNode("operandA");
-
-            final Object valueA = getOperandValue(operandA, sectionNode, prevNb);
-            final Object valueB = getOperandValue(operandB, sectionNode, prevNb);
-            return evalSectionCondition(valueA, valueB, comparator);
-        }
-        // If all goes wrong
-        return false;
-    }
-
-    private boolean isConditionSatisfied(final NodeBuilder nb, final NodeBuilder prevNb)
-        throws RepositoryException
-    {
-        final Node sectionNode = getSectionNode(nb);
-        if (sectionNode.hasNode("condition")) {
-            final Node conditionNode = sectionNode.getNode("condition");
-            /*
-             * Recursively go through all children of the condition node and determine if this condition node evaluates
-             * to True or False.
-             */
-            if (evaluateConditionNodeRecursive(conditionNode, sectionNode, prevNb)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     private void summarizeBuilder(final NodeBuilder selectedNodeBuilder, final NodeBuilder prevNb)
         throws RepositoryException
     {
@@ -677,7 +284,9 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
             final String selectedChildName = childrenNamesIter.next();
             final NodeBuilder selectedChild = selectedNodeBuilder.getChildNode(selectedChildName);
             if ("lfs:AnswerSection".equals(selectedChild.getProperty("jcr:primaryType").getValue(Type.STRING))) {
-                if (!isConditionSatisfied(selectedChild, selectedNodeBuilder)) {
+                final Session resourceSession = this.currentResourceResolver.adaptTo(Session.class);
+                if (!ConditionalSectionUtils.isConditionSatisfied(
+                    resourceSession, selectedChild, selectedNodeBuilder)) {
                     continue;
                 }
             }

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -325,8 +325,10 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                     if (selectedChild.hasProperty("question")) {
                         if (keyANodeUUID.equals(selectedChild.getProperty("question").getValue(Type.STRING))) {
                             LOGGER.warn("....found the match!!");
+                            LOGGER.warn("VALUE({}) = {}", keyA,
+                                selectedChild.getProperty("value").getValue(Type.STRING));
                             if (selectedChild.getProperty("value").getValue(Type.STRING).equals(valueB)) {
-                                LOGGER.warn("VALUE({}) = {}", keyA, valueB);
+                                //LOGGER.warn("VALUE({}) = {}", keyA, valueB);
                                 return true;
                             }
                         }

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -391,6 +391,10 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 testResult = propA.equals(propB);
                 break;
             case PropertyType.LONG:
+                LOGGER.warn("Comparing PropertyType.LONG");
+                if (getPropertyObjectType(propA) != getPropertyObjectType(propB)) {
+                    LOGGER.warn("Ooops...PropertyType mismatch!");
+                }
                 testResult = (propA == propB);
                 break;
             case PropertyType.DOUBLE:
@@ -482,6 +486,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
             //return evalSectionGt(propA, propB);
             boolean testResult = evalSectionGt(propA, propB);
             LOGGER.warn("...returning {}", testResult);
+            return testResult;
         }
         // If we can't evaluate it, assume it to be false
         return false;
@@ -576,7 +581,9 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 return null;
             }
             final PropertyState operandProp = conditionalFormNode.getProperty(PROP_VALUE);
-            returnedValue = getObjectFromPropertyState(operandProp);
+            if (operandProp != null) {
+                returnedValue = getObjectFromPropertyState(operandProp);
+            }
         } else {
             Property nodeProp = operand.getProperty(PROP_VALUE);
             Value nodeVal;

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -330,8 +330,12 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         throws RepositoryException, ValueFormatException
     {
         if ("=".equals(operator)) {
-            if (propA.getValue(Type.STRING).equals(propB.getValues()[0].getString())) {
-                return true;
+            LOGGER.warn("propA is of type {}", propA.getType().toString());
+            if (Type.BOOLEAN.equals(propA.getType())) {
+                LOGGER.warn("COMPARING BOOLEAN TYPES...");
+                if (propA.getValue(Type.BOOLEAN) == propB.getValues()[0].getBoolean()) {
+                    return true;
+                }
             }
         }
         //If we can't evaluate it, assume it to be false

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -350,8 +350,10 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
 
     private int getPropertyStateType(final PropertyState ps)
     {
-        int ret = PropertyType.STRING;
-        if (Type.LONG.equals(ps.getType())) {
+        int ret = PropertyType.UNDEFINED;
+        if (Type.STRING.equals(ps.getType())) {
+            ret = PropertyType.STRING;
+        } else if (Type.LONG.equals(ps.getType())) {
             ret = PropertyType.LONG;
         } else if (Type.DOUBLE.equals(ps.getType())) {
             ret = PropertyType.DOUBLE;
@@ -367,8 +369,10 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
 
     private int getPropertyObjectType(final Object obj)
     {
-        int ret = PropertyType.STRING;
-        if (obj instanceof Long) {
+        int ret = PropertyType.UNDEFINED;
+        if (obj instanceof String) {
+            ret = PropertyType.STRING;
+        } else if (obj instanceof Long) {
             ret = PropertyType.LONG;
         } else if (obj instanceof Double) {
             ret = PropertyType.DOUBLE;

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.List;
 
 import javax.jcr.Node;
 import javax.jcr.Property;
@@ -73,16 +74,16 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     // and the last item corresponding to the current node. By keeping this list, one is capable of
     // moving up the tree and setting status flags of ancestor nodes based on the status flags of a
     // descendant node.
-    private final ArrayList<NodeBuilder> currentNodeBuilderPath;
+    private final List<NodeBuilder> currentNodeBuilderPath;
 
     /**
      * Simple constructor.
      *
-     * @param nodeBuilder an ArrayList of NodeBuilder objects starting from the root of the JCR tree
-     *     and moving down towards the current node.
+     * @param nodeBuilder a list of NodeBuilder objects starting from the root of the JCR tree and moving down towards
+     *            the current node.
      * @param resourceResolver a ResourceResolver object used to obtain answer constraints
      */
-    public AnswerCompletionStatusEditor(ArrayList<NodeBuilder> nodeBuilder, ResourceResolver resourceResolver)
+    public AnswerCompletionStatusEditor(final List<NodeBuilder> nodeBuilder, final ResourceResolver resourceResolver)
     {
         this.currentNodeBuilderPath = nodeBuilder;
         this.currentNodeBuilder = nodeBuilder.get(nodeBuilder.size() - 1);
@@ -112,7 +113,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         if (questionNode != null && PROP_VALUE.equals(after.getName())) {
             Iterable<String> nodeAnswers = after.getValue(Type.STRINGS);
             int numAnswers = iterableLength(nodeAnswers);
-            ArrayList<String> statusFlags = new ArrayList<String>();
+            List<String> statusFlags = new ArrayList<>();
             if (checkInvalidAnswer(questionNode, numAnswers)) {
                 statusFlags.add(STATUS_FLAG_INVALID);
                 statusFlags.add(STATUS_FLAG_INCOMPLETE);
@@ -154,8 +155,8 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         Node questionNode = getQuestionNode(this.currentNodeBuilder);
         if (questionNode != null) {
             if (PROP_VALUE.equals(before.getName())) {
-                ArrayList<String> statusFlags = new ArrayList<String>();
-                //Only add the INVALID,INCOMPLETE flags if the given question requires more than zero answers
+                final List<String> statusFlags = new ArrayList<>();
+                // Only add the INVALID,INCOMPLETE flags if the given question requires more than zero answers
                 if (checkInvalidAnswer(questionNode, 0)) {
                     statusFlags.add(STATUS_FLAG_INVALID);
                     statusFlags.add(STATUS_FLAG_INCOMPLETE);
@@ -184,18 +185,15 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         Node questionNode = getQuestionNode(this.currentNodeBuilder.getChildNode(name));
         if (questionNode != null) {
             if (this.currentNodeBuilder.getChildNode(name).hasProperty(PROP_QUESTION)) {
-                ArrayList<String> statusFlags = new ArrayList<String>();
-                //Only add the INCOMPLETE flag if the given question requires more than zero answers
+                final List<String> statusFlags = new ArrayList<>();
+                // Only add the INCOMPLETE flag if the given question requires more than zero answers
                 if (checkInvalidAnswer(questionNode, 0)) {
                     statusFlags.add(STATUS_FLAG_INCOMPLETE);
                 }
                 this.currentNodeBuilder.getChildNode(name).setProperty(STATUS_FLAGS, statusFlags, Type.STRINGS);
             }
         }
-        ArrayList<NodeBuilder> tmpList = new ArrayList<NodeBuilder>();
-        for (int i = 0; i < this.currentNodeBuilderPath.size(); i++) {
-            tmpList.add(this.currentNodeBuilderPath.get(i));
-        }
+        final List<NodeBuilder> tmpList = new ArrayList<>(this.currentNodeBuilderPath);
         tmpList.add(this.currentNodeBuilder.getChildNode(name));
         return new AnswerCompletionStatusEditor(tmpList, this.currentResourceResolver);
     }
@@ -204,10 +202,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     public Editor childNodeChanged(String name, NodeState before, NodeState after)
         throws CommitFailedException
     {
-        ArrayList<NodeBuilder> tmpList = new ArrayList<NodeBuilder>();
-        for (int i = 0; i < this.currentNodeBuilderPath.size(); i++) {
-            tmpList.add(this.currentNodeBuilderPath.get(i));
-        }
+        final List<NodeBuilder> tmpList = new ArrayList<>(this.currentNodeBuilderPath);
         tmpList.add(this.currentNodeBuilder.getChildNode(name));
         return new AnswerCompletionStatusEditor(tmpList, this.currentResourceResolver);
     }
@@ -293,7 +288,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         return false;
     }
 
-    private void summarizeBuilders(ArrayList<NodeBuilder> nodeBuilders)
+    private void summarizeBuilders(final List<NodeBuilder> nodeBuilders)
         throws RepositoryException
     {
         /*
@@ -591,8 +586,8 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 }
             }
         }
-        //Set the flags in selectedNodeBuilder accordingly
-        ArrayList<String> statusFlags = new ArrayList<String>();
+        // Set the flags in selectedNodeBuilder accordingly
+        final List<String> statusFlags = new ArrayList<>();
         if (isInvalid) {
             statusFlags.add(STATUS_FLAG_INVALID);
         }

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -442,7 +442,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     /**
      * Evaluates the boolean expression {propA} {operator} {propB}.
      */
-    @SuppressWarnings("checkstyle:CyclomaticComplexity")
     private boolean evalSectionCondition(PropertyState propA, Property propB, String operator)
         throws RepositoryException, ValueFormatException
     {
@@ -543,7 +542,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         return false;
     }
 
-    @SuppressWarnings("checkstyle:CyclomaticComplexity")
     private void summarizeBuilder(NodeBuilder selectedNodeBuilder, NodeBuilder prevNb)
         throws RepositoryException
     {

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -406,21 +406,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 testResult = (propA.getValue(Type.BOOLEAN) == valB.getBoolean());
                 break;
             case PropertyType.DATE:
-                LOGGER.warn("The property being compared is PropertyType.DATE");
-                /*
-                LOGGER.warn("Going to compare {} TO {}",
-                    parseDate(propA.getValue(Type.DATE)),
-                    valB.getDate());
-                */
-                LOGGER.warn("The property being compared is A = {}",
-                    propA.getValue(Type.STRING));
-                LOGGER.warn("The property being compared is B = {}",
-                    valB.getString());
                 testResult = parseDate(propA.getValue(Type.DATE)).equals(parseDate(valB.getString()));
-                LOGGER.warn("Checking equality of {} == {} --> {}",
-                    parseDate(propA.getValue(Type.DATE)),
-                    valB.getString(),
-                    testResult);
                 break;
             default:
                 break;
@@ -441,7 +427,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 testResult = (propA.getValue(Type.DOUBLE) < valB.getDouble());
                 break;
             case PropertyType.DATE:
-                testResult = parseDate(propA.getValue(Type.DATE)).before(valB.getDate());
+                testResult = parseDate(propA.getValue(Type.DATE)).before(parseDate(valB.getString()));
                 break;
             default:
                 break;
@@ -462,7 +448,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 testResult = (propA.getValue(Type.DOUBLE) > valB.getDouble());
                 break;
             case PropertyType.DATE:
-                testResult = parseDate(propA.getValue(Type.DATE)).after(valB.getDate());
+                testResult = parseDate(propA.getValue(Type.DATE)).after(parseDate(valB.getString()));
                 break;
             default:
                 break;

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -397,17 +397,9 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         boolean testResult = false;
         switch (getPropertyObjectType(propA)) {
             case PropertyType.STRING:
-                LOGGER.warn("Comparing PropertyType.STRING");
-                if (getPropertyObjectType(propA) != getPropertyObjectType(propB)) {
-                    LOGGER.warn("Ooops...PropertyType mismatch (string)!");
-                }
                 testResult = propA.equals(propB);
                 break;
             case PropertyType.LONG:
-                LOGGER.warn("Comparing PropertyType.LONG");
-                if (getPropertyObjectType(propA) != getPropertyObjectType(propB)) {
-                    LOGGER.warn("Ooops...PropertyType mismatch!");
-                }
                 testResult = (propA == propB);
                 break;
             case PropertyType.DOUBLE:
@@ -420,10 +412,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 testResult = (propA == propB);
                 break;
             case PropertyType.DATE:
-                LOGGER.warn("Comparing PropertyType.DATE");
-                if (getPropertyObjectType(propA) != getPropertyObjectType(propB)) {
-                    LOGGER.warn("Ooops...PropertyType mismatch (date)!");
-                }
                 testResult = propA.equals(propB);
                 break;
             default:
@@ -478,7 +466,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     private boolean evalSectionCondition(final Object propA, final Object propB, final String operator)
         throws RepositoryException, ValueFormatException
     {
-        LOGGER.warn("Comparing: {} {} {}", propA, operator, propB);
         if ("=".equals(operator) || "<>".equals(operator)) {
             /*
              * Type.STRING uses .equals()
@@ -488,7 +475,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
             if ("<>".equals(operator)) {
                 testResult = !testResult;
             }
-            LOGGER.warn("...returning {}", testResult);
             return testResult;
         } else if ("is empty".equals(operator) || "is not empty".equals(operator)) {
             boolean testResult = (propA == null);
@@ -499,11 +485,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         } else if ("<".equals(operator)) {
             return evalSectionLt(propA, propB);
         } else if (">".equals(operator)) {
-            //LOGGER.warn("...returning {}", testResult);
-            //return evalSectionGt(propA, propB);
-            boolean testResult = evalSectionGt(propA, propB);
-            LOGGER.warn("...returning {}", testResult);
-            return testResult;
+            return evalSectionGt(propA, propB);
         }
         // If we can't evaluate it, assume it to be false
         return false;
@@ -530,7 +512,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         switch (getPropertyStateType(ps))
         {
             case PropertyType.STRING:
-                LOGGER.warn("getObjectFromPropertyState() --> PropertyType.STRING");
                 ret = ps.getValue(Type.STRING);
                 break;
             case PropertyType.LONG:
@@ -546,7 +527,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 ret = ps.getValue(Type.BOOLEAN);
                 break;
             case PropertyType.DATE:
-                LOGGER.warn("getObjectFromPropertyState() --> PropertyType.DATE");
                 ret = parseDate(ps.getValue(Type.DATE));
                 break;
             default:
@@ -560,7 +540,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         Object ret = null;
         switch (val.getType()) {
             case PropertyType.STRING:
-                LOGGER.warn("getObjectFromValue() --> PropertyType.STRING");
                 ret = val.getString();
                 break;
             case PropertyType.LONG:
@@ -576,7 +555,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 ret = val.getBoolean();
                 break;
             case PropertyType.DATE:
-                LOGGER.warn("getObjectFromValue() --> PropertyType.DATE");
                 //Calendar calendar = Calendar.getInstance();
                 //calendar.set(val.getDate().get(Calendar.YEAR),
                 //    val.getDate().get(Calendar.MONTH),

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -343,7 +343,6 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     {
         Node sectionNode = getSectionNode(nb);
         if (sectionNode.hasNode("condition")) {
-            //LOGGER.warn("This node specifies a condition!!");
             Node conditionNode = sectionNode.getNode("condition");
             LOGGER.warn("...The condition node is {}", conditionNode.getIdentifier());
             String comparator = conditionNode.getProperty("comparator").getString();
@@ -353,11 +352,8 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 LOGGER.warn("---> has child: {}", conditionChildren.next().getIdentifier());
             }
             if (conditionNode.hasNode("operandB") && conditionNode.hasNode("operandA")) {
-                //LOGGER.warn("===> We have children - operandB and operandA");
                 Node operandB = conditionNode.getNode("operandB");
-                //LOGGER.warn("=====> Got operandB");
                 Node operandA = conditionNode.getNode("operandA");
-                //LOGGER.warn("=====> Got operandA");
                 //Sanitize?
                 String keyA = operandA.getProperty("value").getValues()[0].getString();
                 LOGGER.warn("Value of keyA is {}", keyA);

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -286,6 +286,35 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         }
     }
 
+    /**
+     * Returns the first NodeBuilder with a question value equal to the
+     * String uuid that is a child of the NodeBuilder nb. If no such
+     * child can be found, null is returned
+     *
+     * @param nb the NodeBuilder to search through its children
+     * @param uuid the UUID String for which the child's question
+     *     property must be equal to
+     * @return the first NodeBuilder with a question value equal to the
+     *     String uuid that is a child of the NodeBuilder nb, or null if
+     *     such node does not exist.
+     */
+    private NodeBuilder getChildNodeWithQuestion(NodeBuilder nb, String uuid)
+    {
+        Iterable<String> childrenNames = nb.getChildNodeNames();
+        Iterator<String> childrenNamesIter = childrenNames.iterator();
+        while (childrenNamesIter.hasNext()) {
+            String selectedChildName = childrenNamesIter.next();
+            NodeBuilder selectedChild = nb.getChildNode(selectedChildName);
+            if (selectedChild.hasProperty("question")) {
+                if (uuid.equals(selectedChild.getProperty("question").getValue(Type.STRING))) {
+                    LOGGER.warn("....found the match!!");
+                    return selectedChild;
+                }
+            }
+        }
+        return null;
+    }
+
     @SuppressWarnings("checkstyle:NestedIfDepth")
     private boolean getSectionCondition(NodeBuilder nb, NodeBuilder prevNb) throws RepositoryException
     {
@@ -317,22 +346,9 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 String keyANodeUUID = keyANode.getIdentifier();
                 LOGGER.warn("Checking for a match to {}...", keyANodeUUID);
                 //Get the node from the Form containg the answer to keyANode
-                Iterable<String> childrenNames = prevNb.getChildNodeNames();
-                Iterator<String> childrenNamesIter = childrenNames.iterator();
-                while (childrenNamesIter.hasNext()) {
-                    String selectedChildName = childrenNamesIter.next();
-                    NodeBuilder selectedChild = prevNb.getChildNode(selectedChildName);
-                    if (selectedChild.hasProperty("question")) {
-                        if (keyANodeUUID.equals(selectedChild.getProperty("question").getValue(Type.STRING))) {
-                            LOGGER.warn("....found the match!!");
-                            LOGGER.warn("VALUE({}) = {}", keyA,
-                                selectedChild.getProperty("value").getValue(Type.STRING));
-                            if (selectedChild.getProperty("value").getValue(Type.STRING).equals(valueB)) {
-                                //LOGGER.warn("VALUE({}) = {}", keyA, valueB);
-                                return true;
-                            }
-                        }
-                    }
+                NodeBuilder conditionalFormNode = getChildNodeWithQuestion(prevNb, keyANodeUUID);
+                if (conditionalFormNode.getProperty("value").getValue(Type.STRING).equals(valueB)) {
+                    return true;
                 }
             }
         }

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -524,6 +524,10 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
             final String keyANodeUUID = keyANode.getIdentifier();
             // Get the node from the Form containing the answer to keyANode
             final NodeBuilder conditionalFormNode = getChildNodeWithQuestion(prevNb, keyANodeUUID);
+            // ...if the answer node does not exist, return false - can't compare to something non-existant
+            if (conditionalFormNode == null) {
+                return false;
+            }
             final PropertyState comparedProp = conditionalFormNode.getProperty(PROP_VALUE);
             final Property referenceProp = operandB.getProperty(PROP_VALUE);
             return evalSectionCondition(comparedProp, referenceProp, comparator);

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -144,7 +144,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
             try {
                 summarizeBuilders(this.currentNodeBuilderPath);
             } catch (final RepositoryException e) {
-                LOGGER.warn("Could not run summarize()");
+                LOGGER.warn("Could not run summarize(): {}", e.getMessage(), e);
             }
         }
     }
@@ -169,8 +169,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 try {
                     summarizeBuilders(this.currentNodeBuilderPath);
                 } catch (final RepositoryException e) {
-                    LOGGER.warn("Could not run summarizeBuilders()");
-                    LOGGER.warn(e.toString());
+                    LOGGER.warn("Could not run summarizeBuilders(): {}", e.getMessage(), e);
                 }
             }
         }
@@ -341,7 +340,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
             calendar.setTime(date);
             return calendar;
         } catch (final ParseException e) {
-            LOGGER.warn("PARSING DATE FAILED");
+            LOGGER.warn("PARSING DATE FAILED: Invalid date {}", str);
             return null;
         }
     }

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -340,7 +340,12 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
             final SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd");
             final Date date = fmt.parse(str.split("T")[0]);
             final Calendar calendar = Calendar.getInstance();
+            //calendar.setTimeZone(TimeZone.getTimeZone("GMT"));
             calendar.setTime(date);
+            //calendar.set(Calendar.HOUR, 0);
+            //calendar.set(Calendar.MINUTE, 0);
+            //calendar.set(Calendar.SECOND, 0);
+            //calendar.set(Calendar.MILLISECOND, 0);
             return calendar;
         } catch (final ParseException e) {
             LOGGER.warn("PARSING DATE FAILED: Invalid date {}", str);
@@ -392,6 +397,10 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         boolean testResult = false;
         switch (getPropertyObjectType(propA)) {
             case PropertyType.STRING:
+                LOGGER.warn("Comparing PropertyType.STRING");
+                if (getPropertyObjectType(propA) != getPropertyObjectType(propB)) {
+                    LOGGER.warn("Ooops...PropertyType mismatch (string)!");
+                }
                 testResult = propA.equals(propB);
                 break;
             case PropertyType.LONG:
@@ -411,6 +420,10 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 testResult = (propA == propB);
                 break;
             case PropertyType.DATE:
+                LOGGER.warn("Comparing PropertyType.DATE");
+                if (getPropertyObjectType(propA) != getPropertyObjectType(propB)) {
+                    LOGGER.warn("Ooops...PropertyType mismatch (date)!");
+                }
                 testResult = propA.equals(propB);
                 break;
             default:
@@ -517,6 +530,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         switch (getPropertyStateType(ps))
         {
             case PropertyType.STRING:
+                LOGGER.warn("getObjectFromPropertyState() --> PropertyType.STRING");
                 ret = ps.getValue(Type.STRING);
                 break;
             case PropertyType.LONG:
@@ -532,7 +546,8 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 ret = ps.getValue(Type.BOOLEAN);
                 break;
             case PropertyType.DATE:
-                ret = ps.getValue(Type.DATE);
+                LOGGER.warn("getObjectFromPropertyState() --> PropertyType.DATE");
+                ret = parseDate(ps.getValue(Type.DATE));
                 break;
             default:
                 break;
@@ -545,6 +560,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         Object ret = null;
         switch (val.getType()) {
             case PropertyType.STRING:
+                LOGGER.warn("getObjectFromValue() --> PropertyType.STRING");
                 ret = val.getString();
                 break;
             case PropertyType.LONG:
@@ -560,7 +576,19 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 ret = val.getBoolean();
                 break;
             case PropertyType.DATE:
-                ret = val.getDate();
+                LOGGER.warn("getObjectFromValue() --> PropertyType.DATE");
+                //Calendar calendar = Calendar.getInstance();
+                //calendar.set(val.getDate().get(Calendar.YEAR),
+                //    val.getDate().get(Calendar.MONTH),
+                //    val.getDate().get(Calendar.DAY_OF_MONTH));
+                //ret = val.getDate();
+                Calendar calendar = parseDate(Integer.toString(val.getDate().get(Calendar.YEAR))
+                    + "-"
+                    + Integer.toString(val.getDate().get(Calendar.MONTH) + 1)
+                    + "-"
+                    + Integer.toString(val.getDate().get(Calendar.DAY_OF_MONTH))
+                    + "T00:00");
+                ret = calendar;
                 break;
             default:
                 break;

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -54,6 +54,9 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AnswerCompletionStatusEditor.class);
 
+    private static final String PROP_VALUE = "value";
+    private static final String PROP_QUESTION = "question";
+
     private static final String STATUS_FLAGS = "statusFlags";
     private static final String STATUS_FLAG_INCOMPLETE = "INCOMPLETE";
     private static final String STATUS_FLAG_INVALID = "INVALID";
@@ -102,12 +105,11 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
 
     // Called when the value of an existing property gets changed
     @Override
-    @SuppressWarnings("MultipleStringLiterals")
     public void propertyChanged(PropertyState before, PropertyState after)
         throws CommitFailedException
     {
         Node questionNode = getQuestionNode(this.currentNodeBuilder);
-        if (questionNode != null && "value".equals(after.getName())) {
+        if (questionNode != null && PROP_VALUE.equals(after.getName())) {
             Iterable<String> nodeAnswers = after.getValue(Type.STRINGS);
             int numAnswers = iterableLength(nodeAnswers);
             ArrayList<String> statusFlags = new ArrayList<String>();
@@ -151,7 +153,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     {
         Node questionNode = getQuestionNode(this.currentNodeBuilder);
         if (questionNode != null) {
-            if ("value".equals(before.getName())) {
+            if (PROP_VALUE.equals(before.getName())) {
                 ArrayList<String> statusFlags = new ArrayList<String>();
                 //Only add the INVALID,INCOMPLETE flags if the given question requires more than zero answers
                 if (checkInvalidAnswer(questionNode, 0)) {
@@ -175,13 +177,12 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     // DefaultEditor is to stop at the root, so we must override the following two methods in order for the editor to be
     // invoked on non-root nodes.
     @Override
-    @SuppressWarnings("MultipleStringLiterals")
     public Editor childNodeAdded(String name, NodeState after)
         throws CommitFailedException
     {
         Node questionNode = getQuestionNode(this.currentNodeBuilder.getChildNode(name));
         if (questionNode != null) {
-            if (this.currentNodeBuilder.getChildNode(name).hasProperty("question")) {
+            if (this.currentNodeBuilder.getChildNode(name).hasProperty(PROP_QUESTION)) {
                 ArrayList<String> statusFlags = new ArrayList<String>();
                 //Only add the INCOMPLETE flag if the given question requires more than zero answers
                 if (checkInvalidAnswer(questionNode, 0)) {
@@ -219,9 +220,9 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     private Node getQuestionNode(NodeBuilder nb)
     {
         try {
-            if (nb.hasProperty("question")) {
+            if (nb.hasProperty(PROP_QUESTION)) {
                 Session resourceSession = this.currentResourceResolver.adaptTo(Session.class);
-                String questionNodeReference = nb.getProperty("question").getValue(Type.REFERENCE);
+                String questionNodeReference = nb.getProperty(PROP_QUESTION).getValue(Type.REFERENCE);
                 Node questionNode = resourceSession.getNodeByIdentifier(questionNodeReference);
                 return questionNode;
             }
@@ -323,8 +324,8 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         while (childrenNamesIter.hasNext()) {
             String selectedChildName = childrenNamesIter.next();
             NodeBuilder selectedChild = nb.getChildNode(selectedChildName);
-            if (selectedChild.hasProperty("question")) {
-                if (uuid.equals(selectedChild.getProperty("question").getValue(Type.STRING))) {
+            if (selectedChild.hasProperty(PROP_QUESTION)) {
+                if (uuid.equals(selectedChild.getProperty(PROP_QUESTION).getValue(Type.STRING))) {
                     return selectedChild;
                 }
             }
@@ -509,15 +510,15 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
             Node operandB = conditionNode.getNode("operandB");
             Node operandA = conditionNode.getNode("operandA");
             //TODO: Sanitize?
-            String keyA = operandA.getProperty("value").getValues()[0].getString();
+            String keyA = operandA.getProperty(PROP_VALUE).getValues()[0].getString();
             //Get the node from the Questionnaire corresponding to keyA
             Node sectionNodeParent = sectionNode.getParent();
             Node keyANode = sectionNodeParent.getNode(keyA);
             String keyANodeUUID = keyANode.getIdentifier();
             //Get the node from the Form containg the answer to keyANode
             NodeBuilder conditionalFormNode = getChildNodeWithQuestion(prevNb, keyANodeUUID);
-            PropertyState comparedProp = conditionalFormNode.getProperty("value");
-            Property referenceProp = operandB.getProperty("value");
+            PropertyState comparedProp = conditionalFormNode.getProperty(PROP_VALUE);
+            Property referenceProp = operandB.getProperty(PROP_VALUE);
             return evalSectionCondition(comparedProp, referenceProp, comparator);
         }
         //If all goes wrong

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 
 import javax.jcr.Node;
 import javax.jcr.Property;
+import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.ValueFormatException;
@@ -330,13 +331,44 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         throws RepositoryException, ValueFormatException
     {
         if ("=".equals(operator)) {
+            /*
+             * Type.STRING uses .equals()
+             * Everything else uses ==
+             */
             LOGGER.warn("propA is of type {}", propA.getType().toString());
-            if (Type.BOOLEAN.equals(propA.getType())) {
-                LOGGER.warn("COMPARING BOOLEAN TYPES...");
+            /*
+            if (Type.STRING.equals(propA.getType())) {
+                if (propA.getValue(Type.STRING).equals(propB.getValues()[0].getString())) {
+                    return true;
+                }
+            } else {
+                LOGGER.warn("COMPARING WITH == ...");
                 if (propA.getValue(Type.BOOLEAN) == propB.getValues()[0].getBoolean()) {
                     return true;
                 }
             }
+            */
+            boolean testResult = false;
+            switch (propB.getValues()[0].getType()) {
+                case PropertyType.STRING:
+                    testResult = propA.getValue(Type.STRING).equals(propB.getValues()[0].getString());
+                    break;
+                case PropertyType.LONG:
+                    testResult = (propA.getValue(Type.LONG) == propB.getValues()[0].getLong());
+                    break;
+                case PropertyType.DOUBLE:
+                    testResult = (propA.getValue(Type.DOUBLE) == propB.getValues()[0].getDouble());
+                    break;
+                case PropertyType.DECIMAL:
+                    testResult = (propA.getValue(Type.DECIMAL) == propB.getValues()[0].getDecimal());
+                    break;
+                case PropertyType.BOOLEAN:
+                    testResult = (propA.getValue(Type.BOOLEAN) == propB.getValues()[0].getBoolean());
+                    break;
+                default:
+                    break;
+            }
+            return testResult;
         }
         //If we can't evaluate it, assume it to be false
         return false;

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -532,7 +532,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         return false;
     }
 
-    private boolean getSectionCondition(final NodeBuilder nb, final NodeBuilder prevNb)
+    private boolean isConditionSatisfied(final NodeBuilder nb, final NodeBuilder prevNb)
         throws RepositoryException
     {
         final Node sectionNode = getSectionNode(nb);
@@ -561,7 +561,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
             final String selectedChildName = childrenNamesIter.next();
             final NodeBuilder selectedChild = selectedNodeBuilder.getChildNode(selectedChildName);
             if ("lfs:AnswerSection".equals(selectedChild.getProperty("jcr:primaryType").getValue(Type.STRING))) {
-                if (!getSectionCondition(selectedChild, selectedNodeBuilder)) {
+                if (!isConditionSatisfied(selectedChild, selectedNodeBuilder)) {
                     continue;
                 }
             }

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -477,6 +477,22 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     }
 
     /*
+     * Read in a string, inStr, and return it with any non-allowed
+     * chars removed.
+     */
+    private String sanitizeNodeName(String inStr)
+    {
+        String inStrLower = inStr.toLowerCase();
+        String outStr = "";
+        for (int i = 0; i < inStr.length(); i++) {
+            if ("abcdefghijklmnopqrstuvwxyz 0123456789_-".indexOf(inStrLower.charAt(i)) > -1) {
+                outStr += inStr.charAt(i);
+            }
+        }
+        return outStr;
+    }
+
+    /*
      * Given a "condition" node from the "Questionnaires" and a
      * "lfs:AnswerSection" node from the "Forms" and a NodeBuilder type
      * object referring to the parent of the "lfs:AnswerSection" node,
@@ -508,8 +524,9 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
             String comparator = conditionNode.getProperty("comparator").getString();
             Node operandB = conditionNode.getNode("operandB");
             Node operandA = conditionNode.getNode("operandA");
-            //TODO: Sanitize?
             String keyA = operandA.getProperty(PROP_VALUE).getValues()[0].getString();
+            //Sanitize
+            keyA = sanitizeNodeName(keyA);
             //Get the node from the Questionnaire corresponding to keyA
             Node sectionNodeParent = sectionNode.getParent();
             Node keyANode = sectionNodeParent.getNode(keyA);

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -43,7 +43,6 @@ import org.slf4j.LoggerFactory;
  */
 public class AnswerCompletionStatusEditor extends DefaultEditor
 {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(AnswerCompletionStatusEditor.class);
 
     private static final String PROP_VALUE = "value";
@@ -158,14 +157,12 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     {
         final Node questionNode = getQuestionNode(this.currentNodeBuilder.getChildNode(name));
         if (questionNode != null) {
-            if (this.currentNodeBuilder.getChildNode(name).hasProperty(PROP_QUESTION)) {
-                final List<String> statusFlags = new ArrayList<>();
-                // Only add the INCOMPLETE flag if the given question requires more than zero answers
-                if (checkInvalidAnswer(questionNode, 0)) {
-                    statusFlags.add(STATUS_FLAG_INCOMPLETE);
-                }
-                this.currentNodeBuilder.getChildNode(name).setProperty(STATUS_FLAGS, statusFlags, Type.STRINGS);
+            final List<String> statusFlags = new ArrayList<>();
+            // Only add the INCOMPLETE flag if the given question requires more than zero answers
+            if (checkInvalidAnswer(questionNode, 0)) {
+                statusFlags.add(STATUS_FLAG_INCOMPLETE);
             }
+            this.currentNodeBuilder.getChildNode(name).setProperty(STATUS_FLAGS, statusFlags, Type.STRINGS);
         }
         final List<NodeBuilder> tmpList = new ArrayList<>(this.currentNodeBuilderPath);
         tmpList.add(this.currentNodeBuilder.getChildNode(name));

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -259,7 +259,8 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         // Iterate through all children of this node
         final Iterator<String> childrenNames = this.currentNodeBuilder.getChildNodeNames().iterator();
         boolean isInvalid = false;
-        boolean isIncomplete = false;
+        // If there are no children yet, the form is brand new, thus incomplete
+        boolean isIncomplete = !childrenNames.hasNext();
         while (childrenNames.hasNext()) {
             final String selectedChildName = childrenNames.next();
             final NodeBuilder selectedChild = this.currentNodeBuilder.getChildNode(selectedChildName);

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditorProvider.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditorProvider.java
@@ -54,7 +54,7 @@ public class AnswerCompletionStatusEditorProvider implements EditorProvider
             ResourceResolver myResolver = this.rrf.getThreadResourceResolver();
             if (myResolver != null) {
                 // Each AnswerCompletionStatusEditor maintains a state, so a new instance must be returned each time
-                return new AnswerCompletionStatusEditor(builder, myResolver);
+                return new AnswerCompletionStatusEditor(builder, myResolver, "");
             }
         }
         return null;

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditorProvider.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditorProvider.java
@@ -58,7 +58,7 @@ public class AnswerCompletionStatusEditorProvider implements EditorProvider
                 // Each AnswerCompletionStatusEditor maintains a state, so a new instance must be returned each time
                 ArrayList<NodeBuilder> tmpList = new ArrayList<NodeBuilder>();
                 tmpList.add(builder);
-                return new AnswerCompletionStatusEditor(tmpList, myResolver, "");
+                return new AnswerCompletionStatusEditor(tmpList, myResolver);
             }
         }
         return null;

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditorProvider.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditorProvider.java
@@ -16,6 +16,8 @@
  */
 package ca.sickkids.ccm.lfs.formcompletionstatus;
 
+import java.util.ArrayList;
+
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.commit.Editor;
@@ -54,7 +56,9 @@ public class AnswerCompletionStatusEditorProvider implements EditorProvider
             ResourceResolver myResolver = this.rrf.getThreadResourceResolver();
             if (myResolver != null) {
                 // Each AnswerCompletionStatusEditor maintains a state, so a new instance must be returned each time
-                return new AnswerCompletionStatusEditor(builder, myResolver, "");
+                ArrayList<NodeBuilder> tmpList = new ArrayList<NodeBuilder>();
+                tmpList.add(builder);
+                return new AnswerCompletionStatusEditor(tmpList, myResolver, "");
             }
         }
         return null;

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditorProvider.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditorProvider.java
@@ -17,6 +17,7 @@
 package ca.sickkids.ccm.lfs.formcompletionstatus;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
@@ -56,7 +57,7 @@ public class AnswerCompletionStatusEditorProvider implements EditorProvider
             ResourceResolver myResolver = this.rrf.getThreadResourceResolver();
             if (myResolver != null) {
                 // Each AnswerCompletionStatusEditor maintains a state, so a new instance must be returned each time
-                ArrayList<NodeBuilder> tmpList = new ArrayList<NodeBuilder>();
+                final List<NodeBuilder> tmpList = new ArrayList<>();
                 tmpList.add(builder);
                 return new AnswerCompletionStatusEditor(tmpList, myResolver);
             }

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditorProvider.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditorProvider.java
@@ -43,18 +43,17 @@ import org.osgi.service.component.annotations.ServiceScope;
     scope = ServiceScope.SINGLETON, immediate = true)
 public class AnswerCompletionStatusEditorProvider implements EditorProvider
 {
-
-    @Reference(fieldOption = FieldOption.REPLACE,
-        cardinality = ReferenceCardinality.OPTIONAL,
+    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
         policyOption = ReferencePolicyOption.GREEDY)
     private ResourceResolverFactory rrf;
 
     @Override
-    public Editor getRootEditor(NodeState before, NodeState after, NodeBuilder builder, CommitInfo info)
+    public Editor getRootEditor(final NodeState before, final NodeState after, final NodeBuilder builder,
+        final CommitInfo info)
         throws CommitFailedException
     {
         if (this.rrf != null) {
-            ResourceResolver myResolver = this.rrf.getThreadResourceResolver();
+            final ResourceResolver myResolver = this.rrf.getThreadResourceResolver();
             if (myResolver != null) {
                 // Each AnswerCompletionStatusEditor maintains a state, so a new instance must be returned each time
                 final List<NodeBuilder> tmpList = new ArrayList<>();

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/ConditionalSectionUtils.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/ConditionalSectionUtils.java
@@ -545,7 +545,9 @@ public final class ConditionalSectionUtils
     private static BigDecimal toDecimal(Object o)
     {
         BigDecimal result = null;
-        if (o instanceof Long) {
+        if (o instanceof BigDecimal) {
+            result = (BigDecimal) o;
+        } else if (o instanceof Long) {
             result = BigDecimal.valueOf((Long) o);
         } else if (o instanceof Integer) {
             result = BigDecimal.valueOf((Integer) o);

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/ConditionalSectionUtils.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/ConditionalSectionUtils.java
@@ -19,8 +19,11 @@ package ca.sickkids.ccm.lfs.formcompletionstatus;
 import java.math.BigDecimal;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.Iterator;
 
 import javax.jcr.Node;
@@ -191,25 +194,28 @@ public final class ConditionalSectionUtils
     private static boolean evalSectionEq(final Object propA, final Object propB)
         throws RepositoryException, ValueFormatException
     {
+        if (propA == null || propB == null) {
+            return false;
+        }
         boolean testResult = false;
         switch (getPropertyObjectType(propA)) {
             case PropertyType.STRING:
                 testResult = propA.equals(propB);
                 break;
             case PropertyType.LONG:
-                testResult = (propA == propB);
+                testResult = toLong(propA) == toLong(propB);
                 break;
             case PropertyType.DOUBLE:
-                testResult = (propA.equals(propB));
+                testResult = toDouble(propA) == toDouble(propB);
                 break;
             case PropertyType.DECIMAL:
-                testResult = (((BigDecimal) propA).compareTo((BigDecimal) propB) == 0);
+                testResult = toDecimal(propA).compareTo(toDecimal(propB)) == 0;
                 break;
             case PropertyType.BOOLEAN:
-                testResult = (propA == propB);
+                testResult = toBoolean(propA) == toBoolean(propB);
                 break;
             case PropertyType.DATE:
-                testResult = propA.equals(propB);
+                testResult = toDate(propA).compareTo(toDate(propB)) == 0;
                 break;
             default:
                 break;
@@ -220,19 +226,22 @@ public final class ConditionalSectionUtils
     private static boolean evalSectionLt(final Object propA, final Object propB)
         throws RepositoryException, ValueFormatException
     {
+        if (propA == null || propB == null) {
+            return false;
+        }
         boolean testResult = false;
         switch (getPropertyObjectType(propA)) {
             case PropertyType.LONG:
-                testResult = ((long) propA < (long) propB);
+                testResult = toLong(propA) < toLong(propB);
                 break;
             case PropertyType.DOUBLE:
-                testResult = ((double) propA < (double) propB);
+                testResult = toDouble(propA) < toDouble(propB);
                 break;
             case PropertyType.DECIMAL:
-                testResult = (((BigDecimal) propA).compareTo((BigDecimal) propB) == -1);
+                testResult = toDecimal(propA).compareTo(toDecimal(propB)) < 0;
                 break;
             case PropertyType.DATE:
-                testResult = ((Calendar) propA).before((Calendar) propB);
+                testResult = toDate(propA).before(toDate(propB));
                 break;
             default:
                 break;
@@ -243,19 +252,22 @@ public final class ConditionalSectionUtils
     private static boolean evalSectionGt(final Object propA, final Object propB)
         throws RepositoryException, ValueFormatException
     {
+        if (propA == null || propB == null) {
+            return false;
+        }
         boolean testResult = false;
         switch (getPropertyObjectType(propA)) {
             case PropertyType.LONG:
-                testResult = ((long) propA > (long) propB);
+                testResult = toLong(propA) > toLong(propB);
                 break;
             case PropertyType.DOUBLE:
-                testResult = ((double) propA > (double) propB);
+                testResult = toDouble(propA) > toDouble(propB);
                 break;
             case PropertyType.DECIMAL:
-                testResult = (((BigDecimal) propA).compareTo((BigDecimal) propB) == 1);
+                testResult = toDecimal(propA).compareTo(toDecimal(propB)) > 0;
                 break;
             case PropertyType.DATE:
-                testResult = ((Calendar) propA).after((Calendar) propB);
+                testResult = toDate(propA).after(toDate(propB));
                 break;
             default:
                 break;
@@ -512,5 +524,69 @@ public final class ConditionalSectionUtils
             }
         }
         return false;
+    }
+
+    private static long toLong(Object o)
+    {
+        long result = 0;
+        if (o instanceof Number) {
+            result = ((Number) o).longValue();
+        } else if (o instanceof String) {
+            result = Long.valueOf((String) o);
+        }
+        return result;
+    }
+
+    private static double toDouble(Object o)
+    {
+        double result = Double.NaN;
+        if (o instanceof Number) {
+            result = ((Number) o).doubleValue();
+        } else if (o instanceof String) {
+            result = Double.valueOf((String) o);
+        }
+        return result;
+    }
+
+    private static BigDecimal toDecimal(Object o)
+    {
+        BigDecimal result = null;
+        if (o instanceof Long) {
+            result = BigDecimal.valueOf((Long) o);
+        } else if (o instanceof Integer) {
+            result = BigDecimal.valueOf((Integer) o);
+        } else if (o instanceof Double) {
+            result = BigDecimal.valueOf((Double) o);
+        } else if (o instanceof Float) {
+            result = BigDecimal.valueOf((Float) o);
+        } else if (o instanceof String) {
+            result = new BigDecimal((String) o);
+        }
+        return result;
+    }
+
+    private static boolean toBoolean(Object o)
+    {
+        boolean result = false;
+        if (o instanceof Boolean) {
+            result = (Boolean) o;
+        } else if (o instanceof String) {
+            result = Boolean.getBoolean((String) o);
+        }
+        return result;
+    }
+
+    private static Calendar toDate(Object o)
+    {
+        Calendar result = null;
+        if (o instanceof Calendar) {
+            result = (Calendar) o;
+        } else if (o instanceof Date) {
+            result = Calendar.getInstance();
+            result.setTime((Date) o);
+        } else if (o instanceof String) {
+            result = GregorianCalendar.from(ZonedDateTime.parse((String) o, DateTimeFormatter.ISO_DATE_TIME));
+        }
+        return result;
     }
 }

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/ConditionalSectionUtils.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/ConditionalSectionUtils.java
@@ -232,6 +232,9 @@ public final class ConditionalSectionUtils
             case PropertyType.DOUBLE:
                 testResult = ((double) propA < (double) propB);
                 break;
+            case PropertyType.DECIMAL:
+                testResult = (((BigDecimal) propA).compareTo((BigDecimal) propB) == -1);
+                break;
             case PropertyType.DATE:
                 testResult = ((Calendar) propA).before((Calendar) propB);
                 break;
@@ -251,6 +254,9 @@ public final class ConditionalSectionUtils
                 break;
             case PropertyType.DOUBLE:
                 testResult = ((double) propA > (double) propB);
+                break;
+            case PropertyType.DECIMAL:
+                testResult = (((BigDecimal) propA).compareTo((BigDecimal) propB) == 1);
                 break;
             case PropertyType.DATE:
                 testResult = ((Calendar) propA).after((Calendar) propB);

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/ConditionalSectionUtils.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/ConditionalSectionUtils.java
@@ -1,0 +1,437 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.sickkids.ccm.lfs.formcompletionstatus;
+
+import java.math.BigDecimal;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Iterator;
+
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.PropertyType;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.ValueFormatException;
+
+import org.apache.jackrabbit.oak.api.PropertyState;
+import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public final class ConditionalSectionUtils
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConditionalSectionUtils.class);
+
+    private static final String PROP_QUESTION = "question";
+    private static final String PROP_IS_REFERENCE = "isReference";
+    private static final String PROP_VALUE = "value";
+
+    /**
+     * Hide the utility class constructor.
+     */
+    private ConditionalSectionUtils()
+    {
+    }
+
+    /**
+     * Gets the questionnaire section node referenced by the AnswerSection NodeBuilder nb.
+     *
+     * @return the section Node object referenced by NodeBuilder nb
+     */
+    private static Node getSectionNode(final Session resourceSession, final NodeBuilder nb)
+    {
+        try {
+            if (nb.hasProperty("section")) {
+                //final Session resourceSession = this.currentResourceResolver.adaptTo(Session.class);
+                final String sectionNodeReference = nb.getProperty("section").getValue(Type.REFERENCE);
+                final Node sectionNode = resourceSession.getNodeByIdentifier(sectionNodeReference);
+                return sectionNode;
+            }
+        } catch (final RepositoryException ex) {
+            return null;
+        }
+        return null;
+    }
+
+    /**
+     * Returns the first NodeBuilder with a question value equal to the String uuid that is a child of the NodeBuilder
+     * nb. If no such child can be found, null is returned
+     *
+     * @param nb the NodeBuilder to search through its children
+     * @param uuid the UUID String for which the child's question property must be equal to
+     * @return the first NodeBuilder with a question value equal to the String uuid that is a child of the NodeBuilder
+     *         nb, or null if such node does not exist.
+     */
+    private static NodeBuilder getChildNodeWithQuestion(final NodeBuilder nb, final String uuid)
+    {
+        final Iterable<String> childrenNames = nb.getChildNodeNames();
+        final Iterator<String> childrenNamesIter = childrenNames.iterator();
+        while (childrenNamesIter.hasNext()) {
+            final String selectedChildName = childrenNamesIter.next();
+            final NodeBuilder selectedChild = nb.getChildNode(selectedChildName);
+            if (selectedChild.hasProperty(PROP_QUESTION)) {
+                if (uuid.equals(selectedChild.getProperty(PROP_QUESTION).getValue(Type.STRING))) {
+                    return selectedChild;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Parses a date from the given input string.
+     *
+     * @param str the serialized date to parse
+     * @return the parsed date, or {@code null} if the date cannot be parsed
+     */
+    private static Calendar parseDate(final String str)
+    {
+        try {
+            final SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd");
+            final Date date = fmt.parse(str.split("T")[0]);
+            final Calendar calendar = Calendar.getInstance();
+            //calendar.setTimeZone(TimeZone.getTimeZone("GMT"));
+            calendar.setTime(date);
+            //calendar.set(Calendar.HOUR, 0);
+            //calendar.set(Calendar.MINUTE, 0);
+            //calendar.set(Calendar.SECOND, 0);
+            //calendar.set(Calendar.MILLISECOND, 0);
+            return calendar;
+        } catch (final ParseException e) {
+            LOGGER.warn("PARSING DATE FAILED: Invalid date {}", str);
+            return null;
+        }
+    }
+
+    private static int getPropertyStateType(final PropertyState ps)
+    {
+        int ret = PropertyType.UNDEFINED;
+        if (Type.STRING.equals(ps.getType())) {
+            ret = PropertyType.STRING;
+        } else if (Type.LONG.equals(ps.getType())) {
+            ret = PropertyType.LONG;
+        } else if (Type.DOUBLE.equals(ps.getType())) {
+            ret = PropertyType.DOUBLE;
+        } else if (Type.DECIMAL.equals(ps.getType())) {
+            ret = PropertyType.DECIMAL;
+        } else if (Type.BOOLEAN.equals(ps.getType())) {
+            ret = PropertyType.BOOLEAN;
+        } else if (Type.DATE.equals(ps.getType())) {
+            ret = PropertyType.DATE;
+        }
+        return ret;
+    }
+
+    private static int getPropertyObjectType(final Object obj)
+    {
+        int ret = PropertyType.UNDEFINED;
+        if (obj instanceof String) {
+            ret = PropertyType.STRING;
+        } else if (obj instanceof Long) {
+            ret = PropertyType.LONG;
+        } else if (obj instanceof Double) {
+            ret = PropertyType.DOUBLE;
+        } else if (obj instanceof BigDecimal) {
+            ret = PropertyType.DECIMAL;
+        } else if (obj instanceof Boolean) {
+            ret = PropertyType.BOOLEAN;
+        } else if (obj instanceof Calendar) {
+            ret = PropertyType.DATE;
+        }
+        return ret;
+    }
+
+    private static boolean evalSectionEq(final Object propA, final Object propB)
+        throws RepositoryException, ValueFormatException
+    {
+        boolean testResult = false;
+        switch (getPropertyObjectType(propA)) {
+            case PropertyType.STRING:
+                testResult = propA.equals(propB);
+                break;
+            case PropertyType.LONG:
+                testResult = (propA == propB);
+                break;
+            case PropertyType.DOUBLE:
+                testResult = (propA.equals(propB));
+                break;
+            case PropertyType.DECIMAL:
+                testResult = (((BigDecimal) propA).compareTo((BigDecimal) propB) == 0);
+                break;
+            case PropertyType.BOOLEAN:
+                testResult = (propA == propB);
+                break;
+            case PropertyType.DATE:
+                testResult = propA.equals(propB);
+                break;
+            default:
+                break;
+        }
+        return testResult;
+    }
+
+    private static boolean evalSectionLt(final Object propA, final Object propB)
+        throws RepositoryException, ValueFormatException
+    {
+        boolean testResult = false;
+        switch (getPropertyObjectType(propA)) {
+            case PropertyType.LONG:
+                testResult = ((long) propA < (long) propB);
+                break;
+            case PropertyType.DOUBLE:
+                testResult = ((double) propA < (double) propB);
+                break;
+            case PropertyType.DATE:
+                testResult = ((Calendar) propA).before((Calendar) propB);
+                break;
+            default:
+                break;
+        }
+        return testResult;
+    }
+
+    private static boolean evalSectionGt(final Object propA, final Object propB)
+        throws RepositoryException, ValueFormatException
+    {
+        boolean testResult = false;
+        switch (getPropertyObjectType(propA)) {
+            case PropertyType.LONG:
+                testResult = ((long) propA > (long) propB);
+                break;
+            case PropertyType.DOUBLE:
+                testResult = ((double) propA > (double) propB);
+                break;
+            case PropertyType.DATE:
+                testResult = ((Calendar) propA).after((Calendar) propB);
+                break;
+            default:
+                break;
+        }
+        return testResult;
+    }
+
+    /**
+     * Evaluates the boolean expression {propA} {operator} {propB}.
+     */
+    private static boolean evalSectionCondition(final Object propA, final Object propB, final String operator)
+        throws RepositoryException, ValueFormatException
+    {
+        if ("=".equals(operator) || "<>".equals(operator)) {
+            /*
+             * Type.STRING uses .equals()
+             * Everything else uses ==
+             */
+            boolean testResult = evalSectionEq(propA, propB);
+            if ("<>".equals(operator)) {
+                testResult = !testResult;
+            }
+            return testResult;
+        } else if ("is empty".equals(operator) || "is not empty".equals(operator)) {
+            boolean testResult = (propA == null);
+            if ("is not empty".equals(operator)) {
+                testResult = !testResult;
+            }
+            return testResult;
+        } else if ("<".equals(operator)) {
+            return evalSectionLt(propA, propB);
+        } else if (">".equals(operator)) {
+            return evalSectionGt(propA, propB);
+        }
+        // If we can't evaluate it, assume it to be false
+        return false;
+    }
+
+    /*
+     * Read in a string, inStr, and return it with any non-allowed chars removed.
+     */
+    private static String sanitizeNodeName(final String inStr)
+    {
+        final String inStrLower = inStr.toLowerCase();
+        String outStr = "";
+        for (int i = 0; i < inStr.length(); i++) {
+            if ("abcdefghijklmnopqrstuvwxyz 0123456789_-".indexOf(inStrLower.charAt(i)) > -1) {
+                outStr += inStr.charAt(i);
+            }
+        }
+        return outStr;
+    }
+
+    private static Object getObjectFromPropertyState(PropertyState ps)
+    {
+        Object ret = null;
+        switch (getPropertyStateType(ps))
+        {
+            case PropertyType.STRING:
+                ret = ps.getValue(Type.STRING);
+                break;
+            case PropertyType.LONG:
+                ret = ps.getValue(Type.LONG);
+                break;
+            case PropertyType.DOUBLE:
+                ret = ps.getValue(Type.DOUBLE);
+                break;
+            case PropertyType.DECIMAL:
+                ret = ps.getValue(Type.DECIMAL);
+                break;
+            case PropertyType.BOOLEAN:
+                ret = ps.getValue(Type.BOOLEAN);
+                break;
+            case PropertyType.DATE:
+                ret = parseDate(ps.getValue(Type.DATE));
+                break;
+            default:
+                break;
+        }
+        return ret;
+    }
+
+    private static Object getObjectFromValue(Value val) throws RepositoryException, ValueFormatException
+    {
+        Object ret = null;
+        switch (val.getType()) {
+            case PropertyType.STRING:
+                ret = val.getString();
+                break;
+            case PropertyType.LONG:
+                ret = val.getLong();
+                break;
+            case PropertyType.DOUBLE:
+                ret = val.getDouble();
+                break;
+            case PropertyType.DECIMAL:
+                ret = val.getDecimal();
+                break;
+            case PropertyType.BOOLEAN:
+                ret = val.getBoolean();
+                break;
+            case PropertyType.DATE:
+                //Calendar calendar = Calendar.getInstance();
+                //calendar.set(val.getDate().get(Calendar.YEAR),
+                //    val.getDate().get(Calendar.MONTH),
+                //    val.getDate().get(Calendar.DAY_OF_MONTH));
+                //ret = val.getDate();
+                Calendar calendar = parseDate(Integer.toString(val.getDate().get(Calendar.YEAR))
+                    + "-"
+                    + Integer.toString(val.getDate().get(Calendar.MONTH) + 1)
+                    + "-"
+                    + Integer.toString(val.getDate().get(Calendar.DAY_OF_MONTH))
+                    + "T00:00");
+                ret = calendar;
+                break;
+            default:
+                break;
+        }
+        return ret;
+    }
+
+    private static Object getOperandValue(final Node operand, final Node sectionNode, final NodeBuilder prevNb)
+        throws RepositoryException
+    {
+        Object returnedValue = null;
+        if (operand.getProperty(PROP_IS_REFERENCE).getValue().getBoolean()) {
+            String key = operand.getProperty(PROP_VALUE).getValues()[0].getString();
+            // Sanitize
+            key = sanitizeNodeName(key);
+            final Node sectionNodeParent = sectionNode.getParent();
+            final Node keyNode = sectionNodeParent.getNode(key);
+            final String keyNodeUUID = keyNode.getIdentifier();
+            // Get the node from the Form containing the answer to keyNode
+            final NodeBuilder conditionalFormNode = getChildNodeWithQuestion(prevNb, keyNodeUUID);
+            if (conditionalFormNode == null) {
+                return null;
+            }
+            final PropertyState operandProp = conditionalFormNode.getProperty(PROP_VALUE);
+            if (operandProp != null) {
+                returnedValue = getObjectFromPropertyState(operandProp);
+            }
+        } else {
+            Property nodeProp = operand.getProperty(PROP_VALUE);
+            Value nodeVal;
+            if (nodeProp.isMultiple()) {
+                nodeVal = nodeProp.getValues()[0];
+            } else {
+                nodeVal = nodeProp.getValue();
+            }
+            returnedValue = getObjectFromValue(nodeVal);
+        }
+        return returnedValue;
+    }
+
+    /*
+     * Given a "condition" node from the "Questionnaires" and a "lfs:AnswerSection" node from the "Forms" and a
+     * NodeBuilder type object referring to the parent of the "lfs:AnswerSection" node, evaluate the boolean expression
+     * defined by the descendants of the "condition" Node.
+     */
+    private static boolean evaluateConditionNodeRecursive(final Node conditionNode, final Node sectionNode,
+        final NodeBuilder prevNb)
+        throws RepositoryException
+    {
+        if ("lfs:ConditionalGroup".equals(conditionNode.getProperty("jcr:primaryType").getString())) {
+            // Is this an OR or an AND
+            final boolean requireAll = conditionNode.getProperty("requireAll").getBoolean();
+            // Evaluate recursively
+            final Iterator<Node> conditionChildren = conditionNode.getNodes();
+            boolean downstreamResult = false;
+            if (requireAll) {
+                downstreamResult = true;
+            }
+            while (conditionChildren.hasNext()) {
+                final boolean partialRes =
+                    evaluateConditionNodeRecursive(conditionChildren.next(), sectionNode, prevNb);
+                if (requireAll) {
+                    downstreamResult = downstreamResult && partialRes;
+                } else {
+                    downstreamResult = downstreamResult || partialRes;
+                }
+            }
+            return downstreamResult;
+        } else if ("lfs:Conditional".equals(conditionNode.getProperty("jcr:primaryType").getString())) {
+            final String comparator = conditionNode.getProperty("comparator").getString();
+            final Node operandB = conditionNode.getNode("operandB");
+            final Node operandA = conditionNode.getNode("operandA");
+
+            final Object valueA = getOperandValue(operandA, sectionNode, prevNb);
+            final Object valueB = getOperandValue(operandB, sectionNode, prevNb);
+            return evalSectionCondition(valueA, valueB, comparator);
+        }
+        // If all goes wrong
+        return false;
+    }
+
+    public static boolean isConditionSatisfied(final Session resourceSession,
+        final NodeBuilder nb, final NodeBuilder prevNb) throws RepositoryException
+    {
+        final Node sectionNode = getSectionNode(resourceSession, nb);
+        if (sectionNode.hasNode("condition")) {
+            final Node conditionNode = sectionNode.getNode("condition");
+            /*
+             * Recursively go through all children of the condition node and determine if this condition node evaluates
+             * to True or False.
+             */
+            if (evaluateConditionNodeRecursive(conditionNode, sectionNode, prevNb)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/ConditionalSectionUtils.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/ConditionalSectionUtils.java
@@ -37,14 +37,16 @@ import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public final class ConditionalSectionUtils
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConditionalSectionUtils.class);
 
     private static final String PROP_QUESTION = "question";
+
     private static final String PROP_IS_REFERENCE = "isReference";
+
     private static final String PROP_VALUE = "value";
+
     private static final String PROP_REQUIRE_ALL = "requireAll";
 
     /**
@@ -268,10 +270,6 @@ public final class ConditionalSectionUtils
         throws RepositoryException, ValueFormatException
     {
         if ("=".equals(operator) || "<>".equals(operator)) {
-            /*
-             * Type.STRING uses .equals()
-             * Everything else uses ==
-             */
             boolean testResult = evalSectionEq(propA, propB);
             if ("<>".equals(operator)) {
                 testResult = !testResult;
@@ -304,8 +302,7 @@ public final class ConditionalSectionUtils
     private static Object getObjectFromPropertyState(PropertyState ps, int index)
     {
         Object ret = null;
-        switch (getPropertyStateType(ps))
-        {
+        switch (getPropertyStateType(ps)) {
             case PropertyType.STRING:
                 ret = ps.getValue(Type.STRING, index);
                 break;
@@ -394,7 +391,6 @@ public final class ConditionalSectionUtils
             Property nodeProp = operand.getProperty(PROP_VALUE);
             Value nodeVal;
             if (nodeProp.isMultiple()) {
-                Value[] nodeVals = nodeProp.getValues();
                 nodeVal = nodeProp.getValues()[index];
             } else {
                 nodeVal = nodeProp.getValue();
@@ -435,8 +431,7 @@ public final class ConditionalSectionUtils
         final boolean requireAllA = operandA.getProperty(PROP_REQUIRE_ALL).getBoolean();
 
         /*
-         * Check for "is empty" / "is not empty" as requireAll is not
-         * relevant for these operators
+         * Check for "is empty" / "is not empty" as requireAll is not relevant for these operators
          */
         if ("is empty".equals(comparator) || "is not empty".equals(comparator)) {
             boolean testResult = (lengthB == -1 || lengthA == -1);
@@ -446,7 +441,7 @@ public final class ConditionalSectionUtils
             return testResult;
         }
 
-        //If at least one operand requires all to match
+        // If at least one operand requires all to match
         final boolean requireAllMulti = requireAllB | requireAllA;
 
         boolean res = requireAllMulti;
@@ -475,6 +470,7 @@ public final class ConditionalSectionUtils
             // Is this an OR or an AND
             final boolean requireAll = conditionNode.getProperty(PROP_REQUIRE_ALL).getBoolean();
             // Evaluate recursively
+            @SuppressWarnings("unchecked")
             final Iterator<Node> conditionChildren = conditionNode.getNodes();
             boolean downstreamResult = false;
             if (requireAll) {
@@ -494,15 +490,6 @@ public final class ConditionalSectionUtils
             final String comparator = conditionNode.getProperty("comparator").getString();
             final Node operandB = conditionNode.getNode("operandB");
             final Node operandA = conditionNode.getNode("operandA");
-
-            //Get valueA[0..N] and valueB[0..N]
-            //If requireAll check that all combinations evaluate to true
-            //Otherwise check that at least one combination evaluates to true
-            final boolean requireAllB = operandB.getProperty(PROP_REQUIRE_ALL).getBoolean();
-            final boolean requireAllA = operandA.getProperty(PROP_REQUIRE_ALL).getBoolean();
-
-            //If at least one operand requires all to match
-            final boolean requireAllMulti = requireAllB | requireAllA;
 
             return evalOperands(operandA, operandB, comparator, sectionNode, prevNb);
         }

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/ConditionalSectionUtils.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/ConditionalSectionUtils.java
@@ -63,7 +63,6 @@ public final class ConditionalSectionUtils
     {
         try {
             if (nb.hasProperty("section")) {
-                //final Session resourceSession = this.currentResourceResolver.adaptTo(Session.class);
                 final String sectionNodeReference = nb.getProperty("section").getValue(Type.REFERENCE);
                 final Node sectionNode = resourceSession.getNodeByIdentifier(sectionNodeReference);
                 return sectionNode;
@@ -111,12 +110,7 @@ public final class ConditionalSectionUtils
             final SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd");
             final Date date = fmt.parse(str.split("T")[0]);
             final Calendar calendar = Calendar.getInstance();
-            //calendar.setTimeZone(TimeZone.getTimeZone("GMT"));
             calendar.setTime(date);
-            //calendar.set(Calendar.HOUR, 0);
-            //calendar.set(Calendar.MINUTE, 0);
-            //calendar.set(Calendar.SECOND, 0);
-            //calendar.set(Calendar.MILLISECOND, 0);
             return calendar;
         } catch (final ParseException e) {
             LOGGER.warn("PARSING DATE FAILED: Invalid date {}", str);
@@ -359,11 +353,6 @@ public final class ConditionalSectionUtils
                 ret = val.getBoolean();
                 break;
             case PropertyType.DATE:
-                //Calendar calendar = Calendar.getInstance();
-                //calendar.set(val.getDate().get(Calendar.YEAR),
-                //    val.getDate().get(Calendar.MONTH),
-                //    val.getDate().get(Calendar.DAY_OF_MONTH));
-                //ret = val.getDate();
                 Calendar calendar = parseDate(Integer.toString(val.getDate().get(Calendar.YEAR))
                     + "-"
                     + Integer.toString(val.getDate().get(Calendar.MONTH) + 1)
@@ -521,17 +510,10 @@ public final class ConditionalSectionUtils
 
             //If at least one operand requires all to match
             final boolean requireAllMulti = requireAllB | requireAllA;
-            //LOGGER.warn("requireAllMulti = {}, {}, {}", requireAllMulti, operandB, operandA);
 
-            //return res;
             final boolean result = evalOperands(operandA, operandB, comparator, sectionNode, prevNb);
             LOGGER.warn("RESULT = {}, requireAllMulti = {}, {}, {}", result, requireAllMulti, operandB, operandA);
             return result;
-
-
-            //final Object valueA = getOperandValue(operandA, sectionNode, prevNb);
-            //final Object valueB = getOperandValue(operandB, sectionNode, prevNb);
-            //return evalSectionCondition(valueA, valueB, comparator);
         }
         // If all goes wrong
         return false;

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/ConditionalSectionUtils.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/ConditionalSectionUtils.java
@@ -278,12 +278,6 @@ public final class ConditionalSectionUtils
                 testResult = !testResult;
             }
             return testResult;
-        } else if ("is empty".equals(operator) || "is not empty".equals(operator)) {
-            boolean testResult = (propA == null);
-            if ("is not empty".equals(operator)) {
-                testResult = !testResult;
-            }
-            return testResult;
         } else if ("<".equals(operator)) {
             return evalSectionLt(propA, propB);
         } else if (">".equals(operator)) {
@@ -448,6 +442,18 @@ public final class ConditionalSectionUtils
         final int lengthA = getOperandLength(operandA, sectionNode, prevNb);
         final boolean requireAllB = operandB.getProperty(PROP_REQUIRE_ALL).getBoolean();
         final boolean requireAllA = operandA.getProperty(PROP_REQUIRE_ALL).getBoolean();
+
+        /*
+         * Check for "is empty" / "is not empty" as requireAll is not
+         * relevant for these operators
+         */
+        if ("is empty".equals(comparator) || "is not empty".equals(comparator)) {
+            boolean testResult = (lengthB == -1 || lengthA == -1);
+            if ("is not empty".equals(comparator)) {
+                testResult = !testResult;
+            }
+            return testResult;
+        }
 
         //If at least one operand requires all to match
         final boolean requireAllMulti = requireAllB | requireAllA;

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/ConditionalSectionUtils.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/ConditionalSectionUtils.java
@@ -267,7 +267,6 @@ public final class ConditionalSectionUtils
     private static boolean evalSectionCondition(final Object propA, final Object propB, final String operator)
         throws RepositoryException, ValueFormatException
     {
-        LOGGER.warn("evalSectionCondition: {} {} {}", propA, operator, propB);
         if ("=".equals(operator) || "<>".equals(operator)) {
             /*
              * Type.STRING uses .equals()
@@ -305,7 +304,6 @@ public final class ConditionalSectionUtils
     private static Object getObjectFromPropertyState(PropertyState ps, int index)
     {
         Object ret = null;
-        LOGGER.warn("This PropertyState has {} values.", ps.count());
         switch (getPropertyStateType(ps))
         {
             case PropertyType.STRING:
@@ -327,7 +325,6 @@ public final class ConditionalSectionUtils
                 ret = parseDate(ps.getValue(Type.DATE, index));
                 break;
             default:
-                LOGGER.warn("Unresolved type in getObjectFromPropertyState");
                 break;
         }
         return ret;
@@ -398,7 +395,6 @@ public final class ConditionalSectionUtils
             Value nodeVal;
             if (nodeProp.isMultiple()) {
                 Value[] nodeVals = nodeProp.getValues();
-                LOGGER.warn("This property has {} values.", nodeVals.length);
                 nodeVal = nodeProp.getValues()[index];
             } else {
                 nodeVal = nodeProp.getValue();
@@ -499,9 +495,6 @@ public final class ConditionalSectionUtils
             final Node operandB = conditionNode.getNode("operandB");
             final Node operandA = conditionNode.getNode("operandA");
 
-            LOGGER.warn("operandB is of length: {}", getOperandLength(operandB, sectionNode, prevNb));
-            LOGGER.warn("operandA is of length: {}", getOperandLength(operandA, sectionNode, prevNb));
-
             //Get valueA[0..N] and valueB[0..N]
             //If requireAll check that all combinations evaluate to true
             //Otherwise check that at least one combination evaluates to true
@@ -511,9 +504,7 @@ public final class ConditionalSectionUtils
             //If at least one operand requires all to match
             final boolean requireAllMulti = requireAllB | requireAllA;
 
-            final boolean result = evalOperands(operandA, operandB, comparator, sectionNode, prevNb);
-            LOGGER.warn("RESULT = {}, requireAllMulti = {}, {}, {}", result, requireAllMulti, operandB, operandA);
-            return result;
+            return evalOperands(operandA, operandB, comparator, sectionNode, prevNb);
         }
         // If all goes wrong
         return false;


### PR DESCRIPTION
This PR replaces the **LFS-275** PR by incorporating the code revision commits from **LFS-273** up to commit `287c5e30e473a313c6c97463831b38042ccb5d83`.

The new features (**LFS-275**) added onto **LFS-273** are:

- When a form is instantiated, it starts out with `statusFlags = ["INCOMPLETE"]`
- When a form is saved, it is marked as `INCOMPLETE` if at least one descendant answer is marked as `INCOMPLETE`
- When a form is saved, it is marked as `INVALID` if at least one descendant answer is marked as `INVALID`
- When a form is saved, the `INCOMPLETE` flag is removed if no descendant answers possess this `INCOMPLETE` flag.
- When a form is saved, the `INVALID` flag is removed if no descendant answers possess this `INVALID` flag.

To test, build the `LFS-273-275_test` branch, and create the various _LFS-484_ test forms. Each form is configured so that every _Confirm Okay_ field has `minAnswers = 1`. Open `/bin/browser.html` and ensure that the `statusFlags` of the _root_ node for _each_ form are following the rules properly; `INCOMPLETE` for an initially blank _Confirm Okay_ answer, `INVALID,INCOMPLETE`, for a _Confirm Okay_ answer that was filled but then cleared.