### PR TITLE
LFS-352: Delete subjects, forms, treatments, ...

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 import React, { useState } from "react";
-import { withRouter } from "react-router-dom";
+import { withRouter, useHistory } from "react-router-dom";
 
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton } from "@material-ui/core";
 import { Tooltip, Typography, withStyles } from "@material-ui/core";
@@ -29,9 +29,10 @@ import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
  * A component that renders an icon to open a dialog to delete an entry.
  */
 function DeleteButton(props) {
-  const { classes, entry, onComplete, entryType, size } = props;
+  const { classes, entry, onComplete, entryType, size, shouldGoBack } = props;
   const [ open, setOpen ] = useState(false);
   const [ errorOpen, setErrorOpen ] = useState(false);
+  const history = useHistory();
 
   let openDialog = () => {
     if (!open) {setOpen(true);}
@@ -56,10 +57,19 @@ function DeleteButton(props) {
       if (json.status && json.status === 500) {
         openError();
       } else {
-        onComplete();
+        if (onComplete) {onComplete()};
+        if (shouldGoBack) {goBack()};
       }
     });
     closeDialog();
+  }
+
+  let goBack = () => {
+    if (history.length > 2) {
+      history.goBack();
+    } else {
+      history.replace("/");
+    }
   }
 
   return (

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
@@ -71,7 +71,7 @@ function DeleteButton(props) {
         openError();
       } else {
         // Todo: improve dialog layout
-        setDialogMessage(`${defaultErrorMessage} ${json["status.message"]}`);
+        setDialogMessage(`${json["status.message"].replace("This item", entryName)}`);
         setDialogAction(`Would you like to delete ${entryName} and all items that reference it?`);
         setDeleteRecursive(true);
         openDialog();

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
@@ -21,7 +21,7 @@ import { withRouter, useHistory } from "react-router-dom";
 
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton } from "@material-ui/core";
 import { Tooltip, Typography, withStyles } from "@material-ui/core";
-import { Delete } from "@material-ui/icons"
+import { Delete, Close } from "@material-ui/icons";
 
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 
@@ -29,12 +29,21 @@ import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
  * A component that renders an icon to open a dialog to delete an entry.
  */
 function DeleteButton(props) {
-  const { classes, entryPath, entryName, onComplete, entryType, size, shouldGoBack } = props;
+  const { classes, entryPath, entryName, warning, onComplete, entryType, size, shouldGoBack } = props;
+
   const [ open, setOpen ] = useState(false);
   const [ errorOpen, setErrorOpen ] = useState(false);
+  const [ errorMessage, setErrorMessage ] = useState("");
+  const [ dialogMessage, setDialogMessage ] = useState(null);
+  const [ dialogAction, setDialogAction ] = useState("");
+  const [ deleteRecursive, setDeleteRecursive ] = useState(false);
+
+  const defaultDialogAction = `Are you sure you want to delete ${entryName}?`;
+  const defaultErrorMessage = entryName + " could not be removed.";
   const history = useHistory();
 
   let openDialog = () => {
+    closeError();
     if (!open) {setOpen(true);}
   }
 
@@ -43,6 +52,7 @@ function DeleteButton(props) {
   }
 
   let openError = () => {
+    closeDialog();
     if (!errorOpen) {setErrorOpen(true);}
   }
 
@@ -50,18 +60,58 @@ function DeleteButton(props) {
     if (errorOpen) {setErrorOpen(false);}
   }
 
-  let handleDelete = () => {
-    let request_data = new FormData();
-    request_data.append(':operation', 'delete');
-    fetch( entryPath, { method: 'POST', body: request_data }).then((json) => {
-      if (json.status && json.status === 500) {
+  let handleError = (status, json) => {
+    if (status === 401) {
+      setErrorMessage(`${defaultErrorMessage} You are not permitted to perform that action.`);
+      openError();
+    } else if (status === 409) {
+      if (deleteRecursive) {
+        //Already recursive delete, error out
+        setErrorMessage(`${defaultErrorMessage} ${json["status.message"]}`);
         openError();
       } else {
-        if (onComplete) {onComplete()};
-        if (shouldGoBack) {goBack()};
+        // Todo: improve dialog layout
+        setDialogMessage(`${defaultErrorMessage} ${json["status.message"]}`);
+        setDialogAction(`Would you like to delete ${entryName} and all items that reference it?`);
+        setDeleteRecursive(true);
+        openDialog();
+      }
+    } else if (json.error) {
+      setErrorMessage(`${defaultErrorMessage} An unexpected error occured. ${json.error.class}: ${json.error.message}`);
+    } else {
+      setErrorMessage(defaultErrorMessage);
+      openError();
+    }
+  }
+
+  let handleDelete = () => {
+    let request_data = new FormData();
+    let url = new URL(entryPath.substring(0, entryPath.lastIndexOf("/")) + ".delete", window.location.origin);
+    url.searchParams.set("path", entryPath);
+    if (deleteRecursive) {
+      url.searchParams.set("recursive", true);
+    }
+    fetch( url, {
+      method: 'POST',
+      body: request_data,
+      headers: {
+        Accept: "application/json"
+      }
+    }).then((response) => {
+      if (response.ok)  {
+        if (onComplete) {onComplete();}
+        if (shouldGoBack) {goBack();}
+      } else {
+        response.json().then((json) => handleError(response.status, json));
       }
     });
-    closeDialog();
+  }
+
+  let handleIconClicked = () => {
+    setDialogMessage(null);
+    setDialogAction(defaultDialogAction);
+    setDeleteRecursive(false);
+    openDialog();
   }
 
   let goBack = () => {
@@ -76,30 +126,31 @@ function DeleteButton(props) {
     <React.Fragment>
       <Dialog open={errorOpen} onClose={closeError}>
         <DialogTitle disableTypography>
-          <Typography variant="h6">Error</Typography>
+          <Typography variant="h6" color="error" className={classes.dialogTitle}>Error</Typography>
+          <IconButton onClick={closeError} className={classes.closeButton}>
+            <Close />
+          </IconButton>
         </DialogTitle>
         <DialogContent>
-            <Typography variant="body1">{entryName} could not be removed. This can occur if completed forms reference this {entryType}.</Typography>
+            <Typography variant="body1">{errorMessage}</Typography>
         </DialogContent>
-        <DialogActions className={classes.dialogActions}>
-            <Button variant="contained" size="small" onClick={closeError}>Close</Button>
-        </DialogActions>
       </Dialog>
       <Dialog open={open} onClose={closeDialog}>
         <DialogTitle disableTypography>
-          <Typography variant="h6">Delete {entryName}</Typography>
+        <Typography variant="h6">Delete {entryName}{deleteRecursive ? " and dependent items": null }</Typography>
         </DialogTitle>
         <DialogContent>
-            <Typography variant="body1">Are you sure you want to delete {entryName}?</Typography>
+            <Typography variant="body1">{dialogMessage}</Typography>
+            <Typography variant="body1">{dialogAction}</Typography>
         </DialogContent>
         <DialogActions className={classes.dialogActions}>
-            <Button variant="contained" color="secondary" size="small" onClick={() => handleDelete()}>Delete</Button>
+            <Button variant="contained" color="secondary" size="small" onClick={() => handleDelete()}>Delete{deleteRecursive ? " All" : null}</Button>
             <Button variant="contained" size="small" onClick={closeDialog}>Close</Button>
         </DialogActions>
       </Dialog>
       <Tooltip title={entryType ? "Delete " + entryType : "Delete"}>
-        <IconButton component="span" onClick={openDialog} className={classes.iconButton}>
-          <Delete fontSize={size ? size : "default"}/>
+        <IconButton component="span" onClick={handleIconClicked} className={classes.iconButton}>
+          <Delete fontSize={size ? size : "default"} className={warning ? classes.warningIcon : null}/>
         </IconButton>
       </Tooltip>
     </React.Fragment>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
@@ -29,26 +29,52 @@ import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
  * A component that renders an icon to open a dialog to delete an entry.
  */
 function DeleteButton(props) {
-  const { classes, entry, reload, entryType, size } = props;
+  const { classes, entry, onComplete, entryType, size } = props;
   const [ open, setOpen ] = useState(false);
+  const [ errorOpen, setErrorOpen ] = useState(false);
 
   let openDialog = () => {
-    setOpen(true);
+    if (!open) {setOpen(true);}
   }
 
   let closeDialog = () => {
-    setOpen(false);
+    if (open) {setOpen(false);}
+  }
+
+  let openError = () => {
+    if (!errorOpen) {setErrorOpen(true);}
+  }
+
+  let closeError = () => {
+    if (errorOpen) {setErrorOpen(false);}
   }
 
   let handleDelete = () => {
     let request_data = new FormData();
     request_data.append(':operation', 'delete');
-    fetch( entry["@path"], { method: 'POST', body: request_data }).then(reload());
+    fetch( entry["@path"], { method: 'POST', body: request_data }).then((json) => {
+      if (json.status && json.status === 500) {
+        openError();
+      } else {
+        onComplete();
+      }
+    });
     closeDialog();
   }
 
   return (
     <React.Fragment>
+      <Dialog open={errorOpen} onClose={closeError}>
+        <DialogTitle disableTypography>
+          <Typography variant="h6">Error</Typography>
+        </DialogTitle>
+        <DialogContent>
+            <Typography variant="body1">{entry["@name"]} could not be removed. This can occur if completed forms reference this {entryType}.</Typography>
+        </DialogContent>
+        <DialogActions className={classes.dialogActions}>
+            <Button variant="contained" size="small" onClick={closeError}>Close</Button>
+        </DialogActions>
+      </Dialog>
       <Dialog open={open} onClose={closeDialog}>
         <DialogTitle disableTypography>
           <Typography variant="h6">Delete {entry["@name"]}</Typography>
@@ -63,7 +89,7 @@ function DeleteButton(props) {
       </Dialog>
       <Tooltip title={entryType ? "Delete " + entryType : "Delete"}>
         <IconButton component="span" onClick={openDialog} className={classes.iconButton}>
-          <Delete fontSize={size ? size : "medium"}/>
+          <Delete fontSize={size ? size : "default"}/>
         </IconButton>
       </Tooltip>
     </React.Fragment>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
@@ -100,6 +100,7 @@ function DeleteButton(props) {
       if (response.ok)  {
         if (onComplete) {onComplete();}
         if (shouldGoBack) {goBack();}
+        closeDialog();
       } else {
         response.json().then((json) => handleError(response.status, json));
       }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
@@ -1,0 +1,73 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+import React, { useState } from "react";
+import { withRouter } from "react-router-dom";
+
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton } from "@material-ui/core";
+import { Tooltip, Typography, withStyles } from "@material-ui/core";
+import { Delete } from "@material-ui/icons"
+
+import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
+
+/**
+ * A component that renders an icon to open a dialog to delete an entry.
+ */
+function DeleteButton(props) {
+  const { classes, entry, reload, entryType, size } = props;
+  const [ open, setOpen ] = useState(false);
+
+  let openDialog = () => {
+    setOpen(true);
+  }
+
+  let closeDialog = () => {
+    setOpen(false);
+  }
+
+  let handleDelete = () => {
+    let request_data = new FormData();
+    request_data.append(':operation', 'delete');
+    fetch( entry["@path"], { method: 'POST', body: request_data }).then(reload());
+    closeDialog();
+  }
+
+  return (
+    <React.Fragment>
+      <Dialog open={open} onClose={closeDialog}>
+        <DialogTitle disableTypography>
+          <Typography variant="h6">Delete {entry["@name"]}</Typography>
+        </DialogTitle>
+        <DialogContent>
+            <Typography variant="body1">Are you sure you want to delete {entry["@name"]}?</Typography>
+        </DialogContent>
+        <DialogActions className={classes.dialogActions}>
+            <Button variant="contained" color="secondary" size="small" onClick={() => handleDelete()}>Delete</Button>
+            <Button variant="contained" size="small" onClick={closeDialog}>Close</Button>
+        </DialogActions>
+      </Dialog>
+      <Tooltip title={entryType ? "Delete " + entryType : "Delete"}>
+        <IconButton component="span" onClick={openDialog} className={classes.iconButton}>
+          <Delete fontSize={size ? size : "medium"}/>
+        </IconButton>
+      </Tooltip>
+    </React.Fragment>
+  );
+}
+
+export default withStyles(QuestionnaireStyle)(withRouter(DeleteButton));

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
@@ -86,13 +86,12 @@ function DeleteButton(props) {
 
   let handleDelete = () => {
     let request_data = new FormData();
-    let url = new URL(entryPath.substring(0, entryPath.lastIndexOf("/")) + ".delete", window.location.origin);
-    url.searchParams.set("path", entryPath);
+    let url = new URL(entryPath, window.location.origin);
     if (deleteRecursive) {
       url.searchParams.set("recursive", true);
     }
     fetch( url, {
-      method: 'POST',
+      method: 'DELETE',
       body: request_data,
       headers: {
         Accept: "application/json"

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
@@ -107,14 +107,12 @@ function DeleteButton(props) {
   }
 
   let handleDelete = () => {
-    let request_data = new FormData();
     let url = new URL(entryPath, window.location.origin);
     if (deleteRecursive) {
       url.searchParams.set("recursive", true);
     }
     fetch( url, {
       method: 'DELETE',
-      body: request_data,
       headers: {
         Accept: "application/json"
       }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
@@ -29,7 +29,7 @@ import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
  * A component that renders an icon to open a dialog to delete an entry.
  */
 function DeleteButton(props) {
-  const { classes, entry, onComplete, entryType, size, shouldGoBack } = props;
+  const { classes, entryPath, entryName, onComplete, entryType, size, shouldGoBack } = props;
   const [ open, setOpen ] = useState(false);
   const [ errorOpen, setErrorOpen ] = useState(false);
   const history = useHistory();
@@ -53,7 +53,7 @@ function DeleteButton(props) {
   let handleDelete = () => {
     let request_data = new FormData();
     request_data.append(':operation', 'delete');
-    fetch( entry["@path"], { method: 'POST', body: request_data }).then((json) => {
+    fetch( entryPath, { method: 'POST', body: request_data }).then((json) => {
       if (json.status && json.status === 500) {
         openError();
       } else {
@@ -79,7 +79,7 @@ function DeleteButton(props) {
           <Typography variant="h6">Error</Typography>
         </DialogTitle>
         <DialogContent>
-            <Typography variant="body1">{entry["@name"]} could not be removed. This can occur if completed forms reference this {entryType}.</Typography>
+            <Typography variant="body1">{entryName} could not be removed. This can occur if completed forms reference this {entryType}.</Typography>
         </DialogContent>
         <DialogActions className={classes.dialogActions}>
             <Button variant="contained" size="small" onClick={closeError}>Close</Button>
@@ -87,10 +87,10 @@ function DeleteButton(props) {
       </Dialog>
       <Dialog open={open} onClose={closeDialog}>
         <DialogTitle disableTypography>
-          <Typography variant="h6">Delete {entry["@name"]}</Typography>
+          <Typography variant="h6">Delete {entryName}</Typography>
         </DialogTitle>
         <DialogContent>
-            <Typography variant="body1">Are you sure you want to delete {entry["@name"]}?</Typography>
+            <Typography variant="body1">Are you sure you want to delete {entryName}?</Typography>
         </DialogContent>
         <DialogActions className={classes.dialogActions}>
             <Button variant="contained" color="secondary" size="small" onClick={() => handleDelete()}>Delete</Button>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -21,9 +21,9 @@ import LiveTable from "./LiveTable.jsx";
 import Form from "../questionnaire/Form.jsx";
 
 import { Button, Card, CardContent, CardHeader, Grid, Link, withStyles } from "@material-ui/core";
-import { Lock, Delete } from "@material-ui/icons"
 import questionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 import NewFormDialog from "./NewFormDialog.jsx";
+import DeleteButton from "./DeleteButton.jsx";
 
 function Forms(props) {
   const { match, location, classes } = props;
@@ -92,24 +92,8 @@ function Forms(props) {
     },
   ]
   const actions = [
-    {
-      icon: <Lock />,
-      tooltip: 'Set Permissions',
-      onClick: (event) => {}
-    },
-    {
-      icon: <Delete />,
-      tooltip: 'Delete Form',
-      onClick: (entry, event) => handleDelete(entry)
-    }
+    DeleteButton
   ]
-
-  let handleDelete = (entry) => {
-    // Make a POST request to delete the given form
-    let request_data = new FormData();
-    request_data.append(':operation', 'delete');
-    fetch( entry["@path"], { method: 'POST', body: request_data })
-  };
 
   return (
     <Card>
@@ -136,6 +120,7 @@ function Forms(props) {
           filters
           joinChildren="lfs:Answer"
           actions={actions}
+          entryType="Form"
           />
       </CardContent>
     </Card>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -21,6 +21,7 @@ import LiveTable from "./LiveTable.jsx";
 import Form from "../questionnaire/Form.jsx";
 
 import { Button, Card, CardContent, CardHeader, Grid, Link, withStyles } from "@material-ui/core";
+import { Lock, Delete } from "@material-ui/icons"
 import questionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 import NewFormDialog from "./NewFormDialog.jsx";
 
@@ -90,6 +91,26 @@ function Forms(props) {
       "format": "date:YYYY-MM-DD HH:mm",
     },
   ]
+  const actions = [
+    {
+      icon: <Lock />,
+      tooltip: 'Set Permissions',
+      onClick: (event) => {}
+    },
+    {
+      icon: <Delete />,
+      tooltip: 'Delete Form',
+      onClick: (entry, event) => handleDelete(entry)
+    }
+  ]
+
+  let handleDelete = (entry) => {
+    // Make a POST request to delete the given form
+    let request_data = new FormData();
+    request_data.append(':operation', 'delete');
+    fetch( entry["@path"], { method: 'POST', body: request_data })
+  };
+
   return (
     <Card>
       <CardHeader
@@ -114,6 +135,7 @@ function Forms(props) {
           customUrl={customUrl}
           filters
           joinChildren="lfs:Answer"
+          actions={actions}
           />
       </CardContent>
     </Card>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -19,13 +19,14 @@
 
 import React, { useState, useEffect } from "react";
 import { Paper, Table, TableHead, TableBody, TableRow, TableCell, TablePagination } from "@material-ui/core";
-import { Card, CardHeader, CardContent, CardActions, Chip, IconButton, Typography, Button, LinearProgress, withStyles } from "@material-ui/core";
+import { Card, CardHeader, CardContent, CardActions, Chip, IconButton, Typography, Button, LinearProgress, withStyles, Tooltip } from "@material-ui/core";
 import { Link } from 'react-router-dom';
 import moment from "moment";
 
 import Filters from "./Filters.jsx";
 
 import LiveTableStyle from "./tableStyle.jsx";
+import Form from "../questionnaire/Form.jsx";
 
 import EditIcon from "@material-ui/icons/Edit";
 import DeleteIcon from "@material-ui/icons/Delete";
@@ -44,7 +45,7 @@ function LiveTable(props) {
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Define the component's state
 
-  const { customUrl, columns, defaultLimit, joinChildren, updateData, classes, filters, ...rest } = props;
+  const { customUrl, columns, defaultLimit, joinChildren, updateData, classes, filters, actions, ...rest } = props;
   const [tableData, setTableData] = useState();
   const [cachedFilters, setCachedFilters] = useState(null);
   const [paginationData, setPaginationData] = useState(
@@ -172,6 +173,7 @@ function LiveTable(props) {
             <TableCell><a href={entry["@path"]}>{entry.title}</a></TableCell>
           )
         }
+        { actions ? (makeActions(entry, columns.count)) : null}
       </TableRow>
     );
   };
@@ -193,23 +195,23 @@ function LiveTable(props) {
     // allow livetable to link to components in the admin dashboard
     // if livetable item must link to a component within the admin dashboard, set "admin": true
     let pathPrefix = (column.admin ? "/content.html/admin" : "/content.html");
-    
+
     // Handle links
     if (column.key.startsWith('actions')) {
-      content = ( 
+      content = (
         <div>
           <Link to={pathPrefix + entry["@path"]}>
             <IconButton>
               <EditIcon />
             </IconButton>
-          </Link> 
+          </Link>
           <IconButton onClick={() => { props.delete(entry); }}>
             <DeleteIcon />
         </IconButton>
       </div>
       )
     }
-    
+
     if (column.link) {
       if (column.link === 'path') {
         content = (<a href={entry["@path"]}>{content}</a>);
@@ -229,6 +231,17 @@ function LiveTable(props) {
     // Render the cell
     return <TableCell key={index} {...column.props}>{content}</TableCell>
   };
+
+  let makeActions = (entry, index) => {
+    let content = actions.map((action, index) => {
+      let button = <IconButton key={index} component="span" size="small" onClick={action.onClick.bind(this, entry)}>{action.icon}</IconButton>;
+      if (action.tooltip) {
+        button = <Tooltip key={index} title={action.tooltip}>{button}</Tooltip>;
+      }
+      return button;
+    });
+    return <TableCell key={index}>{content}</TableCell>
+  }
 
   let getNestedValue = (entry, path) => {
     if (!path) return entry;
@@ -367,6 +380,7 @@ function LiveTable(props) {
               <TableCell>Name</TableCell>
             )
           }
+          { actions ? (<TableCell key={columns ? columns.count : 1} className={classes.tableHeader}>Actions</TableCell>) : null}
           </TableRow>
         </TableHead>
         <TableBody>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -19,14 +19,13 @@
 
 import React, { useState, useEffect } from "react";
 import { Paper, Table, TableHead, TableBody, TableRow, TableCell, TablePagination } from "@material-ui/core";
-import { Card, CardHeader, CardContent, CardActions, Chip, IconButton, Typography, Button, LinearProgress, withStyles, Tooltip } from "@material-ui/core";
+import { Card, CardHeader, CardContent, CardActions, Chip, IconButton, Typography, Button, LinearProgress, withStyles } from "@material-ui/core";
 import { Link } from 'react-router-dom';
 import moment from "moment";
 
 import Filters from "./Filters.jsx";
 
 import LiveTableStyle from "./tableStyle.jsx";
-import Form from "../questionnaire/Form.jsx";
 
 import EditIcon from "@material-ui/icons/Edit";
 import DeleteIcon from "@material-ui/icons/Delete";
@@ -45,7 +44,7 @@ function LiveTable(props) {
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Define the component's state
 
-  const { customUrl, columns, defaultLimit, joinChildren, updateData, classes, filters, actions, ...rest } = props;
+  const { customUrl, columns, defaultLimit, joinChildren, updateData, classes, filters, entryType, actions, ...rest } = props;
   const [tableData, setTableData] = useState();
   const [cachedFilters, setCachedFilters] = useState(null);
   const [paginationData, setPaginationData] = useState(
@@ -78,18 +77,18 @@ function LiveTable(props) {
   // When new data is added, trigger a new fetch
   useEffect(() => {
     if (updateData){
-      triggerFetch();
+      refresh();
     }
   }, [updateData]);
 
   // When the data path is changed, trigger a new fetch
   useEffect(() => {
     if (customUrl){
-      triggerFetch();
+      refresh();
     }
   }, [customUrl]);
 
-  let triggerFetch = () => {
+  let refresh = () => {
     setFetchStatus(Object.assign({}, fetchStatus, {
       "currentRequestNumber": -1,
     }));
@@ -173,7 +172,7 @@ function LiveTable(props) {
             <TableCell><a href={entry["@path"]}>{entry.title}</a></TableCell>
           )
         }
-        { actions ? (makeActions(entry, columns.count)) : null}
+        { actions ? makeActions(entry, actions, columns ? columns.count : 0) : null}
       </TableRow>
     );
   };
@@ -232,15 +231,11 @@ function LiveTable(props) {
     return <TableCell key={index} {...column.props}>{content}</TableCell>
   };
 
-  let makeActions = (entry, index) => {
-    let content = actions.map((action, index) => {
-      let button = <IconButton key={index} component="span" size="small" onClick={action.onClick.bind(this, entry)}>{action.icon}</IconButton>;
-      if (action.tooltip) {
-        button = <Tooltip key={index} title={action.tooltip}>{button}</Tooltip>;
-      }
-      return button;
+  let makeActions = (entry, actions, index) => {
+    let content = actions.map((Action, index) => {
+      return <Action key={index} entry={entry} reload={refresh} entryType={entryType} size={"small"} />
     });
-    return <TableCell key={index}>{content}</TableCell>
+    return <TableCell key={index}>{content}</TableCell>;
   }
 
   let getNestedValue = (entry, path) => {
@@ -380,7 +375,7 @@ function LiveTable(props) {
               <TableCell>Name</TableCell>
             )
           }
-          { actions ? (<TableCell key={columns ? columns.count : 1} className={classes.tableHeader}>Actions</TableCell>) : null}
+          {actions ? <TableCell key={columns ? columns.count : 1} className={[classes.tableHeader, classes.tableActionsHeader].join(' ')}>Actions</TableCell> : null}
           </TableRow>
         </TableHead>
         <TableBody>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -232,8 +232,20 @@ function LiveTable(props) {
   };
 
   let makeActions = (entry, actions, index) => {
+    let name;
+    if (entry["jcr:primaryType"] === "lfs:Form") {
+      name = `${getNestedValue(entry, "subject/identifier") || "Subject"}: ${getNestedValue(entry, "questionnaire/title") || entry["@name"]}`
+    } else {
+      name = columns ? getNestedValue(entry, columns[0].key) : entry["@name"];
+    }
     let content = actions.map((Action, index) => {
-      return <Action key={index} entryPath={entry["@path"]} entryName={columns ? getNestedValue(entry, columns[0].key) : entry["@name"]} onComplete={refresh} entryType={entryType} />
+      return <Action
+        key={index}
+        entryPath={entry["@path"]}
+        entryName={name}
+        onComplete={refresh}
+        entryType={entryType}
+        warning={entry["@referenced"]} />
     });
     return <TableCell key={index}>{content}</TableCell>;
   }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -233,7 +233,7 @@ function LiveTable(props) {
 
   let makeActions = (entry, actions, index) => {
     let content = actions.map((Action, index) => {
-      return <Action key={index} entry={entry} reload={refresh} entryType={entryType} size={"small"} />
+      return <Action key={index} entry={entry} onComplete={refresh} entryType={entryType} />
     });
     return <TableCell key={index}>{content}</TableCell>;
   }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -233,7 +233,7 @@ function LiveTable(props) {
 
   let makeActions = (entry, actions, index) => {
     let content = actions.map((Action, index) => {
-      return <Action key={index} entry={entry} onComplete={refresh} entryType={entryType} />
+      return <Action key={index} entryPath={entry["@path"]} entryName={columns ? getNestedValue(entry, columns[0].key) : entry["@name"]} onComplete={refresh} entryType={entryType} />
     });
     return <TableCell key={index}>{content}</TableCell>;
   }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/PermissionsButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/PermissionsButton.jsx
@@ -1,0 +1,51 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+import React from "react";
+import { withRouter } from "react-router-dom";
+
+import { IconButton, Tooltip, Typography, withStyles } from "@material-ui/core";
+import { Lock } from "@material-ui/icons"
+
+import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
+
+/**
+ * A placeholder component that renders a lock icon.
+ */
+function PermissionsButton(props) {
+  const { classes, entry, reload, entryType, size } = props;
+
+  let handleDelete = () => {
+    let request_data = new FormData();
+    request_data.append(':operation', 'delete');
+    fetch( entry["@path"], { method: 'POST', body: request_data }).then(reload());
+    closeDialog();
+  }
+
+  return (
+    <React.Fragment>
+      <Tooltip title={"Set Permissions"}>
+        <IconButton component="span" className={classes.iconButton}>
+          <Lock fontSize={size ? size : "medium"}/>
+        </IconButton>
+      </Tooltip>
+    </React.Fragment>
+  );
+}
+
+export default withStyles(QuestionnaireStyle)(withRouter(PermissionsButton));

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/PermissionsButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/PermissionsButton.jsx
@@ -30,18 +30,11 @@ import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 function PermissionsButton(props) {
   const { classes, entry, reload, entryType, size } = props;
 
-  let handleDelete = () => {
-    let request_data = new FormData();
-    request_data.append(':operation', 'delete');
-    fetch( entry["@path"], { method: 'POST', body: request_data }).then(reload());
-    closeDialog();
-  }
-
   return (
     <React.Fragment>
       <Tooltip title={"Set Permissions"}>
         <IconButton component="span" className={classes.iconButton}>
-          <Lock fontSize={size ? size : "medium"}/>
+          <Lock fontSize={size ? size : "default"}/>
         </IconButton>
       </Tooltip>
     </React.Fragment>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
@@ -23,7 +23,7 @@ import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle";
 import NewQuestionnaireDialog from "../questionnaireEditor/NewQuestionnaireDialog.jsx";
 import DeleteQuestionnaireDialog from "../questionnaireEditor/DeleteQuestionnaireDialog.jsx";
 import { Button, Card, CardHeader, CardContent, Typography, withStyles } from "@material-ui/core";
-import { Lock, Delete } from "@material-ui/icons";
+import DeleteButton from "./DeleteButton.jsx";
 
 function Questionnaires(props) {
   let [ openDialog, setOpenDialog ] = useState(false);
@@ -78,24 +78,8 @@ function Questionnaires(props) {
     }
   ]
   const actions = [
-    {
-      icon: <Lock />,
-      tooltip: 'Set Permissions',
-      onClick: (event) => {}
-    },
-    {
-      icon: <Delete />,
-      tooltip: 'Delete Questionnaire',
-      onClick: (entry, event) => handleDelete(entry)
-    }
+    DeleteButton
   ]
-
-  let handleDelete = (entry) => {
-    // Make a POST request to delete the given questionnaire
-    let request_data = new FormData();
-    request_data.append(':operation', 'delete');
-    fetch( entry["@path"], { method: 'POST', body: request_data })
-  };
 
   return (
     <React.Fragment>
@@ -115,7 +99,13 @@ function Questionnaires(props) {
         }}
         />
         <CardContent>
-          <LiveTable columns={columns} delete={deleteQuestionnaire} updateData={deletionCount} actions={actions}/>
+          <LiveTable
+            columns={columns}
+            delete={deleteQuestionnaire}
+            updateData={deletionCount}
+            actions={actions}
+            entryType={"Questionnaire"}
+            />
           { error &&
             <Typography color="error" variant="h3">
               {error}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
@@ -23,6 +23,7 @@ import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle";
 import NewQuestionnaireDialog from "../questionnaireEditor/NewQuestionnaireDialog.jsx";
 import DeleteQuestionnaireDialog from "../questionnaireEditor/DeleteQuestionnaireDialog.jsx";
 import { Button, Card, CardHeader, CardContent, Typography, withStyles } from "@material-ui/core";
+import { Lock, Delete } from "@material-ui/icons";
 
 function Questionnaires(props) {
   let [ openDialog, setOpenDialog ] = useState(false);
@@ -45,7 +46,7 @@ function Questionnaires(props) {
   if (entry) {
     return <Questionnaire id={entry[1]} key={location.pathname}/>;
   }
-  
+
   let columns = [
     {
       "key": "title",
@@ -76,6 +77,26 @@ function Questionnaires(props) {
       }
     }
   ]
+  const actions = [
+    {
+      icon: <Lock />,
+      tooltip: 'Set Permissions',
+      onClick: (event) => {}
+    },
+    {
+      icon: <Delete />,
+      tooltip: 'Delete Questionnaire',
+      onClick: (entry, event) => handleDelete(entry)
+    }
+  ]
+
+  let handleDelete = (entry) => {
+    // Make a POST request to delete the given questionnaire
+    let request_data = new FormData();
+    request_data.append(':operation', 'delete');
+    fetch( entry["@path"], { method: 'POST', body: request_data })
+  };
+
   return (
     <React.Fragment>
       <Card>
@@ -94,7 +115,7 @@ function Questionnaires(props) {
         }}
         />
         <CardContent>
-          <LiveTable columns={columns} delete={deleteQuestionnaire} updateData={deletionCount}/>
+          <LiveTable columns={columns} delete={deleteQuestionnaire} updateData={deletionCount} actions={actions}/>
           { error &&
             <Typography color="error" variant="h3">
               {error}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
@@ -21,8 +21,8 @@ import LiveTable from "./LiveTable.jsx";
 import SubjectType from "../questionnaire/SubjectType.jsx";
 
 import { Button, Card, CardContent, CardHeader, withStyles } from "@material-ui/core";
-import { Lock, Delete } from "@material-ui/icons"
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
+import DeleteButton from "./DeleteButton.jsx";
 
 function SubjectTypes(props) {
   const { classes } = props;
@@ -47,24 +47,8 @@ function SubjectTypes(props) {
     },
   ]
   const actions = [
-    {
-      icon: <Lock />,
-      tooltip: 'Set Permissions',
-      onClick: (event) => {}
-    },
-    {
-      icon: <Delete />,
-      tooltip: 'Delete Subject Type',
-      onClick: (entry, event) => handleDelete(entry)
-    }
+    DeleteButton
   ]
-
-  let handleDelete = (entry) => {
-    // Make a POST request to delete the given subject type
-    let request_data = new FormData();
-    request_data.append(':operation', 'delete');
-    fetch( entry["@path"], { method: 'POST', body: request_data })
-  };
 
   const entry = /SubjectTypes\/(.+)/.exec(location.pathname);
   if (entry) {
@@ -81,7 +65,10 @@ function SubjectTypes(props) {
         }
       />
       <CardContent>
-        <LiveTable columns={columns} actions={actions} />
+        <LiveTable
+          columns={columns}
+          actions={actions}
+          entryType={"Subject Type"} />
       </CardContent>
     </Card>
   );

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
@@ -21,6 +21,7 @@ import LiveTable from "./LiveTable.jsx";
 import SubjectType from "../questionnaire/SubjectType.jsx";
 
 import { Button, Card, CardContent, CardHeader, withStyles } from "@material-ui/core";
+import { Lock, Delete } from "@material-ui/icons"
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 
 function SubjectTypes(props) {
@@ -45,6 +46,25 @@ function SubjectTypes(props) {
       "format": "date:YYYY-MM-DD HH:mm",
     },
   ]
+  const actions = [
+    {
+      icon: <Lock />,
+      tooltip: 'Set Permissions',
+      onClick: (event) => {}
+    },
+    {
+      icon: <Delete />,
+      tooltip: 'Delete Subject Type',
+      onClick: (entry, event) => handleDelete(entry)
+    }
+  ]
+
+  let handleDelete = (entry) => {
+    // Make a POST request to delete the given subject type
+    let request_data = new FormData();
+    request_data.append(':operation', 'delete');
+    fetch( entry["@path"], { method: 'POST', body: request_data })
+  };
 
   const entry = /SubjectTypes\/(.+)/.exec(location.pathname);
   if (entry) {
@@ -61,7 +81,7 @@ function SubjectTypes(props) {
         }
       />
       <CardContent>
-        <LiveTable columns={columns} />
+        <LiveTable columns={columns} actions={actions} />
       </CardContent>
     </Card>
   );

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
@@ -23,9 +23,9 @@ import { NewSubjectDialog } from "../questionnaire/SubjectSelector.jsx";
 
 import { Button, Card, CardContent, CardHeader, Grid, Link, withStyles, ListItemText, Tooltip, Fab } from "@material-ui/core";
 import AddIcon from "@material-ui/icons/Add";
-import { Lock, Delete } from "@material-ui/icons"
 import { getHierarchy } from "../questionnaire/Subject.jsx";
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
+import DeleteButton from "./DeleteButton.jsx";
 
 function Subjects(props) {
 
@@ -60,24 +60,8 @@ function Subjects(props) {
     },
   ]
   const actions = [
-    {
-      icon: <Lock />,
-      tooltip: 'Set Permissions',
-      onClick: (event) => {}
-    },
-    {
-      icon: <Delete />,
-      tooltip: 'Delete Subject',
-      onClick: (entry, event) => handleDelete(entry)
-    }
+    DeleteButton
   ]
-
-  let handleDelete = (entry) => {
-    // Make a POST request to delete the given subject
-    let request_data = new FormData();
-    request_data.append(':operation', 'delete');
-    fetch( entry["@path"], { method: 'POST', body: request_data })
-  };
 
   const entry = /Subjects\/(.+)/.exec(location.pathname);
   if (entry) {
@@ -110,7 +94,12 @@ function Subjects(props) {
           }
         />
         <CardContent>
-          <LiveTable columns={columns} updateData={requestFetchData} actions={actions}/>
+          <LiveTable
+            columns={columns}
+            updateData={requestFetchData}
+            actions={actions}
+            entryType={"Subject"}
+          />
         </CardContent>
       </Card>
       <NewSubjectDialog

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
@@ -23,6 +23,7 @@ import { NewSubjectDialog } from "../questionnaire/SubjectSelector.jsx";
 
 import { Button, Card, CardContent, CardHeader, Grid, Link, withStyles, ListItemText, Tooltip, Fab } from "@material-ui/core";
 import AddIcon from "@material-ui/icons/Add";
+import { Lock, Delete } from "@material-ui/icons"
 import { getHierarchy } from "../questionnaire/Subject.jsx";
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 
@@ -58,6 +59,25 @@ function Subjects(props) {
       "format": (parent) => (parent ? getHierarchy(parent, React.Fragment, () => ({})) : "No parents"),
     },
   ]
+  const actions = [
+    {
+      icon: <Lock />,
+      tooltip: 'Set Permissions',
+      onClick: (event) => {}
+    },
+    {
+      icon: <Delete />,
+      tooltip: 'Delete Subject',
+      onClick: (entry, event) => handleDelete(entry)
+    }
+  ]
+
+  let handleDelete = (entry) => {
+    // Make a POST request to delete the given subject
+    let request_data = new FormData();
+    request_data.append(':operation', 'delete');
+    fetch( entry["@path"], { method: 'POST', body: request_data })
+  };
 
   const entry = /Subjects\/(.+)/.exec(location.pathname);
   if (entry) {
@@ -90,7 +110,7 @@ function Subjects(props) {
           }
         />
         <CardContent>
-          <LiveTable columns={columns} updateData={requestFetchData}/>
+          <LiveTable columns={columns} updateData={requestFetchData} actions={actions}/>
         </CardContent>
       </Card>
       <NewSubjectDialog

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -22,8 +22,9 @@ import LiveTable from "./LiveTable.jsx";
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 
 import { Button, Card, CardContent, CardHeader, Grid, Link, Typography, withStyles } from "@material-ui/core";
-import { Lock, Delete } from "@material-ui/icons"
 import NewFormDialog from "./NewFormDialog.jsx";
+import DeleteButton from "./DeleteButton.jsx";
+import PermissionsButton from "./PermissionsButton.jsx";
 
 // Component that renders the user's dashboard, with one LiveTable per questionnaire
 // visible by the user. Each LiveTable contains all forms that use the given
@@ -68,16 +69,8 @@ function UserDashboard(props) {
     },
   ]
   const actions = [
-    {
-      icon: <Lock />,
-      tooltip: 'Set Permissions',
-      onClick: (event) => {}
-    },
-    {
-      icon: <Delete />,
-      tooltip: 'Delete Form',
-      onClick: (entry, event) => handleDelete(entry)
-    }
+    DeleteButton,
+    PermissionsButton
   ]
 
   // Obtain information about the questionnaires available to the user
@@ -100,13 +93,6 @@ function UserDashboard(props) {
   let handleError = (response) => {
     setError(response.statusText ? response.statusText : response.toString());
     setQuestionnaires([]);  // Prevent an infinite loop if data was not set
-  };
-
-  let handleDelete = (entry) => {
-    // Make a POST request to delete the given form
-    let request_data = new FormData();
-    request_data.append(':operation', 'delete');
-    fetch( entry["@path"], { method: 'POST', body: request_data })
   };
 
   // If no forms can be obtained, we do not want to keep on re-obtaining questionnaires
@@ -179,6 +165,7 @@ function UserDashboard(props) {
                     defaultLimit={10}
                     joinChildren="lfs:Answer"
                     questionnaire={questionnaire["@path"]}
+                    entryType={questionnaire["title"]}
                     filters
                     actions={actions}
                     />

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -28,7 +28,7 @@ import PermissionsButton from "./PermissionsButton.jsx";
 
 // Component that renders the user's dashboard, with one LiveTable per questionnaire
 // visible by the user. Each LiveTable contains all forms that use the given
-// questionnaire. 
+// questionnaire.
 function UserDashboard(props) {
   const { classes } = props;
   // Store information about each questionnaire and whether or not we have
@@ -131,6 +131,8 @@ function UserDashboard(props) {
                 defaultLimit={10}
                 joinChildren="lfs:Answer"
                 filters
+                entryType={"Form"}
+                actions={actions}
               />
             </CardContent>
           </Card>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -67,11 +67,11 @@ function UserDashboard(props) {
       "format": "date:YYYY-MM-DD HH:mm",
     },
   ]
-  const actions =[
+  const actions = [
     {
       icon: <Lock />,
       tooltip: 'Set Permissions',
-      onClick: (entry) => alert("permissions")/*this.setState({currentUserName: rowData.name, deployChangeUserPassword: true})*/
+      onClick: (event) => {}
     },
     {
       icon: <Delete />,
@@ -79,13 +79,6 @@ function UserDashboard(props) {
       onClick: (entry, event) => handleDelete(entry)
     }
   ]
-
-  let handleDelete = (entry) => {
-    // Make a POST request to delete the given subject
-    let request_data = new FormData();
-    request_data.append(':operation', 'delete');
-    fetch( entry["@path"], { method: 'POST', body: request_data })
-  }
 
   // Obtain information about the questionnaires available to the user
   let initialize = () => {
@@ -107,6 +100,13 @@ function UserDashboard(props) {
   let handleError = (response) => {
     setError(response.statusText ? response.statusText : response.toString());
     setQuestionnaires([]);  // Prevent an infinite loop if data was not set
+  };
+
+  let handleDelete = (entry) => {
+    // Make a POST request to delete the given form
+    let request_data = new FormData();
+    request_data.append(':operation', 'delete');
+    fetch( entry["@path"], { method: 'POST', body: request_data })
   };
 
   // If no forms can be obtained, we do not want to keep on re-obtaining questionnaires

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -22,6 +22,7 @@ import LiveTable from "./LiveTable.jsx";
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 
 import { Button, Card, CardContent, CardHeader, Grid, Link, Typography, withStyles } from "@material-ui/core";
+import { Lock, Delete } from "@material-ui/icons"
 import NewFormDialog from "./NewFormDialog.jsx";
 
 // Component that renders the user's dashboard, with one LiveTable per questionnaire
@@ -66,6 +67,25 @@ function UserDashboard(props) {
       "format": "date:YYYY-MM-DD HH:mm",
     },
   ]
+  const actions =[
+    {
+      icon: <Lock />,
+      tooltip: 'Set Permissions',
+      onClick: (entry) => alert("permissions")/*this.setState({currentUserName: rowData.name, deployChangeUserPassword: true})*/
+    },
+    {
+      icon: <Delete />,
+      tooltip: 'Delete Form',
+      onClick: (entry, event) => handleDelete(entry)
+    }
+  ]
+
+  let handleDelete = (entry) => {
+    // Make a POST request to delete the given subject
+    let request_data = new FormData();
+    request_data.append(':operation', 'delete');
+    fetch( entry["@path"], { method: 'POST', body: request_data })
+  }
 
   // Obtain information about the questionnaires available to the user
   let initialize = () => {
@@ -160,6 +180,7 @@ function UserDashboard(props) {
                     joinChildren="lfs:Answer"
                     questionnaire={questionnaire["@path"]}
                     filters
+                    actions={actions}
                     />
                 </CardContent>
               </Card>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/tableStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/tableStyle.jsx
@@ -21,6 +21,9 @@ const liveTableStyle = theme => ({
     tableHeader: {
         fontWeight: "300"
     },
+    tableActionsHeader: {
+        "text-align": "right"
+    },
     filterLabel: {
         margin: theme.spacing(0, 1, 0, 0)
     },

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -18,7 +18,6 @@
 //
 
 import React, { useState } from "react";
-import { useHistory } from 'react-router-dom';
 import PropTypes from "prop-types";
 
 import {
@@ -77,8 +76,6 @@ function Form (props) {
   let [ errorCode, setErrorCode ] = useState();
   let [ errorMessage, setErrorMessage ] = useState("");
   let [ errorDialogDisplayed, setErrorDialogDisplayed ] = useState(false);
-
-  const history = useHistory();
 
   let formNode = React.useRef();
 
@@ -193,14 +190,6 @@ function Form (props) {
     saveData(event);
   }
 
-  let handleDelete = () => {
-    if (history.length > 2) {
-      history.goBack();
-    } else {
-      history.replace("/");
-    }
-  }
-
   // If the data has not yet been fetched, return an in-progress symbol
   if (!data) {
     fetchData();
@@ -236,8 +225,8 @@ function Form (props) {
             {": " + (data?.questionnaire?.title || id || "")}
             <DeleteButton
               entry={data ? data : {"@path": "/Forms/" + id, "@name": id}}
-              onComplete={handleDelete}
               entryType={data?.questionnaire?.title || "Form"}
+              shouldGoBack={true}
             />
           </Typography>
           {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -225,8 +225,9 @@ function Form (props) {
             {": " + (data?.questionnaire?.title || id || "")}
             <DeleteButton
               entryPath={data ? data["@path"] : "/Forms/"+id}
-              entryName={data?.subject?.identifier + ": " + (data?.questionnaire?.title || id || "")}
+              entryName={(data?.subject?.identifier || "Subject") + ": " + (data?.questionnaire?.title || id || "")}
               entryType={data?.questionnaire?.title || "Form"}
+              warning={data ? data["@referenced"] : false}
               shouldGoBack={true}
             />
           </Typography>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -30,9 +30,11 @@ import {
   Dialog,
   DialogTitle,
   DialogContent,
-  IconButton
+  IconButton,
+  Tooltip
 } from "@material-ui/core";
 import CloseIcon from "@material-ui/icons/Close";
+import { Delete } from "@material-ui/icons"
 
 import QuestionnaireStyle, { FORM_ENTRY_CONTAINER_PROPS } from "./QuestionnaireStyle";
 import FormEntry, { ENTRY_TYPES } from "./FormEntry";
@@ -215,13 +217,18 @@ function Form (props) {
   return (
     <form action={data["@path"]} method="POST" onSubmit={handleSubmit} onChange={()=>setLastSaveStatus(undefined)} key={id} ref={formNode}>
       <Grid container {...FORM_ENTRY_CONTAINER_PROPS} >
-        <Grid item className={classes.formHeader}>
+        <Grid item className={classes.formHeader} xs={12}>
           <Typography variant="overline">{parentDetails}</Typography>
           <Typography variant="h2">
             <Link href="#" onClick={() => {setSelectorDialogOpen(true)}}>
                 {data?.subject?.identifier}
             </Link>
             {": " + (data?.questionnaire?.title || id || "")}
+            <Tooltip key="0" title="Delete Form" className={classes.deleteButton}>
+              <IconButton component="span" onClick={() => {alert("TODO: Delete")}}>
+                <Delete fontSize="large"/>
+              </IconButton>
+            </Tooltip>
           </Typography>
           {
             data && data['jcr:createdBy'] && data['jcr:created'] ?

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -26,15 +26,13 @@ import {
   Grid,
   Link,
   Typography,
-  withStyles,
   Dialog,
   DialogTitle,
   DialogContent,
   IconButton,
-  Tooltip
+  withStyles
 } from "@material-ui/core";
 import CloseIcon from "@material-ui/icons/Close";
-import { Delete } from "@material-ui/icons"
 
 import QuestionnaireStyle, { FORM_ENTRY_CONTAINER_PROPS } from "./QuestionnaireStyle";
 import FormEntry, { ENTRY_TYPES } from "./FormEntry";
@@ -43,6 +41,7 @@ import { getHierarchy } from "./Subject";
 import { SelectorDialog, parseToArray } from "./SubjectSelector";
 import { FormProvider } from "./FormContext";
 import DialogueLoginContainer from "../login/loginDialogue.js";
+import DeleteButton from "../dataHomepage/DeleteButton";
 
 // TODO Once components from the login module can be imported, open the login Dialog in-page instead of opening a popup window
 
@@ -191,6 +190,10 @@ function Form (props) {
     saveData(event);
   }
 
+  let handleDelete = () => {
+    alert("TODO");
+  }
+
   // If the data has not yet been fetched, return an in-progress symbol
   if (!data) {
     fetchData();
@@ -224,11 +227,7 @@ function Form (props) {
                 {data?.subject?.identifier}
             </Link>
             {": " + (data?.questionnaire?.title || id || "")}
-            <Tooltip key="0" title="Delete Form" className={classes.deleteButton}>
-              <IconButton component="span" onClick={() => {alert("TODO: Delete")}}>
-                <Delete fontSize="large"/>
-              </IconButton>
-            </Tooltip>
+            <DeleteButton entry={data} reload={handleDelete} entryType={data?.questionnaire?.title || id || "Form"} />
           </Typography>
           {
             data && data['jcr:createdBy'] && data['jcr:created'] ?

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -224,7 +224,8 @@ function Form (props) {
             </Link>
             {": " + (data?.questionnaire?.title || id || "")}
             <DeleteButton
-              entry={data ? data : {"@path": "/Forms/" + id, "@name": id}}
+              entryPath={data ? data["@path"] : "/Forms/"+id}
+              entryName={data?.subject?.identifier + ": " + (data?.questionnaire?.title || id || "")}
               entryType={data?.questionnaire?.title || "Form"}
               shouldGoBack={true}
             />

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -18,6 +18,7 @@
 //
 
 import React, { useState } from "react";
+import { useHistory } from 'react-router-dom';
 import PropTypes from "prop-types";
 
 import {
@@ -76,6 +77,8 @@ function Form (props) {
   let [ errorCode, setErrorCode ] = useState();
   let [ errorMessage, setErrorMessage ] = useState("");
   let [ errorDialogDisplayed, setErrorDialogDisplayed ] = useState(false);
+
+  const history = useHistory();
 
   let formNode = React.useRef();
 
@@ -191,7 +194,11 @@ function Form (props) {
   }
 
   let handleDelete = () => {
-    alert("TODO");
+    if (history.length > 2) {
+      history.goBack();
+    } else {
+      history.replace("/");
+    }
   }
 
   // If the data has not yet been fetched, return an in-progress symbol
@@ -227,7 +234,11 @@ function Form (props) {
                 {data?.subject?.identifier}
             </Link>
             {": " + (data?.questionnaire?.title || id || "")}
-            <DeleteButton entry={data} reload={handleDelete} entryType={data?.questionnaire?.title || id || "Form"} />
+            <DeleteButton
+              entry={data ? data : {"@path": "/Forms/" + id, "@name": id}}
+              onComplete={handleDelete}
+              entryType={data?.questionnaire?.title || "Form"}
+            />
           </Typography>
           {
             data && data['jcr:createdBy'] && data['jcr:created'] ?

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -17,6 +17,8 @@
 //  under the License.
 //
 
+import { warningColor } from "../../../../../../commons/src/main/frontend/src/themeStyle";
+
 // Props used in grid containers for displaying Form entries
 export const FORM_ENTRY_CONTAINER_PROPS = {
     direction: "column",
@@ -261,6 +263,9 @@ const questionnaireStyle = theme => ({
     fileInfo: {
       padding: theme.spacing(1),
       fontFamily: "'Roboto', 'Helvetica', 'Arial', sans-serif",
+    },
+    warningIcon: {
+      color: theme.palette.warning.main
     },
 });
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -212,7 +212,7 @@ const questionnaireStyle = theme => ({
         opacity: 1,
         zIndex: "1010"
     },
-    deleteButton: {
+    iconButton: {
         float: "right"
     },
     addNewSubjectButton: {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import { warningColor } from "../../../../../../commons/src/main/frontend/src/themeStyle";
-
 // Props used in grid containers for displaying Form entries
 export const FORM_ENTRY_CONTAINER_PROPS = {
     direction: "column",
@@ -216,6 +214,9 @@ const questionnaireStyle = theme => ({
         backgroundColor: "white",
         opacity: 1,
         zIndex: "1010"
+    },
+    formProvider: {
+        paddingTop: theme.spacing(20)
     },
     iconButton: {
         float: "right"

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -139,6 +139,9 @@ const questionnaireStyle = theme => ({
         left: 'auto',
         position: 'fixed',
     },
+    subjectDeleteButton: {
+        marginRight: theme.spacing(10)
+    },
     collapsedSection: {
         padding: "0 !important"
     },

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -205,15 +205,15 @@ const questionnaireStyle = theme => ({
         marginLeft: theme.spacing(6)
     },
     formHeader: {
-        position: "fixed",
+        position: "sticky",
         width: "100%",
         top: theme.spacing(4),
         backgroundColor: "white",
         opacity: 1,
         zIndex: "1010"
     },
-    formProvider: {
-        paddingTop: theme.spacing(20)
+    deleteButton: {
+        float: "right"
     },
     addNewSubjectButton: {
         width: "250px"

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -34,6 +34,7 @@ import {
   withStyles,
   Button,
 } from "@material-ui/core";
+import DeleteButton from "../dataHomepage/DeleteButton.jsx";
 
 const QUESTION_TYPES = ["lfs:Question"];
 const SECTION_TYPES = ["lfs:Section"];
@@ -130,6 +131,10 @@ function SubjectContainer(props) {
     setError(response);
     setData([]);  // Prevent an infinite loop if data was not set
   };
+
+  let handleDelete = () => {
+    alert("TODO");
+  }
 
   // If the data has not yet been fetched, return an in-progress symbol
   if (!data) {
@@ -246,8 +251,13 @@ function SubjectMember (props) {
         }
         {
           data && data.identifier ?
-            <Typography variant={headerStyle}>{data?.type?.label || "Subject"} {data.identifier}</Typography>
-          : <Typography variant={headerStyle}>Subject {id}</Typography>
+            <Typography variant={headerStyle}>{data?.type?.label || "Subject"} {data.identifier}
+              <DeleteButton entry={data} reload={handleDelete} entryType={data.identifier} />
+            </Typography>
+          : <Typography variant={headerStyle}>Subject {id}
+              <DeleteButton entry={data} reload={handleDelete} entryType={id} />
+            </Typography>
+          // TODO: fix {data} where data not present
         }
         {
           data && data['jcr:createdBy'] && data['jcr:created'] ?

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -18,7 +18,7 @@
 //
 
 import React, { useState } from "react";
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import PropTypes from "prop-types";
 import moment from "moment";
 import QuestionnaireStyle from "./QuestionnaireStyle.jsx";
@@ -105,6 +105,7 @@ function SubjectContainer(props) {
   let [relatedSubjects, setRelatedSubjects] = useState();
   // 'level' of subject component
   const currentLevel = level || 0;
+  const history = useHistory();
 
   // Fetch the subject's data as JSON from the server.
   // The data will contain the subject metadata,
@@ -133,7 +134,11 @@ function SubjectContainer(props) {
   };
 
   let handleDelete = () => {
-    alert("TODO");
+    if (history.length > 2) {
+      history.goBack();
+    } else {
+      history.replace("/");
+    }
   }
 
   // If the data has not yet been fetched, return an in-progress symbol
@@ -250,14 +255,13 @@ function SubjectMember (props) {
           parentDetails && <Typography variant="overline">{parentDetails}</Typography>
         }
         {
-          data && data.identifier ?
-            <Typography variant={headerStyle}>{data?.type?.label || "Subject"} {data.identifier}
-              <DeleteButton entry={data} reload={handleDelete} entryType={data.identifier} />
+          <Typography variant={headerStyle}>{data?.type?.label || "Subject"} {data && data.identifier ? data.identifier : id}
+              <DeleteButton
+                entry={data ? data : {"@path": "/Subjects/" + id, "@name": id}}
+                onComplete={handleDelete}
+                entryType={data?.type?.label || "Subject"}
+              />
             </Typography>
-          : <Typography variant={headerStyle}>Subject {id}
-              <DeleteButton entry={data} reload={handleDelete} entryType={id} />
-            </Typography>
-          // TODO: fix {data} where data not present
         }
         {
           data && data['jcr:createdBy'] && data['jcr:created'] ?

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -251,6 +251,7 @@ function SubjectMember (props) {
                 entryPath={data ? data["@path"] : "/Subjects/" + id}
                 entryName={(data?.type?.label || "Subject") + " " + (data && data.identifier ? data.identifier : id)}
                 entryType={data?.type?.label || "Subject"}
+                warning={data ? data["@referenced"] : false}
                 shouldGoBack={true}
               />
             </Typography>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -246,13 +246,13 @@ function SubjectMember (props) {
           parentDetails && <Typography variant="overline">{parentDetails}</Typography>
         }
         {
-          <Typography variant={headerStyle}>{data?.type?.label || "Subject"} {data && data.identifier ? data.identifier : id}
+          <Typography variant={headerStyle} className={level === 0 ? classes.subjectDeleteButton : null}>{data?.type?.label || "Subject"} {data && data.identifier ? data.identifier : id}
               <DeleteButton
                 entryPath={data ? data["@path"] : "/Subjects/" + id}
                 entryName={(data?.type?.label || "Subject") + " " + (data && data.identifier ? data.identifier : id)}
                 entryType={data?.type?.label || "Subject"}
                 warning={data ? data["@referenced"] : false}
-                shouldGoBack={true}
+                shouldGoBack={level === 0}
               />
             </Typography>
         }
@@ -271,11 +271,19 @@ function SubjectMember (props) {
                   <Card className={classes.subjectCard}>
                     <CardHeader
                       title={
-                        <Button size={buttonSize} className={classes.subjectFormHeaderButton}>
-                          {entry.questionnaire["@name"]}
-                        </Button>
+                          <Button size={buttonSize} className={classes.subjectFormHeaderButton}>
+                            {entry.questionnaire["@name"]}
+                          </Button>
                       }
                     className={classes.subjectFormHeader}
+                    action={
+                      <DeleteButton
+                        entryPath={entry["@path"]}
+                        entryName={`${data && data.identifier ? data.identifier : id}: ${entry.questionnaire["@name"]}`}
+                        entryType="Form"
+                        warning={entry ? entry["@referenced"] : false}
+                      />
+                    }
                     />
                     <CardContent>
                       <FormData formID={entry["@name"]} maxDisplayed={maxDisplayed}/>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -248,7 +248,8 @@ function SubjectMember (props) {
         {
           <Typography variant={headerStyle}>{data?.type?.label || "Subject"} {data && data.identifier ? data.identifier : id}
               <DeleteButton
-                entry={data ? data : {"@path": "/Subjects/" + id, "@name": id}}
+                entryPath={data ? data["@path"] : "/Subjects/" + id}
+                entryName={(data?.type?.label || "Subject") + " " + (data && data.identifier ? data.identifier : id)}
                 entryType={data?.type?.label || "Subject"}
                 shouldGoBack={true}
               />

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -18,7 +18,7 @@
 //
 
 import React, { useState } from "react";
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import PropTypes from "prop-types";
 import moment from "moment";
 import QuestionnaireStyle from "./QuestionnaireStyle.jsx";
@@ -105,7 +105,6 @@ function SubjectContainer(props) {
   let [relatedSubjects, setRelatedSubjects] = useState();
   // 'level' of subject component
   const currentLevel = level || 0;
-  const history = useHistory();
 
   // Fetch the subject's data as JSON from the server.
   // The data will contain the subject metadata,
@@ -132,14 +131,6 @@ function SubjectContainer(props) {
     setError(response);
     setData([]);  // Prevent an infinite loop if data was not set
   };
-
-  let handleDelete = () => {
-    if (history.length > 2) {
-      history.goBack();
-    } else {
-      history.replace("/");
-    }
-  }
 
   // If the data has not yet been fetched, return an in-progress symbol
   if (!data) {
@@ -258,8 +249,8 @@ function SubjectMember (props) {
           <Typography variant={headerStyle}>{data?.type?.label || "Subject"} {data && data.identifier ? data.identifier : id}
               <DeleteButton
                 entry={data ? data : {"@path": "/Subjects/" + id, "@name": id}}
-                onComplete={handleDelete}
                 entryType={data?.type?.label || "Subject"}
+                shouldGoBack={true}
               />
             </Typography>
         }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectDirectory.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectDirectory.jsx
@@ -31,6 +31,7 @@ import React from "react";
 import LiveTable from "../dataHomepage/LiveTable.jsx";
 
 import { Button, Card, CardContent, CardHeader, withStyles } from "@material-ui/core";
+import { Lock, Delete } from "@material-ui/icons"
 import QuestionnaireStyle from "./QuestionnaireStyle.jsx";
 
 function SubjectDirectory(props) {
@@ -55,6 +56,25 @@ function SubjectDirectory(props) {
       "format": "date:YYYY-MM-DD HH:mm",
     },
   ]
+  const actions = [
+    {
+      icon: <Lock />,
+      tooltip: 'Set Permissions',
+      onClick: (event) => {}
+    },
+    {
+      icon: <Delete />,
+      tooltip: 'Delete Subject',
+      onClick: (entry, event) => handleDelete(entry)
+    }
+  ]
+
+  let handleDelete = (entry) => {
+    // Make a POST request to delete the given subject
+    let request_data = new FormData();
+    request_data.append(':operation', 'delete');
+    fetch( entry["@path"], { method: 'POST', body: request_data })
+  };
 
   return (
     <div>
@@ -71,6 +91,7 @@ function SubjectDirectory(props) {
             columns={columns}
             customUrl={'/Subjects.paginate?fieldname=type&fieldvalue='+ encodeURIComponent(id)}
             defaultLimit={10}
+            actions={actions}
             />
         </CardContent>
       </Card>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectDirectory.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectDirectory.jsx
@@ -76,7 +76,7 @@ function SubjectDirectory(props) {
             customUrl={'/Subjects.paginate?fieldname=type&fieldvalue='+ encodeURIComponent(id)}
             defaultLimit={10}
             actions={actions}
-            entryType={title}
+            entryType={"Subject"}
             />
         </CardContent>
       </Card>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectDirectory.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectDirectory.jsx
@@ -31,8 +31,8 @@ import React from "react";
 import LiveTable from "../dataHomepage/LiveTable.jsx";
 
 import { Button, Card, CardContent, CardHeader, withStyles } from "@material-ui/core";
-import { Lock, Delete } from "@material-ui/icons"
 import QuestionnaireStyle from "./QuestionnaireStyle.jsx";
+import DeleteButton from "../dataHomepage/DeleteButton.jsx";
 
 function SubjectDirectory(props) {
 
@@ -57,24 +57,8 @@ function SubjectDirectory(props) {
     },
   ]
   const actions = [
-    {
-      icon: <Lock />,
-      tooltip: 'Set Permissions',
-      onClick: (event) => {}
-    },
-    {
-      icon: <Delete />,
-      tooltip: 'Delete Subject',
-      onClick: (entry, event) => handleDelete(entry)
-    }
+    DeleteButton
   ]
-
-  let handleDelete = (entry) => {
-    // Make a POST request to delete the given subject
-    let request_data = new FormData();
-    request_data.append(':operation', 'delete');
-    fetch( entry["@path"], { method: 'POST', body: request_data })
-  };
 
   return (
     <div>
@@ -92,6 +76,7 @@ function SubjectDirectory(props) {
             customUrl={'/Subjects.paginate?fieldname=type&fieldvalue='+ encodeURIComponent(id)}
             defaultLimit={10}
             actions={actions}
+            entryType={title}
             />
         </CardContent>
       </Card>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectType.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectType.jsx
@@ -123,6 +123,7 @@ function SubjectType (props) {
                   entryPath={data ? data["@path"] : "/SubjectTypes/" + id}
                   entryName={"Subject Type: " + (data && data.identifier ? data.identifier : id)}
                   entryType={"Subject Type"}
+                  warning={data ? data["@referenced"] : false}
                   shouldGoBack={true}
                 />
               </Typography>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectType.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectType.jsx
@@ -26,9 +26,9 @@ import {
   Grid,
   Typography
 } from "@material-ui/core";
-import { Lock, Delete } from "@material-ui/icons"
 
 import LiveTable from "../dataHomepage/LiveTable.jsx";
+import DeleteButton from "../dataHomepage/DeleteButton.jsx";
 
 /**
  * Component that displays a SubjectType.
@@ -65,16 +65,7 @@ function SubjectType (props) {
     },
   ]
   const actions = [
-    {
-      icon: <Lock />,
-      tooltip: 'Set Permissions',
-      onClick: (event) => {}
-    },
-    {
-      icon: <Delete />,
-      tooltip: 'Delete Subject',
-      onClick: (entry, event) => handleDelete(entry)
-    }
+    DeleteButton
   ]
 
   // Fetch the subject type as JSON from the server.
@@ -98,12 +89,9 @@ function SubjectType (props) {
     setData([]);  // Prevent an infinite loop if data was not set
   };
 
-  let handleDelete = (entry) => {
-    // Make a POST request to delete the given subject
-    let request_data = new FormData();
-    request_data.append(':operation', 'delete');
-    fetch( entry["@path"], { method: 'POST', body: request_data })
-  };
+  let handleDelete = () => {
+    alert("TODO");
+  }
 
   // If the data has not yet been fetched, return an in-progress symbol
   if (!data) {
@@ -135,8 +123,9 @@ function SubjectType (props) {
         <Grid item>
           {
             data && data.identifier ?
-              <Typography variant="h2">Subject Type: {data.identifier}</Typography>
-            : <Typography variant="h2">Subject Type: {id}</Typography>
+              <Typography variant="h2">Subject Type: {data.identifier}<DeleteButton entry={data} reload={handleDelete} entryType={data.identifier} /></Typography>
+            : <Typography variant="h2">Subject Type: {id}<DeleteButton entry={data} reload={handleDelete} entryType={id} /></Typography>
+            // TODO: fix {data} where data not present
           }
           {
             data && data['jcr:createdBy'] && data['jcr:created'] ?
@@ -151,6 +140,7 @@ function SubjectType (props) {
             customUrl={customUrl}
             defaultLimit={10}
             actions={actions}
+            entryType={(data && (data.identifier || id))}
             />
         </Grid>
       </Grid>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectType.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectType.jsx
@@ -18,6 +18,7 @@
 //
 
 import React, { useState } from "react";
+import { useHistory } from 'react-router-dom';
 import PropTypes from "prop-types";
 import moment from "moment";
 
@@ -44,6 +45,8 @@ function SubjectType (props) {
   let [ data, setData ] = useState();
   // Error message set when fetching the data from the server fails
   let [ error, setError ] = useState();
+
+  const history = useHistory();
 
   // Column configuration for the LiveTables
   const columns = [
@@ -90,7 +93,11 @@ function SubjectType (props) {
   };
 
   let handleDelete = () => {
-    alert("TODO");
+    if (history.length > 2) {
+      history.goBack();
+    } else {
+      history.replace("/");
+    }
   }
 
   // If the data has not yet been fetched, return an in-progress symbol
@@ -122,10 +129,13 @@ function SubjectType (props) {
       <Grid container direction="column" spacing={4} alignItems="stretch" justify="space-between" wrap="nowrap">
         <Grid item>
           {
-            data && data.identifier ?
-              <Typography variant="h2">Subject Type: {data.identifier}<DeleteButton entry={data} reload={handleDelete} entryType={data.identifier} /></Typography>
-            : <Typography variant="h2">Subject Type: {id}<DeleteButton entry={data} reload={handleDelete} entryType={id} /></Typography>
-            // TODO: fix {data} where data not present
+              <Typography variant="h2">Subject Type: {data && data.identifier ? data.identifier : id}
+                <DeleteButton
+                  entry={data ? data : {"@path": "/SubjectTypes/" + id, "@name": id}}
+                  onComplete={handleDelete}
+                  entryType={"Subject Type"}
+                />
+              </Typography>
           }
           {
             data && data['jcr:createdBy'] && data['jcr:created'] ?

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectType.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectType.jsx
@@ -18,7 +18,6 @@
 //
 
 import React, { useState } from "react";
-import { useHistory } from 'react-router-dom';
 import PropTypes from "prop-types";
 import moment from "moment";
 
@@ -45,8 +44,6 @@ function SubjectType (props) {
   let [ data, setData ] = useState();
   // Error message set when fetching the data from the server fails
   let [ error, setError ] = useState();
-
-  const history = useHistory();
 
   // Column configuration for the LiveTables
   const columns = [
@@ -92,14 +89,6 @@ function SubjectType (props) {
     setData([]);  // Prevent an infinite loop if data was not set
   };
 
-  let handleDelete = () => {
-    if (history.length > 2) {
-      history.goBack();
-    } else {
-      history.replace("/");
-    }
-  }
-
   // If the data has not yet been fetched, return an in-progress symbol
   if (!data) {
     fetchData();
@@ -132,8 +121,8 @@ function SubjectType (props) {
               <Typography variant="h2">Subject Type: {data && data.identifier ? data.identifier : id}
                 <DeleteButton
                   entry={data ? data : {"@path": "/SubjectTypes/" + id, "@name": id}}
-                  onComplete={handleDelete}
                   entryType={"Subject Type"}
+                  shouldGoBack={true}
                 />
               </Typography>
           }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectType.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectType.jsx
@@ -120,7 +120,8 @@ function SubjectType (props) {
           {
               <Typography variant="h2">Subject Type: {data && data.identifier ? data.identifier : id}
                 <DeleteButton
-                  entry={data ? data : {"@path": "/SubjectTypes/" + id, "@name": id}}
+                  entryPath={data ? data["@path"] : "/SubjectTypes/" + id}
+                  entryName={"Subject Type: " + (data && data.identifier ? data.identifier : id)}
                   entryType={"Subject Type"}
                   shouldGoBack={true}
                 />

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectType.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectType.jsx
@@ -26,6 +26,7 @@ import {
   Grid,
   Typography
 } from "@material-ui/core";
+import { Lock, Delete } from "@material-ui/icons"
 
 import LiveTable from "../dataHomepage/LiveTable.jsx";
 
@@ -63,6 +64,18 @@ function SubjectType (props) {
       "format": "date:YYYY-MM-DD HH:mm",
     },
   ]
+  const actions = [
+    {
+      icon: <Lock />,
+      tooltip: 'Set Permissions',
+      onClick: (event) => {}
+    },
+    {
+      icon: <Delete />,
+      tooltip: 'Delete Subject',
+      onClick: (entry, event) => handleDelete(entry)
+    }
+  ]
 
   // Fetch the subject type as JSON from the server.
   // The response will contain metadata, such as authorship and versioning information.
@@ -83,6 +96,13 @@ function SubjectType (props) {
   let handleError = (response) => {
     setError(response);
     setData([]);  // Prevent an infinite loop if data was not set
+  };
+
+  let handleDelete = (entry) => {
+    // Make a POST request to delete the given subject
+    let request_data = new FormData();
+    request_data.append(':operation', 'delete');
+    fetch( entry["@path"], { method: 'POST', body: request_data })
   };
 
   // If the data has not yet been fetched, return an in-progress symbol
@@ -130,6 +150,7 @@ function SubjectType (props) {
             columns={columns}
             customUrl={customUrl}
             defaultLimit={10}
+            actions={actions}
             />
         </Grid>
       </Grid>

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/DeleteServlet.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/DeleteServlet.java
@@ -122,7 +122,6 @@ public class DeleteServlet extends SlingAllMethodsServlet
             final String path = request.getResource().getPath();
             final Boolean recursive = Boolean.parseBoolean(request.getParameter("recursive"));
 
-            LOGGER.error(path);
             Node node = request.getResource().adaptTo(Node.class);
             if (recursive) {
                 handleRecursiveDeleteChildren(node);


### PR DESCRIPTION
Delete buttons added to all pages except individual subjects.
Implemented on all tables

Still todo:
- Add popup to confirm deletion
- Refresh tables
- Handle errors (ex. couldn't delete subject as subject had a form)
- Implement delete buttons on form and subject pages