### PR TITLE
LFS-734: Add time question support for minute and second format

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
@@ -59,7 +59,7 @@ class Time {
   }
 
   valueOf() {
-    return this.isValid ? (this.first*60 + this.second) : undefined;
+    return this.isValid ? (this.first*60 + this.second) * (this.isMinuteSeconds ? 1 : 60) : undefined;
   }
 }
 
@@ -89,9 +89,9 @@ function TimeQuestion(props) {
   const [error, setError] = useState(undefined);
   const defaultErrorMessage = errorText || "Please enter a valid time";
   const [errorMessage, setErrorMessage] = useState(defaultErrorMessage);
-  const lowerTime = new Time(lowerLimit);
-  const upperTime = new Time(upperLimit);
   const isMinuteSeconds = typeof(dateFormat) === "string" && dateFormat.toLowerCase() === "mm:ss";
+  const lowerTime = new Time(lowerLimit, isMinuteSeconds);
+  const upperTime = new Time(upperLimit, isMinuteSeconds);
   const minuteSecondTest = new RegExp(/([0-5]\d):([0-5]\d)/);
 
   let checkError = (timeString) => {

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -56,6 +56,7 @@
         "lowerLimit": "string",
         "upperLimit": "string",
         "minAnswers": "long",
+        "maxAnswers": "long",
         "errorText": "string",
         "dateFormat": "string"
       }

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -56,7 +56,8 @@
         "lowerLimit": "string",
         "upperLimit": "string",
         "minAnswers": "long",
-        "errorText": "string"
+        "errorText": "string",
+        "dateFormat": "string"
       }
     }
   }


### PR DESCRIPTION
- Reuses dateFormat question parameter
- If mm:ss is specified, use a regexp backed text field rather than a time input

Testing: Create a question of type time with a dateFormat of either `hh:mm` or `mm:ss`. If hours and minutes, then the browsers date picker should be used. If minutes and seconds, a text field should be created which limits input to the format `##:##`, where both numbers are in the range 00 to 59. Both formats should support minimum and maximum values, specified in the format `##:##`