### PR TITLE
LFS-469: Upgrade versions of sling, jackrabbit, oak and dependencies

### DIFF
--- a/distribution/src/main/provisioning/10-sling-base.txt
+++ b/distribution/src/main/provisioning/10-sling-base.txt
@@ -58,7 +58,7 @@
     org.apache.felix/org.apache.felix.http.whiteboard/4.0.0
     commons-collections/commons-collections/3.2.2
     org.apache.commons/commons-collections4/4.2
-    commons-codec/commons-codec/1.11
+    commons-codec/commons-codec/1.14
     commons-lang/commons-lang/2.6
     commons-io/commons-io/2.6
     org.apache.commons/commons-lang3/3.8.1
@@ -76,8 +76,8 @@
     org.apache.pdfbox/pdfbox/2.0.12
     org.apache.pdfbox/fontbox/2.0.12
     org.apache.pdfbox/jempbox/1.8.16
-    org.apache.tika/tika-core/1.19.1
-    org.apache.tika/tika-parsers/1.19.1
+    org.apache.tika/tika-core/1.24.1
+    org.apache.tika/tika-parsers/1.24.1
 
 # Extra JCR features
 [artifacts startLevel=15]

--- a/modules/custom-jcr-oak-server/pom.xml
+++ b/modules/custom-jcr-oak-server/pom.xml
@@ -45,7 +45,8 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Include-Resource>{maven-resources},META-INF/maven/dependencies.properties=target/classes/META-INF/maven/dependencies.properties,@oak-lucene-*.jar!/org/apache/jackrabbit/oak/plugins/index/*</Include-Resource>
+            <!--<Include-Resource>{maven-resources},META-INF/maven/dependencies.properties=target/classes/META-INF/maven/dependencies.properties,@oak-lucene-*.jar!/org/apache/jackrabbit/oak/plugins/index/*,@oak-store-document-*.jar!/org/apache/jackrabbit/oak/plugins/document/spi/*,@lucene-core-*.jar!/org/apache/lucene/*</Include-Resource>-->
+            <Include-Resource>{maven-resources},META-INF/maven/dependencies.properties=target/classes/META-INF/maven/dependencies.properties,@oak-lucene-*.jar!/org/apache/jackrabbit/oak/plugins/index/*,@oak-store-document-*.jar!/org/apache/jackrabbit/oak/plugins/document/spi/*</Include-Resource>
           </instructions>
         </configuration>
       </plugin>
@@ -105,7 +106,7 @@
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.framework</artifactId>
-      <version>5.6.10</version>
+      <version>6.0.3</version>
       <scope>test</scope>
     </dependency>
     <!-- Apache Jackrabbit -->
@@ -153,6 +154,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
+      <artifactId>oak-store-document</artifactId>
+      <version>${oak.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jackrabbit</groupId>
       <artifactId>oak-security-spi</artifactId>
       <version>${oak.version}</version>
       <scope>provided</scope>
@@ -175,11 +182,17 @@
       <version>${oak.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-analyzers-common</artifactId>
+      <version>4.7.1</version>
+      <scope>provided</scope>
+    </dependency>
     <!-- Apache Sling -->
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.api</artifactId>
-      <version>2.22.0</version>
+      <version>2.18.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/custom-jcr-oak-server/pom.xml
+++ b/modules/custom-jcr-oak-server/pom.xml
@@ -179,31 +179,31 @@
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.api</artifactId>
-      <version>2.16.2</version>
+      <version>2.22.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.commons.threads</artifactId>
-      <version>3.2.0</version>
+      <version>3.2.20</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.jcr.api</artifactId>
-      <version>2.3.0</version>
+      <version>2.4.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.jcr.base</artifactId>
-      <version>3.0.0</version>
+      <version>3.0.6</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.serviceusermapper</artifactId>
-      <version>1.0.0</version>
+      <version>1.4.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -216,37 +216,37 @@
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>osgi.core</artifactId>
-      <version>6.0.0</version>
+      <version>7.0.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.cm</artifactId>
-      <version>1.5.0</version>
+      <version>1.6.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component</artifactId>
-      <version>1.3.0</version>
+      <version>1.4.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component.annotations</artifactId>
-      <version>1.3.0</version>
+      <version>1.4.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.event</artifactId>
-      <version>1.3.1</version>
+      <version>1.4.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.metatype.annotations</artifactId>
-      <version>1.3.0</version>
+      <version>1.4.0</version>
       <scope>provided</scope>
     </dependency>
     <!-- logging -->

--- a/modules/custom-jcr-oak-server/pom.xml
+++ b/modules/custom-jcr-oak-server/pom.xml
@@ -45,7 +45,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Include-Resource>{maven-resources},META-INF/maven/dependencies.properties=target/classes/META-INF/maven/dependencies.properties,@oak-lucene-*.jar!/org/apache/jackrabbit/oak/plugins/index/lucene/util/LuceneIndexHelper.*</Include-Resource>
+            <Include-Resource>{maven-resources},META-INF/maven/dependencies.properties=target/classes/META-INF/maven/dependencies.properties,@oak-lucene-*.jar!/org/apache/jackrabbit/oak/plugins/index/*</Include-Resource>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/custom-jcr-oak-server/src/test/java/ca/sickkids/ccm/lfs/sling/jcr/oak/server/it/OakServerIT.java
+++ b/modules/custom-jcr-oak-server/src/test/java/ca/sickkids/ccm/lfs/sling/jcr/oak/server/it/OakServerIT.java
@@ -238,7 +238,7 @@ public class OakServerIT extends OakServerTestSupport
         final ServiceRegistration reg = listener.register(this.bundleContext, SlingConstants.TOPIC_RESOURCE_ADDED);
         final Session s = this.repository.loginAdministrative(null);
         final int nPaths = 2500 * TEST_SCALE;
-        final int timeoutMsec = 2 * nPaths;
+        final int timeoutMsec = 5 * nPaths;
         final String prefix = uniqueName("testOsgiResourceEvents");
 
         // Create N nodes with a unique name under /
@@ -303,7 +303,7 @@ public class OakServerIT extends OakServerTestSupport
             s.save();
 
             final JcrEventsCounter c = counter;
-            new Retry(5000)
+            new Retry(15000)
             {
                 @Override
                 protected void exec() throws Exception
@@ -330,7 +330,7 @@ public class OakServerIT extends OakServerTestSupport
             s.save();
 
             final JcrEventsCounter c = counter;
-            new Retry(5000)
+            new Retry(15000)
             {
                 @Override
                 protected void exec() throws Exception

--- a/pom.xml
+++ b/pom.xml
@@ -146,8 +146,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <lfs.version>${project.version}</lfs.version>
     <slf4j.version>1.7.30</slf4j.version>
-    <jackrabbit.version>2.18.5</jackrabbit.version>
-    <oak.version>1.20.0</oak.version>
+    <jackrabbit.version>2.18.4</jackrabbit.version>
+    <!--<oak.version>1.22.3</oak.version> ...generates many more dependency errors... -->
+    <oak.version>1.10.8</oak.version>
 
     <enforcer.skip>false</enforcer.skip>
     <checkstyle.skip>false</checkstyle.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -145,9 +145,9 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <lfs.version>${project.version}</lfs.version>
-    <slf4j.version>1.7.26</slf4j.version>
-    <jackrabbit.version>2.16.3</jackrabbit.version>
-    <oak.version>1.8.8</oak.version>
+    <slf4j.version>1.7.30</slf4j.version>
+    <jackrabbit.version>2.18.5</jackrabbit.version>
+    <oak.version>1.20.0</oak.version>
 
     <enforcer.skip>false</enforcer.skip>
     <checkstyle.skip>false</checkstyle.skip>


### PR DESCRIPTION
Notes for @sdumitriu:

- jackrabbit: used 2.18.5 (latest stable version is 2.20.x (http://jackrabbit.apache.org/jcr/downloads.html) but it was not found in all our configured repositories)
- oak: used 1.20.0 (latest stable 1.30.0 (http://jackrabbit.apache.org/jcr/downloads.html), versions 1.22.x and later give some API compatibility problems)

Jackrabbit/Oak dependencies that had to be updated:
- tika: used latest vesion: 1.24.1 (https://tika.apache.org/)
- commons-codec: used latest version: 1.14 (http://commons.apache.org/proper/commons-codec/)

Sling, OSGI and other packages:
- sling-api: used latest stable version 2.22.0 (https://sling.apache.org/downloads.cgi)
- osgi: (osgi.core: v7.0.0), (osgi.service.*: v1.4.0) - development seems to have stopped in ~2018 @ these versions (see https://mvnrepository.com/artifact/org.osgi/osgi.core, https://www.osgi.org/developer/downloads/)
