### PR TITLE
[misc] Upgrade to HTTPS requests when accessing data.bioontology.org

### DIFF
--- a/modules/vocabularies/src/main/frontend/src/vocabularyLinks.json
+++ b/modules/vocabularies/src/main/frontend/src/vocabularyLinks.json
@@ -10,10 +10,10 @@
   },
   "local": "/Vocabularies.1.json",
   "recommender": {
-    "base": "http://data.bioontology.org/recommender?"
+    "base": "https://data.bioontology.org/recommender?"
   },
   "remote": {
-    "base": "http://data.bioontology.org/submissions/?",
+    "base": "https://data.bioontology.org/submissions/?",
     "params": {
       "display_context": false,
       "display_links": false,


### PR DESCRIPTION
This PR fixes an issue where requests to `data.bioontology.org` from the client's browser (eg. searching for a particular vocabulary to install) were done over plaintext HTTP and not secured HTTPS. This would allow anyone capable of running a packet sniffer to obtain the BioPortal API key.