### PR TITLE
LFS-482: Change data type of lfs:ConditionalValue value property from STRING to undefined

### DIFF
--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -325,7 +325,7 @@
   - sling:resourceSuperType (STRING) = "lfs/Resource" mandatory autocreated protected
 
   // The value which may be a reference to a field or a value (or multiple values)
-  - value (STRING) multiple
+  - value (undefined) multiple
 
   // Whether or not this value is a reference or not
   - isReference (BOOLEAN) = false autocreated


### PR DESCRIPTION
Before this bug fix, only `String`s could be used as values for `lfs:ConditionalValue` nodes. Now, the data types may be, `long`, `double`, `String`, `boolean`, `Date`.