### PR TITLE
Subject filter UI improvements: LFS-756, LFS-764

### DIFF
--- a/modules/commons/src/main/frontend/src/SearchBar.jsx
+++ b/modules/commons/src/main/frontend/src/SearchBar.jsx
@@ -255,7 +255,7 @@ function SearchBar(props) {
                       key={i}
                       disabled={result["disabled"]}
                       onClick={(e) => {
-                        // Redirect using React-router
+                        setSearch(result["identifier"]);
                         onSelect(event, result, props);
                         onSelectFinish && onSelectFinish();
                         setPopperOpen(false);

--- a/modules/commons/src/main/frontend/src/SearchBar.jsx
+++ b/modules/commons/src/main/frontend/src/SearchBar.jsx
@@ -256,7 +256,7 @@ function SearchBar(props) {
                       key={i}
                       disabled={result["disabled"]}
                       onClick={(e) => {
-                        setSearch(result.entityIdentifier);
+                        disableDropdownItemLink && setSearch(result.entityIdentifier);
                         onSelect(event, result, props);
                         onSelectFinish && onSelectFinish();
                         setPopperOpen(false);

--- a/modules/commons/src/main/frontend/src/SearchBar.jsx
+++ b/modules/commons/src/main/frontend/src/SearchBar.jsx
@@ -42,15 +42,17 @@ const LFS_QUERY_TEXT_KEY = "text";
  * @param {string} defaultValue The default string to place in the search bar
  * @param {func} onChange Function to call when the input has changed. Default: redirect the user to the found node.
  * @param {func} onPopperClose Function to call when the suggestions list is closed.
- * @param {func} onSelect Function that takes (event, row), called when an option from the autocomplete list is seleceted.
+ * @param {func} onSelect Function that takes (event, row), called when an option from the autocomplete list is selected.
  * @param {func} onSelectFinish Function to call after onSelect
  * @param {func} queryConstructor Function that takes (query, requestID) and returns a URL to query for suggestions. Default: use /query?query
  * @param {func} resultConstructor Function that constructs a DOM element from a row of results.
+ * @param {bool} showAllResultsLink If true, show the link “See all results” of the bottom o the results dropdown
+ * @param {bool} disableDropdownItemLink If true, disable links for results dropdown items
  * @param {object} staticContext Unused, defined here to trap the inserted prop from being passed on with ...rest to the Input, where it is invalid
  * Other props will be forwarded to the Input element
  */
 function SearchBar(props) {
-  const { classes, className, defaultValue, invertColors, onChange, onPopperClose, onSelect, onSelectFinish, queryConstructor, resultConstructor, staticContext, ...rest } = props;
+  const { classes, className, defaultValue, invertColors, onChange, onPopperClose, onSelect, onSelectFinish, queryConstructor, resultConstructor, staticContext, showAllResultsLink, disableDropdownItemLink, ...rest } = props;
   const [ search, setSearch ] = useState(defaultValue);
   const [ results, setResults ] = useState([]);
   const [ moreResults, setMoreResults ] = useState(0);
@@ -149,10 +151,10 @@ function SearchBar(props) {
   // If it's a resource, show avatar, category, and title
   // Otherwise, if it's a generic entry, simply display the name
   function QuickSearchResult(props) {
-    const {resultData} = props;
+    const { resultData, disableLink } = props;
     let ResultConstructor = resultConstructor;
     return resultData["jcr:primaryType"] && (
-      <ResultConstructor resultData={resultData} classes={classes}/>
+      <ResultConstructor resultData={resultData} disableLink={disableLink} classes={classes}/>
     ) || (
        <ListItemText
           primary={resultData.name || ''}
@@ -259,10 +261,10 @@ function SearchBar(props) {
                         setPopperOpen(false);
                         }}
                       >
-                      <QuickSearchResult resultData={result} />
+                      <QuickSearchResult resultData={result} disableLink={disableDropdownItemLink}/>
                     </MenuItem>
                   ))}
-                  { !results[0]?.disabled &&
+                  { !results[0]?.disabled && showAllResultsLink &&
                   <Link to={"/content.html/QuickSearchResults?query=" + encodeURIComponent(search)
                               + allowedResourceTypes.map(i => `&allowedResourceTypes=${encodeURIComponent(i)}`).join('')}
                           className={classes.root}>

--- a/modules/commons/src/main/frontend/src/SearchBar.jsx
+++ b/modules/commons/src/main/frontend/src/SearchBar.jsx
@@ -23,6 +23,7 @@ import { withRouter } from "react-router-dom";
 import { ClickAwayListener, Grow, IconButton, Input, InputAdornment, ListItemText, MenuItem, ListItemAvatar, Avatar }  from "@material-ui/core";
 import { MenuList, Paper, Popper, withStyles } from "@material-ui/core";
 import { Link } from "react-router-dom";
+import { getEntityIdentifier } from "./themePage/EntityIdentifier.jsx";
 import DescriptionIcon from "@material-ui/icons/Description";
 import Search from "@material-ui/icons/Search";
 import HeaderStyle from "./headerStyle.jsx";
@@ -128,7 +129,7 @@ function SearchBar(props) {
 
     // Show the results, if any
     if (json["rows"].length > 0) {
-      setResults(json["rows"]);
+      setResults(json["rows"].map( (item) => { item.entityIdentifier = getEntityIdentifier(item); return item; }) );
       if (json.totalrows > json.returnedrows) {
         let more = json.totalrows - json.returnedrows;
         setMoreResults(more);
@@ -255,7 +256,7 @@ function SearchBar(props) {
                       key={i}
                       disabled={result["disabled"]}
                       onClick={(e) => {
-                        setSearch(result["identifier"]);
+                        setSearch(result.entityIdentifier);
                         onSelect(event, result, props);
                         onSelectFinish && onSelectFinish();
                         setPopperOpen(false);

--- a/modules/commons/src/main/frontend/src/SearchBar.jsx
+++ b/modules/commons/src/main/frontend/src/SearchBar.jsx
@@ -47,7 +47,7 @@ const LFS_QUERY_TEXT_KEY = "text";
  * @param {func} onSelectFinish Function to call after onSelect
  * @param {func} queryConstructor Function that takes (query, requestID) and returns a URL to query for suggestions. Default: use /query?query
  * @param {func} resultConstructor Function that constructs a DOM element from a row of results.
- * @param {bool} showAllResultsLink If true, show the link “See all results” of the bottom o the results dropdown
+ * @param {bool} showAllResultsLink If true, show the link “See all results” of the bottom of the results dropdown
  * @param {bool} disableDropdownItemLink If true, disable links for results dropdown items
  * @param {object} staticContext Unused, defined here to trap the inserted prop from being passed on with ...rest to the Input, where it is invalid
  * Other props will be forwarded to the Input element

--- a/modules/commons/src/main/frontend/src/headerStyle.jsx
+++ b/modules/commons/src/main/frontend/src/headerStyle.jsx
@@ -97,6 +97,13 @@ const headerStyle = theme => ({
   dropdownItem: {
     whiteSpace: "normal"
   },
+  dropdownItemMiddleAligned: {
+    alignItems: "center",
+    padding: 0
+  },
+  dropdownItemTextMiddleAligned: {
+    marginTop: "14px"
+  },
   suggestions: {
     width: theme.spacing(32)
   },

--- a/modules/commons/src/main/frontend/src/headerStyle.jsx
+++ b/modules/commons/src/main/frontend/src/headerStyle.jsx
@@ -95,14 +95,10 @@ const headerStyle = theme => ({
     marginTop: theme.spacing(1)
   },
   dropdownItem: {
-    whiteSpace: "normal"
-  },
-  dropdownItemMiddleAligned: {
-    alignItems: "center",
-    padding: 0
-  },
-  dropdownItemTextMiddleAligned: {
-    marginTop: "14px"
+    whiteSpace: "normal",
+    "& .MuiListItem-root" : {
+      padding: 0,
+    }
   },
   suggestions: {
     width: theme.spacing(32)

--- a/modules/commons/src/main/frontend/src/headerStyle.jsx
+++ b/modules/commons/src/main/frontend/src/headerStyle.jsx
@@ -97,7 +97,8 @@ const headerStyle = theme => ({
   dropdownItem: {
     whiteSpace: "normal",
     "& .MuiListItem-root" : {
-      padding: 0,
+      margin: theme.spacing(-1, -2),
+      width: "auto",
     }
   },
   suggestions: {

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/SubjectFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/SubjectFilter.jsx
@@ -19,7 +19,7 @@
 
 import React, { forwardRef, useState } from "react";
 import { Avatar, InputAdornment, ListItemAvatar, ListItemText, Tooltip, withStyles } from "@material-ui/core";
-import DescriptionIcon from "@material-ui/icons/Description";
+import AssignmentIndIcon from "@material-ui/icons/AssignmentInd";
 import ErrorIcon from "@material-ui/icons/Error";
 import PropTypes from "prop-types";
 
@@ -27,6 +27,7 @@ import SearchBar from "../../SearchBar.jsx";
 import FilterComponentManager from "./FilterComponentManager.jsx";
 import { DEFAULT_COMPARATORS, UNARY_COMPARATORS } from "./FilterComparators.jsx";
 import QuestionnaireStyle from "../../questionnaire/QuestionnaireStyle.jsx";
+import { green } from '@material-ui/core/colors';
 
 const COMPARATORS = DEFAULT_COMPARATORS.slice().concat(UNARY_COMPARATORS);
 
@@ -87,7 +88,7 @@ const SubjectFilter = forwardRef((props, ref) => {
   // Otherwise, if it's a generic entry, simply display the name
   let QuickSearchResult = (props) => (
     <React.Fragment>
-      <ListItemAvatar><Avatar className={classes.searchResultAvatar}><DescriptionIcon /></Avatar></ListItemAvatar>
+      <ListItemAvatar><Avatar className={classes.searchResultAvatar} style={{ backgroundColor: green[500] }}><AssignmentIndIcon/></Avatar></ListItemAvatar>
       <ListItemText
         primary={(<QuickSearchResultHeader resultData={props.resultData} />)}
         className={classes.dropdownItem}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/SubjectFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/SubjectFilter.jsx
@@ -50,7 +50,7 @@ const SubjectFilter = forwardRef((props, ref) => {
 
   // Pass information about a selected subject upwards
   let selectSubject = (event, row) => {
-    onChangeInput(row["jcr:uuid"], row["identifier"]);
+    onChangeInput(row["jcr:uuid"], row["entityIdentifier"]);
     setHasSelectedValidSubject(true);
     setError(false);
   }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/SubjectFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/SubjectFilter.jsx
@@ -19,7 +19,6 @@
 
 import React, { forwardRef, useState } from "react";
 import { Avatar, InputAdornment, ListItemAvatar, ListItemText, Tooltip, withStyles } from "@material-ui/core";
-import AssignmentIndIcon from "@material-ui/icons/AssignmentInd";
 import ErrorIcon from "@material-ui/icons/Error";
 import PropTypes from "prop-types";
 
@@ -27,7 +26,7 @@ import SearchBar from "../../SearchBar.jsx";
 import FilterComponentManager from "./FilterComponentManager.jsx";
 import { DEFAULT_COMPARATORS, UNARY_COMPARATORS } from "./FilterComparators.jsx";
 import QuestionnaireStyle from "../../questionnaire/QuestionnaireStyle.jsx";
-import { green } from '@material-ui/core/colors';
+import { QuickSearchIdentifier } from "../../themePage/Navbars/QuickSearchIdentifier.jsx";
 
 const COMPARATORS = DEFAULT_COMPARATORS.slice().concat(UNARY_COMPARATORS);
 
@@ -73,29 +72,6 @@ const SubjectFilter = forwardRef((props, ref) => {
     }
   }
 
-  // Generate a human-readable info about the subject matching the query
-  function QuickSearchResultHeader(props) {
-    const {resultData} = props;
-    return resultData && (
-      <div>
-        {resultData?.identifier || resultData["jcr:uuid"] || ''}
-      </div>
-    ) || null
-  }
-
-  // Display a quick search result
-  // If it's a resource, show avatar, category, and title
-  // Otherwise, if it's a generic entry, simply display the name
-  let QuickSearchResult = (props) => (
-    <React.Fragment>
-      <ListItemAvatar><Avatar className={classes.searchResultAvatar} style={{ backgroundColor: green[500] }}><AssignmentIndIcon/></Avatar></ListItemAvatar>
-      <ListItemText
-        primary={(<QuickSearchResultHeader resultData={props.resultData} />)}
-        className={classes.dropdownItem}
-      />
-    </React.Fragment>
-  )
-
   return (
     <SearchBar
       defaultValue={defaultLabel}
@@ -103,7 +79,8 @@ const SubjectFilter = forwardRef((props, ref) => {
       onPopperClose={closePopper}
       onSelect={selectSubject}
       queryConstructor={constructQuery}
-      resultConstructor={QuickSearchResult}
+      resultConstructor={QuickSearchIdentifier}
+      disableDropdownItemLink={true}
       error={!!error /* Turn into a boolean to prevent PropTypes warnings */}
       className={(hasSelectedValidSubject ? "" : classes.invalidSubjectText)}
       startAdornment={

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/HeaderSearchBar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/HeaderSearchBar.jsx
@@ -32,6 +32,7 @@ function HeaderSearchBar(props) {
     <SearchBar
       resultConstructor={QuickSearchIdentifier}
       onSelect={() => {}}
+      showAllResultsLink={true}
       {...rest}
       />
   );

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/QuickSearchIdentifier.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/QuickSearchIdentifier.jsx
@@ -89,14 +89,15 @@ export function QuickSearchIdentifier(props) {
     if (resultData["jcr:primaryType"] == "lfs:Questionnaire") {
       fullPath = `/content.html/admin${resultData["@path"]}#${anchorPath}`;
     }
-    return (<ListItemLink href={disableLink ? '#' : fullPath}>
+    let showMatchInfo = !hideMatchInfo && resultData[LFS_QUERY_MATCH_KEY];
+    return (<ListItemLink href={disableLink ? '#' : fullPath} className={ !showMatchInfo && classes.dropdownItemMiddleAligned}>
               <ListItemAvatar>
                 <MatchAvatar matchData={resultData} classes={classes}></MatchAvatar>
               </ListItemAvatar>
               <ListItemText
                 primary={getEntityIdentifier(resultData)}
-                secondary={!hideMatchInfo && (<QuickSearchMatch matchData={resultData[LFS_QUERY_MATCH_KEY]} classes={classes}></QuickSearchMatch>)}
-                className={classes.dropdownItem}
+                secondary={showMatchInfo && (<QuickSearchMatch matchData={resultData[LFS_QUERY_MATCH_KEY]} classes={classes}></QuickSearchMatch>)}
+                className={!showMatchInfo ? classes.dropdownItemTextMiddleAligned : "" + " " + classes.dropdownItem}
               />
            </ListItemLink>)
 }

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/QuickSearchIdentifier.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/QuickSearchIdentifier.jsx
@@ -95,7 +95,7 @@ export function QuickSearchIdentifier(props) {
                 <MatchAvatar matchData={resultData} classes={classes}></MatchAvatar>
               </ListItemAvatar>
               <ListItemText
-                primary={getEntityIdentifier(resultData)}
+                primary={resultData.entityIdentifier || getEntityIdentifier(resultData)}
                 secondary={showMatchInfo && (<QuickSearchMatch matchData={resultData[LFS_QUERY_MATCH_KEY]} classes={classes}></QuickSearchMatch>)}
                 className={!showMatchInfo ? classes.dropdownItemTextMiddleAligned : "" + " " + classes.dropdownItem}
               />

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/QuickSearchIdentifier.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/QuickSearchIdentifier.jsx
@@ -78,7 +78,7 @@ function MatchAvatar(props) {
 }
 
 function ListItemLink(props) {
-  return <ListItem alignItems="flex-start" button component="a" {...props} />;
+  return <ListItem alignItems="center" button component="a" {...props} />;
 }
 
   // Display a quick search result identifier with link to result section
@@ -90,14 +90,14 @@ export function QuickSearchIdentifier(props) {
       fullPath = `/content.html/admin${resultData["@path"]}#${anchorPath}`;
     }
     let showMatchInfo = !hideMatchInfo && resultData[LFS_QUERY_MATCH_KEY];
-    return (<ListItemLink href={disableLink ? '#' : fullPath} className={ !showMatchInfo && classes.dropdownItemMiddleAligned}>
+    return (<ListItemLink href={disableLink ? '#' : fullPath}>
               <ListItemAvatar>
                 <MatchAvatar matchData={resultData} classes={classes}></MatchAvatar>
               </ListItemAvatar>
               <ListItemText
                 primary={resultData.entityIdentifier || getEntityIdentifier(resultData)}
                 secondary={showMatchInfo && (<QuickSearchMatch matchData={resultData[LFS_QUERY_MATCH_KEY]} classes={classes}></QuickSearchMatch>)}
-                className={!showMatchInfo ? classes.dropdownItemTextMiddleAligned : "" + " " + classes.dropdownItem}
+                className={classes.dropdownItem}
               />
            </ListItemLink>)
 }

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/QuickSearchIdentifier.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/QuickSearchIdentifier.jsx
@@ -41,9 +41,10 @@ const LFS_QUERY_MATCH_NOTES_KEY = "inNotes";
 // Display how the query matched the result
 export function QuickSearchMatch(props) {
     const { matchData, classes } = props;
+    if (!matchData) { return null; }
     // Adjust the question text to reflect the notes, if the match was on the notes
     let questionText = matchData[LFS_QUERY_QUESTION_KEY] + (matchData[LFS_QUERY_MATCH_NOTES_KEY] ? " / Notes" : "");
-    return matchData && (
+    return (
       <React.Fragment>
         <span className={classes.queryMatchKey}>{questionText}</span>
         <span className={classes.queryMatchSeparator}>: </span>
@@ -51,7 +52,7 @@ export function QuickSearchMatch(props) {
         <span className={classes.highlightedText}>{matchData[LFS_QUERY_MATCH_TEXT_KEY]}</span>
         <span className={classes.queryMatchAfter}>{matchData[LFS_QUERY_MATCH_AFTER_KEY]}</span>
       </React.Fragment>
-    ) || null
+    )
 }
 
 function MatchAvatar(props) {
@@ -82,13 +83,13 @@ function ListItemLink(props) {
 
   // Display a quick search result identifier with link to result section
 export function QuickSearchIdentifier(props) {
-    let { resultData, hideMatchInfo, classes } = props;
+    let { resultData, hideMatchInfo, disableLink, classes } = props;
     let anchorPath = resultData[LFS_QUERY_MATCH_KEY] ? resultData[LFS_QUERY_MATCH_KEY][LFS_QUERY_MATCH_PATH_KEY] : '';
     let fullPath = `/content.html${resultData["@path"]}#${anchorPath}`;
     if (resultData["jcr:primaryType"] == "lfs:Questionnaire") {
       fullPath = `/content.html/admin${resultData["@path"]}#${anchorPath}`;
     }
-    return (<ListItemLink href={fullPath}>
+    return (<ListItemLink href={disableLink ? '#' : fullPath}>
               <ListItemAvatar>
                 <MatchAvatar matchData={resultData} classes={classes}></MatchAvatar>
               </ListItemAvatar>


### PR DESCRIPTION
[LFS-756](https://phenotips.atlassian.net/browse/LFS-756) SubjectID and corresponding icon are incorrect in the Subject dropdown of the Modfiy filters dialog
[LFS-764](https://phenotips.atlassian.net/browse/LFS-764) Once a subject is selected in the Subjects filter, its full id should be displayed both in the filter input and the filter chip after the dialog is closed
