### PR TITLE
LFS-198: Add multiple vocabularies to a single variable

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/VocabularyFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/VocabularyFilter.jsx
@@ -39,7 +39,7 @@ const COMPARATORS = DEFAULT_COMPARATORS.slice().concat(UNARY_COMPARATORS).concat
  *
  */
 const VocabularyFilter = forwardRef((props, ref) => {
-  const { onChangeInput, questionDefinition, ...rest } = props;
+  const { classes, defaultValue, defaultLabel, onChangeInput, questionDefinition, ...rest } = props;
   let vocabularies = questionDefinition["sourceVocabularies"];
 
   return (
@@ -50,6 +50,7 @@ const VocabularyFilter = forwardRef((props, ref) => {
       vocabularies={vocabularies}
       placeholder="empty"
       inputRef={ref}
+      defaultValue={defaultLabel}
       noMargin
       {...rest}
       />

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/VocabularyFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/VocabularyFilter.jsx
@@ -34,23 +34,19 @@ const COMPARATORS = DEFAULT_COMPARATORS.slice().concat(UNARY_COMPARATORS).concat
  *
  * @param {string} defaultValue The default value to place in the vocabulary filter
  * @param {func} onChangeInput Callback for when the value select has changed
- * @param {object} questionDefinition Object containing the definition of the question. Should include "sourceVocabularies" and "vocabularyFilter" children.
+ * @param {object} questionDefinition Object containing the definition of the question. Should include "sourceVocabularies" and "vocabularyFilters" children.
  * Other props are forwarded to the VocabularyQuery component
  *
  */
 const VocabularyFilter = forwardRef((props, ref) => {
-  const { classes, defaultValue, onChangeInput, questionDefinition, ...rest } = props;
+  const { onChangeInput, questionDefinition, ...rest } = props;
   let vocabularies = questionDefinition["sourceVocabularies"];
-  // Currently there's an issue where some of our fields are strings while the vocab selector only allows arrays
-  // We'll capture and refuse to pass it here
-  let vocabularyFilter = (typeof questionDefinition?.["vocabularyFilter"]) == "string" ? null : questionDefinition?.["vocabularyFilter"];
 
   return (
     <VocabularyQuery
       onClick={(id, name) => {onChangeInput(id, name)}}
       clearOnClick={false}
-      vocabularyFilter={vocabularyFilter}
-      defaultValue={defaultValue}
+      questionDefinition={questionDefinition}
       vocabularies={vocabularies}
       placeholder="empty"
       inputRef={ref}
@@ -65,7 +61,6 @@ VocabularyFilter.propTypes = {
   onChangeInput: PropTypes.func,
   questionDefinition: PropTypes.shape({
     sourceVocabularies: PropTypes.array,
-    vocabularyFilter: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
   })
 }
 

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/VocabularyFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/VocabularyFilter.jsx
@@ -23,7 +23,7 @@ import PropTypes from "prop-types";
 
 import FilterComponentManager from "./FilterComponentManager.jsx";
 import { DEFAULT_COMPARATORS, UNARY_COMPARATORS, VALUE_COMPARATORS } from "./FilterComparators.jsx";
-import VocabularySelector from "../../vocabQuery/query.jsx";
+import VocabularyQuery from "../../vocabQuery/query.jsx";
 import QuestionnaireStyle from "../../questionnaire/QuestionnaireStyle.jsx";
 
 const COMPARATORS = DEFAULT_COMPARATORS.slice().concat(UNARY_COMPARATORS).concat(VALUE_COMPARATORS);
@@ -34,24 +34,24 @@ const COMPARATORS = DEFAULT_COMPARATORS.slice().concat(UNARY_COMPARATORS).concat
  *
  * @param {string} defaultValue The default value to place in the vocabulary filter
  * @param {func} onChangeInput Callback for when the value select has changed
- * @param {object} questionDefinition Object containing the definition of the question. Should include "sourceVocabulary" and "vocabularyFilter" children.
- * Other props are forwarded to the VocabularySelector component
+ * @param {object} questionDefinition Object containing the definition of the question. Should include "sourceVocabularies" and "vocabularyFilter" children.
+ * Other props are forwarded to the VocabularyQuery component
  *
  */
 const VocabularyFilter = forwardRef((props, ref) => {
   const { classes, defaultValue, onChangeInput, questionDefinition, ...rest } = props;
-  let vocabulary = questionDefinition["sourceVocabulary"];
+  let vocabularies = questionDefinition["sourceVocabularies"];
   // Currently there's an issue where some of our fields are strings while the vocab selector only allows arrays
   // We'll capture and refuse to pass it here
   let vocabularyFilter = (typeof questionDefinition?.["vocabularyFilter"]) == "string" ? null : questionDefinition?.["vocabularyFilter"];
 
   return (
-    <VocabularySelector
+    <VocabularyQuery
       onClick={(id, name) => {onChangeInput(id, name)}}
       clearOnClick={false}
       vocabularyFilter={vocabularyFilter}
       defaultValue={defaultValue}
-      vocabulary={vocabulary}
+      vocabularies={vocabularies}
       placeholder="empty"
       inputRef={ref}
       noMargin
@@ -64,7 +64,7 @@ VocabularyFilter.propTypes = {
   defaultValue: PropTypes.string,
   onChangeInput: PropTypes.func,
   questionDefinition: PropTypes.shape({
-    sourceVocabulary: PropTypes.string,
+    sourceVocabularies: PropTypes.array,
     vocabularyFilter: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
   })
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -31,7 +31,7 @@ export const VALUE_POS = 1;
 // for form submission
 function Answer (props) {
   let { answers, answerNodeType, existingAnswer, path, questionName, questionDefinition, valueType, onChangeNote, noteComponent, noteProps, onAddedAnswerPath, sectionAnswersState } = props;
-  let { enableNotes, sourceVocabulary } = { ...props, ...questionDefinition };
+  let { enableNotes } = { ...props, ...questionDefinition };
   let [ answerID ] = useState((existingAnswer && existingAnswer[0]) || uuidv4());
   let answerPath = path + "/" + answerID;
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/VocabularyQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/VocabularyQuestion.jsx
@@ -34,7 +34,7 @@ import VocabularySelector from "../vocabSelector/select.jsx";
 //
 // Required arguments:
 //  text: String containing the question to ask
-//  sourceVocabulary: String denoting the vocabulary source
+//  sourceVocabularies: Array denoting the vocabularies sources
 //
 // Optional arguments:
 //  maxAnswers: Integer indicating the maximum number of terms allowed
@@ -45,24 +45,24 @@ import VocabularySelector from "../vocabSelector/select.jsx";
 //
 // <VocabularyQuestion
 //   text="Does the patient have any co-morbidities (non cancerous), including abnormal incidental imaging/labs?"
-//   sourceVocabulary="hpo"
+//   sourceVocabularies={["hpo"]}
 //   />
 // <VocabularyQuestion
 //   text="Does the patient have any skin conditions?"
-//   sourceVocabulary="hpo"
+//   sourceVocabularies={["hpo"]}
 //   vocabularyFilter={["HP:0000951"]}
 //   />
 // <!-- Alternate method of specifying arguments -->
 // <VocabularyQuestion
 //   questionDefintion={{
 //     text: "Does the patient have any skin conditions?",
-//     sourceVocabulary: "hpo",
+//     sourceVocabularies={["hpo"]},
 //     vocabularyFilter: ["HP:0000951"]
 //   }}
 //   />
 function VocabularyQuestion(props) {
   let { classes, ...rest } = props;
-  let { enableNotes, maxAnswers, sourceVocabulary, vocabularyFilter } = { ...props.questionDefinition, ...props };
+  let { enableNotes, maxAnswers, sourceVocabularies, vocabularyFilter } = { ...props.questionDefinition, ...props };
   let defaultSuggestions = props.defaults || Object.values(props.questionDefinition)
     // Keep only answer options
     // FIXME Must deal with nested options, do this recursively
@@ -80,7 +80,7 @@ function VocabularyQuestion(props) {
         vocabularyFilter = {vocabularyFilter}
         max = {maxAnswers}
         defaultSuggestions = {defaultSuggestions}
-        source = {sourceVocabulary}
+        source = {sourceVocabularies}
         {...rest}
       />
     </Question>);
@@ -90,7 +90,7 @@ VocabularyQuestion.propTypes = {
   classes: PropTypes.object.isRequired,
   questionDefinition: PropTypes.shape({
     text: PropTypes.string.isRequired,
-    sourceVocabulary: PropTypes.string.isRequired
+    sourceVocabularies: PropTypes.array.isRequired
   }).isRequired,
   text: PropTypes.string
 };

--- a/modules/data-entry/src/main/frontend/src/vocabQuery/browse.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/browse.jsx
@@ -33,7 +33,6 @@ import { REST_URL, MakeRequest } from "./util.jsx";
 // Required arguments:
 //  id: Term ID to search
 //  path: Term @path to get the term info
-//  vocabulary: Name of the vocabulary to use to look up terms
 //  changeTerm: callback to change the term id and path being looked up
 //  registerInfo: callback to add a possible hook point for the info box
 //  getInfo: callback to change the currently displayed info box term
@@ -43,7 +42,7 @@ import { REST_URL, MakeRequest } from "./util.jsx";
 // Optional arguments:
 //  fullscreen: whether or not the dialog is fullscreen (default: false)
 function VocabularyBrowser(props) {
-  const { classes, fullscreen, id, path, changeTerm, registerInfo, getInfo, onClose, onError, vocabulary, ...rest } = props;
+  const { classes, fullscreen, id, path, changeTerm, registerInfo, getInfo, onClose, onError, ...rest } = props;
 
   const [ lastKnownTerm, setLastKnownTerm ] = useState("");
   const [ parentNode, setParentNode ] = useState();
@@ -104,7 +103,6 @@ function VocabularyBrowser(props) {
         headNode={!ischildnode}
         bolded={bolded}
         onError={onError}
-        vocabulary={vocabulary}
         knownHasChildren={hasChildren}
       />
     );
@@ -146,7 +144,6 @@ VocabularyBrowser.propTypes = {
   fullscreen: PropTypes.bool,
   id: PropTypes.string.isRequired,
   path: PropTypes.string.isRequired,
-  vocabulary: PropTypes.string.isRequired,
   changeTerm: PropTypes.func.isRequired,
   registerInfo: PropTypes.func.isRequired,
   getInfo: PropTypes.func.isRequired,

--- a/modules/data-entry/src/main/frontend/src/vocabQuery/browseListChild.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/browseListChild.jsx
@@ -40,12 +40,11 @@ import { REST_URL, MakeRequest } from "./util.jsx";
 //  headNode: boolean determining whether or not this node is the topmost node in the browser
 //  bolded: boolean determining whether or not to bold this entry
 //  onError: callback when an error occurs
-//  vocabulary: Name of the vocabulary to use to look up terms
 //
 // Optional arguments:
 //  fullscreen: whether or not the dialog is fullscreen (default: false)
 function ListChild(props) {
-  const { classes, defaultOpen, id, path, name, changeTerm, registerInfo, getInfo, expands, headNode, bolded, onError, vocabulary, knownHasChildren } = props;
+  const { classes, defaultOpen, id, path, name, changeTerm, registerInfo, getInfo, expands, headNode, bolded, onError, knownHasChildren } = props;
 
   const [ lastKnownID, setLastKnownID ] = useState();
   const [ currentlyLoading, setCurrentlyLoading ] = useState(typeof knownHasChildren === "undefined");
@@ -91,7 +90,6 @@ function ListChild(props) {
         key={index}
         headNode={false}
         onError={onError}
-        vocabulary={vocabulary}
         knownHasChildren={row["lfs:hasChildren"]}
       />)
       );

--- a/modules/data-entry/src/main/frontend/src/vocabQuery/query.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/query.jsx
@@ -74,7 +74,7 @@ class VocabularyQuery extends React.Component {
       infoVocabAcronym: props.vocabulary,
       infoVocabURL: "",
       infoVocabDescription: "",
-      infoVocabObtained: false,
+      infoVocabObtained: "",
       buttonRefs: {},
       vocabulary: props.vocabulary,
       noResults: false,
@@ -470,7 +470,7 @@ class VocabularyQuery extends React.Component {
   // Grab information about the given ID and populate the info box
   getInfo = (path) => {
     // If we don't yet know anything about our vocabulary, fill it in
-    if (!this.state.infoVocabObtained) {
+    if (this.state.infoVocabObtained != path) {
       var url = new URL(`${path.split("/").slice(0, -1).join("/")}.json`, REST_URL);
       MakeRequest(url, this.parseVocabInfo);
     }
@@ -485,7 +485,7 @@ class VocabularyQuery extends React.Component {
         infoVocabAcronym: data["identifier"] || "",
         infoVocabURL: data["website"] || "",
         infoVocabDescription: data["description"],
-        infoVocabObtained: true
+        infoVocabObtained: data["@path"]
       });
     } else {
       this.logError("Error: vocabulary details lookup failed with code " + status);

--- a/modules/data-entry/src/main/frontend/src/vocabQuery/query.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/query.jsx
@@ -41,7 +41,7 @@ const MAX_RESULTS = 10;
 //  clearOnClick: Whether selecting an option will clear the search bar
 //  onClick: Callback when the user clicks on this element
 //  onInputFocus: Callback when the input is focused on
-//  vocabulary: String of vocabulary to use (e.g. "hpo")
+//  vocabularies: Array of Strings of vocabularies to use (e.g. ["hpo"])
 //
 // Optional arguments:
 //  disabled: Boolean representing whether or not this element is disabled
@@ -72,19 +72,19 @@ class VocabularyQuery extends React.Component {
       infoAnchor: null,
       infoAboveBackground: false,
       // Information about the vocabulary
-      infoVocabAcronym: props.vocabulary,
+      infoVocabAcronym: "",
       infoVocabURL: "",
       infoVocabDescription: "",
       infoVocabObtained: "",
       infoVocabTobeObtained: "",
       buttonRefs: {},
-      vocabulary: props.vocabulary,
+      vocabularies: props.vocabularies,
       noResults: false,
     };
   }
 
   render() {
-    const { classes, defaultValue, disabled, inputRef, noMargin, onInputFocus, placeholder, searchDefault, vocabulary } = this.props;
+    const { classes, defaultValue, disabled, inputRef, noMargin, onInputFocus, placeholder, searchDefault, vocabularies } = this.props;
 
     const inputEl = (<Input
       disabled={disabled}
@@ -301,7 +301,6 @@ class VocabularyQuery extends React.Component {
           onError={this.logError}
           registerInfo={this.registerInfoButton}
           getInfo={this.getInfo}
-          vocabulary={vocabulary}
           />
         { /* Error snackbar */}
         <Snackbar
@@ -375,7 +374,7 @@ class VocabularyQuery extends React.Component {
 
     // Grab suggestions
     //...Make a queue of vocabularies to search through
-    var vocabQueue = this.props.vocabulary.slice();
+    var vocabQueue = this.props.vocabularies.slice();
     this.makeMultiRequest(vocabQueue, input, []);
 
     // Hide the infobox and stop the timer
@@ -610,7 +609,7 @@ VocabularyQuery.propTypes = {
 };
 
 VocabularyQuery.defaultProps = {
-  vocabulary: 'hpo',
+  vocabularies: ['hpo'],
   searchDefault: 'Search',
   clearOnClick: true
 };

--- a/modules/data-entry/src/main/frontend/src/vocabQuery/query.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/query.jsx
@@ -33,6 +33,7 @@ import { REST_URL, MakeRequest } from "./util.jsx";
 import QueryStyle from "./queryStyle.jsx";
 
 const NO_RESULTS_TEXT = "No results";
+const MAX_RESULTS = 10;
 
 // Component that renders a search bar for vocabulary terms.
 //
@@ -340,7 +341,7 @@ class VocabularyQuery extends React.Component {
     //Get an vocabulary to search through
     var selectedVocab = queue.pop();
     if (selectedVocab === undefined) {
-      this.showSuggestions(null, {rows: prevData});
+      this.showSuggestions(null, {rows: prevData.slice(0, MAX_RESULTS)});
       return;
     }
     var url = new URL(`./${selectedVocab}.search.json`, REST_URL);

--- a/modules/data-entry/src/main/frontend/src/vocabQuery/query.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/query.jsx
@@ -76,6 +76,7 @@ class VocabularyQuery extends React.Component {
       infoVocabURL: "",
       infoVocabDescription: "",
       infoVocabObtained: "",
+      infoVocabTobeObtained: "",
       buttonRefs: {},
       vocabulary: props.vocabulary,
       noResults: false,
@@ -471,8 +472,12 @@ class VocabularyQuery extends React.Component {
   // Grab information about the given ID and populate the info box
   getInfo = (path) => {
     // If we don't yet know anything about our vocabulary, fill it in
-    if (this.state.infoVocabObtained != path) {
-      var url = new URL(`${path.split("/").slice(0, -1).join("/")}.json`, window.location.origin);
+    var vocabPath = `${path.split("/").slice(0, -1).join("/")}.json`;
+    if (this.state.infoVocabObtained != vocabPath) {
+      var url = new URL(vocabPath, window.location.origin);
+      this.setState({
+        infoVocabTobeObtained: vocabPath
+      });
       MakeRequest(url, this.parseVocabInfo);
     }
 
@@ -482,11 +487,12 @@ class VocabularyQuery extends React.Component {
 
   parseVocabInfo = (status, data) => {
     if (status === null) {
+      var vocabPath = this.state.infoVocabTobeObtained;
       this.setState({
-        infoVocabAcronym: data["identifier"] || "",
+        infoVocabAcronym: data["identifier"] || vocabPath.split("/")[2]?.split('.')[0] || "",
         infoVocabURL: data["website"] || "",
         infoVocabDescription: data["description"],
-        infoVocabObtained: data["@path"]
+        infoVocabObtained: vocabPath
       });
     } else {
       this.logError("Error: vocabulary details lookup failed with code " + status);

--- a/modules/data-entry/src/main/frontend/src/vocabQuery/query.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/query.jsx
@@ -396,10 +396,10 @@ class VocabularyQuery extends React.Component {
             suggestions.push(
               <MenuItem
                 className={this.props.classes.dropdownItem}
-                key={element["identifier"]}
+                key={element["@path"]}
                 onClick={(e) => {
                   if (e.target.localName === "li") {
-                    this.props.onClick(element["identifier"], name);
+                    this.props.onClick(element["@path"], name);
                     this.anchorEl.value = name;
                     this.closeDialog();
                   }}

--- a/modules/data-entry/src/main/frontend/src/vocabQuery/query.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/query.jsx
@@ -471,7 +471,7 @@ class VocabularyQuery extends React.Component {
   getInfo = (path) => {
     // If we don't yet know anything about our vocabulary, fill it in
     if (this.state.infoVocabObtained != path) {
-      var url = new URL(`${path.split("/").slice(0, -1).join("/")}.json`, REST_URL);
+      var url = new URL(`${path.split("/").slice(0, -1).join("/")}.json`, window.location.origin);
       MakeRequest(url, this.parseVocabInfo);
     }
 

--- a/modules/data-entry/src/main/frontend/src/vocabSelector/select.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabSelector/select.jsx
@@ -187,7 +187,7 @@ function VocabularySelector(props) {
 
       // Determine the name from our vocab
       var escapedId = id.replace(":", "");  // Vocabulary terms have no colons in their JCR node names
-      var url = new URL(`./${source}/${escapedId}.json`, REST_URL);
+      var url = new URL(`${id}.json`, window.location.origin);
       MakeRequest(url, (status, data) => addDefaultSuggestion(status, data, id));
     };
 
@@ -200,7 +200,7 @@ function VocabularySelector(props) {
         }
         // Determine the name from our vocab
         var escapedId = id.replace(":", "");  // Vocabulary terms have no colons in their JCR node names
-        var url = new URL(`./${source}/${escapedId}.json`, REST_URL);
+        var url = new URL(`${id}.json`, window.location.origin);
         MakeRequest(url, (status, data) => addDefaultSuggestion(status, data, id, false));
       });
     }

--- a/modules/data-entry/src/main/frontend/src/vocabSelector/select.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabSelector/select.jsx
@@ -262,6 +262,7 @@ function VocabularySelector(props) {
     <React.Fragment>
       <Thesaurus
         onClick = {handleThesaurus}
+        questionDefinition = {questionDefinition}
         vocabularyFilter = {vocabularyFilter}
         vocabulary = {source}
         ref = {(ref) => {thesaurusRef = ref;}}

--- a/modules/data-entry/src/main/frontend/src/vocabSelector/select.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabSelector/select.jsx
@@ -23,7 +23,7 @@ import { FormControlLabel, List, RadioGroup, Typography, withStyles, Radio } fro
 
 import { MakeRequest, REST_URL } from "../vocabQuery/util.jsx";
 import Answer from "../questionnaire/Answer.jsx";
-import Thesaurus from "../vocabQuery/query.jsx";
+import VocabularyQuery from "../vocabQuery/query.jsx";
 import SelectorStyle from "./selectorStyle.jsx";
 import VocabularyEntry from "./selectEntry.jsx";
 import SelectionResults from "./selectionResults.jsx";
@@ -260,11 +260,11 @@ function VocabularySelector(props) {
 
   return (
     <React.Fragment>
-      <Thesaurus
+      <VocabularyQuery
         onClick = {handleThesaurus}
         questionDefinition = {questionDefinition}
         vocabularyFilter = {vocabularyFilter}
-        vocabulary = {source}
+        vocabularies = {source}
         ref = {(ref) => {thesaurusRef = ref;}}
         disabled = {disabled}
         overrideText = {disabled ? reminderText : undefined }
@@ -277,7 +277,7 @@ function VocabularySelector(props) {
           // If we don't have an external container, add results here
           typeof selectionContainer === "undefined" && generateList(disabled, isRadio)
         }
-      </Thesaurus>
+      </VocabularyQuery>
       {
         // If we have an external container, open a portal there
         typeof selectionContainer !== "undefined" &&
@@ -309,7 +309,7 @@ function VocabularySelector(props) {
 VocabularySelector.propTypes = {
     classes: PropTypes.object.isRequired,
     title: PropTypes.string,
-    source: PropTypes.string.isRequired,
+    source: PropTypes.array.isRequired,
     max: PropTypes.number.isRequired,
     requiredAncestors: PropTypes.array,
     defaultSuggestions: PropTypes.object,

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -89,6 +89,16 @@
   + * (lfs:AnswerOption) = lfs:AnswerOption
 
 //-----------------------------------------------------------------------------
+[lfs:VocabularyFilterGroup] > sling:Folder, mix:referenceable
+  // Hardcode the resource type.
+  - sling:resourceType (STRING) = "lfs/VocabularyFilterGroup" mandatory autocreated protected
+
+  // Hardcode the resource supertype: each question is a resource.
+  - sling:resourceSuperType (STRING) = "lfs/VocabularyFilterGroup" mandatory autocreated protected
+
+  - value (string)
+
+//-----------------------------------------------------------------------------
 // This is the definition of a question.
 [lfs:Question] > sling:Folder, mix:referenceable
   // Attributes
@@ -216,6 +226,7 @@
   // The list of predefined options displayed to the user.
   // This applies mostly to text answers, but can also be used for the other answer types as well, for example as a list of dates to choose from, or a list of numbers, or a list of vocabulary terms.
   + * (lfs:AnswerOption) = lfs:AnswerOption
+  + * (lfs:VocabularyFilterGroup) = lfs:VocabularyFilterGroup
 
 //-----------------------------------------------------------------------------
 // A section is a collection of questions.

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -181,10 +181,10 @@
   // This is a SimpleDateFormat compatible string.
   - dateFormat (string)
 
-  // For vocabulary answers, the source vocabulary (or category of vocabularies) in which to search.
+  // For vocabulary answers, the source vocabularies array (or categories of vocabularies) in which to search.
   // A simple label like "MONDO", or a value prefixed by "vocabulary:" such as "vocabulary:MONDO" identifies a specific vocabulary.
   // A value prefixed by "category:" such as "category:diseases" identifies a vocabulary category.
-  - sourceVocabulary (string)
+  - sourceVocabularies (string) multiple
 
   // For vocabulary answers, an extra filter to apply to the query, which can be used, for example,
   // to restrict results to a specific sub-branch, or a specific type of terms.

--- a/modules/vocabularies/src/main/frontend/src/vocabularyAction.jsx
+++ b/modules/vocabularies/src/main/frontend/src/vocabularyAction.jsx
@@ -92,7 +92,7 @@ export default function VocabularyAction(props) {
   let fetchQuestionnaires = () => {
     if (questionnaires.length === 0) {
       // Send a fetch request to determine the questionnaires available
-      const query = `select n.* from [lfs:Questionnaire] as n inner join [lfs:Question] as q on isdescendantnode(q, n) where q.sourceVocabulary='${props.acronym}'`;
+      const query = `select n.* from [lfs:Questionnaire] as n inner join [lfs:Question] as q on isdescendantnode(q, n) where contains(q.sourceVocabularies, '${props.acronym}')`;
       fetch(`/query?query=${encodeURIComponent(query)}&limit=100`)
         .then((response) => response.ok ? response.json() : Promise.reject(response))
         .then((json) => {
@@ -138,7 +138,7 @@ export default function VocabularyAction(props) {
 
     data && Object.entries(data)
       .forEach( ([key, value]) => {
-        if (value["jcr:primaryType"] == "lfs:Question" && value['dataType'] == 'vocabulary' && value['sourceVocabulary'] == props.acronym) {
+        if (value["jcr:primaryType"] == "lfs:Question" && value['dataType'] == 'vocabulary' && value['sourceVocabularies'].includes(props.acronym)) {
           value.questionnaireName = title;
           vocQuestions.push(value);
         }

--- a/questionnaires/clinical-data/src/main/resources/SLING-INF/content/Chemotherapy.json
+++ b/questionnaires/clinical-data/src/main/resources/SLING-INF/content/Chemotherapy.json
@@ -56,7 +56,7 @@
       "minAnswers": 1,
       "maxAnswers": 1,
       "dataType": "vocabulary",
-      "sourceVocabulary": "CHEBI"
+      "sourceVocabulary": ["CHEBI"]
     },
     "start_date": {
       "jcr:primaryType": "lfs:Question",

--- a/questionnaires/clinical-data/src/main/resources/SLING-INF/content/Chemotherapy.json
+++ b/questionnaires/clinical-data/src/main/resources/SLING-INF/content/Chemotherapy.json
@@ -56,7 +56,7 @@
       "minAnswers": 1,
       "maxAnswers": 1,
       "dataType": "vocabulary",
-      "sourceVocabulary": ["CHEBI"]
+      "sourceVocabularies": ["CHEBI"]
     },
     "start_date": {
       "jcr:primaryType": "lfs:Question",

--- a/questionnaires/clinical-data/src/main/resources/SLING-INF/content/Demographics.json
+++ b/questionnaires/clinical-data/src/main/resources/SLING-INF/content/Demographics.json
@@ -48,7 +48,7 @@
     "maxAnswers": 0,
     "displayMode": "list+input",
     "dataType": "vocabulary",
-    "sourceVocabulary": ["HANCESTRO"],
+    "sourceVocabularies": ["HANCESTRO"],
     "vocabularyFilters": {
       "jcr:primaryType": "lfs:VocabularyFilterGroup",
       "HANCESTRO": ["HANCESTRO_0004"]
@@ -350,7 +350,7 @@
     "maxAnswers": 0,
     "displayMode": "list+input",
     "dataType": "vocabulary",
-    "sourceVocabulary": ["SNOMEDCT"],
+    "sourceVocabularies": ["SNOMEDCT"],
     "vocabularyFilters": {
       "jcr:primaryType": "lfs:VocabularyFilterGroup",
       "SNOMEDCT": ["children of Relative"]
@@ -483,7 +483,7 @@
     "maxAnswers": 0,
     "displayMode": "input",
     "dataType": "vocabulary",
-    "sourceVocabulary": ["HP"],
+    "sourceVocabularies": ["HP"],
     "vocabularyFilters": {
         "jcr:primaryType": "lfs:VocabularyFilterGroup",
         "HP": ["HP:0000118"]

--- a/questionnaires/clinical-data/src/main/resources/SLING-INF/content/Demographics.json
+++ b/questionnaires/clinical-data/src/main/resources/SLING-INF/content/Demographics.json
@@ -48,8 +48,11 @@
     "maxAnswers": 0,
     "displayMode": "list+input",
     "dataType": "vocabulary",
-    "sourceVocabulary": "HANCESTRO",
-    "vocabularyFilter": "child of Ethnic group or Racial Group",
+    "sourceVocabulary": ["HANCESTRO"],
+    "vocabularyFilters": {
+      "jcr:primaryType": "lfs:VocabularyFilterGroup",
+      "HANCESTRO": ["child of Ethnic group or Racial Group"]
+    },
     "African race": {
       "jcr:primaryType": "lfs:AnswerOption",
       "value": "African race"
@@ -347,8 +350,11 @@
     "maxAnswers": 0,
     "displayMode": "list+input",
     "dataType": "vocabulary",
-    "sourceVocabulary": "SNOMEDCT",
-    "vocabularyFilter": "children of Relative",
+    "sourceVocabulary": ["SNOMEDCT"],
+    "vocabularyFilters": {
+      "jcr:primaryType": "lfs:VocabularyFilterGroup",
+      "SNOMEDCT": ["children of Relative"]
+    },
     "Proband": {
       "jcr:primaryType": "lfs:AnswerOption",
       "value": "Proband",

--- a/questionnaires/clinical-data/src/main/resources/SLING-INF/content/Demographics.json
+++ b/questionnaires/clinical-data/src/main/resources/SLING-INF/content/Demographics.json
@@ -51,7 +51,7 @@
     "sourceVocabulary": ["HANCESTRO"],
     "vocabularyFilters": {
       "jcr:primaryType": "lfs:VocabularyFilterGroup",
-      "HANCESTRO": ["child of Ethnic group or Racial Group"]
+      "HANCESTRO": ["HANCESTRO_0004"]
     },
     "African race": {
       "jcr:primaryType": "lfs:AnswerOption",

--- a/questionnaires/clinical-data/src/main/resources/SLING-INF/content/Demographics.json
+++ b/questionnaires/clinical-data/src/main/resources/SLING-INF/content/Demographics.json
@@ -477,8 +477,12 @@
     "maxAnswers": 0,
     "displayMode": "input",
     "dataType": "vocabulary",
-    "sourceVocabulary": "HP",
-    "vocabularyFilter": ["HP:0000118"],
+    "sourceVocabulary": ["HP", "ICD-O-3-M"],
+    "vocabularyFilters": {
+        "jcr:primaryType": "lfs:VocabularyFilterGroup",
+        "HP": ["HP:0000118"],
+        "ICD-O-3-M": ["Thing"]
+    },
     "enableNotes" : true
   },
   "inherited_from": {

--- a/questionnaires/clinical-data/src/main/resources/SLING-INF/content/Demographics.json
+++ b/questionnaires/clinical-data/src/main/resources/SLING-INF/content/Demographics.json
@@ -483,11 +483,10 @@
     "maxAnswers": 0,
     "displayMode": "input",
     "dataType": "vocabulary",
-    "sourceVocabulary": ["HP", "ICD-O-3-M"],
+    "sourceVocabulary": ["HP"],
     "vocabularyFilters": {
         "jcr:primaryType": "lfs:VocabularyFilterGroup",
-        "HP": ["HP:0000118"],
-        "ICD-O-3-M": ["Thing"]
+        "HP": ["HP:0000118"]
     },
     "enableNotes" : true
   },

--- a/questionnaires/clinical-data/src/main/resources/SLING-INF/content/Tumors.json
+++ b/questionnaires/clinical-data/src/main/resources/SLING-INF/content/Tumors.json
@@ -382,7 +382,7 @@
     "minAnswers": 0,
     "maxAnswers": 0,
     "dataType": "vocabulary",
-    "sourceVocabulary": "HP"
+    "sourceVocabulary": ["HP"]
   },
   "surgery_extent": {
     "jcr:primaryType": "lfs:Question",

--- a/questionnaires/clinical-data/src/main/resources/SLING-INF/content/Tumors.json
+++ b/questionnaires/clinical-data/src/main/resources/SLING-INF/content/Tumors.json
@@ -382,7 +382,7 @@
     "minAnswers": 0,
     "maxAnswers": 0,
     "dataType": "vocabulary",
-    "sourceVocabulary": ["HP"]
+    "sourceVocabularies": ["HP"]
   },
   "surgery_extent": {
     "jcr:primaryType": "lfs:Question",


### PR DESCRIPTION
- This PR allows for multiple vocabularies (each with their own filter) to be used in `vocabulary` typed questions.

- To test:
     - Build the `LFS-198_test` branch
     - Install the *HP* and *ICD-O-3-M* vocabularies.
     - Create a new *Demographics* form.
     - Under *co-morbidities*, type `neoplasm`. You should see results from both the *HP* and *ICD-O-3-M* vocabularies.

- This PR also fixes the bug described by *LFS-526: Unable to use HANCESTRO vocabulary*. To test, install the *HANCESTRO* vocabulary and in a *Demographics* form, type something for the *race/ethnicity* field.