### PR TITLE
LFS-697: Forms with conditional sections are not properly marked as COMPLETE or INCOMPLETE

### DIFF
--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -262,8 +262,13 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         return false;
     }
 
-    private void summarize()
-        throws RepositoryException
+    /**
+     * Gather all status flags from all the (satisfied) descendants of the current node and store them as the status
+     * flags of the current node.
+     *
+     * @throws RepositoryException if accessing the repository fails
+     */
+    private void summarize() throws RepositoryException
     {
         // Iterate through all children of this node
         final Iterator<String> childrenNames = this.currentNodeBuilder.getChildNodeNames().iterator();

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -275,8 +275,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
             final NodeBuilder selectedChild = this.currentNodeBuilder.getChildNode(selectedChildName);
             if (isSection(selectedChild)) {
                 final Session resourceSession = this.currentResourceResolver.adaptTo(Session.class);
-                if (!ConditionalSectionUtils.isConditionSatisfied(
-                    resourceSession, selectedChild, this.currentNodeBuilder)) {
+                if (!ConditionalSectionUtils.isConditionSatisfied(resourceSession, selectedChild, this.form)) {
                     continue;
                 }
             }

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -59,6 +59,8 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     // actual parent node of those properties, so we must manually keep track of the current node.
     private final NodeBuilder currentNodeBuilder;
 
+    private final NodeBuilder form;
+
     // A ResourceResolver object is passed in during the initialization of this object. This ResourceResolver
     // is later used for obtaining the constraints on the answers submitted to a question.
     private final ResourceResolver currentResourceResolver;
@@ -75,12 +77,20 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
      * @param nodeBuilder a list of NodeBuilder objects starting from the root of the JCR tree and moving down towards
      *            the current node.
      * @param resourceResolver a ResourceResolver object used to obtain answer constraints
+     * @param form the form node found up the tree, if any; may be {@code null} if no form node has been encountered so
+     *            far
      */
-    public AnswerCompletionStatusEditor(final List<NodeBuilder> nodeBuilder, final ResourceResolver resourceResolver)
+    public AnswerCompletionStatusEditor(final List<NodeBuilder> nodeBuilder, final NodeBuilder form,
+        final ResourceResolver resourceResolver)
     {
         this.currentNodeBuilderPath = nodeBuilder;
         this.currentNodeBuilder = nodeBuilder.get(nodeBuilder.size() - 1);
         this.currentResourceResolver = resourceResolver;
+        if (isForm(this.currentNodeBuilder)) {
+            this.form = this.currentNodeBuilder;
+        } else {
+            this.form = form;
+        }
     }
 
     // Called when a new property is added
@@ -166,7 +176,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         }
         final List<NodeBuilder> tmpList = new ArrayList<>(this.currentNodeBuilderPath);
         tmpList.add(this.currentNodeBuilder.getChildNode(name));
-        return new AnswerCompletionStatusEditor(tmpList, this.currentResourceResolver);
+        return new AnswerCompletionStatusEditor(tmpList, this.form, this.currentResourceResolver);
     }
 
     @Override
@@ -175,15 +185,14 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     {
         final List<NodeBuilder> tmpList = new ArrayList<>(this.currentNodeBuilderPath);
         tmpList.add(this.currentNodeBuilder.getChildNode(name));
-        return new AnswerCompletionStatusEditor(tmpList, this.currentResourceResolver);
+        return new AnswerCompletionStatusEditor(tmpList, this.form, this.currentResourceResolver);
     }
 
     @Override
     public void leave(NodeState before, NodeState after)
         throws CommitFailedException
     {
-        final String nodeType = this.currentNodeBuilder.getProperty("jcr:primaryType").getValue(Type.STRING);
-        if ("lfs:Form".equals(nodeType) || "lfs:AnswerSection".equals(nodeType)) {
+        if (isForm(this.currentNodeBuilder) || isSection(this.currentNodeBuilder)) {
             try {
                 summarize();
             } catch (RepositoryException e) {
@@ -264,7 +273,7 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         while (childrenNames.hasNext()) {
             final String selectedChildName = childrenNames.next();
             final NodeBuilder selectedChild = this.currentNodeBuilder.getChildNode(selectedChildName);
-            if ("lfs:AnswerSection".equals(selectedChild.getProperty("jcr:primaryType").getValue(Type.STRING))) {
+            if (isSection(selectedChild)) {
                 final Session resourceSession = this.currentResourceResolver.adaptTo(Session.class);
                 if (!ConditionalSectionUtils.isConditionSatisfied(
                     resourceSession, selectedChild, this.currentNodeBuilder)) {
@@ -296,5 +305,38 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         }
         // Write these statusFlags to the JCR repo
         this.currentNodeBuilder.setProperty(STATUS_FLAGS, statusFlags, Type.STRINGS);
+    }
+
+    /**
+     * Checks if the given node is a Form node.
+     *
+     * @param node the JCR Node to check
+     * @return {@code true} if the node is a Form node, {@code false} otherwise
+     */
+    private boolean isForm(NodeBuilder node)
+    {
+        return "lfs:Form".equals(getNodeType(node));
+    }
+
+    /**
+     * Checks if the given node is an AnswerSection node.
+     *
+     * @param node the JCR Node to check
+     * @return {@code true} if the node is an AnswerSection node, {@code false} otherwise
+     */
+    private boolean isSection(NodeBuilder node)
+    {
+        return "lfs:AnswerSection".equals(getNodeType(node));
+    }
+
+    /**
+     * Retrieves the primary node type of a node, as a String.
+     *
+     * @param node the node whose type to retrieve
+     * @return a string
+     */
+    private String getNodeType(NodeBuilder node)
+    {
+        return node.getProperty("jcr:primaryType").getValue(Type.STRING);
     }
 }

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditorProvider.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/AnswerCompletionStatusEditorProvider.java
@@ -58,7 +58,7 @@ public class AnswerCompletionStatusEditorProvider implements EditorProvider
                 // Each AnswerCompletionStatusEditor maintains a state, so a new instance must be returned each time
                 final List<NodeBuilder> tmpList = new ArrayList<>();
                 tmpList.add(builder);
-                return new AnswerCompletionStatusEditor(tmpList, myResolver);
+                return new AnswerCompletionStatusEditor(tmpList, null, myResolver);
             }
         }
         return null;

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/ConditionalSectionUtils.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/ConditionalSectionUtils.java
@@ -530,7 +530,7 @@ public final class ConditionalSectionUtils
     private static boolean evaluateConditionNodeRecursive(final Node conditionNode, final Node sectionNode,
         final NodeBuilder form) throws RepositoryException
     {
-        if ("lfs:ConditionalGroup".equals(conditionNode.getProperty("jcr:primaryType").getString())) {
+        if ("lfs:ConditionalGroup".equals(conditionNode.getPrimaryNodeType().getName())) {
             // Is this an OR or an AND
             final boolean requireAll = conditionNode.getProperty(PROP_REQUIRE_ALL).getBoolean();
             // Evaluate recursively
@@ -550,7 +550,7 @@ public final class ConditionalSectionUtils
                 }
             }
             return downstreamResult;
-        } else if ("lfs:Conditional".equals(conditionNode.getProperty("jcr:primaryType").getString())) {
+        } else if ("lfs:Conditional".equals(conditionNode.getPrimaryNodeType().getName())) {
             final String comparator = conditionNode.getProperty("comparator").getString();
             final Node operandB = conditionNode.getNode("operandB");
             final Node operandA = conditionNode.getNode("operandA");

--- a/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/ConditionalSectionUtils.java
+++ b/modules/form-completion-status/src/main/java/ca/sickkids/ccm/lfs/formcompletionstatus/ConditionalSectionUtils.java
@@ -513,11 +513,11 @@ public final class ConditionalSectionUtils
              * Recursively go through all children of the condition node and determine if this condition node evaluates
              * to True or False.
              */
-            if (evaluateConditionNodeRecursive(conditionNode, sectionNode, prevNb)) {
-                return true;
+            if (!evaluateConditionNodeRecursive(conditionNode, sectionNode, prevNb)) {
+                return false;
             }
         }
-        return false;
+        return true;
     }
 
     private static long toLong(Object o)


### PR DESCRIPTION
Use the `LFS-697-test` branch to test. The Demographics questionnaire has four sections, one which is only displayed if Gender = F, and one which is only displayed if Vital Status = Alive and NED.

The whole diff is quite big, but checking commit by commit should make it more obvious what changed.