### PR TITLE
LFS-619: Improve query performance

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -60,6 +60,7 @@ function LiveTable(props) {
       "fetchError": false,
     }
   );
+  const useQueryManager = Boolean(filters);
   // The base URL to fetch from.
   // This can either be a custom URL provided in props,
   // or an URL obtained from the current location by extracting the last path segment and appending .paginate
@@ -103,6 +104,9 @@ function LiveTable(props) {
     url.searchParams.set("offset", newPage.offset);
     url.searchParams.set("limit", newPage.limit || paginationData.limit);
     url.searchParams.set("req", ++fetchStatus.currentRequestNumber);
+    if (useQueryManager) {
+        url.searchParams.set("usequerymanager", useQueryManager);
+    }
 
     // filters should be nullable, but if left undefined we use the cached filters
     let filters = (newPage.filters === null ? null : (newPage.filters || cachedFilters));

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -60,7 +60,6 @@ function LiveTable(props) {
       "fetchError": false,
     }
   );
-  const useQueryManager = Boolean(filters);
   // The base URL to fetch from.
   // This can either be a custom URL provided in props,
   // or an URL obtained from the current location by extracting the last path segment and appending .paginate
@@ -104,9 +103,6 @@ function LiveTable(props) {
     url.searchParams.set("offset", newPage.offset);
     url.searchParams.set("limit", newPage.limit || paginationData.limit);
     url.searchParams.set("req", ++fetchStatus.currentRequestNumber);
-    if (useQueryManager) {
-        url.searchParams.set("usequerymanager", useQueryManager);
-    }
 
     // filters should be nullable, but if left undefined we use the cached filters
     let filters = (newPage.filters === null ? null : (newPage.filters || cachedFilters));

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
@@ -82,7 +82,7 @@ public class PaginationServlet extends SlingSafeMethodsServlet
 
     private static final String SUBJECT_IDENTIFIER = "lfs:Subject";
 
-    @SuppressWarnings({"checkstyle:ExecutableStatementCount", "checkstyle:JavaNCSS", "checkstyle:NPathComplexity"})
+    @SuppressWarnings({"checkstyle:ExecutableStatementCount", "checkstyle:JavaNCSS"})
     @Override
     public void doGet(final SlingHttpServletRequest request, final SlingHttpServletResponse response)
             throws IOException, IllegalArgumentException

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
@@ -175,7 +175,7 @@ public class PaginationServlet extends SlingSafeMethodsServlet
             Query filterQuery = queryManager.createQuery(finalquery, "JCR-SQL2");
 
             //Set the limit and offset here to improve query performance
-            filterQuery.setLimit(limit);
+            filterQuery.setLimit(limit + 1);
             filterQuery.setOffset(offset);
 
             //Execute the query
@@ -464,7 +464,7 @@ public class PaginationServlet extends SlingSafeMethodsServlet
         jsonGen.write("offset", limits[0]);
         jsonGen.write("limit", limits[1]);
         jsonGen.write("returnedrows", limits[2]);
-        jsonGen.write("totalrows", limits[3]);
+        jsonGen.write("totalrows", (limits[3] > limits[1]) ? -1 : (limits[0] + limits[2]));
     }
 
     private long[] writeResources(final JsonGenerator jsonGen, final Iterator<Resource> nodes,
@@ -476,16 +476,13 @@ public class PaginationServlet extends SlingSafeMethodsServlet
         counts[2] = 0;
         counts[3] = 0;
 
-        long offsetCounter = offset < 0 ? 0 : offset;
         long limitCounter = limit < 0 ? 0 : limit;
 
         jsonGen.writeStartArray("rows");
 
         while (nodes.hasNext()) {
             Resource n = nodes.next();
-            if (offsetCounter > 0) {
-                --offsetCounter;
-            } else if (limitCounter > 0) {
+            if (limitCounter > 0) {
                 jsonGen.write(n.adaptTo(JsonObject.class));
                 --limitCounter;
                 ++counts[2];

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
@@ -91,7 +91,6 @@ public class PaginationServlet extends SlingSafeMethodsServlet
         response.setCharacterEncoding("UTF-8");
         final long limit = getLongValueOrDefault(request.getParameter("limit"), 10);
         final long offset = getLongValueOrDefault(request.getParameter("offset"), 0);
-        final boolean usequerymanager = getBooleanValueOrFalse(request.getParameter("usequerymanager"));
         // If we want this query to be fast, we need to use the exact nodetype requested.
         final Node node = request.getResource().adaptTo(Node.class);
         String nodeType = "";
@@ -506,17 +505,6 @@ public class PaginationServlet extends SlingSafeMethodsServlet
             value = Long.parseLong(stringValue);
         } catch (NumberFormatException exception) {
             value = defaultValue;
-        }
-        return value;
-    }
-
-    private boolean getBooleanValueOrFalse(final String stringValue)
-    {
-        boolean value = false;
-        if (stringValue == null) {
-            value = false;
-        } else if ("true".equals(stringValue)) {
-            value = true;
         }
         return value;
     }

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
@@ -28,7 +28,6 @@ import java.util.List;
 
 import javax.jcr.Node;
 import javax.jcr.Property;
-import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.Workspace;
 import javax.jcr.query.Query;
@@ -45,7 +44,6 @@ import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
-import org.apache.sling.api.wrappers.IteratorWrapper;
 import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
@@ -183,18 +181,7 @@ public class PaginationServlet extends SlingSafeMethodsServlet
 
             //Execute the query
             QueryResult filterResult = filterQuery.execute();
-            results = new IteratorWrapper<Resource>(filterResult.getNodes())
-            {
-                @Override
-                public Resource next()
-                {
-                    try {
-                        return request.getResourceResolver().getResource(((Node) super.next()).getPath());
-                    } catch (RepositoryException e) {
-                        return null;
-                    }
-                }
-            };
+            results = new ResourceIterator(request.getResourceResolver(), filterResult.getNodes());
         } catch (Exception e) {
             return;
         }

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/ResourceIterator.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/ResourceIterator.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.sickkids.ccm.lfs;
+
+import java.util.Iterator;
+
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+
+public class ResourceIterator implements Iterator<Resource>
+{
+    private ResourceResolver resourceResolver;
+    private NodeIterator nodeIterator;
+
+    public ResourceIterator(ResourceResolver rr, NodeIterator nodes)
+    {
+        this.resourceResolver = rr;
+        this.nodeIterator = nodes;
+    }
+
+    @Override
+    public boolean hasNext()
+    {
+        return this.nodeIterator.hasNext();
+    }
+
+    @Override
+    public Resource next()
+    {
+        try {
+            return this.resourceResolver.getResource(this.nodeIterator.nextNode().getPath());
+        } catch (RepositoryException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public void remove()
+    {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
When filters are added by LFS users, the `usequerymanager=true` URL parameter is added to the `Forms.paginate` request and the back-end code uses a `QueryManager` to execute the query in the same way that this process happens in Composum.

To test:

- Start LFS and load 10,000+ Forms
- Apply various filters (eg. `Date of Birth` `=` `2000-01-01`) and note the improved performance. You may also wish to compare performance with the same queries using the same Forms on a build of the `dev` branch.