### PR TITLE
LFS-533: Allow upload of vocabulary files

### DIFF
--- a/modules/vocabularies/pom.xml
+++ b/modules/vocabularies/pom.xml
@@ -31,7 +31,7 @@
   <name>LFS - Vocabularies</name>
 
   <properties>
-    <coverage.instructionRatio>0.27</coverage.instructionRatio>
+    <coverage.instructionRatio>0.24</coverage.instructionRatio>
   </properties>
 
   <build>

--- a/modules/vocabularies/src/main/frontend/src/owlInstaller.jsx
+++ b/modules/vocabularies/src/main/frontend/src/owlInstaller.jsx
@@ -98,7 +98,27 @@ export default function OwlInstaller(props) {
       method: form.method,
       body: new FormData(form)
     })
-    .then((res) => { if (!res.ok) { throw new Error("Server Ontology Error") } else { setPhase("Installed"); props.updateLocalList("add", {source: "fileupload", version: owlVersion, released: new Date().toISOString(), ontology: {acronym: owlIdentifier, name: owlName}}) } })
+    .then((res) => {
+        if (!res.ok) {
+            throw new Error("Server Ontology Error");
+        } else {
+            setPhase("Installed");
+            setOwlSelected("Select File");
+            setOwlIdentifier("");
+            setOwlName("");
+            setOwlVersion("");
+            props.updateLocalList("add", {
+                source: "fileupload",
+                version: owlVersion,
+                released: new Date().toISOString(),
+                ontology: {
+                    acronym: owlIdentifier,
+                    name: owlName
+                    }
+                }
+            );
+        }
+    })
     .catch((err) => { setPhase("Failed") });
     setPhase("Installing");
     event.preventDefault();

--- a/modules/vocabularies/src/main/frontend/src/owlInstaller.jsx
+++ b/modules/vocabularies/src/main/frontend/src/owlInstaller.jsx
@@ -114,14 +114,11 @@ export default function OwlInstaller(props) {
           </Tooltip>
         </label>
 
-        <input style={{ display: 'none' }} name="identifier" type="text" value={owlIdentifier}/>
-        {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlIdentifier(evt.target.value)}} label="Identifier"/>) : (<TextField variant="outlined" onChange={(evt) => {setOwlIdentifier(evt.target.value); setPhase("Install")}} label="Identifier"/>))}
+        {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlIdentifier(evt.target.value)}} value={owlIdentifier} name="identifier" label="Identifier"/>) : (<TextField variant="outlined" onChange={(evt) => {setOwlIdentifier(evt.target.value); setPhase("Install")}} value={owlIdentifier} name="identifier" label="Identifier"/>))}
 
-        <input style={{ display: 'none' }} name="vocabName" type="text" value={owlName}/>
-        {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlName(evt.target.value)}} label="Name"/>) : (<TextField variant="outlined" onChange={(evt) => {setOwlName(evt.target.value); setPhase("Install")}} label="Name"/>))}
+        {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlName(evt.target.value)}} value={owlName} name="vocabName" label="Name"/>) : (<TextField variant="outlined" onChange={(evt) => {setOwlName(evt.target.value); setPhase("Install")}} value={owlName} name="vocabName" label="Name"/>))}
 
-        <input style={{ display: 'none' }} name="version" type="text" value={owlVersion}/>
-        {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlVersion(evt.target.value)}} label="Version"/>) : (<TextField variant="outlined" onChange={(evt) => {setOwlVersion(evt.target.value); setPhase("Install")}} label="Version"/>))}
+        {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlVersion(evt.target.value)}} value={owlVersion} name="version" label="Version"/>) : (<TextField variant="outlined" onChange={(evt) => {setOwlVersion(evt.target.value); setPhase("Install")}} value={owlVersion} name="version" label="Version"/>))}
 
         <label htmlFor="owl-install">
           <input style={{ display: 'none' }} id="owl-install" name="owl-install" type={(phase == "Install") ? "submit" : "button"}/>

--- a/modules/vocabularies/src/main/frontend/src/owlInstaller.jsx
+++ b/modules/vocabularies/src/main/frontend/src/owlInstaller.jsx
@@ -1,0 +1,129 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React, { useState } from "react";
+
+import { 
+  Button,
+  CircularProgress,
+  makeStyles,
+  TextField,
+  Tooltip
+} from "@material-ui/core";
+
+const Status = require("./statusCodes.json");
+
+const useStyles = makeStyles(theme => ({
+  owlInstaller: {
+    margin: theme.spacing(1),
+    textTransform: "none"
+  },
+  buttonProgress: {
+    top: "50%",
+    left: "50%",
+    position: "absolute",
+    marginTop: -12,
+    marginLeft: -12,
+    textTransform: "none"
+  },
+  install: {
+    background: theme.palette.success.main,
+    color: theme.palette.success.contrastText,
+    "&:hover": {
+      background: theme.palette.success.dark
+    }
+  },
+  uninstall: {
+    background: theme.palette.error.main,
+    color: theme.palette.error.contrastText,
+    "&:hover": {
+      background: theme.palette.error.dark
+    }
+  },
+  installingColor: {
+    color: theme.palette.success.main
+  },
+  uninstallingColor: {
+    color: theme.palette.error.main
+  },
+  update: {
+    background: theme.palette.warning.main,
+    color: theme.palette.warning.contrastText,
+    "&:hover": {
+      background: theme.palette.warning.dark
+    }
+  },
+  wrapper: {
+    position: "relative",
+    display: "inline-block"
+  }
+}));
+
+export default function OwlInstaller(props) {
+
+  const classes = useStyles();
+
+  let [ phase, setPhase ] = useState("Install");
+  let [ owlIdentifier, setOwlIdentifier ] = useState("");
+  let [ owlName, setOwlName ] = useState("");
+  let [ owlVersion, setOwlVersion ] = useState("");
+
+  let handleSubmit = (event) => {
+    const form = event.target;
+    fetch(form.action, {
+      method: form.method,
+      body: new FormData(form)
+    })
+    .then((res) => {setPhase("Installed"); props.updateLocalList("add", {version: owlVersion, released: new Date().toISOString(), ontology: {acronym: owlIdentifier, name: owlName}})});
+    setPhase("Installing");
+    event.preventDefault();
+  }
+
+  return(
+    <React.Fragment>
+      <form action="/Vocabularies?source=fileupload&overwrite=true" method="POST" enctype="multipart/form-data" onSubmit={handleSubmit}>
+        <label htmlFor="owl-file">
+          <input style={{ display: 'none' }} id="owl-file" name="filename" type="file"/>
+          <Tooltip title="Select a vocabulary to install">
+            {((phase == "Installing") ? (<Button disabled variant="contained" color="primary" component="span">Select OWL</Button>) : (<Button variant="contained" onClick={() => {setPhase("Install")}} color="primary" component="span">Select OWL</Button>))}
+          </Tooltip>
+        </label>
+
+        <input style={{ display: 'none' }} name="identifier" type="text" value={owlIdentifier}/>
+        {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlIdentifier(evt.target.value)}} label="Identifier"/>) : (<TextField variant="outlined" onChange={(evt) => {setOwlIdentifier(evt.target.value); setPhase("Install")}} label="Identifier"/>))}
+
+        <input style={{ display: 'none' }} name="vocabName" type="text" value={owlName}/>
+        {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlName(evt.target.value)}} label="Name"/>) : (<TextField variant="outlined" onChange={(evt) => {setOwlName(evt.target.value); setPhase("Install")}} label="Name"/>))}
+
+        <input style={{ display: 'none' }} name="version" type="text" value={owlVersion}/>
+        {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlVersion(evt.target.value)}} label="Version"/>) : (<TextField variant="outlined" onChange={(evt) => {setOwlVersion(evt.target.value); setPhase("Install")}} label="Version"/>))}
+
+        <label htmlFor="owl-install">
+          <input style={{ display: 'none' }} id="owl-install" name="owl-install" type="submit"/>
+          <Tooltip title="Install this vocabulary">
+            <span className={classes.wrapper}>
+                {((phase == "Installing") ? (<Button disabled variant="contained" color="primary" component="span" className={classes.owlInstaller}>{phase}</Button>) : (<Button variant="contained" color="primary" component="span" className={classes.owlInstaller + " " + ((phase == "Install") ? classes.install : classes.uninstall)}>{phase}</Button>))}
+                {(phase == "Installing") && (<CircularProgress size={24} className={classes.buttonProgress + " " + classes.installingColor} />)}
+            </span>
+          </Tooltip>
+        </label>
+      </form>
+    </React.Fragment>
+  );
+}

--- a/modules/vocabularies/src/main/frontend/src/owlInstaller.jsx
+++ b/modules/vocabularies/src/main/frontend/src/owlInstaller.jsx
@@ -138,13 +138,13 @@ export default function OwlInstaller(props) {
           </Grid>
 
           <Grid item>
-            {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlIdentifier(evt.target.value)}} value={owlIdentifier} name="identifier" label="Identifier"/>) : (<TextField variant="outlined" onChange={(evt) => {setOwlIdentifier(evt.target.value); setPhase("Install")}} value={owlIdentifier} name="identifier" label="Identifier"/>))}
+            {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlIdentifier(evt.target.value)}} value={owlIdentifier} name="identifier" label="Identifier"/>) : (<TextField variant="outlined" error={(owlIdentifier=="")} onChange={(evt) => {setOwlIdentifier(evt.target.value); setPhase("Install")}} value={owlIdentifier} name="identifier" label="Identifier"/>))}
           </Grid>
           <Grid item>
-            {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlName(evt.target.value)}} value={owlName} name="vocabName" label="Name"/>) : (<TextField variant="outlined" onChange={(evt) => {setOwlName(evt.target.value); setPhase("Install")}} value={owlName} name="vocabName" label="Name"/>))}
+            {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlName(evt.target.value)}} value={owlName} name="vocabName" label="Name"/>) : (<TextField variant="outlined" error={(owlName=="")} onChange={(evt) => {setOwlName(evt.target.value); setPhase("Install")}} value={owlName} name="vocabName" label="Name"/>))}
           </Grid>
           <Grid item>
-            {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlVersion(evt.target.value)}} value={owlVersion} name="version" label="Version"/>) : (<TextField variant="outlined" onChange={(evt) => {setOwlVersion(evt.target.value); setPhase("Install")}} value={owlVersion} name="version" label="Version"/>))}
+            {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlVersion(evt.target.value)}} value={owlVersion} name="version" label="Version"/>) : (<TextField variant="outlined" error={(owlVersion=="")} onChange={(evt) => {setOwlVersion(evt.target.value); setPhase("Install")}} value={owlVersion} name="version" label="Version"/>))}
           </Grid>
 
           <Grid item>

--- a/modules/vocabularies/src/main/frontend/src/owlInstaller.jsx
+++ b/modules/vocabularies/src/main/frontend/src/owlInstaller.jsx
@@ -87,7 +87,7 @@ export default function OwlInstaller(props) {
   const classes = useStyles();
 
   let [ phase, setPhase ] = useState("Install");
-  let [ owlSelected, setOwlSelected ] = useState("Select OWL");
+  let [ owlSelected, setOwlSelected ] = useState("Select File");
   let [ owlIdentifier, setOwlIdentifier ] = useState("");
   let [ owlName, setOwlName ] = useState("");
   let [ owlVersion, setOwlVersion ] = useState("");
@@ -108,7 +108,7 @@ export default function OwlInstaller(props) {
     <React.Fragment>
       <form action="/Vocabularies?source=fileupload&overwrite=true" method="POST" encType="multipart/form-data" onSubmit={handleSubmit}>
         <label htmlFor="owl-file">
-          <input style={{ display: 'none' }} id="owl-file" name="filename" onChange={() => {setOwlSelected("OWL Selected")}} type={(phase == "Install") ? "file" : "button"}/>
+          <input style={{ display: 'none' }} id="owl-file" name="filename" onChange={() => {setOwlSelected("File Selected")}} type={(phase == "Install") ? "file" : "button"}/>
           <Tooltip title={(phase == "Install") ? "Select a vocabulary to install" : ""}>
             <Button disabled={(phase == "Installing")} variant="contained" onClick={() => {setPhase("Install")}} color="primary" component="span">{owlSelected}</Button>
           </Tooltip>

--- a/modules/vocabularies/src/main/frontend/src/owlInstaller.jsx
+++ b/modules/vocabularies/src/main/frontend/src/owlInstaller.jsx
@@ -126,25 +126,111 @@ export default function OwlInstaller(props) {
 
   return(
     <React.Fragment>
-      <form action="/Vocabularies?source=fileupload&overwrite=true" method="POST" encType="multipart/form-data" onSubmit={handleSubmit}>
-        <Grid container direction="row" justify="center" alignItems="center" spacing={1}>
+      <form
+        action="/Vocabularies?source=fileupload&overwrite=true"
+        method="POST"
+        encType="multipart/form-data"
+        onSubmit={handleSubmit}
+      >
+        <Grid container
+          direction="row"
+          justify="center"
+          alignItems="center"
+          spacing={1}
+        >
           <Grid item>
             <label htmlFor="owl-file">
-              <input style={{ display: 'none' }} id="owl-file" name="filename" onChange={() => {setOwlSelected("File Selected")}} type={(phase == "Install") ? "file" : "button"}/>
-                <Tooltip title={(phase == "Install") ? "Select a vocabulary to install" : ""}>
-                  <Button disabled={(phase == "Installing")} variant="contained" onClick={() => {setPhase("Install")}} color="primary" component="span">{owlSelected}</Button>
-                </Tooltip>
+              <input
+                style={{ display: 'none' }}
+                id="owl-file"
+                name="filename"
+                onChange={() => {setOwlSelected("File Selected")}}
+                type={(phase == "Install") ? "file" : "button"}
+              />
+              <Tooltip title={(phase == "Install") ? "Select a vocabulary to install" : ""}>
+                <Button
+                  disabled={(phase == "Installing")}
+                  variant="contained"
+                  onClick={() => {setPhase("Install")}}
+                  color="primary"
+                  component="span">
+                    {owlSelected}
+                </Button>
+              </Tooltip>
             </label>
           </Grid>
 
           <Grid item>
-            {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlIdentifier(evt.target.value)}} value={owlIdentifier} name="identifier" label="Identifier"/>) : (<TextField variant="outlined" error={(owlIdentifier=="")} onChange={(evt) => {setOwlIdentifier(evt.target.value); setPhase("Install")}} value={owlIdentifier} name="identifier" label="Identifier"/>))}
+            {(phase == "Installing") ?
+              (<TextField
+                 disabled
+                 variant="outlined"
+                 onChange={(evt) => {setOwlIdentifier(evt.target.value)}}
+                 value={owlIdentifier}
+                 name="identifier"
+                 label="Identifier"
+               />)
+              :
+              (<TextField
+                 variant="outlined"
+                 error={(owlIdentifier == "")}
+                 onChange={(evt) => {
+                   setOwlIdentifier(evt.target.value);
+                   setPhase("Install")
+                 }}
+                 value={owlIdentifier}
+                 name="identifier"
+                 label="Identifier"
+               />)
+            }
           </Grid>
           <Grid item>
-            {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlName(evt.target.value)}} value={owlName} name="vocabName" label="Name"/>) : (<TextField variant="outlined" error={(owlName=="")} onChange={(evt) => {setOwlName(evt.target.value); setPhase("Install")}} value={owlName} name="vocabName" label="Name"/>))}
+            {(phase == "Installing") ?
+              (<TextField
+                 disabled
+                 variant="outlined"
+                 onChange={(evt) => {setOwlName(evt.target.value)}}
+                 value={owlName}
+                 name="vocabName"
+                 label="Name"
+               />)
+              :
+              (<TextField
+                 variant="outlined"
+                 error={(owlName == "")}
+                 onChange={(evt) => {
+                   setOwlName(evt.target.value);
+                   setPhase("Install")
+                 }}
+                 value={owlName}
+                 name="vocabName"
+                 label="Name"
+               />)
+            }
           </Grid>
           <Grid item>
-            {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlVersion(evt.target.value)}} value={owlVersion} name="version" label="Version"/>) : (<TextField variant="outlined" error={(owlVersion=="")} onChange={(evt) => {setOwlVersion(evt.target.value); setPhase("Install")}} value={owlVersion} name="version" label="Version"/>))}
+            {(phase == "Installing") ?
+              (<TextField
+                 disabled
+                 variant="outlined"
+                 onChange={(evt) => {setOwlVersion(evt.target.value)}}
+                 value={owlVersion}
+                 name="version"
+                 label="Version"
+               />)
+              :
+              (<TextField
+                 variant="outlined"
+                 error={(owlVersion == "")}
+                 onChange={(evt) => {
+                   setOwlVersion(evt.target.value);
+                   setPhase("Install")
+                 }}
+                 value={owlVersion}
+                 name="version"
+                 label="Version"
+              />)
+            }
           </Grid>
 
           <Grid item>
@@ -152,11 +238,53 @@ export default function OwlInstaller(props) {
               <input style={{ display: 'none' }} id="owl-install" name="owl-install" type={(phase == "Install") ? "submit" : "button"}/>
                 <Tooltip title={(phase == "Install") ? "Install this vocabulary" : ""}>
                   <span className={classes.wrapper}>
-                      {(phase == "Install") && (<Button variant="contained" color="primary" component="span" className={classes.owlInstaller + " " + classes.install}>{phase}</Button>)}
-                      {(phase == "Installed") && (<Button variant="contained" color="primary" component="span" className={classes.owlInstaller + " " + classes.installed}>{phase}</Button>)}
-                      {(phase == "Failed") && (<Button variant="contained" color="primary" component="span" className={classes.owlInstaller + " " + classes.failed}>{phase}</Button>)}
-                      {(phase == "Installing") && (<Button disabled variant="contained" color="primary" component="span" className={classes.owlInstaller}>{phase}</Button>)}
-                      {(phase == "Installing") && (<CircularProgress size={24} className={classes.buttonProgress + " " + classes.installingColor} />)}
+                      {(phase == "Install") &&
+                        <Button
+                          variant="contained"
+                          color="primary"
+                          component="span"
+                          className={classes.owlInstaller + " " + classes.install}
+                        >
+                          {phase}
+                        </Button>
+                      }
+                      {(phase == "Installed") &&
+                        <Button
+                          variant="contained"
+                          color="primary"
+                          component="span"
+                          className={classes.owlInstaller + " " + classes.installed}
+                        >
+                          {phase}
+                        </Button>
+                      }
+                      {(phase == "Failed") &&
+                        <Button
+                          variant="contained"
+                          color="primary"
+                          component="span"
+                          className={classes.owlInstaller + " " + classes.failed}
+                        >
+                          {phase}
+                        </Button>
+                      }
+                      {(phase == "Installing") &&
+                        <Button
+                          disabled
+                          variant="contained"
+                          color="primary"
+                          component="span"
+                          className={classes.owlInstaller}
+                        >
+                          {phase}
+                        </Button>
+                      }
+                      {(phase == "Installing") &&
+                        <CircularProgress
+                          size={24}
+                          className={classes.buttonProgress + " " + classes.installingColor}
+                        />
+                      }
                   </span>
                 </Tooltip>
             </label>

--- a/modules/vocabularies/src/main/frontend/src/owlInstaller.jsx
+++ b/modules/vocabularies/src/main/frontend/src/owlInstaller.jsx
@@ -98,7 +98,7 @@ export default function OwlInstaller(props) {
       method: form.method,
       body: new FormData(form)
     })
-    .then((res) => { if (!res.ok) { throw new Error("Server Ontology Error") } else { setPhase("Installed"); props.updateLocalList("add", {version: owlVersion, released: new Date().toISOString(), ontology: {acronym: owlIdentifier, name: owlName}}) } })
+    .then((res) => { if (!res.ok) { throw new Error("Server Ontology Error") } else { setPhase("Installed"); props.updateLocalList("add", {source: "fileupload", version: owlVersion, released: new Date().toISOString(), ontology: {acronym: owlIdentifier, name: owlName}}) } })
     .catch((err) => { setPhase("Failed") });
     setPhase("Installing");
     event.preventDefault();

--- a/modules/vocabularies/src/main/frontend/src/owlInstaller.jsx
+++ b/modules/vocabularies/src/main/frontend/src/owlInstaller.jsx
@@ -92,6 +92,12 @@ export default function OwlInstaller(props) {
   let [ owlName, setOwlName ] = useState("");
   let [ owlVersion, setOwlVersion ] = useState("");
 
+  let disableInstall = (phase != "Install")
+      || (owlSelected == "Select File")
+      || (owlIdentifier == "")
+      || (owlName == "")
+      || (owlVersion == "");
+
   let handleSubmit = (event) => {
     const form = event.target;
     fetch(form.action, {
@@ -235,7 +241,7 @@ export default function OwlInstaller(props) {
 
           <Grid item>
             <label htmlFor="owl-install">
-              <input style={{ display: 'none' }} id="owl-install" name="owl-install" type={(phase == "Install") ? "submit" : "button"}/>
+              <input style={{ display: 'none' }} id="owl-install" name="owl-install" type={disableInstall ? "button" : "submit"}/>
                 <Tooltip title={(phase == "Install") ? "Install this vocabulary" : ""}>
                   <span className={classes.wrapper}>
                       {(phase == "Install") &&
@@ -243,6 +249,7 @@ export default function OwlInstaller(props) {
                           variant="contained"
                           color="primary"
                           component="span"
+                          disabled={disableInstall}
                           className={classes.owlInstaller + " " + classes.install}
                         >
                           {phase}

--- a/modules/vocabularies/src/main/frontend/src/owlInstaller.jsx
+++ b/modules/vocabularies/src/main/frontend/src/owlInstaller.jsx
@@ -22,6 +22,7 @@ import React, { useState } from "react";
 import { 
   Button,
   CircularProgress,
+  Grid,
   makeStyles,
   TextField,
   Tooltip
@@ -31,7 +32,6 @@ const Status = require("./statusCodes.json");
 
 const useStyles = makeStyles(theme => ({
   owlInstaller: {
-    margin: theme.spacing(1),
     textTransform: "none"
   },
   buttonProgress: {
@@ -127,31 +127,41 @@ export default function OwlInstaller(props) {
   return(
     <React.Fragment>
       <form action="/Vocabularies?source=fileupload&overwrite=true" method="POST" encType="multipart/form-data" onSubmit={handleSubmit}>
-        <label htmlFor="owl-file">
-          <input style={{ display: 'none' }} id="owl-file" name="filename" onChange={() => {setOwlSelected("File Selected")}} type={(phase == "Install") ? "file" : "button"}/>
-          <Tooltip title={(phase == "Install") ? "Select a vocabulary to install" : ""}>
-            <Button disabled={(phase == "Installing")} variant="contained" onClick={() => {setPhase("Install")}} color="primary" component="span">{owlSelected}</Button>
-          </Tooltip>
-        </label>
+        <Grid container direction="row" justify="center" alignItems="center" spacing={1}>
+          <Grid item>
+            <label htmlFor="owl-file">
+              <input style={{ display: 'none' }} id="owl-file" name="filename" onChange={() => {setOwlSelected("File Selected")}} type={(phase == "Install") ? "file" : "button"}/>
+                <Tooltip title={(phase == "Install") ? "Select a vocabulary to install" : ""}>
+                  <Button disabled={(phase == "Installing")} variant="contained" onClick={() => {setPhase("Install")}} color="primary" component="span">{owlSelected}</Button>
+                </Tooltip>
+            </label>
+          </Grid>
 
-        {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlIdentifier(evt.target.value)}} value={owlIdentifier} name="identifier" label="Identifier"/>) : (<TextField variant="outlined" onChange={(evt) => {setOwlIdentifier(evt.target.value); setPhase("Install")}} value={owlIdentifier} name="identifier" label="Identifier"/>))}
+          <Grid item>
+            {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlIdentifier(evt.target.value)}} value={owlIdentifier} name="identifier" label="Identifier"/>) : (<TextField variant="outlined" onChange={(evt) => {setOwlIdentifier(evt.target.value); setPhase("Install")}} value={owlIdentifier} name="identifier" label="Identifier"/>))}
+          </Grid>
+          <Grid item>
+            {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlName(evt.target.value)}} value={owlName} name="vocabName" label="Name"/>) : (<TextField variant="outlined" onChange={(evt) => {setOwlName(evt.target.value); setPhase("Install")}} value={owlName} name="vocabName" label="Name"/>))}
+          </Grid>
+          <Grid item>
+            {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlVersion(evt.target.value)}} value={owlVersion} name="version" label="Version"/>) : (<TextField variant="outlined" onChange={(evt) => {setOwlVersion(evt.target.value); setPhase("Install")}} value={owlVersion} name="version" label="Version"/>))}
+          </Grid>
 
-        {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlName(evt.target.value)}} value={owlName} name="vocabName" label="Name"/>) : (<TextField variant="outlined" onChange={(evt) => {setOwlName(evt.target.value); setPhase("Install")}} value={owlName} name="vocabName" label="Name"/>))}
-
-        {((phase == "Installing") ? (<TextField disabled variant="outlined" onChange={(evt) => {setOwlVersion(evt.target.value)}} value={owlVersion} name="version" label="Version"/>) : (<TextField variant="outlined" onChange={(evt) => {setOwlVersion(evt.target.value); setPhase("Install")}} value={owlVersion} name="version" label="Version"/>))}
-
-        <label htmlFor="owl-install">
-          <input style={{ display: 'none' }} id="owl-install" name="owl-install" type={(phase == "Install") ? "submit" : "button"}/>
-          <Tooltip title={(phase == "Install") ? "Install this vocabulary" : ""}>
-            <span className={classes.wrapper}>
-                {(phase == "Install") && (<Button variant="contained" color="primary" component="span" className={classes.owlInstaller + " " + classes.install}>{phase}</Button>)}
-                {(phase == "Installed") && (<Button variant="contained" color="primary" component="span" className={classes.owlInstaller + " " + classes.installed}>{phase}</Button>)}
-                {(phase == "Failed") && (<Button variant="contained" color="primary" component="span" className={classes.owlInstaller + " " + classes.failed}>{phase}</Button>)}
-                {(phase == "Installing") && (<Button disabled variant="contained" color="primary" component="span" className={classes.owlInstaller}>{phase}</Button>)}
-                {(phase == "Installing") && (<CircularProgress size={24} className={classes.buttonProgress + " " + classes.installingColor} />)}
-            </span>
-          </Tooltip>
-        </label>
+          <Grid item>
+            <label htmlFor="owl-install">
+              <input style={{ display: 'none' }} id="owl-install" name="owl-install" type={(phase == "Install") ? "submit" : "button"}/>
+                <Tooltip title={(phase == "Install") ? "Install this vocabulary" : ""}>
+                  <span className={classes.wrapper}>
+                      {(phase == "Install") && (<Button variant="contained" color="primary" component="span" className={classes.owlInstaller + " " + classes.install}>{phase}</Button>)}
+                      {(phase == "Installed") && (<Button variant="contained" color="primary" component="span" className={classes.owlInstaller + " " + classes.installed}>{phase}</Button>)}
+                      {(phase == "Failed") && (<Button variant="contained" color="primary" component="span" className={classes.owlInstaller + " " + classes.failed}>{phase}</Button>)}
+                      {(phase == "Installing") && (<Button disabled variant="contained" color="primary" component="span" className={classes.owlInstaller}>{phase}</Button>)}
+                      {(phase == "Installing") && (<CircularProgress size={24} className={classes.buttonProgress + " " + classes.installingColor} />)}
+                  </span>
+                </Tooltip>
+            </label>
+          </Grid>
+        </Grid>
       </form>
     </React.Fragment>
   );

--- a/modules/vocabularies/src/main/frontend/src/owlInstaller.jsx
+++ b/modules/vocabularies/src/main/frontend/src/owlInstaller.jsx
@@ -106,7 +106,7 @@ export default function OwlInstaller(props) {
 
   return(
     <React.Fragment>
-      <form action="/Vocabularies?source=fileupload&overwrite=true" method="POST" enctype="multipart/form-data" onSubmit={handleSubmit}>
+      <form action="/Vocabularies?source=fileupload&overwrite=true" method="POST" encType="multipart/form-data" onSubmit={handleSubmit}>
         <label htmlFor="owl-file">
           <input style={{ display: 'none' }} id="owl-file" name="filename" onChange={() => {setOwlSelected("OWL Selected")}} type={(phase == "Install") ? "file" : "button"}/>
           <Tooltip title={(phase == "Install") ? "Select a vocabulary to install" : ""}>

--- a/modules/vocabularies/src/main/frontend/src/vocabulariesAdminPage.jsx
+++ b/modules/vocabularies/src/main/frontend/src/vocabulariesAdminPage.jsx
@@ -169,7 +169,7 @@ export default function VocabulariesAdminPage() {
         vocabList={localVocabList}
         setVocabList={processLocalVocabList}
         acronymPhaseObject={acronymPhaseObject}
-        displayTables={displayTables}
+        displayTables={true}
         updateLocalList={updateLocalList}
         addSetter={addSetter}
         setPhase={setPhase}

--- a/modules/vocabularies/src/main/frontend/src/vocabulariesAdminPage.jsx
+++ b/modules/vocabularies/src/main/frontend/src/vocabulariesAdminPage.jsx
@@ -26,6 +26,8 @@ import React from "react";
 
 import VocabularyDirectory from "./vocabularyDirectory";
 
+import OwlInstaller from "./owlInstaller";
+
 import fetchBioPortalApiKey from "./bioportalApiKey";
 
 const Phase = require("./phaseCodes.json");
@@ -172,6 +174,14 @@ export default function VocabulariesAdminPage() {
         addSetter={addSetter}
         setPhase={setPhase}
       />
+
+      <Grid item>
+        <Typography variant="h2">
+          Install from OWL file
+        </Typography>
+      </Grid>
+
+      <OwlInstaller updateLocalList={updateLocalList}/>
 
       <Grid item>
         <Typography variant="h2">

--- a/modules/vocabularies/src/main/frontend/src/vocabulariesAdminPage.jsx
+++ b/modules/vocabularies/src/main/frontend/src/vocabulariesAdminPage.jsx
@@ -151,7 +151,13 @@ export default function VocabulariesAdminPage() {
   }
 
   if (bioPortalApiKey === null) {
-    fetchBioPortalApiKey(setBioPortalApiKey, () => { console.error("Can't fetch bioPortal API key"); });
+    /* If the BioPortal API key cannot be loaded, assume the remote (empty)
+     * data has been loaded.
+     */
+    fetchBioPortalApiKey(setBioPortalApiKey, () => {
+        setRemoteLoaded(true);
+        console.error("Can't fetch bioPortal API key");
+    });
   }
 
   return (
@@ -169,7 +175,7 @@ export default function VocabulariesAdminPage() {
         vocabList={localVocabList}
         setVocabList={processLocalVocabList}
         acronymPhaseObject={acronymPhaseObject}
-        displayTables={true}
+        displayTables={displayTables}
         updateLocalList={updateLocalList}
         addSetter={addSetter}
         setPhase={setPhase}

--- a/modules/vocabularies/src/main/frontend/src/vocabulariesAdminPage.jsx
+++ b/modules/vocabularies/src/main/frontend/src/vocabulariesAdminPage.jsx
@@ -183,7 +183,7 @@ export default function VocabulariesAdminPage() {
 
       <Grid item>
         <Typography variant="h2">
-          Install from OWL file
+          Install from local file
         </Typography>
       </Grid>
 

--- a/modules/vocabularies/src/main/frontend/src/vocabularyDirectory.jsx
+++ b/modules/vocabularies/src/main/frontend/src/vocabularyDirectory.jsx
@@ -65,7 +65,8 @@ function reformat(data) {
     },
     version: filtered[key]["version"],
     released: filtered[key]["jcr:created"],
-    description: filtered[key]["description"]
+    description: filtered[key]["description"],
+    source: filtered[key]["source"]
   }));
   return vocabularies;
 }

--- a/modules/vocabularies/src/main/frontend/src/vocabularyEntry.jsx
+++ b/modules/vocabularies/src/main/frontend/src/vocabularyEntry.jsx
@@ -200,6 +200,7 @@ export default function VocabularyEntry(props) {
                 phase={phase}
               />
 
+              {(!(props?.source == "fileupload")) &&
               <VocabularyDetails
                 acronym={props.acronym}
                 install={install}
@@ -208,6 +209,7 @@ export default function VocabularyEntry(props) {
                 name={props.name}
                 description={props.description}
               />
+              }
             </React.Fragment>
             }
           </StyledTableCell>

--- a/modules/vocabularies/src/main/frontend/src/vocabularyTable.jsx
+++ b/modules/vocabularies/src/main/frontend/src/vocabularyTable.jsx
@@ -123,6 +123,7 @@ export default function VocabularyTable(props) {
                       key={vocab.ontology.acronym}
                       acronym={vocab.ontology.acronym}
                       name={vocab.ontology.name}
+                      source={vocab.source}
                       description={vocab.description}
                       released={vocab.released}
                       version={vocab.version}
@@ -130,7 +131,7 @@ export default function VocabularyTable(props) {
                       // If filterTable is True, then check if the acronym is of a vocabulary to be displayed
                       // If filterTable is False, then don't hide anything
                       hidden={filterTable && !acronymList.includes(vocab.ontology.acronym)}
-                      initPhase={(
+                      initPhase={(vocab.source == "fileupload") ? Phase["Latest"] : (
                         props.acronymPhaseObject.hasOwnProperty(vocab.ontology.acronym) ?
                           props.acronymPhaseObject[vocab.ontology.acronym]
                           :

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/BioOntologyIndexer.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/BioOntologyIndexer.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.util.List;
 
 import javax.jcr.Node;
-import javax.jcr.RepositoryException;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -127,7 +126,7 @@ public class BioOntologyIndexer implements VocabularyIndexer
             temporaryFile = this.repository.downloadVocabularySource(description);
 
             // Create a new Vocabulary node representing this vocabulary
-            this.vocabularyNode.set(createVocabularyNode(homepage, description));
+            this.vocabularyNode.set(OntologyIndexerUtils.createVocabularyNode(homepage, description));
 
             // Parse the source file and create VocabularyTerm node children
             parser.parse(temporaryFile, description, this::createVocabularyTermNode);
@@ -137,7 +136,7 @@ public class BioOntologyIndexer implements VocabularyIndexer
              * the repository will remain in its original state. Lucene indexing is automatically performed by the
              * Jackrabbit Oak repository when this is performed.
              */
-            saveSession(homepage);
+            OntologyIndexerUtils.saveSession(homepage);
 
             // Success response json
             this.utils.writeStatusJson(request, response, true, null);
@@ -152,56 +151,8 @@ public class BioOntologyIndexer implements VocabularyIndexer
         }
     }
 
-    /**
-     * Creates a <code>Vocabulary</code> node that represents the current vocabulary instance with the identifier as the
-     * name of the node.
-     *
-     * @param homepage <code>VocabulariesHomepage</code> node instance that will be parent of the new vocabulary node
-     * @param description the vocabulary description, holding all the relevant information about the vocabulary
-     * @return the <code>Vocabulary</code> node that was created
-     * @throws VocabularyIndexException when node cannot be created
-     */
-    private Node createVocabularyNode(final Node homepage, final VocabularyDescription description)
-        throws VocabularyIndexException
-    {
-        try {
-            Node result = homepage.addNode("./" + description.getIdentifier(), "lfs:Vocabulary");
-            result.setProperty("identifier", description.getIdentifier());
-            result.setProperty("name", description.getName());
-            result.setProperty("description", description.getDescription());
-            result.setProperty("source", description.getSource());
-            result.setProperty("version", description.getVersion());
-            result.setProperty("website", description.getWebsite());
-            result.setProperty("citation", description.getCitation());
-            return result;
-        } catch (RepositoryException e) {
-            String message = "Failed to create Vocabulary node: " + e.getMessage();
-            LOGGER.error(message, e);
-            throw new VocabularyIndexException(message, e);
-        }
-    }
-
     private void createVocabularyTermNode(VocabularyTermSource term)
     {
         OntologyIndexerUtils.createVocabularyTermNode(term, this.vocabularyNode);
-    }
-
-    /**
-     * Saves the JCR session of the homepage node that was obtained from the resource of the request. If this is
-     * successful, then the changes made already will be applied to the JCR repository. If not, then all of the changes
-     * will be discarded, reverting to the original state.
-     *
-     * @param vocabulariesHomepage the <code>VocabulariesHomepage</code> node obtained from the request
-     * @throws VocabularyIndexException if session is not successfully saved
-     */
-    private void saveSession(Node vocabulariesHomepage)
-        throws VocabularyIndexException
-    {
-        try {
-            vocabulariesHomepage.getSession().save();
-        } catch (RepositoryException e) {
-            String message = "Failed to save session: " + e.getMessage();
-            throw new VocabularyIndexException(message, e);
-        }
     }
 }

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/BioOntologyIndexer.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/BioOntologyIndexer.java
@@ -21,18 +21,12 @@ package ca.sickkids.ccm.lfs.vocabularies.internal;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
-import javax.jcr.ItemExistsException;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.osgi.service.component.annotations.Component;
@@ -187,49 +181,9 @@ public class BioOntologyIndexer implements VocabularyIndexer
         }
     }
 
-    /**
-     * Creates a <code>VocabularyTerm</code> node representing an individual term of the vocabulary.
-     *
-     * @param term the term data
-     * @throws VocabularyIndexException when a node cannot be created
-     */
     private void createVocabularyTermNode(VocabularyTermSource term)
     {
-        try {
-            Node vocabularyTermNode;
-            try {
-                vocabularyTermNode = this.vocabularyNode.get()
-                                         .addNode("./" + term.getId()
-                                         .replaceAll("[^A-Za-z0-9_\\.]", ""), "lfs:VocabularyTerm");
-            } catch (ItemExistsException e) {
-                // Sometimes terms appear twice; we'll just update the existing node
-                vocabularyTermNode = this.vocabularyNode.get().getNode(term.getId());
-            }
-            vocabularyTermNode.setProperty("identifier", term.getId());
-
-            vocabularyTermNode.setProperty("label", term.getLabel());
-            vocabularyTermNode.setProperty("parents", term.getParents());
-            vocabularyTermNode.setProperty("ancestors", term.getAncestors());
-
-            Iterator<Map.Entry<String, Collection<String>>> it = term.getAllProperties().asMap().entrySet().iterator();
-            while (it.hasNext()) {
-                Map.Entry<String, Collection<String>> entry = it.next();
-                String[] valuesArray = entry.getValue().toArray(ArrayUtils.EMPTY_STRING_ARRAY);
-                // Sometimes the source may contain more than one label or description, but we can't allow that.
-                // Always use one value for these special fields.
-                if (("label".equals(entry.getKey()) || "description".equals(entry.getKey()))
-                        && valuesArray.length == 1) {
-                    vocabularyTermNode.setProperty(entry.getKey(), valuesArray[0]);
-                } else {
-                    vocabularyTermNode.setProperty(entry.getKey(), valuesArray);
-                }
-            }
-        } catch (RepositoryException e) {
-            // If the identifier exists, print the identifier in the error message to identify node
-            LOGGER.warn("Failed to create VocabularyTerm node {}: {}", StringUtils.defaultString(term.getId()),
-                e.getMessage());
-
-        }
+        OntologyIndexerUtils.createVocabularyTermNode(term, this.vocabularyNode);
     }
 
     /**

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/EbiRepositoryHandler.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/EbiRepositoryHandler.java
@@ -90,7 +90,8 @@ public class EbiRepositoryHandler implements RepositoryHandler
                     .withDescription(configJson.getString("description", null))
                     .withWebsite(configJson.getString("homepage", null))
                     .withSource(configJson.getString("fileLocation", null))
-                    .withSourceFormat(getSourceFormat(configJson.getString("fileLocation", null)));
+                    .withSourceFormat(OntologyFormatDetection.getSourceFormat(
+                        configJson.getString("fileLocation", null)));
                 return desc.build();
             } else {
                 // If the HTTP request is not successful, throw an exception
@@ -145,15 +146,5 @@ public class EbiRepositoryHandler implements RepositoryHandler
             LOGGER.warn(message, e);
             throw new IOException(message, e);
         }
-    }
-
-    private String getSourceFormat(String sourceURL)
-    {
-        if (sourceURL != null && sourceURL.endsWith(".obo")) {
-            return "OBO";
-        }
-        // TODO Can files ending in .rdf be parsed just like .owl files?
-        // They use rdfs:Class instead of owl:Class, but otherwise the structure is similar
-        return "OWL";
     }
 }

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/FileUploadIndexer.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/FileUploadIndexer.java
@@ -127,7 +127,7 @@ public class FileUploadIndexer implements VocabularyIndexer
             } else {
                 description = new VocabularyDescriptionBuilder()
                     .withSource("fileupload")
-                    .withSourceFormat("OWL")
+                    .withSourceFormat(OntologyFormatDetection.getSourceFormat(uploadedOntology.getFileName()))
                     .withIdentifier(identifier)
                     .withName(vocabName)
                     .withVersion(version)

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/FileUploadIndexer.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/FileUploadIndexer.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package ca.sickkids.ccm.lfs.vocabularies.internal;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.jcr.ItemExistsException;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.request.RequestParameter;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ca.sickkids.ccm.lfs.vocabularies.spi.SourceParser;
+import ca.sickkids.ccm.lfs.vocabularies.spi.VocabularyDescription;
+import ca.sickkids.ccm.lfs.vocabularies.spi.VocabularyDescriptionBuilder;
+import ca.sickkids.ccm.lfs.vocabularies.spi.VocabularyIndexException;
+import ca.sickkids.ccm.lfs.vocabularies.spi.VocabularyIndexer;
+import ca.sickkids.ccm.lfs.vocabularies.spi.VocabularyParserUtils;
+import ca.sickkids.ccm.lfs.vocabularies.spi.VocabularyTermSource;
+
+/**
+ * Generic indexer for vocabularies available on the <a href="http://data.bioontology.org/">BioOntology</a> portal.
+ * BioOntology is a RESTfull server serving a large collection of vocabularies, available as OWL sources, along with
+ * meta-information.
+ * <p>
+ * To be invoked, this indexer requires that:
+ * <ul>
+ * <li>the {@code source} request parameter is {@code bioontology}</li>
+ * <li>the {@code identifier} request parameter is a valid, case-sensitive identifier of a vocabulary available in the
+ * BioOntology server</li>
+ * </ul>
+ * An optional {@code version} parameter can be used to index a specific version of the target vocabulary. If not
+ * specified, then the latest available version will be used.
+ *
+ * @version $Id$
+ */
+@Component(
+    service = VocabularyIndexer.class,
+    name = "VocabularyIndexer.fileupload")
+public class FileUploadIndexer implements VocabularyIndexer
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileUploadIndexer.class);
+
+    @Reference
+    private VocabularyParserUtils utils;
+
+    /**
+     * Automatically injected list of all available parsers. A {@code volatile} list dynamically changes when
+     * implementations are added, removed, or replaced.
+     */
+    @Reference
+    private volatile List<SourceParser> parsers;
+
+    /** The vocabulary node where the indexed data must be placed. */
+    private InheritableThreadLocal<Node> vocabularyNode = new InheritableThreadLocal<>();
+
+    @Override
+    public boolean canIndex(String source)
+    {
+        return "fileupload".equals(source);
+    }
+
+    @Override
+    public void index(final String source, final SlingHttpServletRequest request,
+        final SlingHttpServletResponse response)
+        throws IOException, VocabularyIndexException
+    {
+        // Obtain relevant request parameters.
+        String identifier = request.getParameter("identifier");
+        String version = request.getParameter("version");
+        String vocabName = request.getParameter("vocabName");
+        String overwrite = request.getParameter("overwrite");
+        RequestParameter uploadedOntology = request.getRequestParameter("filename");
+
+        // Obtain the resource of the request and adapt it to a JCR node. This must be the /Vocabularies homepage node.
+        Node homepage = request.getResource().adaptTo(Node.class);
+
+        File temporaryFile = null;
+        try {
+            // Throw exceptions if mandatory parameters are not found or if homepage node cannot be found
+            if (identifier == null) {
+                throw new VocabularyIndexException("Mandatory [identifier] parameter not provided.");
+            }
+
+            if (homepage == null) {
+                throw new VocabularyIndexException("Could not access resource of your request.");
+            }
+
+            // Delete the Vocabulary node already representing this vocabulary instance if it exists
+            this.utils.clearVocabularyNode(homepage, identifier, overwrite);
+
+            // Load the description
+            VocabularyDescription description;
+            if (uploadedOntology == null) {
+                description = null;
+            } else {
+                description = new VocabularyDescriptionBuilder()
+                    .withSource("")
+                    .withSourceFormat("OWL")
+                    .withIdentifier(identifier)
+                    .withName(vocabName)
+                    .withVersion(version)
+                    .build();
+            }
+
+            // Check that we have a known parser for this vocabulary
+            SourceParser parser =
+                this.parsers.stream().filter(p -> p.canParse(description.getSourceFormat())).findFirst()
+                    .orElseThrow(() -> new VocabularyIndexException("No known parsers for vocabulary [" + identifier
+                        + "] in format [" + description.getSourceFormat() + "]"));
+
+            // Download the source
+            if (uploadedOntology == null) {
+                temporaryFile = null;
+            } else {
+                temporaryFile = File.createTempFile("LocalUpload-" + identifier, "");
+                FileUtils.copyInputStreamToFile(uploadedOntology.getInputStream(), temporaryFile);
+            }
+
+            // Create a new Vocabulary node representing this vocabulary
+            this.vocabularyNode.set(createVocabularyNode(homepage, description));
+
+            // Parse the source file and create VocabularyTerm node children
+            parser.parse(temporaryFile, description, this::createVocabularyTermNode);
+
+            /*
+             * Save the JCR session. If any errors occur before this step, all proposed changes will not be applied and
+             * the repository will remain in its original state. Lucene indexing is automatically performed by the
+             * Jackrabbit Oak repository when this is performed.
+             */
+            saveSession(homepage);
+
+            // Success response json
+            this.utils.writeStatusJson(request, response, true, null);
+        } catch (Exception e) {
+            // If parsing fails, return an error json with the exception message
+            this.utils.writeStatusJson(request, response, false, "Vocabulary indexing error: " + e.getMessage());
+            LOGGER.error("Vocabulary indexing error: {}", e.getMessage(), e);
+        } finally {
+            // Delete temporary source file
+            FileUtils.deleteQuietly(temporaryFile);
+            this.vocabularyNode.remove();
+        }
+    }
+
+    /**
+     * Creates a <code>Vocabulary</code> node that represents the current vocabulary instance with the identifier as the
+     * name of the node.
+     *
+     * @param homepage <code>VocabulariesHomepage</code> node instance that will be parent of the new vocabulary node
+     * @param description the vocabulary description, holding all the relevant information about the vocabulary
+     * @return the <code>Vocabulary</code> node that was created
+     * @throws VocabularyIndexException when node cannot be created
+     */
+    private Node createVocabularyNode(final Node homepage, final VocabularyDescription description)
+        throws VocabularyIndexException
+    {
+        try {
+            Node result = homepage.addNode("./" + description.getIdentifier(), "lfs:Vocabulary");
+            result.setProperty("identifier", description.getIdentifier());
+            result.setProperty("name", description.getName());
+            result.setProperty("description", description.getDescription());
+            result.setProperty("source", description.getSource());
+            result.setProperty("version", description.getVersion());
+            result.setProperty("website", description.getWebsite());
+            result.setProperty("citation", description.getCitation());
+            return result;
+        } catch (RepositoryException e) {
+            String message = "Failed to create Vocabulary node: " + e.getMessage();
+            LOGGER.error(message, e);
+            throw new VocabularyIndexException(message, e);
+        }
+    }
+
+    /**
+     * Creates a <code>VocabularyTerm</code> node representing an individual term of the vocabulary.
+     *
+     * @param term the term data
+     * @throws VocabularyIndexException when a node cannot be created
+     */
+    private void createVocabularyTermNode(VocabularyTermSource term)
+    {
+        try {
+            Node vocabularyTermNode;
+            try {
+                //Hack to deal with testing with limited RAM
+                /*
+                if (!(term.getLabel().startsWith("As"))) {
+                    return;
+                }
+                */
+                vocabularyTermNode = this.vocabularyNode.get()
+                                         .addNode("./" + term.getId()
+                                         .replaceAll("[^A-Za-z0-9_\\.]", ""), "lfs:VocabularyTerm");
+            } catch (ItemExistsException e) {
+                // Sometimes terms appear twice; we'll just update the existing node
+                vocabularyTermNode = this.vocabularyNode.get().getNode(term.getId());
+            }
+            vocabularyTermNode.setProperty("identifier", term.getId());
+
+            vocabularyTermNode.setProperty("label", term.getLabel());
+            vocabularyTermNode.setProperty("parents", term.getParents());
+            vocabularyTermNode.setProperty("ancestors", term.getAncestors());
+
+            Iterator<Map.Entry<String, Collection<String>>> it = term.getAllProperties().asMap().entrySet().iterator();
+            while (it.hasNext()) {
+                Map.Entry<String, Collection<String>> entry = it.next();
+                String[] valuesArray = entry.getValue().toArray(ArrayUtils.EMPTY_STRING_ARRAY);
+                // Sometimes the source may contain more than one label or description, but we can't allow that.
+                // Always use one value for these special fields.
+                if (("label".equals(entry.getKey()) || "description".equals(entry.getKey()))
+                        && valuesArray.length == 1) {
+                    vocabularyTermNode.setProperty(entry.getKey(), valuesArray[0]);
+                } else {
+                    vocabularyTermNode.setProperty(entry.getKey(), valuesArray);
+                }
+            }
+        } catch (RepositoryException e) {
+            // If the identifier exists, print the identifier in the error message to identify node
+            LOGGER.warn("Failed to create VocabularyTerm node {}: {}", StringUtils.defaultString(term.getId()),
+                e.getMessage());
+
+        }
+    }
+
+    /**
+     * Saves the JCR session of the homepage node that was obtained from the resource of the request. If this is
+     * successful, then the changes made already will be applied to the JCR repository. If not, then all of the changes
+     * will be discarded, reverting to the original state.
+     *
+     * @param vocabulariesHomepage the <code>VocabulariesHomepage</code> node obtained from the request
+     * @throws VocabularyIndexException if session is not successfully saved
+     */
+    private void saveSession(Node vocabulariesHomepage)
+        throws VocabularyIndexException
+    {
+        try {
+            vocabulariesHomepage.getSession().save();
+        } catch (RepositoryException e) {
+            String message = "Failed to save session: " + e.getMessage();
+            throw new VocabularyIndexException(message, e);
+        }
+    }
+}

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/FileUploadIndexer.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/FileUploadIndexer.java
@@ -21,18 +21,12 @@ package ca.sickkids.ccm.lfs.vocabularies.internal;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
-import javax.jcr.ItemExistsException;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.request.RequestParameter;
@@ -211,47 +205,7 @@ public class FileUploadIndexer implements VocabularyIndexer
      */
     private void createVocabularyTermNode(VocabularyTermSource term)
     {
-        try {
-            Node vocabularyTermNode;
-            try {
-                //Hack to deal with testing with limited RAM
-                /*
-                if (!(term.getLabel().startsWith("As"))) {
-                    return;
-                }
-                */
-                vocabularyTermNode = this.vocabularyNode.get()
-                                         .addNode("./" + term.getId()
-                                         .replaceAll("[^A-Za-z0-9_\\.]", ""), "lfs:VocabularyTerm");
-            } catch (ItemExistsException e) {
-                // Sometimes terms appear twice; we'll just update the existing node
-                vocabularyTermNode = this.vocabularyNode.get().getNode(term.getId());
-            }
-            vocabularyTermNode.setProperty("identifier", term.getId());
-
-            vocabularyTermNode.setProperty("label", term.getLabel());
-            vocabularyTermNode.setProperty("parents", term.getParents());
-            vocabularyTermNode.setProperty("ancestors", term.getAncestors());
-
-            Iterator<Map.Entry<String, Collection<String>>> it = term.getAllProperties().asMap().entrySet().iterator();
-            while (it.hasNext()) {
-                Map.Entry<String, Collection<String>> entry = it.next();
-                String[] valuesArray = entry.getValue().toArray(ArrayUtils.EMPTY_STRING_ARRAY);
-                // Sometimes the source may contain more than one label or description, but we can't allow that.
-                // Always use one value for these special fields.
-                if (("label".equals(entry.getKey()) || "description".equals(entry.getKey()))
-                        && valuesArray.length == 1) {
-                    vocabularyTermNode.setProperty(entry.getKey(), valuesArray[0]);
-                } else {
-                    vocabularyTermNode.setProperty(entry.getKey(), valuesArray);
-                }
-            }
-        } catch (RepositoryException e) {
-            // If the identifier exists, print the identifier in the error message to identify node
-            LOGGER.warn("Failed to create VocabularyTerm node {}: {}", StringUtils.defaultString(term.getId()),
-                e.getMessage());
-
-        }
+        OntologyIndexerUtils.createVocabularyTermNode(term, this.vocabularyNode);
     }
 
     /**

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/FileUploadIndexer.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/FileUploadIndexer.java
@@ -126,7 +126,7 @@ public class FileUploadIndexer implements VocabularyIndexer
                 description = null;
             } else {
                 description = new VocabularyDescriptionBuilder()
-                    .withSource("")
+                    .withSource("fileupload")
                     .withSourceFormat("OWL")
                     .withIdentifier(identifier)
                     .withName(vocabName)

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/OntologyFormatDetection.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/OntologyFormatDetection.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package ca.sickkids.ccm.lfs.vocabularies.internal;
+
+public final class OntologyFormatDetection
+{
+    //Hide the utility class constructor
+    private OntologyFormatDetection()
+    {
+    }
+
+    public static String getSourceFormat(String sourceURL)
+    {
+        if (sourceURL != null && sourceURL.endsWith(".obo")) {
+            return "OBO";
+        }
+        // TODO Can files ending in .rdf be parsed just like .owl files?
+        // They use rdfs:Class instead of owl:Class, but otherwise the structure is similar
+        return "OWL";
+    }
+}

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/OntologyIndexerUtils.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/OntologyIndexerUtils.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package ca.sickkids.ccm.lfs.vocabularies.internal;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.jcr.ItemExistsException;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ca.sickkids.ccm.lfs.vocabularies.spi.VocabularyTermSource;
+
+public final class OntologyIndexerUtils
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(OntologyIndexerUtils.class);
+
+    //Hide the utility class constructor
+    private OntologyIndexerUtils()
+    {
+    }
+
+    /**
+     * Creates a <code>VocabularyTerm</code> node representing an individual term of the vocabulary.
+     *
+     * @param term the term data
+     * @param vocabularyNode must be passed from the calling class
+     * @throws VocabularyIndexException when a node cannot be created
+     */
+    public static void createVocabularyTermNode(VocabularyTermSource term, InheritableThreadLocal<Node> vocabularyNode)
+    {
+        try {
+            Node vocabularyTermNode;
+            try {
+                vocabularyTermNode = vocabularyNode.get()
+                                         .addNode("./" + term.getId()
+                                         .replaceAll("[^A-Za-z0-9_\\.]", ""), "lfs:VocabularyTerm");
+            } catch (ItemExistsException e) {
+                // Sometimes terms appear twice; we'll just update the existing node
+                vocabularyTermNode = vocabularyNode.get().getNode(term.getId());
+            }
+            vocabularyTermNode.setProperty("identifier", term.getId());
+
+            vocabularyTermNode.setProperty("label", term.getLabel());
+            vocabularyTermNode.setProperty("parents", term.getParents());
+            vocabularyTermNode.setProperty("ancestors", term.getAncestors());
+
+            Iterator<Map.Entry<String, Collection<String>>> it = term.getAllProperties().asMap().entrySet().iterator();
+            while (it.hasNext()) {
+                Map.Entry<String, Collection<String>> entry = it.next();
+                String[] valuesArray = entry.getValue().toArray(ArrayUtils.EMPTY_STRING_ARRAY);
+                // Sometimes the source may contain more than one label or description, but we can't allow that.
+                // Always use one value for these special fields.
+                if (("label".equals(entry.getKey()) || "description".equals(entry.getKey()))
+                        && valuesArray.length == 1) {
+                    vocabularyTermNode.setProperty(entry.getKey(), valuesArray[0]);
+                } else {
+                    vocabularyTermNode.setProperty(entry.getKey(), valuesArray);
+                }
+            }
+        } catch (RepositoryException e) {
+            // If the identifier exists, print the identifier in the error message to identify node
+            LOGGER.warn("Failed to create VocabularyTerm node {}: {}", StringUtils.defaultString(term.getId()),
+                e.getMessage());
+
+        }
+    }
+}

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/OwlParser.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/OwlParser.java
@@ -49,8 +49,6 @@ import org.apache.jena.tdb2.TDB2Factory;
 import org.apache.jena.util.iterator.ExtendedIterator;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import ca.sickkids.ccm.lfs.vocabularies.spi.SourceParser;
 import ca.sickkids.ccm.lfs.vocabularies.spi.VocabularyDescription;
@@ -69,7 +67,6 @@ import ca.sickkids.ccm.lfs.vocabularies.spi.VocabularyTermSource;
 @SuppressWarnings("checkstyle:ClassFanOutComplexity")
 public class OwlParser implements SourceParser
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(OwlParser.class);
 
     @Reference
     private VocabularyParserUtils utils;
@@ -139,7 +136,6 @@ public class OwlParser implements SourceParser
     private void processTerm(final OntClass term, final Consumer<VocabularyTermSource> consumer)
         throws VocabularyIndexException
     {
-        //LOGGER.warn("Processing term: {}", term.getURI());
         // Identifier code is the local name of the term
         String identifier = term.getLocalName();
 
@@ -164,7 +160,6 @@ public class OwlParser implements SourceParser
             int uriDepth = term.getURI().split("/").length;
             identifier = term.getURI().split("/")[uriDepth - 1];
         }
-        LOGGER.warn("Using identifier: {}", identifier);
 
         String[] parents = getAncestors(term, false);
         String[] ancestors = getAncestors(term, true);

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/OwlParser.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/OwlParser.java
@@ -49,6 +49,8 @@ import org.apache.jena.tdb2.TDB2Factory;
 import org.apache.jena.util.iterator.ExtendedIterator;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ca.sickkids.ccm.lfs.vocabularies.spi.SourceParser;
 import ca.sickkids.ccm.lfs.vocabularies.spi.VocabularyDescription;
@@ -67,6 +69,8 @@ import ca.sickkids.ccm.lfs.vocabularies.spi.VocabularyTermSource;
 @SuppressWarnings("checkstyle:ClassFanOutComplexity")
 public class OwlParser implements SourceParser
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OwlParser.class);
+
     @Reference
     private VocabularyParserUtils utils;
 
@@ -135,6 +139,7 @@ public class OwlParser implements SourceParser
     private void processTerm(final OntClass term, final Consumer<VocabularyTermSource> consumer)
         throws VocabularyIndexException
     {
+        //LOGGER.warn("Processing term: {}", term.getURI());
         // Identifier code is the local name of the term
         String identifier = term.getLocalName();
 
@@ -155,7 +160,11 @@ public class OwlParser implements SourceParser
         // Backing up if rdf jena utils failed to get Identifier from term uri
         if (identifier.length() == 0 && gatheredProperties.get("id").size() > 0) {
             identifier = gatheredProperties.get("id").iterator().next();
+        } else if (identifier.length() == 0 && term.getURI().split("/").length > 0) {
+            int uriDepth = term.getURI().split("/").length;
+            identifier = term.getURI().split("/")[uriDepth - 1];
         }
+        LOGGER.warn("Using identifier: {}", identifier);
 
         String[] parents = getAncestors(term, false);
         String[] ancestors = getAncestors(term, true);

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/spi/VocabularyParserUtils.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/spi/VocabularyParserUtils.java
@@ -88,6 +88,8 @@ public class VocabularyParserUtils
     public void writeStatusJson(final SlingHttpServletRequest request, final SlingHttpServletResponse response,
         final boolean isSuccessful, final String error) throws IOException
     {
+        response.setStatus(isSuccessful
+            ? SlingHttpServletResponse.SC_OK : SlingHttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         Writer out = response.getWriter();
         JsonGenerator generator = Json.createGenerator(out);
         generator.writeStartObject();


### PR DESCRIPTION
Allows for vocabularies to be uploaded in RDF/XML format, thus allowing for the installation of vocabularies that are not available through BioPortal.


To test:

1. Build the `LFS-533_test` branch
2. Download the **Human Phenotype Ontology** in **RDF/XML** format from https://bioportal.bioontology.org/ontologies/HP
3. Ensure that the `BIOPORTAL_APIKEY` environment variable is **not** set
4. Start LFS
5. Go to *Administration* ... *Vocabularies* and install the downloaded ontology file with the following parameters; `Identifier` = `HP`, `Name` = `Human Phenotype Ontology`, `Version` = `1`
6. Once installation is finished, create a new *Demographics* form.
7. Type something like `myopia` in the co-morbidities field. Auto-complete should happen and answers should allow for selection.