### PR TITLE
LFS-525: Propogate subject access to nested subjects

### DIFF
--- a/modules/permissions/src/main/java/ca/sickkids/ccm/lfs/permissions/internal/SubjectRestrictionFactory.java
+++ b/modules/permissions/src/main/java/ca/sickkids/ccm/lfs/permissions/internal/SubjectRestrictionFactory.java
@@ -18,10 +18,17 @@
  */
 package ca.sickkids.ccm.lfs.permissions.internal;
 
+import javax.jcr.Session;
+
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionPattern;
+import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.FieldOption;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import ca.sickkids.ccm.lfs.permissions.spi.RestrictionFactory;
 
@@ -36,10 +43,19 @@ public class SubjectRestrictionFactory implements RestrictionFactory
     /** @see #getName */
     public static final String NAME = "lfs:subject";
 
+    @Reference(fieldOption = FieldOption.REPLACE,
+        cardinality = ReferenceCardinality.OPTIONAL,
+        policyOption = ReferencePolicyOption.GREEDY)
+    private ResourceResolverFactory rrf;
+
     @Override
     public RestrictionPattern forValue(PropertyState value)
     {
-        return new SubjectRestrictionPattern(value.getValue(Type.STRING));
+        Session session = null;
+        if (this.rrf != null && this.rrf.getThreadResourceResolver() != null) {
+            session = this.rrf.getThreadResourceResolver().adaptTo(Session.class);
+        }
+        return new SubjectRestrictionPattern(value.getValue(Type.STRING), session);
     }
 
     @Override

--- a/modules/permissions/src/main/java/ca/sickkids/ccm/lfs/permissions/internal/SubjectRestrictionPattern.java
+++ b/modules/permissions/src/main/java/ca/sickkids/ccm/lfs/permissions/internal/SubjectRestrictionPattern.java
@@ -71,14 +71,7 @@ public class SubjectRestrictionPattern implements RestrictionPattern
 
         // Check if the form's subject is the same as the one specified in the restriction
         String subject = formTree.getProperty("subject").getValue(Type.REFERENCE);
-        boolean result = StringUtils.equals(subject, this.targetSubject);
-
-        if (!result) {
-            // Check if the form's subject references the specified subject
-            result = matchesReference(subject);
-        }
-
-        return result;
+        return matchesReference(subject);
     }
 
     @Override
@@ -102,6 +95,10 @@ public class SubjectRestrictionPattern implements RestrictionPattern
      */
     private boolean matchesReference(String uuid)
     {
+        if (StringUtils.equals(uuid, this.targetSubject)) {
+            return true;
+        }
+
         if (this.session == null) {
             LOGGER.warn("Could not match subject UUID {}: session not found.", uuid);
             return false;

--- a/modules/permissions/src/main/java/ca/sickkids/ccm/lfs/permissions/internal/SubjectRestrictionPattern.java
+++ b/modules/permissions/src/main/java/ca/sickkids/ccm/lfs/permissions/internal/SubjectRestrictionPattern.java
@@ -60,7 +60,8 @@ public class SubjectRestrictionPattern implements RestrictionPattern
         // This restriction only applies to Forms and their descendant items.
         // If this is not a Form node, look for one among its ancestors.
         Tree formTree = tree;
-        while (!formTree.getProperty("jcr:primaryType").getValue(Type.STRING).equals("lfs:Form")
+        while ((formTree.getProperty("jcr:primaryType") == null
+            || !formTree.getProperty("jcr:primaryType").getValue(Type.STRING).equals("lfs:Form"))
             && !formTree.isRoot()) {
             formTree = formTree.getParent();
         }

--- a/modules/permissions/src/main/java/ca/sickkids/ccm/lfs/permissions/internal/SubjectRestrictionPattern.java
+++ b/modules/permissions/src/main/java/ca/sickkids/ccm/lfs/permissions/internal/SubjectRestrictionPattern.java
@@ -18,6 +18,7 @@
  */
 package ca.sickkids.ccm.lfs.permissions.internal;
 
+import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
@@ -115,10 +116,11 @@ public class SubjectRestrictionPattern implements RestrictionPattern
                 }
                 subject = this.session.getNodeByIdentifier(nextUuid);
             }
+        } catch (ItemNotFoundException e) {
+            LOGGER.debug("Subject UUID {} is inaccessible", nextUuid, e);
         } catch (RepositoryException e) {
             LOGGER.error("Failed to find subject UUID {}", nextUuid, e);
         }
-
         return false;
     }
 }


### PR DESCRIPTION
Iteratively search for parent subjects when applying subject restriction pattern
- If a subject is referenced by a second subject, forms for this second subject can now be accessed by users with lfs:subject access to the first subject.

For example, if a user has lfs:subject access to patient p1, and patient p1 has a tumor t1, the user can access forms under both p1 and t1