### PR TITLE
LFS-383 fixup

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -35,7 +35,7 @@ function Answer (props) {
   let [ answerID ] = useState((existingAnswer && existingAnswer[0]) || uuidv4());
   let answerPath = path + "/" + answerID;
   const [ isInitialized, setInitialized ] = useState(false);
-  if (isInitialized == false && answersTracker !== null) {
+  if (isInitialized == false && answersTracker) {
     if (!(answerPath in answersTracker[0])) {
       answersTracker[1](answersTracker[0].concat(answerPath));
       didGrow(true);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -30,19 +30,24 @@ export const VALUE_POS = 1;
 // Holds answers and automatically generates hidden inputs
 // for form submission
 function Answer (props) {
-  let { answers, answerNodeType, existingAnswer, path, questionName, questionDefinition, valueType, onChangeNote, noteComponent, noteProps, answersTracker, didGrow } = props;
+  let { answers, answerNodeType, existingAnswer, path, questionName, questionDefinition, valueType, onChangeNote, noteComponent, noteProps, onAddedAnswerPath, sectionAnswersState } = props;
   let { enableNotes, sourceVocabulary } = { ...props, ...questionDefinition };
   let [ answerID ] = useState((existingAnswer && existingAnswer[0]) || uuidv4());
   let answerPath = path + "/" + answerID;
-  const [ isInitialized, setInitialized ] = useState(false);
 
   useEffect(() => {
-    if (isInitialized == false && answersTracker) {
-      if (!(answerPath in answersTracker[0])) {
-        answersTracker[1](answersTracker[0].concat(answerPath));
-        didGrow(true);
+    if (sectionAnswersState !== undefined) {
+      let idHistory = [];
+      if (questionName in sectionAnswersState[0]) {
+        idHistory = sectionAnswersState[0][questionName];
       }
-      setInitialized(true);
+      if (idHistory.indexOf(answerPath) < 0)
+      {
+        idHistory.push(answerPath);
+        sectionAnswersState[0][questionName] = idHistory;
+        sectionAnswersState[1](sectionAnswersState[0]);
+        onAddedAnswerPath(true);
+      }
     }
   });
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -30,14 +30,14 @@ export const VALUE_POS = 1;
 // Holds answers and automatically generates hidden inputs
 // for form submission
 function Answer (props) {
-  let { answers, answerNodeType, existingAnswer, path, questionName, questionDefinition, valueType, onChangeNote, noteComponent, noteProps, onConfigured, didGrow } = props;
+  let { answers, answerNodeType, existingAnswer, path, questionName, questionDefinition, valueType, onChangeNote, noteComponent, noteProps, answersTracker, didGrow } = props;
   let { enableNotes, sourceVocabulary } = { ...props, ...questionDefinition };
   let [ answerID ] = useState((existingAnswer && existingAnswer[0]) || uuidv4());
   let answerPath = path + "/" + answerID;
   const [ isInitialized, setInitialized ] = useState(false);
-  if (isInitialized == false && onConfigured !== null) {
-    if (!(answerPath in onConfigured[0])) {
-      onConfigured[1](onConfigured[0].concat(answerPath));
+  if (isInitialized == false && answersTracker !== null) {
+    if (!(answerPath in answersTracker[0])) {
+      answersTracker[1](answersTracker[0].concat(answerPath));
       didGrow(true);
     }
     setInitialized(true);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -38,15 +38,14 @@ function Answer (props) {
   useEffect(() => {
     if (sectionAnswersState !== undefined) {
       let idHistory = [];
-      if (questionName in sectionAnswersState[0]) {
-        idHistory = sectionAnswersState[0][questionName];
+      if (questionName in sectionAnswersState) {
+        idHistory = sectionAnswersState[questionName];
       }
       if (idHistory.indexOf(answerPath) < 0)
       {
         idHistory.push(answerPath);
-        sectionAnswersState[0][questionName] = idHistory;
-        sectionAnswersState[1](sectionAnswersState[0]);
-        onAddedAnswerPath(true);
+        sectionAnswersState[questionName] = idHistory;
+        onAddedAnswerPath(sectionAnswersState);
       }
     }
   });

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -30,12 +30,22 @@ export const VALUE_POS = 1;
 // Holds answers and automatically generates hidden inputs
 // for form submission
 function Answer (props) {
-  let { answers, answerNodeType, existingAnswer, path, questionName, questionDefinition, valueType, onChangeNote, noteComponent, noteProps, onConfigured } = props;
+  let { answers, answerNodeType, existingAnswer, path, questionName, questionDefinition, valueType, onChangeNote, noteComponent, noteProps, onConfigured, didGrow } = props;
   let { enableNotes, sourceVocabulary } = { ...props, ...questionDefinition };
   let [ answerID ] = useState((existingAnswer && existingAnswer[0]) || uuidv4());
   let answerPath = path + "/" + answerID;
-  console.log("Answer.jsx: Creating Answer with answerPath=" + answerPath);
-  onConfigured(answerPath);
+  const [ isInitialized, setInitialized ] = useState(false);
+  if (isInitialized == false && onConfigured !== null) {
+    console.log("Answer.jsx: Creating Answer with answerPath=" + answerPath);
+    //onConfigured(answerPath);
+    //console.log("Answer.jsx: onConfigured = " + onConfigured);
+    //onConfigured.push(answerPath);
+    if (!(answerPath in onConfigured[0])) {
+      onConfigured[1](onConfigured[0].concat(answerPath));
+      didGrow(true);
+    }
+    setInitialized(true);
+  }
   // Hooks must be pulled from the top level, so this cannot be moved to inside the useEffect()
   const changeFormContext = useFormWriterContext();
   // Rename this variable to start with a capital letter so React knows it is a component

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -36,10 +36,6 @@ function Answer (props) {
   let answerPath = path + "/" + answerID;
   const [ isInitialized, setInitialized ] = useState(false);
   if (isInitialized == false && onConfigured !== null) {
-    console.log("Answer.jsx: Creating Answer with answerPath=" + answerPath);
-    //onConfigured(answerPath);
-    //console.log("Answer.jsx: onConfigured = " + onConfigured);
-    //onConfigured.push(answerPath);
     if (!(answerPath in onConfigured[0])) {
       onConfigured[1](onConfigured[0].concat(answerPath));
       didGrow(true);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -30,10 +30,12 @@ export const VALUE_POS = 1;
 // Holds answers and automatically generates hidden inputs
 // for form submission
 function Answer (props) {
-  let { answers, answerNodeType, existingAnswer, path, questionName, questionDefinition, valueType, onChangeNote, noteComponent, noteProps } = props;
+  let { answers, answerNodeType, existingAnswer, path, questionName, questionDefinition, valueType, onChangeNote, noteComponent, noteProps, onConfigured } = props;
   let { enableNotes, sourceVocabulary } = { ...props, ...questionDefinition };
   let [ answerID ] = useState((existingAnswer && existingAnswer[0]) || uuidv4());
   let answerPath = path + "/" + answerID;
+  console.log("Answer.jsx: Creating Answer with answerPath=" + answerPath);
+  onConfigured(answerPath);
   // Hooks must be pulled from the top level, so this cannot be moved to inside the useEffect()
   const changeFormContext = useFormWriterContext();
   // Rename this variable to start with a capital letter so React knows it is a component

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -35,13 +35,17 @@ function Answer (props) {
   let [ answerID ] = useState((existingAnswer && existingAnswer[0]) || uuidv4());
   let answerPath = path + "/" + answerID;
   const [ isInitialized, setInitialized ] = useState(false);
-  if (isInitialized == false && answersTracker) {
-    if (!(answerPath in answersTracker[0])) {
-      answersTracker[1](answersTracker[0].concat(answerPath));
-      didGrow(true);
+
+  useEffect(() => {
+    if (isInitialized == false && answersTracker) {
+      if (!(answerPath in answersTracker[0])) {
+        answersTracker[1](answersTracker[0].concat(answerPath));
+        didGrow(true);
+      }
+      setInitialized(true);
     }
-    setInitialized(true);
-  }
+  });
+
   // Hooks must be pulled from the top level, so this cannot be moved to inside the useEffect()
   const changeFormContext = useFormWriterContext();
   // Rename this variable to start with a capital letter so React knows it is a component

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -48,7 +48,7 @@ export const ENTRY_TYPES = QUESTION_TYPES.concat(SECTION_TYPES);
  * @param {Object} classes style classes
  * @returns a React component that renders the question
  */
-let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, onConfigured) => {
+let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, onConfigured, didGrow) => {
   const questionRef = useRef();
   const anchor = location.hash.substr(1);
   // create a ref to store the question container DOM element
@@ -76,6 +76,7 @@ let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, o
         path={path}
         questionName={key}
         onConfigured={onConfigured}
+        didGrow={didGrow}
         />
     </Grid>
   );
@@ -121,12 +122,12 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key) => {
  * @returns a React component that renders the section
  */
  export default function FormEntry(props) {
-  let { classes, entryDefinition, path, depth, existingAnswers, keyProp, onConfigured } = { ...{onConfigured: (id) => {}}, ...props };
+  let { classes, entryDefinition, path, depth, existingAnswers, keyProp, onConfigured, didGrow } = { ...{onConfigured: null, didGrow: null}, ...props };
   // TODO: As before, I'm writing something that's basically an if statement
   // this should instead be via a componentManager
   if (QUESTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
     console.log("FormEntry.jsx: Creating a displayQuestion()");
-    return displayQuestion(entryDefinition, path, existingAnswers, keyProp, classes, onConfigured);
+    return displayQuestion(entryDefinition, path, existingAnswers, keyProp, classes, onConfigured, didGrow);
   } else if (SECTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
     console.log("FormEntry.jsx: Creating a displaySection()");
     return displaySection(entryDefinition, path, depth, existingAnswers, keyProp);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -122,7 +122,7 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key) => {
  * @returns a React component that renders the section
  */
  export default function FormEntry(props) {
-  let { classes, entryDefinition, path, depth, existingAnswers, keyProp, answersTracker, didGrow } = { ...{answersTracker: null, didGrow: null}, ...props };
+  let { classes, entryDefinition, path, depth, existingAnswers, keyProp, answersTracker, didGrow } = props;
   // TODO: As before, I'm writing something that's basically an if statement
   // this should instead be via a componentManager
   if (QUESTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -126,12 +126,8 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key) => {
   // TODO: As before, I'm writing something that's basically an if statement
   // this should instead be via a componentManager
   if (QUESTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
-    console.log("FormEntry.jsx: Creating a displayQuestion()");
     return displayQuestion(entryDefinition, path, existingAnswers, keyProp, classes, onConfigured, didGrow);
   } else if (SECTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
-    console.log("FormEntry.jsx: Creating a displaySection()");
     return displaySection(entryDefinition, path, depth, existingAnswers, keyProp);
-  } else {
-    console.log("Unknown FormEntry Type");
   }
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -48,7 +48,7 @@ export const ENTRY_TYPES = QUESTION_TYPES.concat(SECTION_TYPES);
  * @param {Object} classes style classes
  * @returns a React component that renders the question
  */
-let displayQuestion = (questionDefinition, path, existingAnswer, key, classes) => {
+let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, onConfigured) => {
   const questionRef = useRef();
   const anchor = location.hash.substr(1);
   // create a ref to store the question container DOM element
@@ -75,6 +75,7 @@ let displayQuestion = (questionDefinition, path, existingAnswer, key, classes) =
         existingAnswer={existingQuestionAnswer}
         path={path}
         questionName={key}
+        onConfigured={onConfigured}
         />
     </Grid>
   );
@@ -120,12 +121,16 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key) => {
  * @returns a React component that renders the section
  */
  export default function FormEntry(props) {
-  let { classes, entryDefinition, path, depth, existingAnswers, keyProp } = props;
+  let { classes, entryDefinition, path, depth, existingAnswers, keyProp, onConfigured } = { ...{onConfigured: (id) => {}}, ...props };
   // TODO: As before, I'm writing something that's basically an if statement
   // this should instead be via a componentManager
   if (QUESTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
-    return displayQuestion(entryDefinition, path, existingAnswers, keyProp, classes);
+    console.log("FormEntry.jsx: Creating a displayQuestion()");
+    return displayQuestion(entryDefinition, path, existingAnswers, keyProp, classes, onConfigured);
   } else if (SECTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
+    console.log("FormEntry.jsx: Creating a displaySection()");
     return displaySection(entryDefinition, path, depth, existingAnswers, keyProp);
+  } else {
+    console.log("Unknown FormEntry Type");
   }
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -48,7 +48,7 @@ export const ENTRY_TYPES = QUESTION_TYPES.concat(SECTION_TYPES);
  * @param {Object} classes style classes
  * @returns a React component that renders the question
  */
-let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, answersTracker, didGrow) => {
+let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, onAddedAnswerPath, sectionAnswersState) => {
   const questionRef = useRef();
   const anchor = location.hash.substr(1);
   // create a ref to store the question container DOM element
@@ -75,8 +75,8 @@ let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, a
         existingAnswer={existingQuestionAnswer}
         path={path}
         questionName={key}
-        answersTracker={answersTracker}
-        didGrow={didGrow}
+        onAddedAnswerPath={onAddedAnswerPath}
+        sectionAnswersState={sectionAnswersState}
         />
     </Grid>
   );
@@ -122,11 +122,11 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key) => {
  * @returns a React component that renders the section
  */
  export default function FormEntry(props) {
-  let { classes, entryDefinition, path, depth, existingAnswers, keyProp, answersTracker, didGrow } = props;
+  let { classes, entryDefinition, path, depth, existingAnswers, keyProp, onAddedAnswerPath, sectionAnswersState } = props;
   // TODO: As before, I'm writing something that's basically an if statement
   // this should instead be via a componentManager
   if (QUESTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
-    return displayQuestion(entryDefinition, path, existingAnswers, keyProp, classes, answersTracker, didGrow);
+    return displayQuestion(entryDefinition, path, existingAnswers, keyProp, classes, onAddedAnswerPath, sectionAnswersState);
   } else if (SECTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
     return displaySection(entryDefinition, path, depth, existingAnswers, keyProp);
   }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -48,7 +48,7 @@ export const ENTRY_TYPES = QUESTION_TYPES.concat(SECTION_TYPES);
  * @param {Object} classes style classes
  * @returns a React component that renders the question
  */
-let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, onConfigured, didGrow) => {
+let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, answersTracker, didGrow) => {
   const questionRef = useRef();
   const anchor = location.hash.substr(1);
   // create a ref to store the question container DOM element
@@ -75,7 +75,7 @@ let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, o
         existingAnswer={existingQuestionAnswer}
         path={path}
         questionName={key}
-        onConfigured={onConfigured}
+        answersTracker={answersTracker}
         didGrow={didGrow}
         />
     </Grid>
@@ -122,11 +122,11 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key) => {
  * @returns a React component that renders the section
  */
  export default function FormEntry(props) {
-  let { classes, entryDefinition, path, depth, existingAnswers, keyProp, onConfigured, didGrow } = { ...{onConfigured: null, didGrow: null}, ...props };
+  let { classes, entryDefinition, path, depth, existingAnswers, keyProp, answersTracker, didGrow } = { ...{answersTracker: null, didGrow: null}, ...props };
   // TODO: As before, I'm writing something that's basically an if statement
   // this should instead be via a componentManager
   if (QUESTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
-    return displayQuestion(entryDefinition, path, existingAnswers, keyProp, classes, onConfigured, didGrow);
+    return displayQuestion(entryDefinition, path, existingAnswers, keyProp, classes, answersTracker, didGrow);
   } else if (SECTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
     return displaySection(entryDefinition, path, depth, existingAnswers, keyProp);
   }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -92,6 +92,7 @@ function Section(props) {
   const [ dialogOpen, setDialogOpen ] = useState(false);
   const [ selectedUUID, setSelectedUUID ] = useState();
   const [ uuid ] = useState(uuidv4());  // To keep our IDs separate from any other sections
+  const [ removableAnswers, setRemovableAnswers ] = useState([]);
 
   // Determine if we have any conditionals in our definition that would cause us to be hidden
   const displayed = ConditionalComponentManager.evaluateCondition(
@@ -101,6 +102,13 @@ function Section(props) {
   let closeDialog = () => {
     setSelectedUUID(undefined);
     setDialogOpen(false);
+  }
+
+  var allAnswerIds = [];
+  function addAnswerId(id) {
+    console.log("Section.jsx: Adding answerId: " + id);
+    allAnswerIds.push(id);
+    console.log(allAnswerIds);
   }
 
   // mountOnEnter and unmountOnExit force the inputs and children to be outside of the DOM during form submission
@@ -187,14 +195,16 @@ function Section(props) {
                 item
                 >
                 <Grid container {...FORM_ENTRY_CONTAINER_PROPS}>
-                  {/* delete any existing answer section before inputting new answers in section */}
-                  {instanceLabels.map((uuid) =>
-                    <input type="hidden" name={`${path + "/" + uuid}@Delete`} value="0" key={uuid}></input>
-                  )}
+                  {console.log("instanceLabels = " + instanceLabels)}
                   {/* Section contents are strange if this isn't a direct child of the above grid, so we wrap another container*/
                     Object.entries(sectionDefinition)
                       .filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType']))
-                      .map(([key, definition]) => <FormEntry key={key} entryDefinition={definition} path={sectionPath} depth={depth+1} existingAnswers={existingSectionAnswer} keyProp={key} classes={classes}></FormEntry>)
+                      .map(([key, definition]) => <FormEntry key={key} entryDefinition={definition} path={sectionPath} depth={depth+1} existingAnswers={existingSectionAnswer} keyProp={key} classes={classes} onConfigured={(id) => {addAnswerId(id)}}></FormEntry>)
+                  }
+                  {
+                    removableAnswers.map((path) =>
+                      <input type="hidden" name={`${path}@Delete`} value="0" key={path}></input>
+                    )
                   }
                 </Grid>
               </Collapse>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -94,7 +94,7 @@ function Section(props) {
   const [ dialogOpen, setDialogOpen ] = useState(false);
   const [ selectedUUID, setSelectedUUID ] = useState();
   const [ uuid ] = useState(uuidv4());  // To keep our IDs separate from any other sections
-  const [ removableAnswers, setRemovableAnswers ] = useState({ID_STATE_KEY: 1});
+  const [ removableAnswers, setRemovableAnswers ] = useState({[ID_STATE_KEY]: 1});
 
   // Determine if we have any conditionals in our definition that would cause us to be hidden
   const displayed = ConditionalComponentManager.evaluateCondition(

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -214,7 +214,7 @@ function Section(props) {
                   {/* Section contents are strange if this isn't a direct child of the above grid, so we wrap another container*/
                     Object.entries(sectionDefinition)
                       .filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType']))
-                      .map(([key, definition]) => <FormEntry key={key} entryDefinition={definition} path={sectionPath} depth={depth+1} existingAnswers={existingSectionAnswer} keyProp={key} classes={classes} onConfigured={answerStateVars[renderedAnswers++]} didGrow={setNeedsUpdate}></FormEntry>)
+                      .map(([key, definition]) => <FormEntry key={key} entryDefinition={definition} path={sectionPath} depth={depth+1} existingAnswers={existingSectionAnswer} keyProp={key} classes={classes} answersTracker={answerStateVars[renderedAnswers++]} didGrow={setNeedsUpdate}></FormEntry>)
                   }
                   {
                     calculateDeletion().map((delPath) =>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -128,50 +128,6 @@ function Section(props) {
     return delList;
   }
 
-  const allAnswerIds = ["Section.jsx"];
-  //this.addAnswerId = this.addAnswerId.bind(this);
-  function addAnswerId(id) {
-    console.log("Section.jsx: Adding answerId: " + id);
-    allAnswerIds.push(id);
-    console.log(allAnswerIds);
-    storeAnswerIds(allAnswerIds);
-  }
-  function storeAnswerIds(allAnswerIds) {
-    //setRemovableAnswers(removableAnswers.concat([allAnswerIds]));
-    /*
-    for (var i = 0; i < removableAnswers.length; i++) {
-      //Is there an array that is equal to allAnswerIds
-      if (removableAnswers[i].length != allAnswerIds.length) {
-        continue;
-      }
-      var foundMatch = true;
-      for (var j = 0; j < allAnswerIds.length; j++) {
-        if (removableAnswers[i][j] != allAnswerIds[j]) {
-          foundMatch = false;
-          break;
-        }
-      }
-      if (foundMatch) {
-        return;
-      }
-    }
-    */
-    //setRemovableAnswers(removableAnswers.concat([allAnswerIds]));
-    /*
-    for (var i = 0; i < allAnswerIds.length; i++) {
-      console.log("Section.jsx: Checking ... " + allAnswerIds[i]);
-      if (allAnswerIds[i] in removableAnswers) {
-        continue;
-      }
-      console.log("Section.jsx: Adding ... " + allAnswerIds[i]);
-      //setRemovableAnswers(removableAnswers.concat(allAnswerIds[i]));
-      //this.setState({removableAnswers: removableAnswers.concat(allAnswerIds[i])});
-    }
-    console.log("Section.jsx: storeAnswerIds()");
-    console.log(removableAnswers);
-    */
-  }
-
   // mountOnEnter and unmountOnExit force the inputs and children to be outside of the DOM during form submission
   // if it is not currently visible
   return useCallback(

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -35,6 +35,8 @@ import QuestionnaireStyle, { FORM_ENTRY_CONTAINER_PROPS } from "./QuestionnaireS
 import ConditionalGroup from "./ConditionalGroup";
 import ConditionalSingle from "./ConditionalSingle";
 
+const ID_STATE_KEY = ":AccessCount";
+
 // The heading levels that @material-ui supports
 const MAX_HEADING_LEVEL = 6;
 const MIN_HEADING_LEVEL = 4;
@@ -92,8 +94,7 @@ function Section(props) {
   const [ dialogOpen, setDialogOpen ] = useState(false);
   const [ selectedUUID, setSelectedUUID ] = useState();
   const [ uuid ] = useState(uuidv4());  // To keep our IDs separate from any other sections
-  const [ needsUpdate, setNeedsUpdate ] = useState(false);
-  const [ removableAnswers, setRemovableAnswers ] = useState({});
+  const [ removableAnswers, setRemovableAnswers ] = useState({ID_STATE_KEY: 1});
 
   // Determine if we have any conditionals in our definition that would cause us to be hidden
   const displayed = ConditionalComponentManager.evaluateCondition(
@@ -105,12 +106,7 @@ function Section(props) {
     setDialogOpen(false);
   }
 
-  if (needsUpdate == true) {
-    setNeedsUpdate(false);
-  }
-
   const sectionAnswers = Object.entries(sectionDefinition).filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType']));
-  const totalAnswers = sectionAnswers.length;
 
   function calculateDeletion() {
     let delList = [];
@@ -218,8 +214,11 @@ function Section(props) {
                         existingAnswers={existingSectionAnswer}
                         keyProp={key}
                         classes={classes}
-                        sectionAnswersState={[removableAnswers, setRemovableAnswers]}
-                        onAddedAnswerPath={setNeedsUpdate}>
+                        sectionAnswersState={removableAnswers}
+                        onAddedAnswerPath={(newAnswers) => {
+                          newAnswers[ID_STATE_KEY] = newAnswers[ID_STATE_KEY] + 1;
+                          setRemovableAnswers(newAnswers);
+                        }}>
                       </FormEntry>)
                   }
                   {
@@ -279,7 +278,7 @@ function Section(props) {
       </DialogActions>
     </Dialog>
     </React.Fragment>
-    , [displayed, instanceLabels, labelsToHide, dialogOpen, needsUpdate]);
+    , [displayed, instanceLabels, labelsToHide, dialogOpen, removableAnswers[ID_STATE_KEY]]);
 }
 
 Section.propTypes = {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -121,7 +121,6 @@ function Section(props) {
     let delList = [];
     for (let i = 0; i < answerStateVars.length; i++) {
       for (let j = 0; j < answerStateVars[i][0].length - 1; j++) {
-        console.log("Section.jsx: ... DELETING: " + answerStateVars[i][0][j]);
         delList.push(answerStateVars[i][0][j]);
       }
     }
@@ -212,18 +211,14 @@ function Section(props) {
                 item
                 >
                 <Grid container {...FORM_ENTRY_CONTAINER_PROPS}>
-                  {console.log("instanceLabels = " + instanceLabels)}
                   {/* Section contents are strange if this isn't a direct child of the above grid, so we wrap another container*/
                     Object.entries(sectionDefinition)
                       .filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType']))
                       .map(([key, definition]) => <FormEntry key={key} entryDefinition={definition} path={sectionPath} depth={depth+1} existingAnswers={existingSectionAnswer} keyProp={key} classes={classes} onConfigured={answerStateVars[renderedAnswers++]} didGrow={setNeedsUpdate}></FormEntry>)
                   }
-                  {console.log("N_ANSWERS=" + Object.entries(sectionDefinition).filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType'])).length)}
-                  {console.log(answerStateVars)}
-                  {console.log("END OF ANSWER STATE VARS")}
                   {
                     calculateDeletion().map((delPath) =>
-                      <input type="hidden" name={`${delPath}@Delete`} value="0" key={delPath}>{console.log("Calculated deleting of: " + delPath)}</input>
+                      <input type="hidden" name={`${delPath}@Delete`} value="0" key={delPath}></input>
                   )}
                 </Grid>
               </Collapse>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -92,8 +92,8 @@ function Section(props) {
   const [ dialogOpen, setDialogOpen ] = useState(false);
   const [ selectedUUID, setSelectedUUID ] = useState();
   const [ uuid ] = useState(uuidv4());  // To keep our IDs separate from any other sections
-  const [ removableAnswers, setRemovableAnswers ] = useState([]);
   const [ needsUpdate, setNeedsUpdate ] = useState(false);
+  const [ removableAnswers, setRemovableAnswers ] = useState({});
 
   // Determine if we have any conditionals in our definition that would cause us to be hidden
   const displayed = ConditionalComponentManager.evaluateCondition(
@@ -111,18 +111,14 @@ function Section(props) {
 
   const sectionAnswers = Object.entries(sectionDefinition).filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType']));
   const totalAnswers = sectionAnswers.length;
-  const answerStateVars = [];
-  for (let i = 0; i < totalAnswers; i++) {
-    let [ stateVar, stateVarSetter ] = useState([]);
-    answerStateVars.push([stateVar, stateVarSetter]);
-  }
-  let renderedAnswers = 0;
 
   function calculateDeletion() {
     let delList = [];
-    for (let i = 0; i < answerStateVars.length; i++) {
-      for (let j = 0; j < answerStateVars[i][0].length - 1; j++) {
-        delList.push(answerStateVars[i][0][j]);
+    let keySet = Object.keys(removableAnswers);
+    for (let i = 0; i < keySet.length; i++) {
+      let key = keySet[i];
+      for (let j = 0; j < removableAnswers[key].length-1; j++) {
+        delList.push(removableAnswers[key][j]);
       }
     }
     return delList;
@@ -222,8 +218,8 @@ function Section(props) {
                         existingAnswers={existingSectionAnswer}
                         keyProp={key}
                         classes={classes}
-                        answersTracker={answerStateVars[renderedAnswers++]}
-                        didGrow={setNeedsUpdate}>
+                        sectionAnswersState={[removableAnswers, setRemovableAnswers]}
+                        onAddedAnswerPath={setNeedsUpdate}>
                       </FormEntry>)
                   }
                   {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -109,7 +109,8 @@ function Section(props) {
     setNeedsUpdate(false);
   }
 
-  const totalAnswers = Object.entries(sectionDefinition).filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType'])).length;
+  const sectionAnswers = Object.entries(sectionDefinition).filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType']));
+  const totalAnswers = sectionAnswers.length;
   const answerStateVars = [];
   for (let i = 0; i < totalAnswers; i++) {
     let [ stateVar, stateVarSetter ] = useState([]);
@@ -212,9 +213,18 @@ function Section(props) {
                 >
                 <Grid container {...FORM_ENTRY_CONTAINER_PROPS}>
                   {/* Section contents are strange if this isn't a direct child of the above grid, so we wrap another container*/
-                    Object.entries(sectionDefinition)
-                      .filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType']))
-                      .map(([key, definition]) => <FormEntry key={key} entryDefinition={definition} path={sectionPath} depth={depth+1} existingAnswers={existingSectionAnswer} keyProp={key} classes={classes} answersTracker={answerStateVars[renderedAnswers++]} didGrow={setNeedsUpdate}></FormEntry>)
+                    sectionAnswers.map(([key, definition]) =>
+                      <FormEntry
+                        key={key}
+                        entryDefinition={definition}
+                        path={sectionPath}
+                        depth={depth+1}
+                        existingAnswers={existingSectionAnswer}
+                        keyProp={key}
+                        classes={classes}
+                        answersTracker={answerStateVars[renderedAnswers++]}
+                        didGrow={setNeedsUpdate}>
+                      </FormEntry>)
                   }
                   {
                     calculateDeletion().map((delPath) =>


### PR DESCRIPTION
Addresses the changes addressed in **LFS-383** but replaces the deletion and re-creation of answer sections (which breaks **LFS-273**) with a front-end fix that only deletes obsolete JCR nodes.

To test:
 - The test described on https://phenotips.atlassian.net/browse/LFS-383 should pass
 - The test described on https://phenotips.atlassian.net/browse/LFS-415 should pass
-  The test described on https://github.com/ccmbioinfo/lfs/pull/203#pullrequestreview-429826421 should pass

Additionally the following behavior should be observed:

 - Create a new *Demographics* form
 - Select **Yes** for *Undergoing surveillance*
 - **Save**
- In the JCR browser, the nodes corresponding to *Surveilled since* and *Surveilled until* should be flagged as *INCOMPLETE*
 - Enter a value for *Surveilled since*
 - **Save**
 - In the JCR browser, the status flags for *Surveilled since* should be empty
 - In the JCR browser, the status flags for *Surveilled until* should still be *INCOMPLETE*