### PR TITLE
LFS-562: Add a progress bar to indicate that quick search filtering is working

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
@@ -273,6 +273,7 @@ function Filters(props) {
               key={label}
               size="small"
               label={label}
+              disabled={disabled}
               onDelete={()=>{
                 const newFilters = activeFilters.slice();
                 newFilters.splice(index, 1);
@@ -290,20 +291,19 @@ function Filters(props) {
           );
         })
       }
-      { !disabled && (
-        <Button
-          size="small"
-          variant="contained"
-          color="default"
-          className={classes.addFilterButton}
-          onClick={() => {
-            openDialogAndAdd();
-            setFocusRow(activeFilters.length);
-          }}
-          >
-          <Add fontSize="small" />
-        </Button>
-      )}
+      <Button
+        size="small"
+        variant="contained"
+        color="default"
+        className={classes.addFilterButton}
+        disabled={disabled}
+        onClick={() => {
+          openDialogAndAdd();
+          setFocusRow(activeFilters.length);
+        }}
+        >
+        <Add fontSize="small" />
+      </Button>
       {/* Dialog for setting up filters */}
       <Dialog
         open={dialogOpen}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
@@ -38,7 +38,7 @@ import { UNARY_COMPARATORS } from "./FilterComponents/FilterComparators.jsx";
 const FILTER_URL = "/Questionnaires.filters";
 
 function Filters(props) {
-  const { classes, onChangeFilters, questionnaire } = props;
+  const { classes, disabled, onChangeFilters, questionnaire } = props;
   // Filters, as displayed in the dialog, and filters as actually saved
   const [editingFilters, setEditingFilters] = useState([]);
   const [activeFilters, setActiveFilters] = useState([]);
@@ -290,18 +290,20 @@ function Filters(props) {
           );
         })
       }
-      <Button
-        size="small"
-        variant="contained"
-        color="default"
-        className={classes.addFilterButton}
-        onClick={() => {
-          openDialogAndAdd();
-          setFocusRow(activeFilters.length);
-        }}
-        >
-        <Add fontSize="small" />
-      </Button>
+      { !disabled && (
+        <Button
+          size="small"
+          variant="contained"
+          color="default"
+          className={classes.addFilterButton}
+          onClick={() => {
+            openDialogAndAdd();
+            setFocusRow(activeFilters.length);
+          }}
+          >
+          <Add fontSize="small" />
+        </Button>
+      )}
       {/* Dialog for setting up filters */}
       <Dialog
         open={dialogOpen}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -19,7 +19,7 @@
 
 import React, { useState, useEffect } from "react";
 import { Paper, Table, TableHead, TableBody, TableRow, TableCell, TablePagination } from "@material-ui/core";
-import { Card, CardHeader, CardContent, CardActions, Chip, IconButton, Typography, Button, withStyles } from "@material-ui/core";
+import { Card, CardHeader, CardContent, CardActions, Chip, IconButton, Typography, Button, LinearProgress, withStyles } from "@material-ui/core";
 import { Link } from 'react-router-dom';
 import moment from "moment";
 
@@ -124,6 +124,8 @@ function LiveTable(props) {
       "currentFetch": currentFetch,
       "fetchError": false,
     }));
+    // Clear tableData (set it to undefined) so that Please wait... is displayed
+    setTableData();
     currentFetch.then((response) => response.ok ? response.json() : Promise.reject(response)).then(handleResponse).catch(handleError);
     // TODO: update the displayed URL with pagination details, so that we can share/reload at the same page
   };
@@ -337,7 +339,7 @@ function LiveTable(props) {
   return (
     // We wrap everything in a Paper for a nice separation, as a Table has no background or border of its own.
     <Paper elevation={0}>
-      {filters && <Filters onChangeFilters={handleChangeFilters} {...rest} />}
+      {filters && <Filters onChangeFilters={handleChangeFilters} disabled={!Boolean(tableData)} {...rest} />}
       <div>
         {paginationControls}
       </div>
@@ -385,11 +387,11 @@ function LiveTable(props) {
               ( tableData.map(makeRow) )
               :
               ( <TableRow><TableCell colSpan={columns ? columns.length : 1}>Please wait...</TableCell></TableRow> )
-            /* TODO: Better progress bar, add some Suspense */
           }
         </TableBody>
       </Table>
       {paginationControls}
+      {!tableData && (<LinearProgress className={classes.progressIndicator}/>)}
     </Paper>
   );
 }


### PR DESCRIPTION
When a filter query has been sent to the JCR back-end, but the query has not yet returned with the filtered results, display a _Please Wait_ message and a loading bar to notify the user that the filtering is not yet complete.

Also, disable the ability to add a new filter while the filtering process is still occurring.

To test:

- Build the `LFS-562_test` branch
- Start LFS and login as admin
- Run `./load_examples.sh` (requires cURL to be installed) to load 4000 fake Tissue Metrix Forms
- Once `./load_examples.sh` is complete, refresh the LFS page and try _Tissue Metrix_ filters such as:
  - (`Life status = Deceased`)
  - (`Life status = Deceased`) (`File1 = 2`)