### PR TITLE
LFS-486: Behavior of requireAll property on condition operand nodes is reversed

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
@@ -61,8 +61,8 @@ export function isConditionalObjSatisfied(conditional, context) {
     return false;
   }
 
-  const firstCondition = requireAllOperandA ? ((func) => operandA.some(func)) : ((func) => operandA.every(func));
-  const secondCondition = requireAllOperandB ? ((func) => operandB.some(func)) : ((func) => operandB.every(func));
+  const firstCondition = requireAllOperandA ? ((func) => operandA.every(func)) : ((func) => operandA.some(func));
+  const secondCondition = requireAllOperandB ? ((func) => operandB.every(func)) : ((func) => operandB.some(func));
 
   return firstCondition( (valueA) => {
     return secondCondition( (valueB) => {


### PR DESCRIPTION
Proper functionality for the `requireAll` property when used on `operand` nodes under `condition` nodes is to require all comparisons to return `True` when the `requireAll` property is set to `True` and only require one comparison to return `True` when the `requireAll` property is set to `False`.

The behavior is reversed, and therefore this PR fixes it.

To test, build the `LFS-486_test` branch and create a Form based on the Questionnaire *LFS Multi-String Bug Test*