### PR TITLE
LFS-577: Fix broken filtering by date entries

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
@@ -174,10 +174,10 @@ function Filters(props) {
     });
   }
 
-  let handleChangeOutput = (index, newValue, newLabel) => {
+  let handleChangeOutput = (index, newValue, newLabel, dataType) => {
     setEditingFilters( oldfilters => {
       let newFilters = oldfilters.slice();
-      let newFilter =  {...newFilters[index], value: newValue };
+      let newFilter =  {...newFilters[index], value: newValue, type: dataType};
       if (newLabel != null) {
         newFilter.label = newLabel;
       }
@@ -241,6 +241,7 @@ function Filters(props) {
 
   // Return the pre-computed input element, and focus it if we were asked to
   let getCachedInput = (filterDatum, index, focusRef) => {
+    let dataType = questionDefinitions[filterDatum.name]?.dataType || "text";
 
     let CachedComponent = filterDatum.comparator === notesComparator ?
       textFilterComponent[filterDatum.name]
@@ -252,7 +253,7 @@ function Filters(props) {
         questionDefinition={questionDefinitions[filterDatum.name]}
         defaultValue={editingFilters[index].value}
         defaultLabel={editingFilters[index].label}
-        onChangeInput={(newValue, label) => {handleChangeOutput(index, newValue, label);}}
+        onChangeInput={(newValue, label) => {handleChangeOutput(index, newValue, label, dataType);}}
         />);
   }
 

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -116,6 +116,7 @@ function LiveTable(props) {
       filters["fields"].forEach((field) => {url.searchParams.append("filternames", field)});
       filters["comparators"].forEach((comparator) => {url.searchParams.append("filtercomparators", comparator)});
       filters["values"].forEach((value) => {url.searchParams.append("filtervalues", value)});
+      filters["types"].forEach((type) => {url.searchParams.append("filtertypes", type)});
       filters["empties"].forEach((value) => {url.searchParams.append("filterempty", value)});
       filters["notempties"].forEach((value) => {url.searchParams.append("filternotempty", value)});
     }
@@ -274,6 +275,7 @@ function LiveTable(props) {
     let fields = [];
     let comparators = [];
     let values = [];
+    let types = [];
     let empties = [];
     let notempties = [];
 
@@ -288,6 +290,7 @@ function LiveTable(props) {
         fields.push(filter.uuid);
         comparators.push(filter.comparator);
         values.push(filter.value);
+        types.push(filter.type || "text");
       }
     });
 
@@ -296,6 +299,7 @@ function LiveTable(props) {
         fields: fields,
         comparators: comparators,
         values: values,
+        types: types,
         empties: empties,
         notempties: notempties
       };


### PR DESCRIPTION
This PR fixes the bug described by LFS-577 (filtering by dates is broken).

To test:

- Build this branch
- Start LFS
- Create a new Demographics Form
- Set the _Date of Birth_ to `2020-01-01`
- Complete the rest of the Form and save it
- On the dashboard page, filter through Demographics forms for `Date of birth` = `2020-01-01`
- Try searching for other dates
- Try searching for other non-date typed values
- Ensure that the results are as expected