### PR TITLE
Disable self-registration by default

### DIFF
--- a/distribution/src/main/provisioning/40-startup.txt
+++ b/distribution/src/main/provisioning/40-startup.txt
@@ -24,9 +24,9 @@
     org.apache.sling/org.apache.sling.starter.startup/1.0.7-SNAPSHOT
 
 [configurations]
-  # Allow self-registration
+  # By default, deny self-registration
   org.apache.sling.jackrabbit.usermanager.impl.post.CreateUserServlet
-    self.registration.enabled=B"true"
+    self.registration.enabled=B"false"
 
   # Authentication requirements
   org.apache.sling.engine.impl.auth.SlingAuthenticator

--- a/modules/login/src/main/frontend/src/login/signUpForm.js
+++ b/modules/login/src/main/frontend/src/login/signUpForm.js
@@ -215,6 +215,12 @@ class SignUpForm extends React.Component {
               errorOpen: true,
               errorMsg: (errMsg ? errMsg : "Unknown Error")
             });
+          })
+          .catch(error => {
+            this.setState({
+              errorOpen: true,
+              errorMsg: "Unknown Error (JSON Parsing Failed)"
+            });
           });
           throw Error(response.statusText);
         }

--- a/modules/login/src/main/frontend/src/login/signUpForm.js
+++ b/modules/login/src/main/frontend/src/login/signUpForm.js
@@ -19,11 +19,16 @@
 import React from 'react';
 import {
     Button,
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    IconButton,
     TextField,
     Tooltip,
     Typography,
     withStyles
 } from '@material-ui/core';
+import { Close } from "@material-ui/icons";
 import { Formik } from "formik";
 import * as Yup from "yup";
 
@@ -145,6 +150,11 @@ class SignUpForm extends React.Component {
   constructor(props) {
     super(props);
 
+    this.state = {
+      errorOpen: false,
+      errorMsg: ""
+    };
+
     this.submitValues = this.submitValues.bind(this);
   }
 
@@ -199,6 +209,13 @@ class SignUpForm extends React.Component {
         // Therefore, you must handle the error code yourself.
         if (!response.ok) {
           this.props.handleLogin && this.props.handleLogin(false);
+          response.json().then((data) => {
+            let errMsg = data?.error?.message;
+            this.setState({
+              errorOpen: true,
+              errorMsg: (errMsg ? errMsg : "Unknown Error")
+            });
+          });
           throw Error(response.statusText);
         }
 
@@ -233,6 +250,17 @@ class SignUpForm extends React.Component {
     // Hooks only work inside functional components
     return (
       <React.Fragment>
+        <Dialog open={this.state.errorOpen} onClose={() => this.setState({errorOpen: false})}>
+          <DialogTitle disableTypography>
+            <Typography variant="h6" color="error" className={classes.dialogTitle}>Error</Typography>
+            <IconButton onClick={() => this.setState({errorOpen: false})} className={classes.closeButton}>
+              <Close />
+            </IconButton>
+          </DialogTitle>
+          <DialogContent>
+            <Typography variant="body1">{this.state.errorMsg}</Typography>
+          </DialogContent>
+        </Dialog>
         <div className={classes.main}>
           <Formik
             render={props => <FormFieldsComponent {...props} />}

--- a/modules/login/src/main/frontend/src/login/signUpForm.js
+++ b/modules/login/src/main/frontend/src/login/signUpForm.js
@@ -252,8 +252,8 @@ class SignUpForm extends React.Component {
       <React.Fragment>
         <Dialog open={this.state.errorOpen} onClose={() => this.setState({errorOpen: false})}>
           <DialogTitle disableTypography>
-            <Typography variant="h6" color="error" className={classes.dialogTitle}>Error</Typography>
-            <IconButton onClick={() => this.setState({errorOpen: false})} className={classes.closeButton}>
+            <Typography variant="h6" color="error" className={classes.errorDialogTitle}>Error</Typography>
+            <IconButton onClick={() => this.setState({errorOpen: false})} className={classes.errorCloseButton}>
               <Close />
             </IconButton>
           </DialogTitle>

--- a/modules/login/src/main/frontend/src/login/signUpForm.js
+++ b/modules/login/src/main/frontend/src/login/signUpForm.js
@@ -211,16 +211,19 @@ class SignUpForm extends React.Component {
           this.props.handleLogin && this.props.handleLogin(false);
           response.json().then((data) => {
             let errMsg = data?.error?.message;
+            errMsg = (errMsg ? errMsg : "Unknown Error");
             this.setState({
               errorOpen: true,
-              errorMsg: (errMsg ? errMsg : "Unknown Error")
+              errorMsg: errMsg
             });
+            this.form.setFieldError("username", errMsg);
           })
           .catch(error => {
             this.setState({
               errorOpen: true,
               errorMsg: "Unknown Error (JSON Parsing Failed)"
             });
+            this.form.setFieldError("username", "Unknown Error (JSON Parsing Failed)");
           });
           throw Error(response.statusText);
         }
@@ -230,7 +233,6 @@ class SignUpForm extends React.Component {
       })
       .catch(error => {
         console.log(error);
-        this.form.setFieldError("username", "Looks like this user is taken. Please try a different username.");
         this.props.handleLogin && this.props.handleLogin(false);
       });
   }
@@ -274,7 +276,7 @@ class SignUpForm extends React.Component {
             validationSchema={validationSchema}
             onSubmit={this.submitValues}
             onReset={this.props.handleExit}
-            ref={el => (this.form = el)}
+            innerRef={el => (this.form = el)}
           />
         </div>
       </React.Fragment>

--- a/modules/login/src/main/frontend/src/styling/styles.js
+++ b/modules/login/src/main/frontend/src/styling/styles.js
@@ -66,6 +66,15 @@ const styles = theme => ({
   dialogTitle: {
     padding: theme.spacing(2,0,2,3)
   },
+  errorDialogTitle: {
+    marginRight: theme.spacing(5)
+  },
+  errorCloseButton: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+    color: theme.palette.grey[500]
+  },
   errorMessage: {
     background: theme.palette.error.dark,
     padding: theme.spacing(1, 2),


### PR DESCRIPTION
As default settings should always be the safest settings, this PR causes the default behavior of Apache Sling to deny self-registration attempts. Additional users therefore must be added by logging in as `admin` and creating the new user account.

If the administrator wishes to enable self-registration, they can do so by logging in as `admin`, visiting `/system/console/configMgr`, editing `Apache Sling Create User` and enabling self-registration. 