### PR TITLE
LFS-655: Handle re-login globally

### DIFF
--- a/modules/commons/src/main/frontend/src/SearchBar.jsx
+++ b/modules/commons/src/main/frontend/src/SearchBar.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 import PropTypes from "prop-types";
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { withRouter } from "react-router-dom";
 
 import { ClickAwayListener, Grow, IconButton, Input, InputAdornment, ListItemText, MenuItem, ListItemAvatar, Avatar }  from "@material-ui/core";
@@ -26,6 +26,7 @@ import { Link } from "react-router-dom";
 import DescriptionIcon from "@material-ui/icons/Description";
 import Search from "@material-ui/icons/Search";
 import HeaderStyle from "./headerStyle.jsx";
+import { fetchWithReLogin, GlobalLoginContext } from "./login/loginDialogue.js";
 
 export const DEFAULT_QUERY_URL = "/query";
 export const DEFAULT_MAX_RESULTS = 5;
@@ -64,13 +65,15 @@ function SearchBar(props) {
   const [ showTotalRows, setShowTotalRows ] = useState(true);
   const [ fetched, setFetched ] = useState(false);
 
+  const globalLoginDisplay = useContext(GlobalLoginContext);
+
   let input = React.useRef();
   let suggestionMenu = React.useRef();
   let searchBar = React.useRef();
 
   // Fetch saved admin config settings
   let getQuickSearchSettings = () => {
-    fetch('/apps/lfs/config/QuickSearch.json')
+    fetchWithReLogin(globalLoginDisplay, '/apps/lfs/config/QuickSearch.json')
       .then((response) => response.ok ? response.json() : Promise.reject(response))
       .then((json) => {
         setFetched(true);
@@ -111,7 +114,7 @@ function SearchBar(props) {
     let new_url = queryConstructor(query, requestID, showTotalRows, allowedResourceTypes, limit);
     // In the closure generated, postprocessResults will look for req_id, instead of requestID+1
     setRequestID(requestID+1);
-    fetch(new_url)
+    fetchWithReLogin(globalLoginDisplay, new_url)
       .then(response => response.ok ? response.json() : Promise.reject(response))
       .then(postprocessResults)
       .catch(handleError);

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useRef, useState, useContext } from "react";
 import { Chip, Typography, Button, Dialog, CircularProgress, IconButton } from "@material-ui/core";
 import { DialogActions, DialogContent, DialogTitle, Grid, Select, MenuItem, TextField, withStyles } from "@material-ui/core";
 import Add from "@material-ui/icons/Add";
@@ -24,6 +24,7 @@ import CloseIcon from '@material-ui/icons/Close';
 
 import LiveTableStyle from "./tableStyle.jsx";
 import FilterComponentManager from "./FilterComponents/FilterComponentManager.jsx";
+import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
 
 // We have to import each filter dependency here to load them properly into the FilterComponentManager
 import DateFilter from "./FilterComponents/DateFilter.jsx";
@@ -58,6 +59,8 @@ function Filters(props) {
   const [toFocus, setFocusRow] = useState(null);
   const notesComparator = "notes contain";
 
+  const globalLoginDisplay = useContext(GlobalLoginContext);
+
   // Focus on inputs as they are flagged for focus
   const focusRef = useRef();
   const focusCallback = useCallback(node => {
@@ -87,7 +90,7 @@ function Filters(props) {
       url.searchParams.set("questionnaire", questionnaire);
     }
 
-    fetch(url)
+    fetchWithReLogin(globalLoginDisplay, url)
       .then((response) => response.ok ? response.json() : Promise.reject(response))
       .then(parseFilterData)
       .catch(setError);

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { Paper, Table, TableHead, TableBody, TableRow, TableCell, TablePagination } from "@material-ui/core";
 import { Card, CardHeader, CardContent, CardActions, Chip, IconButton, Typography, Button, LinearProgress, withStyles } from "@material-ui/core";
 import { Link } from 'react-router-dom';
@@ -25,6 +25,7 @@ import moment from "moment";
 
 import Filters from "./Filters.jsx";
 import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
+import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
 
 import LiveTableStyle from "./tableStyle.jsx";
 
@@ -72,6 +73,8 @@ function LiveTable(props) {
       new URL(window.location.pathname.substring(window.location.pathname.lastIndexOf("/")) + ".paginate", window.location.origin)
   );
 
+  const globalLoginDisplay = useContext(GlobalLoginContext);
+
   // When new data is added, trigger a new fetch
   useEffect(() => {
     if (updateData){
@@ -118,7 +121,7 @@ function LiveTable(props) {
       filters["empties"].forEach((value) => {url.searchParams.append("filterempty", value)});
       filters["notempties"].forEach((value) => {url.searchParams.append("filternotempty", value)});
     }
-    let currentFetch = fetch(url);
+    let currentFetch = fetchWithReLogin(globalLoginDisplay, url);
     setFetchStatus(Object.assign({}, fetchStatus, {
       "currentFetch": currentFetch,
       "fetchError": false,

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { withRouter } from "react-router-dom";
 import { v4 as uuidv4 } from 'uuid';
 
@@ -27,6 +27,7 @@ import MaterialTable from "material-table";
 
 import SubjectSelectorList, { NewSubjectDialog, parseToArray } from "../questionnaire/SubjectSelector.jsx";
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
+import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
 
 const PROGRESS_SELECT_QUESTIONNAIRE = 0;
 const PROGRESS_SELECT_SUBJECT = 1;
@@ -53,6 +54,8 @@ function NewFormDialog(props) {
   const [ rowCount, setRowCount ] = useState(5);
   const [ wasOpen, setWasOpen ] = useState(false);
 
+  const globalLoginDisplay = useContext(GlobalLoginContext);
+
   let createForm = (subject) => {
     setError("");
 
@@ -69,7 +72,7 @@ function NewFormDialog(props) {
     request_data.append('questionnaire@TypeHint', 'Reference');
     request_data.append('subject', subject);
     request_data.append('subject@TypeHint', 'Reference');
-    fetch( URL, { method: 'POST', body: request_data })
+    fetchWithReLogin(globalLoginDisplay, URL, { method: 'POST', body: request_data })
       .then( (response) => {
         setNumFetchRequests((num) => (num-1));
         if (response.ok) {
@@ -100,7 +103,7 @@ function NewFormDialog(props) {
   let fetchQuestionnaire = (questionnaireName) => {
     // Send a fetch request to determine the subjects available for the specified questionnaire
     let query = `select * from [lfs:Questionnaire] as n where name()='${questionnaireName}'`;
-    fetch('/query?query=' + encodeURIComponent(query))
+    fetchWithReLogin(globalLoginDisplay, '/query?query=' + encodeURIComponent(query))
       .then((response) => response.ok ? response.json() : Promise.reject(response))
       .then((json) => {
         // If a matching questionnaire was found, turn it into the actual questionnaire object
@@ -190,7 +193,7 @@ function NewFormDialog(props) {
 
   // get all the forms related to the selectedSubject, saved in the `relatedForms` state
   let filterQuestionnaire = () => {
-    fetch(`/query?query=SELECT distinct q.* FROM [lfs:Questionnaire] AS q inner join [lfs:Form] as f on f.'questionnaire'=q.'jcr:uuid' where f.'subject'='${(currentSubject || selectedSubject)?.['jcr:uuid']}'`)
+    fetchWithReLogin(globalLoginDisplay, `/query?query=SELECT distinct q.* FROM [lfs:Questionnaire] AS q inner join [lfs:Form] as f on f.'questionnaire'=q.'jcr:uuid' where f.'subject'='${(currentSubject || selectedSubject)?.['jcr:uuid']}'`)
     .then((response) => response.ok ? response.json() : Promise.reject(response))
     .then((response) => {
       setRelatedForms(response.rows);
@@ -255,7 +258,7 @@ function NewFormDialog(props) {
                   url.searchParams.set("query", `select * from [lfs:Questionnaire] as n${query.search ? ` WHERE CONTAINS(n.'title', '*${query.search}*')` : ""}`);
                   url.searchParams.set("limit", query.pageSize);
                   url.searchParams.set("offset", query.page*query.pageSize);
-                  return fetch(url)
+                  return fetchWithReLogin(globalLoginDisplay, url)
                     .then(response => response.json())
                     .then(result => {
                       return {

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import LiveTable from "./LiveTable.jsx";
 
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
@@ -40,6 +40,7 @@ import AssignmentIndIcon from '@material-ui/icons/AssignmentInd';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import DeleteButton from "./DeleteButton.jsx";
 import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
+import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
 
 function SubjectView(props) {
   const { classes } = props;
@@ -47,6 +48,8 @@ function SubjectView(props) {
   const [ subjectTypes, setSubjectTypes] = useState([])
   const [ tabsLoading, setTabsLoading ] = useState(null);
   const hasSubjects = tabsLoading === false && subjectTypes.length > 0;
+
+  const globalLoginDisplay = useContext(GlobalLoginContext);
 
   // Column configuration for the LiveTables
   const columns = [
@@ -77,7 +80,7 @@ function SubjectView(props) {
     // TODO: Handle pagination?
     url.searchParams.set("limit", 10);
     url.searchParams.set("offset", 0);
-    return fetch(url)
+    return fetchWithReLogin(globalLoginDisplay, url)
       .then(response => response.json())
       .then(result => {
         setSubjectTypes(result.rows);

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -16,13 +16,14 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect } from "react";
+import React, { useState, useContext, useEffect } from "react";
 
 import MaterialTable from "material-table";
 
 import { loadExtensions } from "../uiextension/extensionManager";
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 import { MODE_DIALOG } from "../dataHomepage/NewFormDialog.jsx"
+import { GlobalLoginContext } from "../login/loginDialogue.js";
 
 import {
   Button,
@@ -73,6 +74,8 @@ function UserDashboard(props) {
     setOpen(false);
   }
 
+  let globalLoginDisplay = useContext(GlobalLoginContext);
+
   useEffect(() => {
     getDashboardExtensions()
       .then(extensions => setDashboardExtensions(extensions))
@@ -86,7 +89,7 @@ function UserDashboard(props) {
       .finally(() => setCreationLoading(false));
   }, [])
 
-  if (loading) {
+  if (loading || globalLoginDisplay.getDialogOpenStatus()) {
     return (
       <Grid container justify="center"><Grid item><CircularProgress/></Grid></Grid>
     );

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -318,7 +318,7 @@ function Form (props) {
               buttonClass={classes.titleButton}
             />
           </Typography>
-          <Breadcrumbs separator=".">
+          <Breadcrumbs separator="·">
           {
             data && data['jcr:createdBy'] && data['jcr:created'] ?
             <Typography variant="overline">Entered by {data['jcr:createdBy']} on {moment(data['jcr:created']).format("dddd, MMMM Do YYYY")}</Typography>

--- a/modules/homepage/src/main/frontend/src/themePage/index.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/index.jsx
@@ -28,6 +28,7 @@ import Navbar from "./Navbars/Navbar";
 import Page from "./Page";
 import PageStart from "./PageStart/PageStart";
 import IndexStyle from "./indexStyle.jsx";
+import DialogueLoginContainer, { GlobalLoginContext } from "../login/loginDialogue.js";
 
 class Main extends React.Component {
   constructor(props) {
@@ -41,7 +42,9 @@ class Main extends React.Component {
       mobileOpen: false,
       routes: [],
       contentOffset: 0,
-      title: document.querySelector('meta[name="title"]').content
+      title: document.querySelector('meta[name="title"]').content,
+      loginDialogOpen: false,
+      loginHandler: undefined,
     };
 
     getRoutes().then(routes => this.setState({routes: routes}));
@@ -98,6 +101,26 @@ class Main extends React.Component {
 
     return (
       <React.Fragment>
+      <GlobalLoginContext.Provider
+        value={{
+          dialogOpen: (loginHandlerFcn) => {
+            let handler = ((success) => {
+              success && this.setState({
+                loginDialogOpen: false,
+                loginHandler: undefined
+              });
+              success && loginHandlerFcn();
+            });
+            (!this.state.loginDialogOpen) && this.setState({
+              loginDialogOpen: true,
+              loginHandler: handler
+            });
+          },
+          getDialogOpenStatus: () => {
+            return this.state.loginDialogOpen;
+          }
+        }}
+      >
         <PageStart
           setTotalHeight={(th) => {
               if (this.state.contentOffset != th) {
@@ -106,6 +129,7 @@ class Main extends React.Component {
             }
           }
         />
+        <DialogueLoginContainer isOpen={this.state.loginDialogOpen} handleLogin={this.state.loginHandler}/>
         <div className={classes.wrapper} style={ { position: 'relative', top: this.state.contentOffset + 'px' } }>
           <Suspense fallback={<div>Loading...</div>}>
             <Sidebar
@@ -129,6 +153,7 @@ class Main extends React.Component {
             </div>
           </Suspense>
         </div>
+      </GlobalLoginContext.Provider>
       </React.Fragment>
     );
   }

--- a/modules/login/src/main/frontend/src/login/loginDialogue.js
+++ b/modules/login/src/main/frontend/src/login/loginDialogue.js
@@ -21,6 +21,29 @@ import { Dialog } from '@material-ui/core';
 
 import MainLoginComponent from './loginMainComponent';
 
+export const GlobalLoginContext = React.createContext();
+
+export function fetchWithReLogin(displayLoginCtx, url, fetchArgs) {
+    return new Promise(function(resolve, reject) {
+      function fetchFunc() {
+        fetch(url, fetchArgs)
+        .then((response) => {
+          if (response.status == 401 || response.status == 500) {
+              displayLoginCtx.dialogOpen(fetchFunc);
+          } else if (response.ok && response.url.startsWith(window.location.origin + "/login")) {
+              displayLoginCtx.dialogOpen(fetchFunc);
+          } else if (response.ok) {
+              resolve(response);
+          } else {
+              reject(response);
+          }
+        })
+        .catch((err) => {reject(err)});
+      }
+      fetchFunc();
+    });
+}
+
 class DialogueLoginContainer extends React.Component {
   constructor(props) {
     super(props);


### PR DESCRIPTION
This PR is in _draft mode_ as the standardized re-login procedure has not been added to all `fetch()` calls requiring authentication. Nonetheless, any feedback on the changed functionalities thus far would be greatly appreciated. These changed functionalities are:

- _User dashboard_
- _Subjects_ page
- _Forms_ page

- Any individual subject page (eg. a patient chart)
- Any individual form (eg. a Demographics Data form)

- The Delete button (eg. delete a form), has some minor issues handling incorrect logins when deleting a form when the form is open.

To test, login to LFS in two different browser tabs. On one browser tab logout. On the other tab, try the various above listed functionalities (eg. visit the _User dashboard_, visit the _Subjects page_, etc...)