### PR TITLE
[misc] Fix form header gap due to LFS-352

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -237,7 +237,6 @@ function Form (props) {
             : ""
           }
         </Grid>
-        <div className={classes.formProvider}></div>
         <FormProvider>
           <SelectorDialog
             allowedTypes={parseToArray(data?.['questionnaire']?.['requiredSubjectTypes'])}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -220,9 +220,6 @@ const questionnaireStyle = theme => ({
         opacity: 1,
         zIndex: "1010"
     },
-    formProvider: {
-        paddingTop: theme.spacing(20)
-    },
     iconButton: {
         float: "right"
     },


### PR DESCRIPTION
- Remove div and CSS class in forms used to create gap.
  - No longer required due to header changed from fixed to sticky