### PR TITLE
LFS-426 / LFS-453: Change the Subject view to show its type and hierarchy

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -118,17 +118,17 @@ function Subject (props) {
         + encodeURIComponent(data['jcr:uuid']);
 
   // Recursive function to get a flat list of parents
-  let getParents = (node) => {
+  let getHierarchy = (node) => {
     let output = <React.Fragment>{node.type.label} <Link to={"/content.html" + node["@path"]}>{node.identifier}</Link></React.Fragment>;
     if (node["parents"]) {
-      let parent = getParents(node["parents"]);
-      return <React.Fragment>{parent} / {output}</React.Fragment>
+      let ancestors = getHierarchy(node["parents"]);
+      return <React.Fragment>{ancestors} / {output}</React.Fragment>
     } else {
       return output;
     }
   }
 
-  let parentDetails = data && data['parents'] && getParents(data['parents']);
+  let parentDetails = data && data['parents'] && getHierarchy(data['parents']);
 
   return (
     <div>
@@ -139,8 +139,8 @@ function Subject (props) {
           }
           {
             data && data.identifier ?
-              <Typography variant="h2">{data?.type?.label || "Subject"}: {data.identifier}</Typography>
-            : <Typography variant="h2">Subject: {id}</Typography>
+              <Typography variant="h2">{data?.type?.label || "Subject"} {data.identifier}</Typography>
+            : <Typography variant="h2">Subject {id}</Typography>
           }
           {
             data && data['jcr:createdBy'] && data['jcr:created'] ?

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -18,6 +18,7 @@
 //
 
 import React, { useState } from "react";
+import { Link } from 'react-router-dom';
 import PropTypes from "prop-types";
 import moment from "moment";
 
@@ -116,21 +117,30 @@ function Subject (props) {
   const customUrl='/Forms.paginate?fieldname=subject&fieldvalue='
         + encodeURIComponent(data['jcr:uuid']);
 
-  let parentDetails = data && data['parents'] && (Array.isArray(data['parents']) ?
-    data['parents'].map((parent) => (parent.type.label + " " + parent.identifier)).join(" / ")
-    : data.parents.type.label + " " + data.parents.identifier);
+  // Recursive function to get a flat list of parents
+  let getParents = (node) => {
+    let output = <React.Fragment>{node.type.label} <Link to={"/content.html" + node["@path"]}>{node.identifier}</Link></React.Fragment>;
+    if (node["parents"]) {
+      let parent = getParents(node["parents"]);
+      return <React.Fragment>{parent} / {output}</React.Fragment>
+    } else {
+      return output;
+    }
+  }
+
+  let parentDetails = data && data['parents'] && getParents(data['parents']);
 
   return (
     <div>
       <Grid container direction="column" spacing={4} alignItems="stretch" justify="space-between" wrap="nowrap">
         <Grid item>
           {
-            data && data.identifier ?
-              <Typography variant="h2">Subject: {data.identifier}</Typography>
-            : <Typography variant="h2">Subject: {id}</Typography>
+            parentDetails && <Typography variant="overline">{parentDetails}</Typography>
           }
           {
-            parentDetails && <Typography variant="h3">{parentDetails}</Typography>
+            data && data.identifier ?
+              <Typography variant="h2">{data?.type?.label || "Subject"}: {data.identifier}</Typography>
+            : <Typography variant="h2">Subject: {id}</Typography>
           }
           {
             data && data['jcr:createdBy'] && data['jcr:created'] ?

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -116,6 +116,10 @@ function Subject (props) {
   const customUrl='/Forms.paginate?fieldname=subject&fieldvalue='
         + encodeURIComponent(data['jcr:uuid']);
 
+  let parentDetails = data && data['parents'] && (Array.isArray(data['parents']) ?
+    data['parents'].map((parent) => (parent.type.label + " " + parent.identifier)).join(" / ")
+    : data.parents.type.label + " " + data.parents.identifier);
+
   return (
     <div>
       <Grid container direction="column" spacing={4} alignItems="stretch" justify="space-between" wrap="nowrap">
@@ -124,6 +128,9 @@ function Subject (props) {
             data && data.identifier ?
               <Typography variant="h2">Subject: {data.identifier}</Typography>
             : <Typography variant="h2">Subject: {id}</Typography>
+          }
+          {
+            parentDetails && <Typography variant="h3">{parentDetails}</Typography>
           }
           {
             data && data['jcr:createdBy'] && data['jcr:created'] ?


### PR DESCRIPTION
**TO VIEW ONLY COMMITS FROM THIS BRANCH:** [link](https://github.com/ccmbioinfo/lfs/pull/215/files/5a8a775d13493bbdccfb6a56f1e4911687872e45..0aad497597ed1c07d512b65a25ef2e60b60553f8)

Jira links: [LFS-426](https://phenotips.atlassian.net/browse/LFS-426), [LFS-453](https://phenotips.atlassian.net/browse/LFS-453)

**To test**: Create a subject, go to the "Subjects" page from the sidebar, and click on your newly created Subject. It should accurately display the type, and any parents and the parents of those parents (For this, a Tumor will display which patient it belongs to, and a TumorRegion will display both its tumor parent, and that tumor's patient).

Should've been made a draft until #211 is merged.