### PR TITLE
LFS-639 / LFS-640: Chemotherapy: Chemo agent should be multiselect

### DIFF
--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Chemotherapy.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Chemotherapy.xml
@@ -231,11 +231,6 @@
 				<type>Long</type>
 			</property>
 			<property>
-				<name>maxAnswers</name>
-				<value>1</value>
-				<type>Long</type>
-			</property>
-			<property>
 				<name>dataType</name>
 				<value>vocabulary</value>
 				<type>String</type>


### PR DESCRIPTION
You should now be able to enter more than one option into the chemo agent field of chemotherapy. CHEBI must be installed to test.