### PR TITLE
LFS-735: Computed fields should handle numbers stored as strings

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -81,6 +81,9 @@ let ComputedQuestion = (props) => {
     if (typeof(value) === undefined || value === "") {
       missingValue = true;
     }
+    if (!isNaN(Number(value))) {
+      value = Number(value);
+    }
     return value;
   }
 
@@ -112,7 +115,7 @@ let ComputedQuestion = (props) => {
       let expressionArguments = ["form", "setError"].concat(parseResults[0]);
       result = new Function(expressionArguments, parseResults[2])
         (form, (errorMessage) => {expressionError = errorMessage}, ...parseResults[1]);
-      if (missingValue || typeof(result) === undefined || isNaN(result)) {
+      if (missingValue || typeof(result) === undefined || (typeof(result) === "number" && isNaN(result))) {
         result = "";
       }
     }

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -214,6 +214,9 @@
   // We allow users to place these answers in a Notes section
   - enableNotes (boolean)
 
+  // For computed answers, the expression used to calculate the value
+  - expression (string)
+
   // Since not all properties are mandatory, customizing a question requires defining only
   // the properties of interest.
   //


### PR DESCRIPTION
- If the value of an expression input is exclusively a number,
  convert its type to Number before passing the value.

Testing: Perform numerical expressions on text fields filled with strictly numerical text (eg. "12.3", but not "a1"). This includes lists with numerical options, since list values are stored as strings.

Example:
Question `s1`, list of type text with options `1.2` and `2.3`.
Question `s2`, input of type text.
Question `c1`, input of type computed with expression `return @{s1}+@{s2}`

If s2 is numerical, c2 should be the sum of s1 and s2 (such as 3.2). If s2 is non-numerical, it should be the string concatenation (1.2some_string)