### PR TITLE
[misc] Stop showing the loading dialog if loading fails with an error

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -157,7 +157,7 @@ function LiveTable(props) {
       "currentFetch": false,
       "fetchError": err,
     }));
-    setTableData();
+    setTableData([]);
   };
 
   let makeRow = (entry, i) => {


### PR DESCRIPTION
If a filter is applied and the `fetch` request fails, stop showing the loading bar and allow the user to either _Retry_ or change the filters.

To test, simulate a failed network request by opening the browser's _Network Tools_ and blocking the URL `http://localhost:8080/Forms.paginate`