### PR TITLE
LFS-539: Allow LiveTable to have custom props

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -194,7 +194,7 @@ function LiveTable(props) {
     }
 
     // Render the cell
-    return <TableCell key={index}>{content}</TableCell>
+    return <TableCell key={index} {...column.props}>{content}</TableCell>
   };
 
   let getNestedValue = (entry, path) => {
@@ -323,7 +323,7 @@ function LiveTable(props) {
           <TableRow>
           { columns ?
             (
-              columns.map((column, index) => <TableCell key={index} className={classes.tableHeader}>{column.label}</TableCell>)
+              columns.map((column, index) => <TableCell key={index} className={classes.tableHeader} {...column.props}>{column.label}</TableCell>)
             )
           :
             (


### PR DESCRIPTION
A feature improvement needed to resolve [this issue](https://github.com/ccmbioinfo/lfs/pull/232#issuecomment-682353387).
This will allow components to adjust the themeing of individual columns within LiveTable.

**To test**: Test branch is `LFS-539-test` -- within it, the "Created on" date in the questionnaires list is right-aligned.