### PR TITLE
LFS-602: Pagination for Forms

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -352,7 +352,7 @@ function Form (props) {
               })
           }
         </FormProvider>
-        <Grid item className={classes.formFooter} xs={12}>
+        <Grid item xs={12} className={classes.formFooter}>
           <FormPagination
             lastPage={lastValidPage}
             activePage={activePage}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -36,7 +36,7 @@ import CloseIcon from "@material-ui/icons/Close";
 import EditIcon from '@material-ui/icons/Edit';
 
 import QuestionnaireStyle, { FORM_ENTRY_CONTAINER_PROPS } from "./QuestionnaireStyle";
-import FormEntry, { ENTRY_TYPES } from "./FormEntry";
+import FormEntry, { QUESTION_TYPES, ENTRY_TYPES } from "./FormEntry";
 import moment from "moment";
 import { getHierarchy } from "./Subject";
 import { SelectorDialog, parseToArray } from "./SubjectSelector";
@@ -44,6 +44,19 @@ import { FormProvider } from "./FormContext";
 import DialogueLoginContainer from "../login/loginDialogue.js";
 import DeleteButton from "../dataHomepage/DeleteButton";
 import FormPagination from "./FormPagination";
+
+class Page {
+  constructor(visible) {
+    this.visible = visible;
+    this.canBeVisible = true;
+  }
+  conditionalVisible = [];
+
+  addConditionalVisible(visible, index) {
+    this.conditionalVisible[index] = visible;
+    this.canBeVisible = this.conditionalVisible.length === 0 || this.conditionalVisible.includes(true);
+  }
+}
 
 // TODO Once components from the login module can be imported, open the login Dialog in-page instead of opening a popup window
 
@@ -80,6 +93,7 @@ function Form (props) {
   let [ errorDialogDisplayed, setErrorDialogDisplayed ] = useState(false);
   let [ activePage, setActivePage ] = useState(0);
   let [ pages, setPages ] = useState([]);
+  let [ paginationEnabled, setPaginationEnabled ] = useState(false);
 
   let formNode = React.useRef();
 
@@ -99,6 +113,8 @@ function Form (props) {
   // Callback method for the `fetchData` method, invoked when the data successfully arrived from the server.
   let handleResponse = (json) => {
     setData(json);
+    setPaginationEnabled(!!json?.['questionnaire']?.['paginate']);
+    setPages([]);
   };
 
   // Callback method for the `fetchData` method, invoked when the request failed.
@@ -184,12 +200,6 @@ function Form (props) {
     }
   }
 
-  let handlePageChange = (page) => {
-    if (page >= 0 && page < pages.length && lastSaveStatus !== false) {
-      setActivePage(page);
-    }
-  }
-
   let handleSubmit = (event) => {
     // Do not save when login in progress
     // Prevents issue where submitting login dialog would try to save twice,
@@ -208,6 +218,60 @@ function Form (props) {
     );
   }
 
+  // Pagination logic
+
+  let lastValidPage = () => {
+    let result = pages.length - 1;
+    while (result > 0 && !pages[result].canBeVisible) {
+      result--;
+    }
+    return result;
+  }
+
+  let handlePageChange = (direction) => {
+    if (paginationEnabled) {
+      let change = (direction === "next" ? 1 : -1);
+      let lastPage = lastValidPage();
+      let nextPage = activePage;
+      while ((change === 1 || nextPage > 0) && (change === -1 || nextPage < lastPage)) {
+        nextPage += change;
+        if (pages[nextPage].canBeVisible) break;
+      }
+      if (nextPage !== activePage) {
+        window.scrollTo(0, 0);
+      }
+      setActivePage(nextPage);
+    }
+  }
+
+  let previousEntryType;
+  let questionIndex = 0;
+
+  let addPage = (entryDefinition) => {
+    if (paginationEnabled) {
+      let page;
+      if (QUESTION_TYPES.includes(entryDefinition["jcr:primaryType"]) && previousEntryType && QUESTION_TYPES.includes(previousEntryType)) {
+        page = pages[pages.length - 1];
+        questionIndex++;
+      } else {
+        page = new Page(!paginationEnabled || activePage == pages.length);
+        pages.push(page);
+        questionIndex = 0;
+      }
+      previousEntryType = entryDefinition["jcr:primaryType"];
+
+      return {
+        page: page,
+        callback: (visible) => {page.addConditionalVisible(visible, questionIndex);}
+      }
+    } else {
+      if (pages.length === 0) {
+        pages.push(new Page(true));
+      }
+      return {page: pages[0], callback: ()=>{}}
+    }
+  }
+
   // If an error was returned, do not display a form at all, but report the error
   if (error) {
     return (
@@ -222,6 +286,7 @@ function Form (props) {
   }
 
   let parentDetails = data?.subject && getHierarchy(data.subject, Link, (node) => ({href: "/content.html" + node["@path"], target :"_blank"}));
+  pages.length = 0;
 
   return (
     <form action={data["@path"]} method="POST" onSubmit={handleSubmit} onChange={()=>setLastSaveStatus(undefined)} key={id} ref={formNode}>
@@ -270,8 +335,9 @@ function Form (props) {
           {
             Object.entries(data.questionnaire)
               .filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType']))
-              .map(([key, entryDefinition]) =>
-                <FormEntry
+              .map(([key, entryDefinition]) => {
+                let pageResult = addPage(entryDefinition);
+                return <FormEntry
                   key={key}
                   entryDefinition={entryDefinition}
                   path={"."}
@@ -280,14 +346,15 @@ function Form (props) {
                   keyProp={key}
                   classes={classes}
                   onChange={()=>setLastSaveStatus(undefined)}
-                  displayedPage={activePage}
-                  pageList={pages}
-                />)
+                  visibleCallback={pageResult.callback}
+                  pageActive={pageResult.page.visible}
+                />
+              })
           }
         </FormProvider>
         <Grid item className={classes.formFooter} xs={12}>
           <FormPagination
-            pages={pages}
+            lastPage={lastValidPage}
             activePage={activePage}
             saveInProgress={saveInProgress}
             lastSaveStatus={lastSaveStatus}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -43,6 +43,7 @@ import { SelectorDialog, parseToArray } from "./SubjectSelector";
 import { FormProvider } from "./FormContext";
 import DialogueLoginContainer from "../login/loginDialogue.js";
 import DeleteButton from "../dataHomepage/DeleteButton";
+import FormPagination from "./FormPagination";
 
 // TODO Once components from the login module can be imported, open the login Dialog in-page instead of opening a popup window
 
@@ -77,6 +78,8 @@ function Form (props) {
   let [ errorCode, setErrorCode ] = useState();
   let [ errorMessage, setErrorMessage ] = useState("");
   let [ errorDialogDisplayed, setErrorDialogDisplayed ] = useState(false);
+  let [ activePage, setActivePage ] = useState(0);
+  let [ pages, setPages ] = useState([]);
 
   let formNode = React.useRef();
 
@@ -181,6 +184,12 @@ function Form (props) {
     }
   }
 
+  let handlePageChange = (page) => {
+    if (page >= 0 && page < pages.length && lastSaveStatus !== false) {
+      setActivePage(page);
+    }
+  }
+
   let handleSubmit = (event) => {
     // Do not save when login in progress
     // Prevents issue where submitting login dialog would try to save twice,
@@ -261,23 +270,31 @@ function Form (props) {
           {
             Object.entries(data.questionnaire)
               .filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType']))
-              .map(([key, entryDefinition]) => <FormEntry key={key} entryDefinition={entryDefinition} path={"."} depth={0} existingAnswers={data} keyProp={key} classes={classes} onChange={()=>setLastSaveStatus(undefined)}></FormEntry>)
+              .map(([key, entryDefinition]) =>
+                <FormEntry
+                  key={key}
+                  entryDefinition={entryDefinition}
+                  path={"."}
+                  depth={0}
+                  existingAnswers={data}
+                  keyProp={key}
+                  classes={classes}
+                  onChange={()=>setLastSaveStatus(undefined)}
+                  displayedPage={activePage}
+                  pageList={pages}
+                />)
           }
         </FormProvider>
+        <Grid item className={classes.formFooter} xs={12}>
+          <FormPagination
+            pages={pages}
+            activePage={activePage}
+            saveInProgress={saveInProgress}
+            lastSaveStatus={lastSaveStatus}
+            handlePageChange={handlePageChange}
+            />
+        </Grid>
       </Grid>
-
-      <Button
-        type="submit"
-        variant="contained"
-        color="primary"
-        disabled={saveInProgress}
-        className={classes.saveButton}
-      >
-        {saveInProgress ? 'Saving' :
-        lastSaveStatus === true ? 'Saved' :
-        lastSaveStatus === false ? 'Save failed, log in and try again?' :
-        'Save'}
-      </Button>
       <DialogueLoginContainer isOpen={loginDialogShow} handleLogin={handleLogin}/>
       <Dialog open={errorDialogDisplayed} onClose={closeErrorDialog}>
         <DialogTitle disableTypography>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -98,7 +98,7 @@ let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, o
  * @param {string} key the node name of the section definition JCR node
  * @returns a React component that renders the section
  */
-let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onChange) => {
+let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onChange, displayedPage, pageList) => {
   // Find the existing AnswerSection for this section, if available
   const existingQuestionAnswer = existingAnswer && Object.entries(existingAnswer)
     .filter(([key, value]) => value["sling:resourceType"] == "lfs/AnswerSection"
@@ -112,6 +112,8 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onCha
       existingAnswer={existingQuestionAnswer}
       path={path}
       onChange={onChange}
+      displayedPage={displayedPage}
+      pageList={pageList}
       />
   );
 }
@@ -128,12 +130,12 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onCha
  * @returns a React component that renders the section
  */
  export default function FormEntry(props) {
-  let { classes, entryDefinition, path, depth, existingAnswers, keyProp, onAddedAnswerPath, sectionAnswersState, onChange } = props;
+  let { classes, entryDefinition, path, depth, existingAnswers, keyProp, onAddedAnswerPath, sectionAnswersState, onChange, displayedPage, pageList} = props;
   // TODO: As before, I'm writing something that's basically an if statement
   // this should instead be via a componentManager
   if (QUESTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
     return displayQuestion(entryDefinition, path, existingAnswers, keyProp, classes, onAddedAnswerPath, sectionAnswersState, onChange);
   } else if (SECTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
-    return displaySection(entryDefinition, path, depth, existingAnswers, keyProp, onChange);
+    return displaySection(entryDefinition, path, depth, existingAnswers, keyProp, onChange, displayedPage, pageList);
   }
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -31,24 +31,26 @@ import QuestionnaireStyle, { FORM_ENTRY_CONTAINER_PROPS } from "./QuestionnaireS
  * Component that displays an page of a Form.
  */
 function FormPagination (props) {
-  let { classes, pages, activePage, saveInProgress, lastSaveStatus, handlePageChange } = props;
+  let { classes, lastPage, activePage, saveInProgress, lastSaveStatus, handlePageChange } = props;
 
   let [ savedLastPage, setSavedLastPage ] = useState(false);
   let [ pendingSubmission, setPendingSubmission ] = useState(false);
 
   let handleNext = () => {
-    if (pages.length === 0 || activePage === pages.length - 1) {
+    setPendingSubmission(true);
+    if (activePage === lastPage()) {
       setSavedLastPage(true);
     } else {
       setSavedLastPage(false);
+      handlePageChange("next");
     }
-    setPendingSubmission(true);
-    handlePageChange(activePage + 1);
   }
 
   let handleBack = () => {
     setPendingSubmission(true);
-    handlePageChange(activePage - 1);
+    if (activePage > 0) {
+      handlePageChange("back");
+    }
   }
 
   if (saveInProgress && pendingSubmission) {
@@ -64,24 +66,24 @@ function FormPagination (props) {
       className={classes.paginationButton}
       onClick={handleNext}
     >
-      {((pages.length === 0 || activePage === pages.length - 1) && saveInProgress) ? 'Saving' :
+      {((lastPage() === 0 || activePage === lastPage()) && saveInProgress) ? 'Saving' :
       lastSaveStatus === false ? 'Save failed, log in and try again?' :
-      activePage < pages.length -1 ? "Next" :
+      activePage < lastPage() ? "Next" :
       lastSaveStatus && savedLastPage ? 'Saved' :
       'Save'}
     </Button>
 
   return (
-    pages && pages.length > 0 ?
+    lastPage() > 0 ?
       <React.Fragment>
         <MobileStepper
-          activeStep={activePage}
+          activeStep={activePage + 1}
           className={classes.formStepper}
           variant="progress"
-          steps={pages.length}
+          steps={lastPage() + 3}
           nextButton={saveButton}
           backButton={
-            pages.length > 1
+            lastPage() > 0
               ? <Button
                   type="submit"
                   disabled={(activePage === 0 && !pendingSubmission) /* Don't disable until form submission started */

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -21,9 +21,7 @@ import React, { useState } from "react";
 
 import {
   Button,
-  Step,
-  StepLabel,
-  Stepper,
+  MobileStepper,
   withStyles,
 } from "@material-ui/core";
 
@@ -57,49 +55,52 @@ function FormPagination (props) {
     setPendingSubmission(false);
   }
 
+  let saveButton =
+    <Button
+      type="submit"
+      variant="contained"
+      color="primary"
+      disabled={saveInProgress}
+      className={classes.paginationButton}
+      onClick={handleNext}
+    >
+      {((pages.length === 0 || activePage === pages.length - 1) && saveInProgress) ? 'Saving' :
+      lastSaveStatus === false ? 'Save failed, log in and try again?' :
+      activePage < pages.length -1 ? "Next" :
+      lastSaveStatus && savedLastPage ? 'Saved' :
+      'Save'}
+    </Button>
+
   return (
-    pages ?
+    pages && pages.length > 0 ?
       <React.Fragment>
-        <Stepper activeStep={activePage} className={classes.formStepper} alternativeLabel>
-          {pages.map((label) => (
-            <Step key={label}>
-              <StepLabel>{label}</StepLabel>
-            </Step>
-          ))}
-        </Stepper>
-        <Button
-          type="submit"
-          variant="contained"
-          color="primary"
-          disabled={saveInProgress}
-          className={classes.paginationButton}
-          onClick={handleNext}
-        >
-          {/* {activePage === pages.length -1 ? "Save" : "Next"} */}
-          {saveInProgress ? 'Saving' :
-          lastSaveStatus === false ? 'Save failed, log in and try again?' :
-          activePage < pages.length -1 ? "Next" :
-          lastSaveStatus && savedLastPage ? 'Saved' :
-          'Save'}
-        </Button>
+        <MobileStepper
+          activeStep={activePage}
+          className={classes.formStepper}
+          variant="progress"
+          steps={pages.length}
+          nextButton={saveButton}
+          backButton={
+            pages.length > 1
+              ? <Button
+                  type="submit"
+                  disabled={(activePage === 0 && !pendingSubmission) /* Don't disable until form submission started */
+                    || saveInProgress
+                    || lastSaveStatus === false}
+                  onClick={handleBack}
+                  className={classes.paginationButton}
+                  color="primary"
+                >
+                  Back
+                </Button>
+              : null
+          }
+        />
         {
-          pages.length > 1
-            ? <Button
-                type="submit"
-                disabled={(activePage === 0 && !pendingSubmission) /* Don't disable until form submission started */
-                  || saveInProgress
-                  || lastSaveStatus === false}
-                onClick={handleBack}
-                className={classes.paginationButton}
-                color="primary"
-              >
-                Back
-              </Button>
-            : null
         }
       </React.Fragment>
     :
-      null
+      saveButton
   );
 };
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -1,0 +1,106 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React, { useState } from "react";
+
+import {
+  Button,
+  Step,
+  StepLabel,
+  Stepper,
+  withStyles,
+} from "@material-ui/core";
+
+import QuestionnaireStyle, { FORM_ENTRY_CONTAINER_PROPS } from "./QuestionnaireStyle";
+
+/**
+ * Component that displays an page of a Form.
+ */
+function FormPagination (props) {
+  let { classes, pages, activePage, saveInProgress, lastSaveStatus, handlePageChange } = props;
+
+  let [ savedLastPage, setSavedLastPage ] = useState(false);
+  let [ pendingSubmission, setPendingSubmission ] = useState(false);
+
+  let handleNext = () => {
+    if (pages.length === 0 || activePage === pages.length - 1) {
+      setSavedLastPage(true);
+    } else {
+      setSavedLastPage(false);
+    }
+    setPendingSubmission(true);
+    handlePageChange(activePage + 1);
+  }
+
+  let handleBack = () => {
+    setPendingSubmission(true);
+    handlePageChange(activePage - 1);
+  }
+
+  if (saveInProgress && pendingSubmission) {
+    setPendingSubmission(false);
+  }
+
+  return (
+    pages ?
+      <React.Fragment>
+        <Stepper activeStep={activePage} className={classes.formStepper} alternativeLabel>
+          {pages.map((label) => (
+            <Step key={label}>
+              <StepLabel>{label}</StepLabel>
+            </Step>
+          ))}
+        </Stepper>
+        <Button
+          type="submit"
+          variant="contained"
+          color="primary"
+          disabled={saveInProgress}
+          className={classes.paginationButton}
+          onClick={handleNext}
+        >
+          {/* {activePage === pages.length -1 ? "Save" : "Next"} */}
+          {saveInProgress ? 'Saving' :
+          lastSaveStatus === false ? 'Save failed, log in and try again?' :
+          activePage < pages.length -1 ? "Next" :
+          lastSaveStatus && savedLastPage ? 'Saved' :
+          'Save'}
+        </Button>
+        {
+          pages.length > 1
+            ? <Button
+                type="submit"
+                disabled={(activePage === 0 && !pendingSubmission) /* Don't disable until form submission started */
+                  || saveInProgress
+                  || lastSaveStatus === false}
+                onClick={handleBack}
+                className={classes.paginationButton}
+                color="primary"
+              >
+                Back
+              </Button>
+            : null
+        }
+      </React.Fragment>
+    :
+      null
+  );
+};
+
+export default withStyles(QuestionnaireStyle)(FormPagination);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -73,33 +73,44 @@ function FormPagination (props) {
       'Save'}
     </Button>
 
+  let stepper = (isBack) =>
+    <MobileStepper
+      variant="progress"
+      // Offset back bar 1 to create a "current page" region
+      activeStep={activePage + (isBack ? 1 : 0)}
+      // Change the color of the back bar
+      LinearProgressProps={isBack ? {classes: {barColorPrimary: classes.formStepperTopBar}}: null}
+      // Hide the backround of the front bar to segment of back bar
+      className={`${classes.formStepper} ${isBack ? classes.formStepperTop : classes.formStepperBottom}`}
+      classes={isBack ? null : {progress:classes.formStepperBottom}}
+      // base 0 to base 1, plus 1 for the "current page" region
+      steps={lastPage() + 2}
+      nextButton={saveButton}
+      backButton={
+        lastPage() > 0
+          ? <Button
+              type="submit"
+              // Don't disable until form submission started
+              disabled={(activePage === 0 && !pendingSubmission)
+                || saveInProgress
+                || lastSaveStatus === false}
+              onClick={handleBack}
+              className={classes.paginationButton}
+              color="primary"
+            >
+              Back
+            </Button>
+          : null
+      }
+    />
+
   return (
     lastPage() > 0 ?
       <React.Fragment>
-        <MobileStepper
-          activeStep={activePage + 1}
-          className={classes.formStepper}
-          variant="progress"
-          steps={lastPage() + 3}
-          nextButton={saveButton}
-          backButton={
-            lastPage() > 0
-              ? <Button
-                  type="submit"
-                  disabled={(activePage === 0 && !pendingSubmission) /* Don't disable until form submission started */
-                    || saveInProgress
-                    || lastSaveStatus === false}
-                  onClick={handleBack}
-                  className={classes.paginationButton}
-                  color="primary"
-                >
-                  Back
-                </Button>
-              : null
-          }
-        />
-        {
-        }
+        {/* Back bar to show a different colored current page section*/}
+        {stepper(true)}
+        {/* Front bar to color completed pages differently from current page */}
+        {stepper(false)}
       </React.Fragment>
     :
       saveButton

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -76,13 +76,14 @@ function FormPagination (props) {
   let stepper = (isBack) =>
     <MobileStepper
       variant="progress"
-      // Offset back bar 1 to create a "current page" region
-      activeStep={activePage + (isBack ? 1 : 0)}
+      // Offset back bar 1 to create a "current page" region.
+      // If the final page has been saved, progress the front bar to complete
+      activeStep={activePage + (isBack ? 1 : (lastSaveStatus && savedLastPage ? 1 : 0))}
       // Change the color of the back bar
       LinearProgressProps={isBack ? {classes: {barColorPrimary: classes.formStepperTopBar}}: null}
       // Hide the backround of the front bar to segment of back bar
       className={`${classes.formStepper} ${isBack ? classes.formStepperTop : classes.formStepperBottom}`}
-      classes={isBack ? null : {progress:classes.formStepperBottom}}
+      classes={isBack ? null : {progress:classes.formStepperBottomBackground}}
       // base 0 to base 1, plus 1 for the "current page" region
       steps={lastPage() + 2}
       nextButton={saveButton}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -150,6 +150,9 @@ const questionnaireStyle = theme => ({
     collapsedSection: {
         padding: "0 !important"
     },
+    hiddenSection: {
+        display: "none"
+    },
     addSectionButton: {
         marginTop: theme.spacing(GRID_SPACE_UNIT * 2)
     },
@@ -222,6 +225,20 @@ const questionnaireStyle = theme => ({
         opacity: 1,
         zIndex: "1010",
         margin: theme.spacing(2),
+    },
+    formFooter: {
+        position: "sticky",
+        top: 'auto',
+        bottom: theme.spacing(0),
+        backgroundColor: "white",
+    },
+    formStepper: {
+        paddingLeft: theme.spacing(1),
+        paddingRight: theme.spacing(1),
+    },
+    paginationButton: {
+        float: "right",
+        margin: theme.spacing(1)
     },
     titleButton: {
         float: "right"

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -228,13 +228,10 @@ const questionnaireStyle = theme => ({
     },
     formFooter: {
         position: "sticky",
-        top: 'auto',
-        bottom: theme.spacing(0),
-        backgroundColor: "white",
+        bottom: 0,
     },
     formStepper: {
-        paddingLeft: theme.spacing(1),
-        paddingRight: theme.spacing(1),
+        position: "sticky",
     },
     paginationButton: {
         float: "right",

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -237,6 +237,15 @@ const questionnaireStyle = theme => ({
     formStepper: {
         position: "relative",
     },
+    formStepperTop: {
+        bottom: "-68px",
+    },
+    formStepperBottom: {
+        background: "transparent",
+    },
+    formStepperTopBar: {
+        backgroundColor: theme.palette.secondary.main,
+    },
     paginationButton: {
         float: "right",
         margin: theme.spacing(1),

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -231,16 +231,21 @@ const questionnaireStyle = theme => ({
     },
     formFooter: {
         position: "sticky",
-        bottom: theme.spacing(-2),
+        bottom: theme.spacing(0),
         zIndex: 1000,
+        maxHeight: "68px",
     },
     formStepper: {
         position: "relative",
     },
     formStepperTop: {
-        bottom: "-68px",
+        bottom: "16px",
     },
     formStepperBottom: {
+        background: "transparent",
+        bottom: "84px",
+    },
+    formStepperBottomBackground: {
         background: "transparent",
     },
     formStepperTopBar: {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -85,6 +85,9 @@ const questionnaireStyle = theme => ({
     questionHeader: {
         paddingBottom: theme.spacing(0),
     },
+    hiddenQuestion: {
+        display: "none"
+    },
     warningTypography: {
         padding: theme.spacing(1, 1),
     },
@@ -228,14 +231,15 @@ const questionnaireStyle = theme => ({
     },
     formFooter: {
         position: "sticky",
-        bottom: 0,
+        bottom: theme.spacing(-2),
+        zIndex: 1000,
     },
     formStepper: {
-        position: "sticky",
+        position: "relative",
     },
     paginationButton: {
         float: "right",
-        margin: theme.spacing(1)
+        margin: theme.spacing(1),
     },
     titleButton: {
         float: "right"

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -63,7 +63,7 @@ function createTitle(label, idx) {
  * @param {Object} sectionDefinition the section definition JSON
  */
 function Section(props) {
-  const { classes, depth, existingAnswer, path, sectionDefinition, onChange, displayedPage, pageList } = props;
+  const { classes, depth, existingAnswer, path, sectionDefinition, onChange, visibleCallback, pageActive } = props;
 
   const headerVariant = (depth > MAX_HEADING_LEVEL - MIN_HEADING_LEVEL ? "body1" : ("h" + (depth+MIN_HEADING_LEVEL)));
   const titleEl = sectionDefinition["label"] &&
@@ -95,12 +95,13 @@ function Section(props) {
   const [ selectedUUID, setSelectedUUID ] = useState();
   const [ uuid ] = useState(uuidv4());  // To keep our IDs separate from any other sections
   const [ removableAnswers, setRemovableAnswers ] = useState({[ID_STATE_KEY]: 1});
-  const [ pageNumber, setPageNumber ] = useState(0);
 
   // Determine if we have any conditionals in our definition that would cause us to be hidden
   const displayed = ConditionalComponentManager.evaluateCondition(
     sectionDefinition,
     formContext);
+
+  if (visibleCallback) visibleCallback(displayed);
 
   let closeDialog = () => {
     setSelectedUUID(undefined);
@@ -121,13 +122,6 @@ function Section(props) {
     return delList;
   }
 
-  const isPage = !!sectionDefinition["paginate"];
-  if (isPage && pageList && pageList.indexOf(sectionDefinition["label"]) === -1) {
-    pageList.push(sectionDefinition["label"]);
-    setPageNumber(pageList.length - 1);
-  }
-  const pageVisible = !isPage || displayedPage === pageNumber;
-
   const collapseClasses = [];
   if (!displayed) {
     collapseClasses.push(classes.collapsedSection);
@@ -135,7 +129,8 @@ function Section(props) {
   if (hasHeader) {
     collapseClasses.push(classes.collapseWrapper);
   }
-  if (isPage && !pageVisible) {
+  // Don't hide for undefined or null values
+  if (pageActive === false) {
     collapseClasses.push(classes.hiddenSection);
   }
 
@@ -191,7 +186,7 @@ function Section(props) {
                           <Delete fontSize="small" />
                         </IconButton>
                       </Tooltip>}
-                    {!isPage &&
+                    {pageActive !== true  &&
                       <Tooltip title="Expand section" aria-label="Expand section" >
                         <IconButton
                           color="default"
@@ -297,7 +292,7 @@ function Section(props) {
       </DialogActions>
     </Dialog>
     </React.Fragment>
-    , [displayed, instanceLabels, labelsToHide, dialogOpen, removableAnswers[ID_STATE_KEY], pageVisible]);
+    , [displayed, instanceLabels, labelsToHide, dialogOpen, removableAnswers[ID_STATE_KEY], pageActive]);
 }
 
 Section.propTypes = {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -369,17 +369,16 @@ function FormData(props) {
       return displayQuestion(entryDefinition, data, key);
     } else if (SECTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
       // If a section is found, filter questions inside the section
-      let currentSection = (
-        Object.entries(data.questionnaire).filter(([key, value]) => SECTION_TYPES.includes(value['jcr:primaryType']))[0][1]
-      );
-      let currentAnswers = (
-        (Object.entries(data).filter(([key, value]) => value["sling:resourceType"] == "lfs/AnswerSection")[0])
-        ? (Object.entries(data).filter(([key, value]) => value["sling:resourceType"] == "lfs/AnswerSection")[0][1]) : ""
-      )
+      let currentSection = Object.entries(data.questionnaire)
+        .filter(([key, value]) => SECTION_TYPES.includes(value['jcr:primaryType']) && value["@name"] == entryDefinition["@name"])[0]
+      currentSection = currentSection ? currentSection[1] : "";
+      let currentAnswers = Object.entries(data)
+        .filter(([key, value]) => value["sling:resourceType"] == "lfs/AnswerSection" && value["section"]["@name"] == entryDefinition["@name"])[0];
+      currentAnswers = currentAnswers ? currentAnswers[1] : "";
       return (
         Object.entries(currentSection)
         .filter(([key, value]) => QUESTION_TYPES.includes(value['jcr:primaryType']))
-        .map(([key, entryDefinition]) => displayQuestion(entryDefinition, currentAnswers, key))
+        .map(([key, entryDefinition]) => handleDisplay(entryDefinition, currentAnswers, key))
       )
     }
   }

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -259,9 +259,6 @@
   // Can this section be repeated?
   - recurrent (boolean) = false autocreated
 
-  // Should this section be displayed as a page
-  - paginate (boolean) = false autocreated
-
   // Children
 
   // The questions and sub-sections that make up this section.
@@ -389,6 +386,9 @@
   // An optional maximum number of a certain form that can be created for a subject
   // If present, the maximum number cannot be exceeded
   - maxPerSubject (long)
+
+  // Should this section be displayed as a page
+  - paginate (boolean) = false autocreated
 
   // Children
 

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -259,6 +259,9 @@
   // Can this section be repeated?
   - recurrent (boolean) = false autocreated
 
+  // Should this section be displayed as a page
+  - paginate (boolean) = false autocreated
+
   // Children
 
   // The questions and sub-sections that make up this section.


### PR DESCRIPTION
Implement stepper and pagination
- Next button changes text to save/saving based on page state
- Both back and next buttons save on click and are disabled when saving
- Sections with the paginate property to true will be detected and displayed as a page

Testing should be performed with the [LFS-602-test](https://github.com/ccmbioinfo/lfs/tree/LFS-602-test) branch
- The test branch adds pagination to the LFS demographic and cardiac 0-5NDVariables forms for testing purposes
- This branch also makes the 2nd and 4th page of the demographics forms conditional: Page 2 is shown when Page 1 `Gender` = `Female`, page 4 is shown when Page 3 `Vital status` = `alive and NED`

Missing features:
- Re-import cardiac forms with pagination (Out of scope, future PR)
- Pagination option in form editor (Out of scope, future PR)
- Handle forms with too many pages