### PR TITLE
LFS-648: Implement .bare.json for exporting forms without the JCR-specific metadata

### DIFF
--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/BareFormProcessor.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/BareFormProcessor.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package ca.sickkids.ccm.lfs.dataentry.internal.serialize;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonValue;
+
+import org.apache.sling.api.resource.Resource;
+import org.osgi.service.component.annotations.Component;
+
+import ca.sickkids.ccm.lfs.serialize.spi.ResourceJsonProcessor;
+
+/**
+ * Simplify Form serialization by including only the name of the subject, questionnaire, and each section and question.
+ * It should be used together with {@code deep}, {@code -dereference} and {@code -identify}. The name of this processor
+ * is {@code bare}.
+ *
+ * @version $Id$
+ */
+@Component(immediate = true)
+public class BareFormProcessor implements ResourceJsonProcessor
+{
+    private ThreadLocal<Map<String, JsonObject>> childrenJsons = ThreadLocal.withInitial(HashMap::new);
+
+    private ThreadLocal<Map<String, String>> questionNames = ThreadLocal.withInitial(HashMap::new);
+
+    @Override
+    public String getName()
+    {
+        return "bare";
+    }
+
+    @Override
+    public int getPriority()
+    {
+        return 95;
+    }
+
+    @Override
+    public boolean canProcess(Resource resource)
+    {
+        // This only simplifies forms
+        return resource.isResourceType("lfs/Form");
+    }
+
+    @Override
+    public JsonValue processProperty(final Node node, final Property property, final JsonValue input,
+        final Function<Node, JsonValue> serializeNode)
+    {
+        if (property == null) {
+            return null;
+        }
+        try {
+            JsonValue result = input;
+            result = simplifyQuestionnaire(node, property, result);
+            result = simplifySubject(node, property, result);
+            result = simplifySection(node, property, result);
+            result = simplifyQuestion(node, property, result);
+            result = removeStatusFlags(node, property, result);
+            return result;
+        } catch (RepositoryException e) {
+            // Really shouldn't happen
+        }
+        return input;
+    }
+
+    @Override
+    public JsonValue processChild(final Node node, final Node child, final JsonValue input,
+        final Function<Node, JsonValue> serializeNode)
+    {
+        if (input == null) {
+            return null;
+        }
+        try {
+            // Do not recursively serialize questionnaire items
+            if (node.isNodeType("lfs:Questionnaire") || node.isNodeType("lfs:Section")
+                || node.isNodeType("lfs:Question")) {
+                return null;
+            }
+            if (child.isNodeType("lfs:Answer") || child.isNodeType("lfs:AnswerSection")) {
+                this.childrenJsons.get().put(child.getIdentifier(), input.asJsonObject());
+                return null;
+            }
+        } catch (RepositoryException e) {
+            // Really shouldn't happen
+        }
+        return input;
+    }
+
+    @Override
+    public void leave(Node node, JsonObjectBuilder json, Function<Node, JsonValue> serializeNode)
+    {
+        addSections(node, json);
+        addAnswers(node, json);
+    }
+
+    @Override
+    public void end(Resource resource)
+    {
+        this.childrenJsons.remove();
+        this.questionNames.remove();
+    }
+
+    private void addSections(Node node, JsonObjectBuilder json)
+    {
+        try {
+            final NodeIterator children = node.getNodes();
+            while (children.hasNext()) {
+                final Node child = children.nextNode();
+                final String childId = child.getIdentifier();
+                if (child.isNodeType("lfs:AnswerSection") && this.childrenJsons.get().containsKey(childId)) {
+                    final JsonObject childJson = this.childrenJsons.get().get(childId);
+                    final String childLabel = childJson.getString("section");
+                    json.add(childLabel, Json.createObjectBuilder(childJson).remove("section").build());
+                    this.childrenJsons.get().remove(childId);
+                }
+            }
+        } catch (RepositoryException e) {
+            // Shouldn't happen
+        }
+    }
+
+    private void addAnswers(Node node, JsonObjectBuilder json)
+    {
+        try {
+            final NodeIterator children = node.getNodes();
+            while (children.hasNext()) {
+                final Node child = children.nextNode();
+                final String childId = child.getIdentifier();
+                if (child.isNodeType("lfs:Answer") && this.childrenJsons.get().containsKey(childId)) {
+                    final JsonObject childJson = this.childrenJsons.get().get(childId);
+                    if (childJson.size() > 1) {
+                        // The question label is always present, so only one item means the answer is empty
+                        // Only include non-empty answers in the parent JSON
+                        final String childLabel = this.questionNames.get().get(childId);
+                        json.add(childLabel, childJson);
+                    }
+                    this.childrenJsons.get().remove(childId);
+                    this.questionNames.get().remove(childId);
+                }
+            }
+        } catch (RepositoryException e) {
+            // Shouldn't happen
+        }
+    }
+
+    private JsonValue simplifyQuestionnaire(final Node node, final Property property, final JsonValue input)
+        throws RepositoryException
+    {
+        // Replace the questionnaire reference with the title of the actual questionnaire
+        if (node.isNodeType("lfs:Form") && "questionnaire".equals(property.getName())) {
+            return Json.createValue(property.getNode().getProperty("title").getString());
+        }
+        return input;
+    }
+
+    private JsonValue simplifySubject(final Node node, final Property property, final JsonValue input)
+        throws RepositoryException
+    {
+        // Replace the subject reference with the label of the actual subject (and its parents)
+        if (node.isNodeType("lfs:Form") && "subject".equals(property.getName())) {
+            try {
+                Node subject = property.getNode();
+                final List<String> identifiers = new ArrayList<>();
+                while (subject != null) {
+                    identifiers.add(subject.getProperty("identifier").getString());
+                    if (!subject.hasProperty("parents")) {
+                        break;
+                    }
+                    Value parent;
+                    if (subject.getProperty("parents").isMultiple()) {
+                        parent = subject.getProperty("parents").getValues()[0];
+                    } else {
+                        parent = subject.getProperty("parents").getValue();
+                    }
+                    subject = node.getSession().getNodeByIdentifier(parent.getString());
+                }
+
+                return Json.createValue(identifiers.stream().reduce((result, parent) -> parent + " / " + result).get());
+            } catch (RepositoryException | NullPointerException e) {
+                // Bad data, just return the original input
+            }
+        }
+        return input;
+    }
+
+    private JsonValue simplifySection(final Node node, final Property property, final JsonValue input)
+        throws RepositoryException
+    {
+        // Replace the section reference with the label of the actual section, if present, or the section node name
+        // otherwise
+        if (node.isNodeType("lfs:AnswerSection") && "section".equals(property.getName())) {
+            final Node section = property.getNode();
+            if (section.hasProperty("label")) {
+                return Json.createValue(section.getProperty("label").getString());
+            }
+            return Json.createValue(section.getName());
+        }
+        return input;
+    }
+
+    private JsonValue simplifyQuestion(final Node node, final Property property, final JsonValue input)
+        throws RepositoryException
+    {
+        // Replace the question reference with the label of the actual question
+        if (node.isNodeType("lfs:Answer") && "question".equals(property.getName())) {
+            Node question = property.getNode();
+            this.questionNames.get().put(node.getIdentifier(), question.getName());
+            return Json.createValue(question.getProperty("text").getString());
+        }
+        return input;
+    }
+
+    private JsonValue removeStatusFlags(final Node node, final Property property, final JsonValue input)
+        throws RepositoryException
+    {
+        // Status flags are not needed
+        if ("statusFlags".equals(property.getName())) {
+            return null;
+        }
+        return input;
+    }
+}

--- a/modules/utils/src/main/java/ca/sickkids/ccm/lfs/serialize/internal/BareProcessor.java
+++ b/modules/utils/src/main/java/ca/sickkids/ccm/lfs/serialize/internal/BareProcessor.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package ca.sickkids.ccm.lfs.serialize.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.function.Function;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.json.Json;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonValue;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.sling.api.resource.Resource;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ca.sickkids.ccm.lfs.serialize.spi.ResourceJsonProcessor;
+
+/**
+ * Simplify serialization for all resource types by removing all technical properties, renaming {@code "jcr:created"} to
+ * simply {@code "created"}, and storing file attachments in a {@code "content"} property. The name of this processor is
+ * {@code bare}.
+ *
+ * @version $Id$
+ */
+@Component(immediate = true, scope = ServiceScope.SINGLETON)
+public class BareProcessor implements ResourceJsonProcessor
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(BareProcessor.class);
+
+    private ThreadLocal<Integer> depth = ThreadLocal.withInitial(() -> 0);
+
+    @Override
+    public String getName()
+    {
+        return "bare";
+    }
+
+    @Override
+    public int getPriority()
+    {
+        return 90;
+    }
+
+    @Override
+    public void start(Resource resource)
+    {
+        this.depth.set(0);
+    }
+
+    @Override
+    public void enter(Node node, JsonObjectBuilder input, Function<Node, JsonValue> serializeNode)
+    {
+        this.depth.set(this.depth.get() + 1);
+    }
+
+    @Override
+    public JsonValue processProperty(final Node node, final Property property, final JsonValue input,
+        final Function<Node, JsonValue> serializeNode)
+    {
+        if (property == null) {
+            return null;
+        }
+        try {
+            final String name = property.getName();
+            JsonValue result = input;
+            result = removeSlingProperties(name, result);
+            result = removeJcrProperties(node, name, result);
+            return result;
+        } catch (RepositoryException e) {
+            // Really shouldn't happen
+        }
+        return input;
+    }
+
+    @Override
+    public JsonValue processChild(Node node, Node child, JsonValue input, Function<Node, JsonValue> serializeNode)
+    {
+        try {
+            if (child.getName().startsWith("jcr:")) {
+                return null;
+            }
+        } catch (RepositoryException e) {
+            // Shouldn't happen
+        }
+        return input;
+    }
+
+    @Override
+    public void leave(final Node node, final JsonObjectBuilder json,
+        final Function<Node, JsonValue> serializeNode)
+    {
+        this.depth.set(this.depth.get() - 1);
+        addCreationDate(node, json);
+        addFileContent(node, json);
+    }
+
+    private JsonValue removeSlingProperties(final String propertyName, final JsonValue input)
+    {
+        if (propertyName.startsWith("sling:")) {
+            return null;
+        }
+        return input;
+    }
+
+    private JsonValue removeJcrProperties(final Node node, final String propertyName, final JsonValue input)
+        throws RepositoryException
+    {
+        if (propertyName.startsWith("jcr:")) {
+            return null;
+        }
+        return input;
+    }
+
+    private void addCreationDate(final Node node, final JsonObjectBuilder json)
+    {
+        if (this.depth.get() == 0) {
+            try {
+                if (node.hasProperty("jcr:created")) {
+                    json.add("created", serializeDate(node.getProperty("jcr:created").getDate()));
+                }
+            } catch (RepositoryException e) {
+                // Should't happen, and fixing the date is not that critical
+            }
+        }
+    }
+
+    private void addFileContent(final Node node, final JsonObjectBuilder json)
+    {
+        try {
+            if (node.isNodeType("nt:file")) {
+                Node resourceNode = null;
+                for (NodeIterator children = node.getNodes(); children.hasNext();) {
+                    final Node child = children.nextNode();
+                    if (child.isNodeType("nt:resource")) {
+                        resourceNode = child;
+                        break;
+                    }
+                }
+                if (resourceNode != null && resourceNode.hasProperty("jcr:data")) {
+                    json.add("content",
+                        serializeInputStream(resourceNode.getProperty("jcr:data").getBinary().getStream()));
+                }
+            }
+        } catch (RepositoryException e) {
+            // Should't happen, and fixing the date is not that critical
+        }
+    }
+
+    private JsonValue serializeDate(final Calendar value)
+    {
+        // Use the ISO 8601 date+time format
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+        sdf.setTimeZone(value.getTimeZone());
+        return Json.createValue(sdf.format(value.getTime()));
+    }
+
+    private JsonValue serializeInputStream(final InputStream value)
+    {
+        try {
+            return Json.createValue(IOUtils.toString(value, StandardCharsets.ISO_8859_1));
+        } catch (IOException e) {
+            LOGGER.warn("Failed to read InputStream: {}", e.getMessage(), e);
+        }
+        return JsonValue.NULL;
+    }
+}


### PR DESCRIPTION
With the modular nature of the export, the right URL suffix to use is `.deep.bare.-identify.-dereference.json` to get the proper output. For example `http://localhost:8080/Forms/fd66586c-c0c7-46b9-b2e4-48ce4c971f5e.deep.bare.-identify.-dereference.json`.

Draft since it depends on LFS-725.