### PR TITLE
LFS-370: Add Notes to filters

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/FilterComponentManager.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/FilterComponentManager.jsx
@@ -18,6 +18,7 @@
 //
 
 let _registeredComponents = [];
+let _registeredTextFilterComponents = [];
 
 // This is a utility class which helps the Filter component determine how to handle different filters.
 export default class FilterComponentManager {
@@ -28,6 +29,17 @@ export default class FilterComponentManager {
   //     The confidence is a number between 0 and 100, with a bigger number indicating more confidence. The registered component with the highest confidence will be used to display the question.
   static registerFilterComponent(component) {
     _registeredComponents.push(component);
+  }
+
+  static registerTextFilterComponent(component) {
+    _registeredTextFilterComponents.push(component);
+  }
+
+  static getTextFilterComponent(questionDefinition) {
+    return (_registeredTextFilterComponents
+      .map(component => (component)(questionDefinition))
+      .reduce(([displayer]) => displayer)
+    )
   }
 
   // Picks and returns the registered component with the highest confidence that it can display a filter for the given question,

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/TextFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/TextFilter.jsx
@@ -27,6 +27,13 @@ import QuestionnaireStyle from "../../questionnaire/QuestionnaireStyle.jsx";
 
 const COMPARATORS = DEFAULT_COMPARATORS.slice().concat(UNARY_COMPARATORS);
 
+const QuestionnaireStyleNotesContain = theme => ({ 
+  ...QuestionnaireStyle,
+  textField: {
+    // The default min-width is 250 px, which is too wide when the comparator is "notes contain"
+    minWidth: "155px !important",
+}});
+
 /**
  * Display a filter on a numeric answer of a form. This is not meant to be instantiated directly, but is returned from FilterComponentManager's
  * getFilterComparatorsAndComponent method.
@@ -69,13 +76,13 @@ TextFilter.propTypes = {
 }
 
 const StyledTextFilter = withStyles(QuestionnaireStyle)(TextFilter)
-export default StyledTextFilter;
+const StyledNotesContainFilter = withStyles(QuestionnaireStyleNotesContain)(TextFilter)
+export default { StyledTextFilter, StyledNotesContainFilter }
 
 FilterComponentManager.registerFilterComponent((questionDefinition) => {
   return [COMPARATORS, StyledTextFilter, 10];
 });
 
 FilterComponentManager.registerTextFilterComponent((questionDefinition) => {
-  return StyledTextFilter;
+  return StyledNotesContainFilter;
 });
-

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/TextFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/TextFilter.jsx
@@ -69,9 +69,13 @@ TextFilter.propTypes = {
 }
 
 const StyledTextFilter = withStyles(QuestionnaireStyle)(TextFilter)
-
 export default StyledTextFilter;
 
 FilterComponentManager.registerFilterComponent((questionDefinition) => {
   return [COMPARATORS, StyledTextFilter, 10];
 });
+
+FilterComponentManager.registerTextFilterComponent((questionDefinition) => {
+  return StyledTextFilter;
+});
+

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
@@ -55,6 +55,7 @@ function Filters(props) {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [filterRequestSent, setFilterRequestSent] = useState(false);
   const [toFocus, setFocusRow] = useState(null);
+  const notesComparator = "notes contain";
 
   // Focus on inputs as they are flagged for focus
   const focusRef = useRef();
@@ -111,7 +112,6 @@ function Filters(props) {
     setFilterableTitles(titles);
     setFilterableUUIDs(uuids);
   }
-
 
   // Open the filter selection dialog
   let openDialogAndAdd = () => {
@@ -188,9 +188,13 @@ function Filters(props) {
 
   let getOutputChoices = (field, overridefilters) => {
     let [comparators, component] = FilterComponentManager.getFilterComparatorsAndComponent(questionDefinitions[field]);
-   
-    if (!questionDefinitions[field].enableNotes && comparators.includes("notes contain")){
-      comparators.pop("notes contain");
+    if (questionDefinitions[field].enableNotes && !comparators.includes(notesComparator)) {
+      comparators = comparators.slice();
+      comparators.push(notesComparator);
+      setTextFilterComponent(old => ({
+        ...old,
+        [field]: FilterComponentManager.getTextFilterComponent(questionDefinitions[field])
+      }));
     }
     setFilterComparators( old => ({
       ...old,
@@ -200,14 +204,6 @@ function Filters(props) {
       ...old,
       [field]: component
     }));
-
-    if (questionDefinitions[field].enableNotes && !comparators.includes("notes contain")) {
-      setTextFilterComponent(old => ({
-        ...old,
-        [field]: FilterComponentManager.getTextFilterComponent(questionDefinitions[field])})
-      );
-      comparators.push("notes contain");
-    }
     return [comparators, component]
   }
 
@@ -246,7 +242,7 @@ function Filters(props) {
   // Return the pre-computed input element, and focus it if we were asked to
   let getCachedInput = (filterDatum, index, focusRef) => {
 
-    let CachedComponent = filterDatum.comparator === "notes contain" && textFilterComponent ?
+    let CachedComponent = filterDatum.comparator === notesComparator ?
       textFilterComponent[filterDatum.name]
       :
       filterableAnswers[filterDatum.name];
@@ -330,7 +326,7 @@ function Filters(props) {
             {editingFilters.map( (filterDatum, index) => {
               // We grab focus on the field if we were asked to
               let isUnary = filterDatum.comparator && UNARY_COMPARATORS.includes(filterDatum.comparator);
-              let isNotesContain = filterDatum.comparator && (filterDatum.comparator === "notes contain");
+              let isNotesContain = filterDatum.comparator && (filterDatum.comparator === notesComparator);
               return(
                 <React.Fragment key={index}>
                   {/* Select the field to filter */}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
@@ -354,7 +354,7 @@ function Filters(props) {
                     </Select>
                   </Grid>
                   {/* Depending on whether or not the comparator chosen is unary, the size can change */}
-                  <Grid item xs={ isUnary ? 6 : (isNotesContain ? 3 : 1) } className={index == editingFilters.length-1 ? classes.hidden : ""}>
+                  <Grid item xs={isUnary ? 6 : (isNotesContain ? 3 : 1)} className={index == editingFilters.length-1 ? classes.hidden : ""}>
                     <Select
                       value={filterDatum.comparator || ""}
                       onChange={(event) => {handleChangeComparator(index, event.target.value);}}

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
@@ -65,7 +65,8 @@ public class PaginationServlet extends SlingSafeMethodsServlet
     private static final long serialVersionUID = -6068156942302219324L;
 
     // Allowed JCR-SQL2 operators (from https://docs.adobe.com/docs/en/spec/jcr/2.0/6_Query.html#6.7.17%20Operator)
-    private static final List<String> COMPARATORS = Arrays.asList("=", "<>", "<", "<=", ">", ">=", "LIKE");
+    private static final List<String> COMPARATORS =
+        Arrays.asList("=", "<>", "<", "<=", ">", ">=", "LIKE", "notes contain");
 
     private static final String SUBJECT_IDENTIFIER = "lfs:Subject";
 
@@ -271,8 +272,8 @@ public class PaginationServlet extends SlingSafeMethodsServlet
                 for (int j = 0; j < possibleQuestions.length; j++) {
                     filterdata.append(
                         String.format(" child%d.'question'='%s'",
-                            i,
-                            this.sanitizeField(possibleQuestions[j])
+                        i,
+                        this.sanitizeField(possibleQuestions[j])
                         )
                     );
                     // Add an 'or' if there are more possible conditions
@@ -280,16 +281,25 @@ public class PaginationServlet extends SlingSafeMethodsServlet
                         filterdata.append(" or");
                     }
                 }
-
                 // Condition 2: the value must exactly match
-                filterdata.append(
-                    String.format(
-                        ") and child%d.'value'%s'%s'",
-                        i,
-                        this.sanitizeComparator(comparators[i]),
-                        this.sanitizeField(values[i])
-                    )
-                );
+                if (comparators[i].equals("notes contain")) {
+                    filterdata.append(
+                        String.format(
+                            ") and contains(child%d.'note', '*%s*')",
+                            i,
+                            this.sanitizeField(values[i])
+                        )
+                    );
+                } else {
+                    filterdata.append(
+                        String.format(
+                            ") and child%d.'value'%s'%s'",
+                            i,
+                            this.sanitizeComparator(comparators[i]),
+                            this.sanitizeField(values[i])
+                        )
+                    );
+                }
             }
         }
         return filterdata.toString();

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
@@ -271,9 +271,10 @@ public class PaginationServlet extends SlingSafeMethodsServlet
                 filterdata.append(" and (");
                 for (int j = 0; j < possibleQuestions.length; j++) {
                     filterdata.append(
-                        String.format(" child%d.'question'='%s'",
-                        i,
-                        this.sanitizeField(possibleQuestions[j])
+                        String.format(
+                            " child%d.'question'='%s'",
+                            i,
+                            this.sanitizeField(possibleQuestions[j])
                         )
                     );
                     // Add an 'or' if there are more possible conditions

--- a/modules/ui-extension/src/main/frontend/webpack.config.js
+++ b/modules/ui-extension/src/main/frontend/webpack.config.js
@@ -28,6 +28,6 @@ module.exports = {
   output: {
     path: __dirname + '/dist/SLING-INF/content/libs/lfs/resources/',
     publicPath: '/',
-    filename: '[name].[contenthash].js',
+    filename: '[name].js',
   }
 };

--- a/modules/ui-extension/src/main/frontend/webpack.config.js
+++ b/modules/ui-extension/src/main/frontend/webpack.config.js
@@ -28,6 +28,6 @@ module.exports = {
   output: {
     path: __dirname + '/dist/SLING-INF/content/libs/lfs/resources/',
     publicPath: '/',
-    filename: '[name].js',
+    filename: '[name].[contenthash].js',
   }
 };


### PR DESCRIPTION
Details: [https://phenotips.atlassian.net/browse/LFS-370](https://phenotips.atlassian.net/browse/LFS-370)

This PR adds a new operator “notes contain” which allows filtering answers by notes matching a specific query. It can be used on any field where notesEnabled is true.

Known Issues: For fields which show up in multiple forms, such as Date of Birth, the "notes contain" operator will not show if notes are enabled in only one of the instances.