### PR TITLE
LFS-647: Time question type

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -31,6 +31,7 @@ import DateQuestion from "./DateQuestion";
 import NumberQuestion from "./NumberQuestion";
 import ChromosomeQuestion from "./ChromosomeQuestion";
 import PedigreeQuestion from "./PedigreeQuestion";
+import TimeQuestion from "./TimeQuestion";
 import TextQuestion from "./TextQuestion";
 import VocabularyQuestion from "./VocabularyQuestion";
 import SomaticVariantsQuestion from "./SomaticVariantsQuestion";

--- a/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
@@ -81,11 +81,11 @@ class Time {
 //  />
 function TimeQuestion(props) {
   let {existingAnswer, classes, ...rest} = props;
-  let {text, lowerLimit, upperLimit, errorText} = {...props.questionDefinition, ...props};
+  let {text, lowerLimit, upperLimit, errorText, minAnswers} = {...props.questionDefinition, ...props};
   let currentStartValue = (existingAnswer && existingAnswer[1].value && new Time(existingAnswer[1].value).isValid)
     ? existingAnswer[1].value : "";
   const [selectedTime, changeTime] = useState(currentStartValue);
-  const [error, setError] = useState(false);
+  const [error, setError] = useState(undefined);
   const lowerTime = new Time(lowerLimit);
   const upperTime = new Time(upperLimit);
 
@@ -95,16 +95,19 @@ function TimeQuestion(props) {
 
   let checkError = (timeString) => {
     let time = new Time(timeString);
-    if ((upperLimit && upperTime < time) || (lowerLimit && lowerTime >= time)) {
+    if ((minAnswers > 0 && !time.isValid) || (upperLimit && upperTime < time) || (lowerLimit && lowerTime > time)) {
       setError(true);
     } else {
       setError(false);
     }
   }
 
-  // Determine how to display the currently selected value
-  let outputAnswers = [["time", selectedTime]];
+  // Error check existing answers when first loading the page
+  if (typeof(error) === "undefined" && selectedTime !== "") {
+    checkError(selectedTime);
+  }
 
+  let outputAnswers = [["time", selectedTime]];
   return (
     <Question
       text={text}
@@ -145,6 +148,7 @@ function TimeQuestion(props) {
 TimeQuestion.propTypes = {
   classes: PropTypes.object.isRequired,
   text: PropTypes.string,
+  minAnswers: PropTypes.number,
   lowerLimit: PropTypes.string,
   upperLimit: PropTypes.string,
   errorText: PropTypes.string

--- a/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
@@ -50,11 +50,7 @@ class Time {
 
   numberToDoubleDigit(num) {
     num = num.toFixed(0);
-    if (num.length === 1) {
-      return `0${num}`
-    } else {
-      return num
-    }
+    return `${num}`.padStart(2, "0");
   }
 
   toString() {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
@@ -1,0 +1,164 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React, { useState } from "react";
+
+import { TextField, Typography, withStyles } from "@material-ui/core";
+
+import PropTypes from "prop-types";
+
+import Answer from "./Answer";
+import Question from "./Question";
+import QuestionnaireStyle from "./QuestionnaireStyle";
+
+import AnswerComponentManager from "./AnswerComponentManager";
+
+class Time {
+  constructor (timeString) {
+    if (typeof(timeString) === "string" && timeString.length === 5 && timeString.charAt(2) === ':') {
+      let values = timeString.split(":");
+      this.hours = parseInt(values[0]);
+      this.minutes = parseInt(values[1]);
+      this.isValid = this.checkValid();
+    } else {
+      this.isValid = false;
+    }
+  }
+
+  checkValid() {
+    return typeof(this.hours) === "number"
+      && typeof(this.minutes) === "number"
+      && this.hours < 24 && this.hours >= 0
+      && this.minutes < 60 && this.minutes >= 0
+  }
+
+  numberToDoubleDigit(num) {
+    num = num.toFixed(0);
+    if (num.length === 1) {
+      return `0${num}`
+    } else {
+      return num
+    }
+  }
+
+  toString() {
+    return this.isValid ? `${this.numberToDoubleDigit(this.hours)}:${this.numberToDoubleDigit(this.minutes)}` : ""
+  }
+
+  valueOf() {
+    return this.isValid ? (this.hours*60 + this.minutes) : undefined;
+  }
+}
+
+// Component that renders a time question
+// Selected answers are placed in a series of <input type="hidden"> tags for
+// submission.
+//
+// Optional props:
+// text: the question to be displayed
+// lowerLimit: lower time limit (inclusive) given as a string in the format HH:mm
+// upperLimit: upper date limit (inclusive) given as a string in the format HH:mm
+// errorText: text to be displayed if the input time is not within the specified range
+// Other options are passed to the <question> widget
+//
+// Sample usage:
+//<TimeQuestion
+//  text="Please enter a time after noon"
+//  lowerLimit={new Date("12:01")}
+//  upperLimit={new Date("23:59")}
+//  />
+function TimeQuestion(props) {
+  let {existingAnswer, classes, ...rest} = props;
+  let {text, lowerLimit, upperLimit, errorText} = {...props.questionDefinition, ...props};
+  let currentStartValue = (existingAnswer && existingAnswer[1].value && new Time(existingAnswer[1].value).isValid)
+    ? existingAnswer[1].value : "";
+  const [selectedTime, changeTime] = useState(currentStartValue);
+  const [error, setError] = useState(false);
+  const lowerTime = new Time(lowerLimit);
+  const upperTime = new Time(upperLimit);
+
+  if (!errorText) {
+    errorText = "Please enter a valid time";
+  }
+
+  let checkError = (timeString) => {
+    let time = new Time(timeString);
+    if ((upperLimit && upperTime < time) || (lowerLimit && lowerTime >= time)) {
+      setError(true);
+    } else {
+      setError(false);
+    }
+  }
+
+  // Determine how to display the currently selected value
+  let outputAnswers = [["time", selectedTime]];
+
+  return (
+    <Question
+      text={text}
+      {...rest}
+      >
+      {error && <Typography color='error'>{errorText}</Typography>}
+      <TextField
+        type="time"
+        className={classes.textField + " " + classes.answerField}
+        InputLabelProps={{
+          shrink: true,
+        }}
+        InputProps={{
+          className: classes.textField
+        }}
+        inputProps={{
+          max: upperLimit,
+          min: lowerLimit
+        }}
+        onChange={(event) => {
+          checkError(event.target.value);
+          changeTime(event.target.value);
+        }}
+
+        value={selectedTime}
+      />
+      <Answer
+        answers={outputAnswers}
+        questionDefinition={props.questionDefinition}
+        existingAnswer={existingAnswer}
+        answerNodeType="lfs:TimeAnswer"
+        valueType="Time"
+        {...rest}
+        />
+    </Question>);
+}
+
+TimeQuestion.propTypes = {
+  classes: PropTypes.object.isRequired,
+  text: PropTypes.string,
+  lowerLimit: PropTypes.string,
+  upperLimit: PropTypes.string,
+  errorText: PropTypes.string
+};
+
+const StyledTimeQuestion = withStyles(QuestionnaireStyle)(TimeQuestion);
+export default StyledTimeQuestion;
+
+AnswerComponentManager.registerAnswerComponent((questionDefinition) => {
+  if (questionDefinition.dataType === "time") {
+    return [StyledTimeQuestion, 50];
+  }
+});

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -48,6 +48,7 @@
       "time": {
         "lowerLimit": "string",
         "upperLimit": "string",
+        "minAnswers": "long",
         "errorText": "string"
       }
     }

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -35,16 +35,21 @@
         "maxAnswers": "long",
         "unitOfMeasurement" : "string"
       },
-      "vocabulary": { 
+      "vocabulary": {
         "sourceVocabulary": "string",
         "vocabularyFilter": "string",
         "minAnswers": "long",
         "maxAnswers": "long"
-        },
-        "computed": {
-          "minAnswers": "long",
-          "maxAnswers": "long"
-        }
+      },
+      "computed": {
+        "minAnswers": "long",
+        "maxAnswers": "long"
+      },
+      "time": {
+        "lowerLimit": "string",
+        "upperLimit": "string",
+        "errorText": "string"
       }
     }
-  ]
+  }
+]

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/DataImportServlet.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/DataImportServlet.java
@@ -493,6 +493,9 @@ public class DataImportServlet extends SlingAllMethodsServlet
             case "date":
                 result = "lfs:DateAnswer";
                 break;
+            case "time":
+                result = "lfs:TimeAnswer";
+                break;
             case "text":
             default:
                 result = "lfs:TextAnswer";

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -540,6 +540,17 @@
   - sling:resourceSuperType (STRING) = "lfs/Answer" mandatory autocreated protected
 
 //-----------------------------------------------------------------------------
+// Time
+[lfs:TimeAnswer] > lfs:Answer
+  - value (string)
+
+  // Hardcode the resource type.
+  - sling:resourceType (STRING) = "lfs/lfs:TimeAnswer" mandatory autocreated protected
+
+  // Hardcode the resource supertype.
+  - sling:resourceSuperType (STRING) = "lfs/Answer" mandatory autocreated protected
+
+//-----------------------------------------------------------------------------
 // Pedigree, stored mainly as a JSON representation, but also as a cached SVG image
 [lfs:PedigreeAnswer] > lfs:Answer
   // The pedigree data is stored here, as a JSON


### PR DESCRIPTION
Add a time question type using the browser's built in time picker
- Add support for this type in the questionnaire builder

The [test branch](https://github.com/ccmbioinfo/lfs/tree/LFS-647-test) has 4 examples of the time question in the demographics form, and more questions can be added or edited via the questionnaire editor in either branch.

Known issue: The Google Chrome time picker on linux may not allow for hour values higher than 19, despite a lack of AM/PM selector. This can be worked around using the time picker UI ([LFS-657](https://phenotips.atlassian.net/browse/LFS-657))