### PR TITLE
LFS-395: Boolean questions should have the undefined options saved in db

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/BooleanQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/BooleanQuestion.jsx
@@ -60,9 +60,9 @@ function BooleanQuestion(props) {
   const {yesLabel, noLabel, unknownLabel, enableUnknown} = { ...props.questionDefinition, ...props }
   // Define the defaults for yesLabel, etc. here because we want questionDefinition to be able to
   // override them, and the props to be able to override the questionDefinition
-  let options = [[yesLabel || "Yes", "true", true], [noLabel || "No", "false", true]];
+  let options = [[yesLabel || "Yes", "1", true], [noLabel || "No", "0", true]];
   if (enableUnknown) {
-    options.push([unknownLabel || "Unknown", "undefined", true]);
+    options.push([unknownLabel || "Unknown", "-1", true]);
   }
 
   return (
@@ -71,7 +71,7 @@ function BooleanQuestion(props) {
       >
       <MultipleChoice
         answerNodeType="lfs:BooleanAnswer"
-        valueType="Boolean"
+        valueType="long" /* Notably not "Boolean", since we need it to be stored as a long in the backend */
         maxAnswers={1}
         defaults={options}
         {...rest}

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/DataImportServlet.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/DataImportServlet.java
@@ -450,7 +450,8 @@ public class DataImportServlet extends SlingAllMethodsServlet
                     result = valueFactory.createValue(new BigDecimal(rawValue));
                     break;
                 case "boolean":
-                    result = valueFactory.createValue(BooleanUtils.toBoolean(rawValue));
+                    result = valueFactory.createValue(
+                        BooleanUtils.toInteger(BooleanUtils.toBooleanObject(rawValue), 1, 0, -1));
                     break;
                 case "date":
                     result = valueFactory.createValue(parseDate(rawValue));

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -428,7 +428,8 @@
 //-----------------------------------------------------------------------------
 // Yes/No
 [lfs:BooleanAnswer] > lfs:Answer
-  - value (boolean)
+  // Though we could use a boolean here, we want to handle three states (true/false/undefined), which is best defined by long.
+  - value (long)
 
   // Hardcode the resource type.
   - sling:resourceType (STRING) = "lfs/BooleanAnswer" mandatory autocreated protected


### PR DESCRIPTION
This also switches the backend datatype for booleans to long, and handles conversion when JSONifying the resource.

**To test**: Create a new Demographics questionnaire. The _Undergoing Surveillance?_ field should handle saving 'Unknown' properly. Nothing else to do with boolean questions should have broken in this patch.