### PR TITLE
LFS-411: add requireAll property to lfs:ConditionalGroup node type

### DIFF
--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -253,6 +253,8 @@
   // Hardcode the resource supertype: each section link is a resource.
   - sling:resourceSuperType (STRING) = "lfs/Resource" mandatory autocreated protected
 
+  - requireAll (BOOLEAN) = false mandatory autocreated
+
   // This conditional may contain any number of conditionals or conditional groups
   + * (lfs:ConditionalGroup, lfs:Conditional) = lfs:Question
 


### PR DESCRIPTION
Simple bug-fix for the LFS-411 bug logged in JIRA - the `requireAll` property is now supported on the `lfs:ConditionGroup` type of JCR nodes thus allowing the **AND** operator to be used in Boolean expressions for conditional sections.