### PR TITLE
LFS-461: Fixes bug where term lookup fails with error code 400 for vocabulary terms containing a period

### DIFF
--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/BioOntologyIndexer.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/BioOntologyIndexer.java
@@ -199,7 +199,8 @@ public class BioOntologyIndexer implements VocabularyIndexer
             Node vocabularyTermNode;
             try {
                 vocabularyTermNode = this.vocabularyNode.get()
-                                         .addNode("./" + term.getId().replaceAll("\\W", ""), "lfs:VocabularyTerm");
+                                         .addNode("./" + term.getId()
+                                         .replaceAll("[^A-Za-z0-9_\\.]", ""), "lfs:VocabularyTerm");
             } catch (ItemExistsException e) {
                 // Sometimes terms appear twice; we'll just update the existing node
                 vocabularyTermNode = this.vocabularyNode.get().getNode(term.getId());


### PR DESCRIPTION
**Please note that this PR is branched off of LFS-462 and includes changes from it.**

By modifying the `createVocabularyTermNode()` function in `BioOntologyIndexer.java`, this PR allows for the `.` character to be present in `Vocabulary` nodes in the JCR tree and solves the *LFS-461* issue as these nodes now have the expected name in the JCR tree.

To test, build the **LFS-461_test** branch, install the **ICD-O-3-T** vocabulary, create a new *Demographics* form, and under *comorbidities* type `brain`. You will now be able to click on the blue information icon beside child terms (eg. *brain stem*).