### PR TITLE
LFS-593: Lock the version of material-table to prevent the recent SplitChunkPlugin update from blocking compilation

### DIFF
--- a/modules/data-entry/src/main/frontend/package.json
+++ b/modules/data-entry/src/main/frontend/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@material-ui/core": "^4.4.3",
     "@material-ui/icons": "^4.4.3",
-    "material-table": "^1.57.2",
+    "material-table": "1.69.0",
     "moment-jdateformatparser": "^1.2.1",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",

--- a/modules/principals/src/main/frontend/package.json
+++ b/modules/principals/src/main/frontend/package.json
@@ -40,7 +40,7 @@
       "formik": "^1.5.7",
       "formik-material-fields": "0.0.4",
       "history": "^4.9.0",
-      "material-table": "^1.50.0",
+      "material-table": "1.69.0",
       "moment": "^2.24.0",
       "react": "^16.9.0",
       "react-dom": "^16.9.0",


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/LFS-593)

Based on the conversation in our logs that was causing an issue. 

Special thanks to @acrowthe for finding the cause/fix of the bug.