### PR TITLE
LFS-622: Create a "demo" runmode

### DIFF
--- a/modules/homepage/src/main/frontend/src/themePage/index.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/index.jsx
@@ -39,9 +39,13 @@ class Main extends React.Component {
       fixedClasses: "dropdown show",
       mobileOpen: false,
       routes: [],
+      display_demo_response: 0,
     };
 
     getRoutes().then(routes => this.setState({routes: routes}));
+    fetch("/display_demo_warning").then((res) => {
+        this.setState({display_demo_response: res.status});
+    });
   }
 
   handleDrawerToggle = () => {
@@ -84,6 +88,7 @@ class Main extends React.Component {
     const { classes, ...rest } = this.props;
 
     return (
+      (this.state.display_demo_response != 0) &&
       <div className={classes.wrapper}>
         <Suspense fallback={<div>Loading...</div>}>
           <Sidebar
@@ -97,19 +102,22 @@ class Main extends React.Component {
           />
           <div className={classes.mainPanel} ref={this.mainPanel} id="main-panel">
             <div className={classes.content}>
-              <AppBar className={classes.warningBanner} position="sticky">
-                <Toolbar>
-                  <IconButton edge="start" color="inherit">
-                    <WarningIcon fontsize="large"/>
-                  </IconButton>
-                  <Typography variant="h6">
-                    This installation is for demo purposes only.
-                    Data entered here can be accessed by anyone and is
-                    periodically deleted. Do not enter any real
-                    data / patient identifiable information.
-                  </Typography>
-                </Toolbar>
-              </AppBar>
+              {
+                (this.state.display_demo_response == 403) &&
+                <AppBar className={classes.warningBanner} position="sticky">
+                  <Toolbar>
+                    <IconButton edge="start" color="inherit">
+                      <WarningIcon fontsize="large"/>
+                    </IconButton>
+                    <Typography variant="h6">
+                      This installation is for demo purposes only.
+                      Data entered here can be accessed by anyone and is
+                      periodically deleted. Do not enter any real
+                      data / patient identifiable information.
+                    </Typography>
+                  </Toolbar>
+                </AppBar>
+              }
               <div className={classes.container}>{this.switchRoutes(this.state.routes)}</div>
             </div>
             <Navbar

--- a/modules/homepage/src/main/frontend/src/themePage/index.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/index.jsx
@@ -21,7 +21,8 @@ import React, { Suspense } from "react";
 import ReactDOM from "react-dom";
 import Sidebar from "./Sidebar/sidebar"
 import { getRoutes } from '../routes';
-import { withStyles } from '@material-ui/core';
+import { AppBar, withStyles, IconButton, Toolbar, Typography } from '@material-ui/core';
+import WarningIcon from '@material-ui/icons/Warning';
 import { Redirect, Router, Route, Switch } from "react-router-dom";
 import { createBrowserHistory } from "history";
 import Navbar from "./Navbars/Navbar";
@@ -96,6 +97,19 @@ class Main extends React.Component {
           />
           <div className={classes.mainPanel} ref={this.mainPanel} id="main-panel">
             <div className={classes.content}>
+              <AppBar className={classes.warningBanner} position="sticky">
+                <Toolbar>
+                  <IconButton edge="start" color="inherit">
+                    <WarningIcon fontsize="large"/>
+                  </IconButton>
+                  <Typography variant="h6">
+                    This installation is for demo purposes only.
+                    Data entered here can be accessed by anyone and is
+                    periodically deleted. Do not enter any real
+                    data / patient identifiable information.
+                  </Typography>
+                </Toolbar>
+              </AppBar>
               <div className={classes.container}>{this.switchRoutes(this.state.routes)}</div>
             </div>
             <Navbar

--- a/modules/homepage/src/main/frontend/src/themePage/indexStyle.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/indexStyle.jsx
@@ -38,6 +38,9 @@ const appStyle = theme => ({
   container,
   map: {
     marginTop: "70px"
+  },
+  warningBanner: {
+    background: "#FFA500"
   }
 });
 

--- a/modules/homepage/src/main/provisioning/model.txt
+++ b/modules/homepage/src/main/provisioning/model.txt
@@ -26,3 +26,14 @@
     set ACL for everyone
         allow   jcr:read    on /content
     end
+
+
+[configurations runModes=demo]
+    org.apache.sling.jcr.repoinit.RepositoryInitializer-demo
+        scripts=["\
+            create path (nt:unstructured) /display_demo_warning
+\
+            set ACL for everyone \
+                allow   jcr:read    on /display_demo_warning \
+            end \
+          "]


### PR DESCRIPTION
This PR implements the LFS-622 feature described on https://phenotips.atlassian.net/browse/LFS-622 by adding a warning banner if LFS is started with the `demo` runmode.

To test:

- Start LFS normally with `java -jar distribution/target/lfs-0.1-SNAPSHOT.jar`. Everything should work as normal.
- Stop LFS and restart with the `demo` runmode
  - `rm -rf sling/`
  - `java -jar distribution/target/lfs-0.1-SNAPSHOT.jar -Dsling.run.modes=demo`
- Everything should also still work, but a orange warning banner should be _always_ present, except for the login screen