### PR TITLE
LFS-422: Parent conditional sections cannot close if a child conditional section is open.

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalGroup.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalGroup.jsx
@@ -26,7 +26,7 @@ import ConditionalComponentManager from "./ConditionalComponentManager";
  */
 export function isConditionalGroupSatisfied(conditional, context) {
   let conditionalChildren = Object.values(conditional)
-    .filter((child) => ConditionalComponentManager.isValidConditional(child));
+    .filter((child) => ConditionalComponentManager.isValidConditional(child) && child?.["jcr:primaryType"] != "lfs:Section");
 
   if (conditionalChildren.length == 0) {
     return true;


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/LFS-422)

*To test*: Open up a Radiotherapy form. Enter "Yes" to the Radiotherapy and "Yes" to the Boost question. Then try changing the Radiotherapy answer to "No". The entire form should collapse properly now.