### PR TITLE
LFS-484: Equivalence of empty fields should always be false

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
@@ -97,13 +97,7 @@ export function isConditionalObjSatisfied(conditional, context) {
 }
 
 function removeAllNull(lst) {
-  var new_lst = [];
-  for (var i = 0; i < lst.length; i++) {
-    if (EMPTY.indexOf(lst[i]) < 0) {
-      new_lst.push(lst[i]);
-    }
-  }
-  return new_lst;
+  return lst.filter(item => (EMPTY.indexOf(item) < 0));
 }
 
 function allIsNull(lst) {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
@@ -28,7 +28,7 @@ const COMPARE_MAP = {
     "<": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (a < b)),
     ">": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (a > b)),
     "<>": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (a !== b)),
-    "is empty": (a) => (EMPTY.indexOf(a) >= 0)
+    "is empty": (a) => (EMPTY.indexOf(a) >= 0),
     "is not empty": (a) => (EMPTY.indexOf(a) < 0)
   },
   "date": {
@@ -36,7 +36,7 @@ const COMPARE_MAP = {
     "<": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (new Date(a).getTime() < new Date(b).getTime())),
     ">": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (new Date(a).getTime() > new Date(b).getTime())),
     "<>": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (new Date(a).getTime() !== new Date(b).getTime())),
-    "is empty": (a) => (EMPTY.indexOf(a) >= 0)
+    "is empty": (a) => (EMPTY.indexOf(a) >= 0),
     "is not empty": (a) => (EMPTY.indexOf(a) < 0)
   },
   "long": {
@@ -44,7 +44,7 @@ const COMPARE_MAP = {
     "<": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseInt(a) < parseInt(b))),
     ">": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseInt(a) > parseInt(b))),
     "<>": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseInt(a) !== parseInt(b))),
-    "is empty": (a) => (EMPTY.indexOf(a) >= 0)
+    "is empty": (a) => (EMPTY.indexOf(a) >= 0),
     "is not empty": (a) => (EMPTY.indexOf(a) < 0)
   },
   "decimal": {
@@ -52,7 +52,7 @@ const COMPARE_MAP = {
     "<": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) < parseFloat(b))),
     ">": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) > parseFloat(b))),
     "<>": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) !== parseFloat(b))),
-    "is empty": (a) => (EMPTY.indexOf(a) >= 0)
+    "is empty": (a) => (EMPTY.indexOf(a) >= 0),
     "is not empty": (a) => (EMPTY.indexOf(a) < 0)
   },
   "double": {
@@ -60,7 +60,7 @@ const COMPARE_MAP = {
     "<": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) < parseFloat(b))),
     ">": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) > parseFloat(b))),
     "<>": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) !== parseFloat(b))),
-    "is empty": (a) => (EMPTY.indexOf(a) >= 0)
+    "is empty": (a) => (EMPTY.indexOf(a) >= 0),
     "is not empty": (a) => (EMPTY.indexOf(a) < 0)
   }
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
@@ -21,46 +21,47 @@ import { VALUE_POS } from "./Answer";
 import ConditionalComponentManager from "./ConditionalComponentManager";
 
 // A mapping from operands to conditionals
+const EMPTY = [null, undefined, ""];
 const COMPARE_MAP = {
   "text": {
-    "=": (a, b) => (a == b),
-    "<": (a, b) => (a < b),
-    ">": (a, b) => (a > b),
-    "<>": (a, b) => (a !== b),
-    "is empty": (a) => (a == null || a == undefined),
-    "is not empty": (a) => (a != null && a != undefined)
+    "=": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (a == b)),
+    "<": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (a < b)),
+    ">": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (a > b)),
+    "<>": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (a !== b)),
+    "is empty": (a) => (EMPTY.indexOf(a) >= 0)
+    "is not empty": (a) => (EMPTY.indexOf(a) < 0)
   },
   "date": {
-    "=": (a, b) => (new Date(a).getTime() == new Date(b).getTime()),
-    "<": (a, b) => (new Date(a).getTime() < new Date(b).getTime()),
-    ">": (a, b) => (new Date(a).getTime() > new Date(b).getTime()),
-    "<>": (a, b) => (new Date(a).getTime() !== new Date(b).getTime()),
-    "is empty": (a) => (a == null || a == undefined),
-    "is not empty": (a) => (a != null && a != undefined)
+    "=": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (new Date(a).getTime() == new Date(b).getTime())),
+    "<": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (new Date(a).getTime() < new Date(b).getTime())),
+    ">": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (new Date(a).getTime() > new Date(b).getTime())),
+    "<>": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (new Date(a).getTime() !== new Date(b).getTime())),
+    "is empty": (a) => (EMPTY.indexOf(a) >= 0)
+    "is not empty": (a) => (EMPTY.indexOf(a) < 0)
   },
   "long": {
-    "=": (a, b) => (parseInt(a) == parseInt(b)),
-    "<": (a, b) => (parseInt(a) < parseInt(b)),
-    ">": (a, b) => (parseInt(a) > parseInt(b)),
-    "<>": (a, b) => (parseInt(a) !== parseInt(b)),
-    "is empty": (a) => (a == null || a == undefined),
-    "is not empty": (a) => (a != null && a != undefined)
+    "=": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseInt(a) == parseInt(b))),
+    "<": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseInt(a) < parseInt(b))),
+    ">": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseInt(a) > parseInt(b))),
+    "<>": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseInt(a) !== parseInt(b))),
+    "is empty": (a) => (EMPTY.indexOf(a) >= 0)
+    "is not empty": (a) => (EMPTY.indexOf(a) < 0)
   },
   "decimal": {
-    "=": (a, b) => (parseFloat(a) == parseFloat(b)),
-    "<": (a, b) => (parseFloat(a) < parseFloat(b)),
-    ">": (a, b) => (parseFloat(a) > parseFloat(b)),
-    "<>": (a, b) => (parseFloat(a) !== parseFloat(b)),
-    "is empty": (a) => (a == null || a == undefined),
-    "is not empty": (a) => (a != null && a != undefined)
+    "=": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) == parseFloat(b))),
+    "<": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) < parseFloat(b))),
+    ">": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) > parseFloat(b))),
+    "<>": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) !== parseFloat(b))),
+    "is empty": (a) => (EMPTY.indexOf(a) >= 0)
+    "is not empty": (a) => (EMPTY.indexOf(a) < 0)
   },
   "double": {
-    "=": (a, b) => (parseFloat(a) == parseFloat(b)),
-    "<": (a, b) => (parseFloat(a) < parseFloat(b)),
-    ">": (a, b) => (parseFloat(a) > parseFloat(b)),
-    "<>": (a, b) => (parseFloat(a) !== parseFloat(b)),
-    "is empty": (a) => (a == null || a == undefined),
-    "is not empty": (a) => (a != null && a != undefined)
+    "=": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) == parseFloat(b))),
+    "<": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) < parseFloat(b))),
+    ">": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) > parseFloat(b))),
+    "<>": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) !== parseFloat(b))),
+    "is empty": (a) => (EMPTY.indexOf(a) >= 0)
+    "is not empty": (a) => (EMPTY.indexOf(a) < 0)
   }
 }
 
@@ -88,6 +89,13 @@ export function isConditionalSatisfied(compareDataType, comparator, ...operands)
  * @param {Object} context The React Context from which to pull values
  */
 export function isConditionalObjSatisfied(conditional, context) {
+
+  //By default assume that we are comparing strings
+  var compareDataType = "string";
+  if ("dataType" in conditional) {
+    compareDataType = conditional["dataType"];
+  }
+
   const requireAllOperandA = conditional["operandA"]["requireAll"];
   const requireAllOperandB = conditional["operandB"]?.requireAll;
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
@@ -70,6 +70,14 @@ const COMPARE_MAP = {
     "<>": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseInt(a) != parseInt(b))),
     "is empty": (a) => (EMPTY.indexOf(a) >= 0),
     "is not empty": (a) => (EMPTY.indexOf(a) < 0)
+  },
+  "decimal": {
+    "=": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) == parseFloat(b))),
+    "<": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) < parseFloat(b))),
+    ">": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) > parseFloat(b))),
+    "<>": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) != parseFloat(b))),
+    "is empty": (a) => (EMPTY.indexOf(a) >= 0),
+    "is not empty": (a) => (EMPTY.indexOf(a) < 0)
   }
 }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
@@ -116,8 +116,15 @@ export function isConditionalObjSatisfied(conditional, context) {
   const requireAllOperandB = conditional["operandB"]?.requireAll;
 
   // If the operands aren't loaded yet, treat them as being empty
-  const operandA = getValue(context, conditional["operandA"]) || [""];
-  const operandB = getValue(context, conditional["operandB"]) || [""];
+  var operandA = getValue(context, conditional["operandA"]) || [""];
+  if (!allIsNull(operandA)) {
+      operandA = removeAllNull(operandA);
+  }
+
+  var operandB = getValue(context, conditional["operandB"]) || [""];
+  if (!allIsNull(operandB)) {
+      operandB = removeAllNull(operandB);
+  }
 
   const firstCondition = requireAllOperandA ? ((func) => operandA.every(func)) : ((func) => operandA.some(func));
   const secondCondition = requireAllOperandB ? ((func) => operandB.every(func)) : ((func) => operandB.some(func));
@@ -127,6 +134,25 @@ export function isConditionalObjSatisfied(conditional, context) {
       return isConditionalSatisfied(conditional["dataType"], conditional["comparator"], valueA, valueB);
     })
   })
+}
+
+function removeAllNull(lst) {
+  var new_lst = [];
+  for (var i = 0; i < lst.length; i++) {
+    if (EMPTY.indexOf(lst[i]) < 0) {
+      new_lst.push(lst[i]);
+    }
+  }
+  return new_lst;
+}
+
+function allIsNull(lst) {
+  for (var i = 0; i < lst.length; i++) {
+    if (EMPTY.indexOf(lst[i]) < 0) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /**

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
@@ -99,13 +99,9 @@ export function isConditionalObjSatisfied(conditional, context) {
   const requireAllOperandA = conditional["operandA"]["requireAll"];
   const requireAllOperandB = conditional["operandB"]?.requireAll;
 
-  const operandA = getValue(context, conditional["operandA"]);
-  const operandB = getValue(context, conditional["operandB"]);
-
-  // Don't try to run if operandA isn't loaded yet
-  if (!operandA) {
-    return false;
-  }
+  // If the operands aren't loaded yet, treat them as being empty
+  const operandA = getValue(context, conditional["operandA"]) || [""];
+  const operandB = getValue(context, conditional["operandB"]) || [""];
 
   const firstCondition = requireAllOperandA ? ((func) => operandA.every(func)) : ((func) => operandA.some(func));
   const secondCondition = requireAllOperandB ? ((func) => operandB.every(func)) : ((func) => operandB.some(func));

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
@@ -89,13 +89,6 @@ export function isConditionalSatisfied(compareDataType, comparator, ...operands)
  * @param {Object} context The React Context from which to pull values
  */
 export function isConditionalObjSatisfied(conditional, context) {
-
-  //By default assume that we are comparing strings
-  var compareDataType = "string";
-  if ("dataType" in conditional) {
-    compareDataType = conditional["dataType"];
-  }
-
   const requireAllOperandA = conditional["operandA"]["requireAll"];
   const requireAllOperandB = conditional["operandB"]?.requireAll;
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
@@ -62,6 +62,14 @@ const COMPARE_MAP = {
     "<>": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) !== parseFloat(b))),
     "is empty": (a) => (EMPTY.indexOf(a) >= 0)
     "is not empty": (a) => (EMPTY.indexOf(a) < 0)
+  },
+  "long": {
+    "=": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseInt(a) == parseInt(b))),
+    "<": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseInt(a) < parseInt(b))),
+    ">": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseInt(a) > parseInt(b))),
+    "<>": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseInt(a) != parseInt(b))),
+    "is empty": (a) => (EMPTY.indexOf(a) >= 0),
+    "is not empty": (a) => (EMPTY.indexOf(a) < 0)
   }
 }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
@@ -62,22 +62,6 @@ const COMPARE_MAP = {
     "<>": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) !== parseFloat(b))),
     "is empty": (a) => (EMPTY.indexOf(a) >= 0)
     "is not empty": (a) => (EMPTY.indexOf(a) < 0)
-  },
-  "long": {
-    "=": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseInt(a) == parseInt(b))),
-    "<": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseInt(a) < parseInt(b))),
-    ">": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseInt(a) > parseInt(b))),
-    "<>": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseInt(a) != parseInt(b))),
-    "is empty": (a) => (EMPTY.indexOf(a) >= 0),
-    "is not empty": (a) => (EMPTY.indexOf(a) < 0)
-  },
-  "decimal": {
-    "=": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) == parseFloat(b))),
-    "<": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) < parseFloat(b))),
-    ">": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) > parseFloat(b))),
-    "<>": (a, b) => ((EMPTY.indexOf(a) < 0) && (EMPTY.indexOf(b) < 0) && (parseFloat(a) != parseFloat(b))),
-    "is empty": (a) => (EMPTY.indexOf(a) >= 0),
-    "is not empty": (a) => (EMPTY.indexOf(a) < 0)
   }
 }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -206,7 +206,7 @@ function MultipleChoice(props) {
 
   // Remove the ["", ""] unless there are only zero or one answer items
   var answers = selection.map(item => item[VALUE_POS] === GHOST_SENTINEL ? [item[LABEL_POS], item[LABEL_POS]] : item);
-  answers = ((answers.length < 2) ? answers : answers.filter(item => item[0] !== ''));
+  answers = ((answers.length < 2) ? answers : answers.filter(item => item[LABEL_POS] !== ''));
 
   if (isSelect) {
     return (

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -186,6 +186,8 @@ function MultipleChoice(props) {
         inputRef={ref => {inputEl = ref}}
       />
     </div>);
+    (maxAnswers !== 1) && addOption("", "");
+    (maxAnswers !== 1) && selectOption("", "");
 
   let selectNonGhostOption = (...args) => {
     // Clear the ghost input
@@ -200,7 +202,18 @@ function MultipleChoice(props) {
     </Typography>
     );
 
-  const answers = selection.map(item => item[VALUE_POS] === GHOST_SENTINEL ? [item[LABEL_POS], item[LABEL_POS]] : item);
+  //Remove the ["", ""]
+  const tmp_answers = selection.map(item => item[VALUE_POS] === GHOST_SENTINEL ? [item[LABEL_POS], item[LABEL_POS]] : item);
+  var answers = [];
+  if (tmp_answers.length < 2) {
+    answers = tmp_answers.slice();
+  } else {
+    for (var i = 0; i < tmp_answers.length; i++) {
+      if (tmp_answers[i][0] != "") {
+        answers.push(tmp_answers[i]);
+      }
+    }
+  }
 
   if (isSelect) {
     return (
@@ -354,7 +367,7 @@ function ResponseChild(props) {
                   label: classes.inputLabel
                 }}
               />
-            ) : (
+            ) : ((name !== "") && (
             <React.Fragment>
               <IconButton
                 onClick={() => {onDelete(id, name)}}
@@ -370,7 +383,7 @@ function ResponseChild(props) {
                 </Typography>
               </div>
             </React.Fragment>
-          )
+          ))
           }
       </ListItem>
     </React.Fragment>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -186,6 +186,8 @@ function MultipleChoice(props) {
         inputRef={ref => {inputEl = ref}}
       />
     </div>);
+    // If the field allows for multiple inputs (eg. maxAnswers !== 1),
+    // allow for the possibility of no user input (aka. an empty input)
     (maxAnswers !== 1) && addOption("", "");
     (maxAnswers !== 1) && selectOption("", "");
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -204,18 +204,9 @@ function MultipleChoice(props) {
     </Typography>
     );
 
-  //Remove the ["", ""]
-  const tmp_answers = selection.map(item => item[VALUE_POS] === GHOST_SENTINEL ? [item[LABEL_POS], item[LABEL_POS]] : item);
-  var answers = [];
-  if (tmp_answers.length < 2) {
-    answers = tmp_answers.slice();
-  } else {
-    for (var i = 0; i < tmp_answers.length; i++) {
-      if (tmp_answers[i][0] != "") {
-        answers.push(tmp_answers[i]);
-      }
-    }
-  }
+  // Remove the ["", ""] unless there are only zero or one answer items
+  var answers = selection.map(item => item[VALUE_POS] === GHOST_SENTINEL ? [item[LABEL_POS], item[LABEL_POS]] : item);
+  answers = ((answers.length < 2) ? answers : answers.filter(item => item[0] !== ''));
 
   if (isSelect) {
     return (


### PR DESCRIPTION
Please see https://phenotips.atlassian.net/browse/LFS-484 for a detailed description of this bug.

To see this bug in action, build the `LFS-484_bugdemo` branch and observe the following:

- Under LFS-484 (Long Test)
  - The field _Must NOT be equal to 22_ evaluates to **True** when it is empty
  - When the fields _Long Value C_ and _Long Value D_ are empty, the conditional statement evaluates to **True**
  - _Must be empty_ ... add a number ... _Confirm Okay_ goes away ... remove the number ... _Confirm Okay_ does not come back
  - _Must not be empty_ ... add a number ... _Confirm Okay_ appears ... remove the number ... _Confirm Okay_ does not go away

- Under LFS-484 (String Test)
  - _Must NOT be equal to hello_ evaluates to **True** when it is empty
  - _Must be empty_ does not show _Confirm Okay_ even when it is empty
  - _Must not be empty_ ... add something ... _Confirm Okay_ appears ... remove it ... _Confirm Okay_ does not go away

- Under LFS-484 (Double Test)
  - The field _Must NOT be equal to 22.5_ evaluates to **True** when it is empty
  - When the fields _Double Value C_ and _Double Value D_ are empty, the conditional statement evaluates to **True**
  - _Must be empty_ ... add a number ... _Confirm Okay_ goes away ... remove the number ... _Confirm Okay_ does not come back
  - _Must not be empty_ ... add a number ... _Confirm Okay_ appears ... remove the number ... _Confirm Okay_ does not go away

- Under LFS-484 (Date Test)
  - The field _Must NOT be equal to 2020-06-30_ evaluates to **True** when it is empty
  - When the fields _Date Value C_ and _Date Value D_ are empty, the conditional statement evaluates to **True**
  - _Must be empty_ ... conditional _Confirm Okay_ statement is not shown even when the field is empty
  - _Must not be empty_ ... conditional _Confirm Okay_ statement is always shown

- Under LFS-484 (Decimal Test)
  - The field _Must NOT be equal to 22.5_ evaluates to **True** when it is empty
  - When the fields _Decimal Value C_ and _Decimal Value D_ are empty, the conditional statement evaluates to **True**
  - _Must be empty_ ... add a number ... _Confirm Okay_ goes away ... remove the number ... _Confirm Okay_ does not come back
  - _Must not be empty_ ... add a number ... _Confirm Okay_ appears ... remove the number ... _Confirm Okay_ does not go away

Now, build `LFS-484_test` and run through the above tests - all these bugs should be fixed.