### PR TITLE
LFS-426 / LFS-467: Show the subject's hierarchy in the subject selector table

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -167,6 +167,7 @@ function UnstyledSelectParentDialog (props) {
 
   const COLUMNS = [
     { title: 'Subject', field: 'identifier' },
+    { title: 'Hierarchy', field: 'hierarchy' },
   ];
 
   let initialized = parentType && childType;
@@ -191,7 +192,10 @@ function UnstyledSelectParentDialog (props) {
                     .then(response => response.json())
                     .then(result => {
                       return {
-                        data: result["rows"],
+                        data: result["rows"].map((row) => ({
+                          hierarchy: row["parents"] ? getHierarchy(row["parents"], React.Fragment, ()=>({})) : "No parents",
+                          ...row
+                        })),
                         page: Math.trunc(result["offset"]/result["limit"]),
                         totalCount: result["totalrows"],
                       }}


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/LFS-467). 

Some of this code has already been included in #229 because I confused the two. This includes changes from the rework in #226 so it's based off of it as well.