### PR TITLE
LFS-702: Filtering sometimes doesn't return correct results

### DIFF
--- a/modules/data-entry/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
@@ -7,22 +7,6 @@
     "includedPaths": ["/Forms"],
     "indexRules" : {
         "jcr:primaryType": "nt:unstructured",
-        "lfs:Answer": {
-            "jcr:primaryType": "nt:unstructured",
-            "properties": {
-                "jcr:primaryType": "nt:unstructured",
-                "question": {
-                    "name": "question",
-                    "propertyIndex": true,
-                    "jcr:primaryType": "nt:unstructured"
-                },
-                "value": {
-                    "name": "value",
-                    "propertyIndex": true,
-                    "jcr:primaryType": "nt:unstructured"
-                }
-            }
-        },
         "lfs:Form" : {
             "jcr:primaryType": "nt:unstructured",
             "properties": {


### PR DESCRIPTION
Ugly fix: disable the Lucene index for answers

Correctness should be tested, but performance with a thousand forms should also be tested.