### PR TITLE
LFS-746: When a conditional section is hidden, its title should also be hidden

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalGroup.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalGroup.jsx
@@ -26,7 +26,7 @@ import ConditionalComponentManager from "./ConditionalComponentManager";
  */
 export function isConditionalGroupSatisfied(conditional, context) {
   let conditionalChildren = Object.values(conditional)
-    .filter((child) => ConditionalComponentManager.isValidConditional(child) && child?.["jcr:primaryType"] != "lfs:Section");
+    .filter((child) => ConditionalComponentManager.isValidConditional(child));
 
   if (conditionalChildren.length == 0) {
     return true;


### PR DESCRIPTION
Allow conditional children of type section to be parsed by parents

Testing:
Have a section with a label which can have all of its child questions be conditionally hidden. When any of the children are present, the section and label should be visible. When none of the children are visible, the section and label should not be visible.

Testing branch which was used for development is available [here](https://github.com/ccmbioinfo/lfs/tree/LFS-746-test). Creates a new 746-test form, which is available alongside LFS forms and (default) runmodes.