### PR TITLE
LFS-715: Display the questionnaire description when available

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -23,6 +23,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { CircularProgress, Button, Dialog, DialogActions, DialogContent, DialogTitle, Fab, Input, List} from "@material-ui/core";
 import { ListItemText, Tooltip, Typography, withStyles } from "@material-ui/core";
 import AddIcon from "@material-ui/icons/Add";
+import AssignmentIcon from "@material-ui/icons/Assignment";
 
 import SubjectSelectorList, { NewSubjectDialog, SubjectListItem, parseToArray } from "../questionnaire/SubjectSelector.jsx";
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
@@ -244,9 +245,10 @@ function NewFormDialog(props) {
                     onClick={() => {setSelectedQuestionnaire(questionnaire)}}
                     disabled={isFetching}
                     selected={questionnaire["jcr:uuid"] === selectedQuestionnaire?.["jcr:uuid"]}
+                    avatarIcon={AssignmentIcon}
                     >
                     <div className={`${atMax ? classes.questionnaireDisabledListItem : classes.questionnaireListItem}`}>
-                      <ListItemText primary={questionnaire["title"]} />
+                      <ListItemText primary={questionnaire["title"]} secondary={questionnaire["description"]}/>
                     </div>
                   </SubjectListItem>);
                 })}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
@@ -42,6 +42,11 @@ function Questionnaires(props) {
       "link": "dashboard+path",
     },
     {
+      "key": "description",
+      "label": "Description",
+      "format": "string",
+    },
+    {
       "key": "jcr:created",
       "label": "Created on",
       "format": "date:YYYY-MM-DD HH:mm",

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
@@ -110,6 +110,7 @@ let Questionnaire = (props) => {
               <FieldsGrid
                 classes={classes}
                 fields= {Array(
+                          {name: "description", label: "Description", value : data.description},
                           {name: "maxPerType", label: "Maximum forms of this type per subject", value : data.maxPerSubject || 'Unlimited'},
                           {name: "subjectTypes", label: "Subject types", value: data.requiredSubjectTypes?.label || data.requiredSubjectTypes?.map(t => t.label).join(', ') || 'Any'},
                         )}

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Properties.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Properties.json
@@ -1,5 +1,6 @@
 [
   {
+    "description" : "string",
     "maxPerSubject": "long",
     "requiredSubjectTypes": "list"
   }


### PR DESCRIPTION
Includes 3/4 subtasks:
* [LFS-716](https://phenotips.atlassian.net/browse/LFS-716): Questionnaire selector displays questionnaire description
* [LFS-718](https://phenotips.atlassian.net/browse/LFS-718): Questionnaires table displays questionnaire description
* [LFS-719](https://phenotips.atlassian.net/browse/LFS-719): Questionnaire description can be viewed and updated in the questionnaire wizard


[LFS-717](https://phenotips.atlassian.net/browse/LFS-717) (Subject chart displays questionnaire description) should be implemented together with or after [LFS-698](https://phenotips.atlassian.net/browse/LFS-698) (Restructure the patient chart).

To test, first use the questionnaire wizard to add descriptions to any existing questionnaires, then check it gets displayed in the questionnaire table and questionnaire selector.