### PR TITLE
LFS-505: Very big decimal answers are not loaded and resaved correctly

### DIFF
--- a/modules/utils/src/main/java/ca/sickkids/ccm/lfs/commons/internal/ResourceToJsonAdapterFactory.java
+++ b/modules/utils/src/main/java/ca/sickkids/ccm/lfs/commons/internal/ResourceToJsonAdapterFactory.java
@@ -390,7 +390,8 @@ public class ResourceToJsonAdapterFactory
                 addDate(objectBuilder, name, value.getDate());
                 break;
             case PropertyType.DECIMAL:
-                objectBuilder.add(name, value.getDecimal());
+                // Send as string to prevent Javascript JSON parser from losing precision
+                objectBuilder.add(name, value.getString());
                 break;
             case PropertyType.DOUBLE:
                 objectBuilder.add(name, value.getDouble());
@@ -435,7 +436,8 @@ public class ResourceToJsonAdapterFactory
                     addDate(arrayBuilder, value.getDate());
                     break;
                 case PropertyType.DECIMAL:
-                    arrayBuilder.add(value.getDecimal());
+                    // Send as string to prevent Javascript JSON parser from losing precision
+                    arrayBuilder.add(value.getString());
                     break;
                 case PropertyType.DOUBLE:
                     arrayBuilder.add(value.getDouble());


### PR DESCRIPTION
Send decimal fields as JSON strings not numbers
- Javascript json parser was converting numbers to doubles,
  losing precision on load which became permanently lost on resave