### PR TITLE
LFS-751: Computed fields with value 0 handled incorrectly

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -68,7 +68,7 @@ let ComputedQuestion = (props) => {
   let setValue = (input) => {
     if (value !== input) {
       changeValue(input);
-      changeAnswer(input ? [["value", input]] : []);
+      changeAnswer([["value", typeof(input) === "undefined" ? "" : input]]);
     }
   }
 
@@ -78,7 +78,7 @@ let ComputedQuestion = (props) => {
     if (form[name] && form[name][0]) {
       value = form[name][0][1];
     }
-    if (typeof(value) === undefined || value === "") {
+    if (typeof(value) === "undefined" || value === "") {
       missingValue = true;
     }
     if (!isNaN(Number(value))) {
@@ -115,7 +115,7 @@ let ComputedQuestion = (props) => {
       let expressionArguments = ["form", "setError"].concat(parseResults[0]);
       result = new Function(expressionArguments, parseResults[2])
         (form, (errorMessage) => {expressionError = errorMessage}, ...parseResults[1]);
-      if (missingValue || typeof(result) === undefined || (typeof(result) === "number" && isNaN(result))) {
+      if (missingValue || typeof(result) === "undefined" || (typeof(result) === "number" && isNaN(result))) {
         result = "";
       }
     }
@@ -131,7 +131,7 @@ let ComputedQuestion = (props) => {
       setError(false);
     }
 
-    setValue(result);
+    setValue(typeof(result) === "undefined" ? "" : result.toString());
   }
 
   const muiInputProps = {}


### PR DESCRIPTION
Convert computed values to string before setting answer to match input type="text"
- Resolves form context and saving issues

Testing:
Run using runmode dev to be able to verify values are saved correctly.
Using the questionnaire editor, create 3 questions:
- Variable name: `n1`. Type: `decimal`, text: `Number`
- Variable name: `c1`. Type: `computed`, text: `Computed1`, expression: `return @{n1}`
- Variable name: `c2`. Type: `computed`, text: `Computed2`, expression: `return @{c1} + 1`

Expected behavior: c2 should have value 1 when n1 and c1 are 0. Via composum, ensure that c1 and c2 correctly save values of 0 when the field shows 0.