### PR TITLE
LFS-757: As an API consumer, I can access the data recorded for a subject

### DIFF
--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/BareFormProcessor.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/BareFormProcessor.java
@@ -158,12 +158,8 @@ public class BareFormProcessor implements ResourceJsonProcessor
                 final String childId = child.getIdentifier();
                 if (child.isNodeType("lfs:Answer") && this.childrenJsons.get().containsKey(childId)) {
                     final JsonObject childJson = this.childrenJsons.get().get(childId);
-                    if (childJson.size() > 1) {
-                        // The question label is always present, so only one item means the answer is empty
-                        // Only include non-empty answers in the parent JSON
-                        final String childLabel = this.questionNames.get().get(childId);
-                        json.add(childLabel, childJson);
-                    }
+                    final String childLabel = this.questionNames.get().get(childId);
+                    json.add(childLabel, childJson);
                     this.childrenJsons.get().remove(childId);
                     this.questionNames.get().remove(childId);
                 }

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/BareSubjectProcessor.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/BareSubjectProcessor.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package ca.sickkids.ccm.lfs.dataentry.internal.serialize;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.json.Json;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonValue;
+
+import org.apache.sling.api.resource.Resource;
+import org.osgi.service.component.annotations.Component;
+
+import ca.sickkids.ccm.lfs.serialize.spi.ResourceJsonProcessor;
+
+/**
+ * Simplify Subject serialization by including only simple labels for the name, type, and parents of a subject. It
+ * should be used together with {@code -dereference} and {@code -identify}. The name of this processor is {@code bare}.
+ *
+ * @version $Id$
+ */
+@Component(immediate = true)
+public class BareSubjectProcessor implements ResourceJsonProcessor
+{
+    @Override
+    public String getName()
+    {
+        return "bare";
+    }
+
+    @Override
+    public int getPriority()
+    {
+        return 95;
+    }
+
+    @Override
+    public boolean canProcess(Resource resource)
+    {
+        return resource.isResourceType("lfs/Subject");
+    }
+
+    @Override
+    public JsonValue processProperty(final Node node, final Property property, final JsonValue input,
+        final Function<Node, JsonValue> serializeNode)
+    {
+        if (property == null) {
+            return null;
+        }
+        try {
+            JsonValue result = input;
+            result = simplifyType(node, property, result);
+            result = simplifyParents(node, property, result);
+            return result;
+        } catch (RepositoryException e) {
+            // Really shouldn't happen
+        }
+        return input;
+    }
+
+    @Override
+    public void leave(Node node, JsonObjectBuilder json, Function<Node, JsonValue> serializeNode)
+    {
+        try {
+            if (node.isNodeType("lfs:Subject")) {
+                // Replace the "identifier" property with a prettier "subject" property
+                json.remove("identifier");
+                json.add("subject", simplifyIdentifier(node));
+            }
+        } catch (RepositoryException e) {
+            // Really shouldn't happen
+        }
+    }
+
+    private JsonValue simplifyIdentifier(final Node subject) throws RepositoryException
+    {
+        return Json.createValue(recursivelyCollect(subject, "identifier", "parents"));
+    }
+
+    private JsonValue simplifyType(final Node node, final Property property, final JsonValue input)
+        throws RepositoryException
+    {
+        // Replace the "type" reference with the labels of the actual subject type (and its ancestors)
+        if (node.isNodeType("lfs:Subject") && "type".equals(property.getName())) {
+            try {
+                return Json.createValue(recursivelyCollect(property.getNode(), "label", "parent"));
+            } catch (RepositoryException | NullPointerException e) {
+                // Bad data, just return the original input
+            }
+        }
+        return input;
+    }
+
+    private JsonValue simplifyParents(final Node node, final Property property, final JsonValue input)
+        throws RepositoryException
+    {
+        // Replace the "parents" reference with the labels of the actual ancestors
+        if (node.isNodeType("lfs:Subject") && "parents".equals(property.getName())) {
+            try {
+                return Json.createValue(recursivelyCollect(property.getNode(), "identifier", "parents"));
+            } catch (RepositoryException | NullPointerException e) {
+                // Bad data, just return the original input
+            }
+        }
+        return input;
+    }
+
+    private String recursivelyCollect(final Node start, final String propertyToRead, final String parentProperty)
+        throws RepositoryException
+    {
+        Node node = start;
+        final List<String> properties = new ArrayList<>();
+        while (node != null) {
+            properties.add(node.getProperty(propertyToRead).getString());
+            if (!node.hasProperty(parentProperty)) {
+                break;
+            }
+            node = node.getProperty(parentProperty).getNode();
+        }
+
+        return properties.stream().reduce((result, parent) -> parent + " / " + result).get();
+    }
+}

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/DataSubjectProcessor.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/DataSubjectProcessor.java
@@ -80,10 +80,11 @@ public class DataSubjectProcessor implements ResourceJsonProcessor
         // We only serialize data for the serialized subject, not other nodes
         this.rootNode.set(resource.getPath());
         final Map<String, String> filtersMap = new HashMap<>();
-        Arrays.asList(this.selectors.get().split("\\.")).stream()
+        Arrays.asList(this.selectors.get().split("(?<!\\\\)(?:\\\\\\\\)*\\.")).stream()
             .filter(s -> StringUtils.startsWith(s, "dataFilter:"))
             .map(s -> StringUtils.substringAfter(s, "dataFilter:"))
-            .forEach(s -> filtersMap.put(StringUtils.substringBefore(s, "="), StringUtils.substringAfter(s, "=")));
+            .forEach(s -> filtersMap.put(StringUtils.substringBefore(s, "="),
+                StringUtils.substringAfter(s, "=").replaceAll("\\\\\\.", ".")));
         this.filters.set(filtersMap);
 
     }

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/DataSubjectProcessor.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/DataSubjectProcessor.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package ca.sickkids.ccm.lfs.dataentry.internal.serialize;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.function.Function;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.query.Query;
+import javax.json.Json;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonValue;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.osgi.service.component.annotations.Component;
+
+import ca.sickkids.ccm.lfs.serialize.spi.ResourceJsonProcessor;
+
+/**
+ * Serialize a subject along with its forms. The name of this processor is {@code data}.
+ *
+ * @version $Id$
+ */
+@Component(immediate = true)
+public class DataSubjectProcessor implements ResourceJsonProcessor
+{
+    private ThreadLocal<ResourceResolver> resolver = new ThreadLocal<>();
+
+    private ThreadLocal<String> selectors = new ThreadLocal<>();
+
+    private ThreadLocal<String> rootNode = new ThreadLocal<>();
+
+    @Override
+    public String getName()
+    {
+        return "data";
+    }
+
+    @Override
+    public int getPriority()
+    {
+        return 90;
+    }
+
+    @Override
+    public void start(Resource resource)
+    {
+        // We will need the resource resolver to query for forms
+        this.resolver.set(resource.getResourceResolver());
+        // We want to forward the selectors to the forms serialization as well
+        this.selectors.set(resource.getResourceMetadata().getResolutionPathInfo());
+        // We only serialize data for the serialized subject, not other nodes
+        this.rootNode.set(resource.getPath());
+    }
+
+    @Override
+    public boolean canProcess(Resource resource)
+    {
+        return resource.isResourceType("lfs/Subject");
+    }
+
+    @Override
+    public void leave(Node node, JsonObjectBuilder json, Function<Node, JsonValue> serializeNode)
+    {
+        try {
+            // Only the original subject node will have its data appended
+            if (!node.getPath().equals(this.rootNode.get())) {
+                return;
+            }
+            Iterator<Resource> forms = this.resolver.get().findResources(
+                "select * from [lfs:Form] as n where n.subject = '" + node.getIdentifier() + "'", Query.JCR_SQL2);
+            final Map<String, JsonArrayBuilder> formsJsons = new HashMap<>();
+
+            // Since the adaptTo serialization process uses ThreadLocal variables, we need to serialize other resources
+            // in a separate thread in order to not pollute the current state. We must extract the needed state from the
+            // current ThreadLocals to be used in the sub-thread.
+            final ResourceResolver currentResolver = this.resolver.get();
+            final String currentSelectors = this.selectors.get();
+            final Thread serializer = new Thread(() -> forms
+                .forEachRemaining(f -> storeForm(currentResolver.resolve(f.getPath() + currentSelectors), formsJsons)));
+            serializer.start();
+            // Wait for the serialization of forms to finish
+            serializer.join();
+            // Now the data JSONs should be available, add them to the subject's JSON
+            formsJsons.forEach(json::add);
+        } catch (RepositoryException | InterruptedException e) {
+            // Really shouldn't happen
+        }
+    }
+
+    private void storeForm(final Resource form, final Map<String, JsonArrayBuilder> formsJsons)
+    {
+        try {
+            final Node questionnaire = form.adaptTo(Node.class).getProperty("questionnaire").getNode();
+            final String questionnaireTitle = questionnaire.getProperty("title").getString();
+            final JsonArrayBuilder arrayForQuestionnaire =
+                formsJsons.computeIfAbsent(questionnaireTitle, k -> Json.createArrayBuilder());
+            arrayForQuestionnaire.add(form.adaptTo(JsonObject.class));
+        } catch (RepositoryException e) {
+            // Really shouldn't happen
+        }
+    }
+}

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/DataSubjectProcessor.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/DataSubjectProcessor.java
@@ -80,6 +80,14 @@ public class DataSubjectProcessor implements ResourceJsonProcessor
         // We only serialize data for the serialized subject, not other nodes
         this.rootNode.set(resource.getPath());
         final Map<String, String> filtersMap = new HashMap<>();
+        // Split by unescaped dots. A backslash escapes a dot, but two backslashes are just one escaped backslash.
+        // Match by:
+        // - no preceding backslash, i.e. start counting at the first backslash (?<!\)
+        // - an even number of backslashes, i.e. any number of groups of two backslashes (?:\\)*
+        // - a literal dot \.
+        // Each backslash, except the \., is escaped twice, once as a special escape char inside a Java string, and
+        // once as a special escape char inside a RegExp. The one before the dot is escaped only once as a special
+        // char inside a Java string, since it must retain its escaping meaning in the RegExp.
         Arrays.asList(this.selectors.get().split("(?<!\\\\)(?:\\\\\\\\)*\\.")).stream()
             .filter(s -> StringUtils.startsWith(s, "dataFilter:"))
             .map(s -> StringUtils.substringAfter(s, "dataFilter:"))

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/DataSubjectProcessor.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/DataSubjectProcessor.java
@@ -18,7 +18,9 @@
  */
 package ca.sickkids.ccm.lfs.dataentry.internal.serialize;
 
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -118,6 +120,8 @@ public class DataSubjectProcessor implements ResourceJsonProcessor
             final JsonObjectBuilder filtersJson = Json.createObjectBuilder();
             this.filters.get().forEach(filtersJson::add);
             json.add("dataFilters", filtersJson);
+            json.add("exportDate",
+                new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").format(Calendar.getInstance().getTime()));
         } catch (RepositoryException | InterruptedException e) {
             // Really shouldn't happen
         }

--- a/modules/utils/src/main/java/ca/sickkids/ccm/lfs/serialize/ResourceToJsonAdapterFactory.java
+++ b/modules/utils/src/main/java/ca/sickkids/ccm/lfs/serialize/ResourceToJsonAdapterFactory.java
@@ -261,7 +261,8 @@ public class ResourceToJsonAdapterFactory
         // These have been requested
         final List<String> requestedProcessors =
             new ArrayList<>(resource.getResourceMetadata().getResolutionPathInfo() != null
-                ? Arrays.asList(resource.getResourceMetadata().getResolutionPathInfo().split("\\."))
+                ? Arrays
+                    .asList(resource.getResourceMetadata().getResolutionPathInfo().split("(?<!\\\\)(?:\\\\\\\\)*\\."))
                 : defaults);
         // Add the defaults, if not already selected and not explicitly excluded
         for (String def : defaults) {

--- a/modules/utils/src/main/java/ca/sickkids/ccm/lfs/serialize/ResourceToJsonAdapterFactory.java
+++ b/modules/utils/src/main/java/ca/sickkids/ccm/lfs/serialize/ResourceToJsonAdapterFactory.java
@@ -260,6 +260,14 @@ public class ResourceToJsonAdapterFactory
             .map(ResourceJsonProcessor::getName).collect(Collectors.toList());
         // These have been requested
         final List<String> requestedProcessors =
+            // Split by unescaped dots. A backslash escapes a dot, but two backslashes are just one escaped backslash.
+            // Match by:
+            // - no preceding backslash, i.e. start counting at the first backslash (?<!\)
+            // - an even number of backslashes, i.e. any number of groups of two backslashes (?:\\)*
+            // - a literal dot \.
+            // Each backslash, except the \., is escaped twice, once as a special escape char inside a Java string, and
+            // once as a special escape char inside a RegExp. The one before the dot is escaped only once as a special
+            // char inside a Java string, since it must retain its escaping meaning in the RegExp.
             new ArrayList<>(resource.getResourceMetadata().getResolutionPathInfo() != null
                 ? Arrays
                     .asList(resource.getResourceMetadata().getResolutionPathInfo().split("(?<!\\\\)(?:\\\\\\\\)*\\."))

--- a/modules/utils/src/main/java/ca/sickkids/ccm/lfs/serialize/ResourceToJsonAdapterFactory.java
+++ b/modules/utils/src/main/java/ca/sickkids/ccm/lfs/serialize/ResourceToJsonAdapterFactory.java
@@ -56,6 +56,20 @@ import ca.sickkids.ccm.lfs.serialize.spi.ResourceJsonProcessor;
  * {@link ResourceJsonProcessor#isEnabledByDefault(Resource) enabled by default}, for example the {@code properties},
  * {@code identify}, and {@code dereference} processors; to disable them, use their name prefixed by {@code -} in the
  * selectors, e.g. {@code /path/to/resource.-dereference.json}.
+ * <p>
+ * This class uses ThreadLocal variables to maintain state, which means that nested invocations in the same thread are
+ * not supported. If a processor needs to call {@code resource.adaptTo(JsonObject.class)}, it should do so in a new
+ * Thread, for example:
+ * </p>
+ * <code>
+ * final Iterator&lt;Resource&gt; resources = ...;
+ * final List&lt;JsonObject&gt; result = new ArrayList&lt;&gt;();
+ * final Thread serializer = new Thread(() -> resources
+ *     .forEachRemaining(r -> result.add(r.adaptTo(JsonObject.class))));
+ * serializer.start();
+ * serializer.join();
+ * // Now result contains the serialized subresources
+ * </code>
  *
  * @version $Id$
  */


### PR DESCRIPTION
New things in this PR:

- `http://localhost:8080/Subjects/[uuid].bare.json` for a bare JSON for subjects
  - `"subject": "P01 / T1 / TR3"`
  - `"parents": "P01 / T1"`
  - `"type": "Patient / Tumor / TumorRegion"`
- `http://localhost:8080/Subjects/[uuid].data.json` for including forms (no actual answers though)
- `http://localhost:8080/Subjects/[uuid].data.deep.bare.-identify.json` for including forms, with all answers, in a bare format
- `http://localhost:8080/Subjects/[uuid].data.deep.bare.-identify.dataFilter:createdAfter=2020-12-08.dataFilter:createdBy=admin.json` for filtering
- `http://localhost:8080/Subjects/[uuid].data.deep.bare.-identify.dataFilter:createdAfter=2020-12-08T20:00.dataFilter:createdBefore=2020-12-08T21:00.dataFilter:createdBy=admin.json`
- `http://localhost:8080/Subjects/[uuid].data.deep.bare.-identify.dataFilter:createdBy=john%5C.doe.json` for filtering by `john.doe` (`%5C` must be used, not `\`, even though the browser may show it as `\` in the URL bar)
