### PR TITLE
LFS-499: On the front-end, conditional values should be compared as their proper data type, not always as strings

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
@@ -22,12 +22,46 @@ import ConditionalComponentManager from "./ConditionalComponentManager";
 
 // A mapping from operands to conditionals
 const COMPARE_MAP = {
-  "=": (a, b) => (a == b),
-  "<": (a, b) => (a < b),
-  ">": (a, b) => (a > b),
-  "<>": (a, b) => (a !== b),
-  "is empty": (a) => (a == null || a == undefined),
-  "is not empty": (a) => (a != null && a != undefined)
+  "text": {
+    "=": (a, b) => (a == b),
+    "<": (a, b) => (a < b),
+    ">": (a, b) => (a > b),
+    "<>": (a, b) => (a !== b),
+    "is empty": (a) => (a == null || a == undefined),
+    "is not empty": (a) => (a != null && a != undefined)
+  },
+  "date": {
+    "=": (a, b) => (new Date(a).getTime() == new Date(b).getTime()),
+    "<": (a, b) => (new Date(a).getTime() < new Date(b).getTime()),
+    ">": (a, b) => (new Date(a).getTime() > new Date(b).getTime()),
+    "<>": (a, b) => (new Date(a).getTime() !== new Date(b).getTime()),
+    "is empty": (a) => (a == null || a == undefined),
+    "is not empty": (a) => (a != null && a != undefined)
+  },
+  "long": {
+    "=": (a, b) => (parseInt(a) == parseInt(b)),
+    "<": (a, b) => (parseInt(a) < parseInt(b)),
+    ">": (a, b) => (parseInt(a) > parseInt(b)),
+    "<>": (a, b) => (parseInt(a) !== parseInt(b)),
+    "is empty": (a) => (a == null || a == undefined),
+    "is not empty": (a) => (a != null && a != undefined)
+  },
+  "decimal": {
+    "=": (a, b) => (parseFloat(a) == parseFloat(b)),
+    "<": (a, b) => (parseFloat(a) < parseFloat(b)),
+    ">": (a, b) => (parseFloat(a) > parseFloat(b)),
+    "<>": (a, b) => (parseFloat(a) !== parseFloat(b)),
+    "is empty": (a) => (a == null || a == undefined),
+    "is not empty": (a) => (a != null && a != undefined)
+  },
+  "double": {
+    "=": (a, b) => (parseFloat(a) == parseFloat(b)),
+    "<": (a, b) => (parseFloat(a) < parseFloat(b)),
+    ">": (a, b) => (parseFloat(a) > parseFloat(b)),
+    "<>": (a, b) => (parseFloat(a) !== parseFloat(b)),
+    "is empty": (a) => (a == null || a == undefined),
+    "is not empty": (a) => (a != null && a != undefined)
+  }
 }
 
 /**
@@ -35,13 +69,17 @@ const COMPARE_MAP = {
  * @param {STRING} comparator The operator to use as a comparison
  * @param {STRING...} operands Any number of operands used for the comparison
  */
-export function isConditionalSatisfied(comparator, ...operands) {
-  if (!(comparator in COMPARE_MAP)) {
+export function isConditionalSatisfied(compareDataType, comparator, ...operands) {
+  if (!(compareDataType in COMPARE_MAP)) {
+    // Invalid data type
+    throw new Error("Invalid data type specified.")
+  }
+  if (!(comparator in COMPARE_MAP[compareDataType])) {
     // Invalid operand
     throw new Error("Invalid operand specified.")
   }
 
-  return COMPARE_MAP[comparator]?.apply(null, operands);
+  return COMPARE_MAP[compareDataType][comparator]?.apply(null, operands);
 }
 
 /**
@@ -66,7 +104,7 @@ export function isConditionalObjSatisfied(conditional, context) {
 
   return firstCondition( (valueA) => {
     return secondCondition( (valueB) => {
-      return isConditionalSatisfied(conditional["comparator"], valueA, valueB);
+      return isConditionalSatisfied(conditional["dataType"], conditional["comparator"], valueA, valueB);
     })
   })
 }

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -304,6 +304,9 @@
   // A second child operandB may be specified, but leaving it as the default is OK if the comparator is singular
   + operandB (lfs:ConditionalValue) = lfs:ConditionalValue autocreated
 
+  // Specifies how the operands should be treated when performing the comparison (default: string)
+  - dataType (STRING) = "string" autocreated
+
 //-----------------------------------------------------------------------------
 // A conditional value is either a value or a method of getting a value.
 [lfs:ConditionalValue] > sling:Resource

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -305,7 +305,7 @@
   + operandB (lfs:ConditionalValue) = lfs:ConditionalValue autocreated
 
   // Specifies how the operands should be treated when performing the comparison (default: string)
-  - dataType (STRING) = "string" autocreated
+  - dataType (STRING) = "text" autocreated
 
 //-----------------------------------------------------------------------------
 // A conditional value is either a value or a method of getting a value.


### PR DESCRIPTION
Please see https://phenotips.atlassian.net/browse/LFS-499 for a detailed description of the bug and how to trigger it.

#### Testing:

To test, build the `LFS-499_test` branch and create a *Bug* form. Follow the directions on the form (eg. *Enter an integer less than Value B*).