### PR TITLE
LFS-709: Subject selector improvements; LFS-721:Unable to create Tumor form in a specific situation; LFS-688: UI anomaly when having multiple tumors with the same name

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -205,7 +205,7 @@ function UnstyledSelectParentDialog (props) {
                 addRowPosition: 'first',
                 rowStyle: rowData => ({
                   /* It doesn't seem possible to alter the className from here */
-                  backgroundColor: (value?.["identifier"] === rowData["identifier"]) ? theme.palette.grey["200"] : theme.palette.background.default
+                  backgroundColor: (value?.["jcr:uuid"] === rowData["jcr:uuid"]) ? theme.palette.grey["200"] : theme.palette.background.default
                 })
               }}
               onRowClick={(event, rowData) => {onChangeParent(rowData);}}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -767,7 +767,7 @@ function SubjectSelectorList(props) {
 
   // if the number of related forms of a certain questionnaire/subject is at the maxPerSubject, an error is set
   let handleSelection = (rowData) => {
-    let atMax = (relatedSubjects && selectedQuestionnaire && (relatedSubjects.filter((i) => (i.identifier == rowData.identifier)).length >= selectedQuestionnaire?.["maxPerSubject"]))
+    let atMax = (relatedSubjects && selectedQuestionnaire && (relatedSubjects.filter((i) => (i["jcr:uuid"] == rowData["jcr:uuid"])).length >= selectedQuestionnaire?.["maxPerSubject"]))
     if (atMax) {
       onError(`${rowData?.["type"]["@name"]} ${rowData?.["identifier"]} already has ${selectedQuestionnaire?.["maxPerSubject"]} ${selectedQuestionnaire?.["title"]} form(s) filled out.`);
       disableProgress(true);
@@ -921,7 +921,7 @@ function SubjectSelectorList(props) {
             /* It doesn't seem possible to alter the className from here */
             backgroundColor: (selectedSubject?.["jcr:uuid"] === rowData["jcr:uuid"]) ? theme.palette.grey["200"] : theme.palette.background.default,
             // grey out subjects that have already reached maxPerSubject
-            color: ((relatedSubjects && selectedQuestionnaire && (relatedSubjects.filter((i) => (i.identifier == rowData.identifier)).length >= selectedQuestionnaire?.["maxPerSubject"]))
+            color: ((relatedSubjects && selectedQuestionnaire && (relatedSubjects.filter((i) => (i["jcr:uuid"] == rowData["jcr:uuid"])).length >= selectedQuestionnaire?.["maxPerSubject"]))
             ? theme.palette.grey["500"]
             : theme.palette.grey["900"]
             )

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -181,6 +181,7 @@ function UnstyledSelectParentDialog (props) {
         {
           initialized &&
             <MaterialTable
+              title=""
               columns={COLUMNS}
               data={query => {
                   let url = createQueryURL(` WHERE n.type='${parentType?.["jcr:uuid"]}'` + (query.search ? ` AND CONTAINS(n.identifier, '*${query.search}*')` : ""), "lfs:Subject");

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -673,10 +673,12 @@ export function createSubjects(newSubjects, subjectType, subjectParents, subject
       .then( (json) => {
         if (json?.rows?.length > 0) {
           // Create an error message, adding the parents if they exist
-          let error_msg = `Subject ${subjectName} already exists`;
+          let error_msg = subjectType?.['@name'] || "Subject";
+          error_msg += ` ${subjectName} already exists`;
           let id = json["rows"][0]["parents"]?.["identifier"];
           if (id) {
-            error_msg += " for parent " + id;
+            let parentType = json["rows"][0]["parents"]?.["type"]?.["@name"] || "parent";
+            error_msg += ` for ${parentType} ${id}.`;
           }
 
           return Promise.reject(error_msg);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -191,9 +191,8 @@ function UnstyledSelectParentDialog (props) {
                     .then(result => {
                       return {
                         data: result["rows"].map((row) => ({
-                          hierarchy: getHierarchy(rowData, React.Fragment, ()=>({})),
-                          ...row
-                        })),
+                          hierarchy: getHierarchy(row, React.Fragment, ()=>({})),
+                          ...row })),
                         page: Math.trunc(result["offset"]/result["limit"]),
                         totalCount: result["totalrows"],
                       }}
@@ -844,7 +843,7 @@ function SubjectSelectorList(props) {
                     ? result['rows'].filter((e) => filterRelated(e)) : result["rows"]
                   ).map((row) => ({
                     hierarchy: getHierarchy(row, React.Fragment, () => ({})),
-                    ...row})),
+                    ...row })),
                   page: Math.trunc(result["offset"]/result["limit"]),
                   totalCount: result["totalrows"],
                 }}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -182,7 +182,6 @@ function UnstyledSelectParentDialog (props) {
         {
           initialized &&
             <MaterialTable
-              title={"Select a " + parentType?.['label']}
               columns={COLUMNS}
               data={query => {
                   let url = createQueryURL(` WHERE n.type='${parentType?.["jcr:uuid"]}'` + (query.search ? ` AND CONTAINS(n.identifier, '*${query.search}*')` : ""), "lfs:Subject");

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -166,8 +166,7 @@ function UnstyledSelectParentDialog (props) {
   const { classes, childType, continueDisabled, disabled, error, isLast, open, onBack, onChangeParent, onCreateParent, onClose, onSubmit, parentType, tableRef, theme, value } = props;
 
   const COLUMNS = [
-    { title: 'Subject', field: 'identifier' },
-    { title: 'Hierarchy', field: 'hierarchy' },
+    { title: 'Subject', field: 'hierarchy' },
   ];
 
   let initialized = parentType && childType;
@@ -192,7 +191,7 @@ function UnstyledSelectParentDialog (props) {
                     .then(result => {
                       return {
                         data: result["rows"].map((row) => ({
-                          hierarchy: row["parents"] ? getHierarchy(row["parents"], React.Fragment, ()=>({})) : "No parents",
+                          hierarchy: getHierarchy(rowData, React.Fragment, ()=>({})),
                           ...row
                         })),
                         page: Math.trunc(result["offset"]/result["limit"]),
@@ -749,8 +748,7 @@ function SubjectSelectorList(props) {
   const { allowedTypes, allowAddSubjects, allowDeleteSubjects, classes, disabled, onDelete, onEdit, onError, onSelect, selectedSubject, selectedQuestionnaire, disableProgress,
     currentSubject, theme, ...rest } = props;
   const COLUMNS = [
-    { title: 'Identifier', field: 'identifier' },
-    { title: 'Hierarchy', field: 'hierarchy' },
+    { title: 'Identifier', field: 'hierarchy' },
   ];
   const [ relatedSubjects, setRelatedSubjects ] = useState();
 
@@ -845,7 +843,7 @@ function SubjectSelectorList(props) {
                     (currentSubject && (result['rows'].map((row) => isSubjectRelated(row).includes(currentSubject.type.label)))[0])
                     ? result['rows'].filter((e) => filterRelated(e)) : result["rows"]
                   ).map((row) => ({
-                    hierarchy: row["parents"] ? getHierarchy(row["parents"], React.Fragment, () => ({})) : "No parents",
+                    hierarchy: getHierarchy(row, React.Fragment, () => ({})),
                     ...row})),
                   page: Math.trunc(result["offset"]/result["limit"]),
                   totalCount: result["totalrows"],


### PR DESCRIPTION
[LFS-709](https://phenotips.atlassian.net/browse/LFS-709): Subject selector improvements - 3/4 subtasks:
* [LFS-711](https://phenotips.atlassian.net/browse/LFS-711): Remove Select a <SubjectType> from the dialog body
* [LFS-708](https://phenotips.atlassian.net/browse/LFS-708): Display the full id for available subjects
* [LFS-720](https://phenotips.atlassian.net/browse/LFS-720): Improve error message

[LFS-721](https://phenotips.atlassian.net/browse/LFS-721):Unable to create Tumor form in a specific situation

[LFS-688](https://phenotips.atlassian.net/browse/LFS-688): UI anomaly when having multiple tumors with the same name