### PR TITLE
LFS-159: As a user I can access a dashboard

### DIFF
--- a/modules/commons/src/main/frontend/src/assetManager.jsx
+++ b/modules/commons/src/main/frontend/src/assetManager.jsx
@@ -68,26 +68,15 @@ var getAssetURL = async function(assetUrl) {
     .then(json => "/libs/lfs/resources/" + json[assetName]);
 }
 
-// Get the URL parameters from the provided string.
-// Parameters should follow standard URL parameter format, using ?, = and & as separators
+// Get the URL parameters from the provided URL or asset URL string.
 //
-// @param {string} assetURL the URL to extract the parameters from
-// @return an object containing the parameters as key value pairs
+// @param {string} assetURL the URL to extract the parameters from, potentially prefixed with ASSET_PREFIX
+// @return a URLSearchParams object containing the parameters from the input
 var getURLParameters = (assetUrl) => {
-  var result = {};
   if (!assetUrl || !assetUrl.includes("?")) {
-    return result;
+    return new URLSearchParams();
   }
-
-  var parameters = assetUrl.slice(assetUrl.indexOf("?") + 1).split("&");
-  parameters.forEach(parameter => {
-    var split = parameter.split("=");
-    if (split.length == 1) {
-      split.push(undefined);
-    }
-    result[split[0]] = split[1];
-  })
-  return result;
+  return new URLSearchParams(assetUrl.slice(assetUrl.indexOf("?") + 1));
 }
 
 // Load a React component from a URL.
@@ -111,8 +100,7 @@ var loadAsset = async function(assetURL) {
             .then(response => response.ok ? response.text() : Promise.reject(response))
             .then(remoteComponentSrc => {
               var returnVal = window.eval(remoteComponentSrc);
-              return parameters?.component ? returnVal[parameters.component] : returnVal.default;
-              // return returnVal.default;
+              return parameters.has("component") ? returnVal[parameters.get("component")] : returnVal.default;
             });
           })
         .finally(() => assetRequests[assetURL] = null);

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
@@ -287,6 +287,8 @@ function Filters(props) {
               size="small"
               label={label}
               disabled={disabled}
+              variant="outlined"
+              color="primary"
               onDelete={()=>{
                 const newFilters = activeFilters.slice();
                 newFilters.splice(index, 1);
@@ -306,8 +308,7 @@ function Filters(props) {
       }
       <Button
         size="small"
-        variant="contained"
-        color="default"
+        color="primary"
         className={classes.addFilterButton}
         disabled={disabled}
         onClick={() => {

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -1,0 +1,84 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+import React, { useState } from "react";
+import LiveTable from "./LiveTable.jsx";
+
+import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
+
+import { Button, Card, CardContent, CardHeader, Tab, Tabs, withStyles } from "@material-ui/core";
+import DeleteButton from "./DeleteButton.jsx";
+import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
+
+function FormView(props) {
+  const { classes } = props;
+  const [ activeTab, setActiveTab ] = useState(0);
+
+  // Column configuration for the LiveTables
+  const columns = [
+    {
+      "key": "@name",
+      "label": "Identifier",
+      "format": getEntityIdentifier,
+      "link": "dashboard+path",
+    },
+    {
+      "key": "jcr:created",
+      "label": "Created on",
+      "format": "date:YYYY-MM-DD HH:mm",
+    },
+    {
+      "key": "jcr:createdBy",
+      "label": "Created by",
+      "format": "string",
+    },
+  ]
+  const actions = [
+    DeleteButton
+  ]
+  const tabs = ["Completed", "Draft"];
+
+  return (
+    <Card>
+      <CardHeader
+        title={
+          <Button className={classes.cardHeaderButton}>
+            Forms
+          </Button>
+        }
+      />
+      <Tabs value={activeTab} onChange={(event, value) => setActiveTab(value)}>
+        {tabs.map(value => {
+          return <Tab label={value} />;
+        })}
+      </Tabs>
+      <CardContent>
+        <LiveTable
+          columns={columns}
+          customUrl={`/Forms.paginate?descending=true${activeTab == tabs.indexOf("Draft") ? '&fieldname=statusFlags&fieldvalue=INCOMPLETE' : ''}`}
+          defaultLimit={10}
+          filters
+          entryType={"Form"}
+          actions={actions}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+export default withStyles(QuestionnaireStyle)(FormView);

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -21,7 +21,22 @@ import LiveTable from "./LiveTable.jsx";
 
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 
-import { Button, Card, CardContent, CardHeader, Divider, Tab, Tabs, withStyles } from "@material-ui/core";
+import {
+  Avatar,
+  Card,
+  CardContent,
+  CardHeader,
+  Divider,
+  IconButton,
+  Tab,
+  Tabs,
+  Tooltip,
+  Typography,
+  withStyles
+} from "@material-ui/core";
+import { Link } from 'react-router-dom';
+import DescriptionIcon from '@material-ui/icons/Description';
+import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import DeleteButton from "./DeleteButton.jsx";
 import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
 
@@ -54,12 +69,18 @@ function FormView(props) {
   const tabs = ["Completed", "Draft"];
 
   return (
-    <Card>
+    <Card className={classes.formView}>
       <CardHeader
-        title={
-          <Button className={classes.cardHeaderButton}>
-            Forms
-          </Button>
+        avatar={<Avatar className={classes.formViewAvatar}><DescriptionIcon/></Avatar>}
+        title={<Typography variant="h6">Forms</Typography>}
+        action={
+          <Tooltip title="See more">
+            <Link to={"/content.html/Forms"}>
+              <IconButton>
+                <MoreHorizIcon/>
+              </IconButton>
+            </Link>
+          </Tooltip>
         }
       />
       <Tabs value={activeTab} onChange={(event, value) => setActiveTab(value)}>
@@ -76,6 +97,7 @@ function FormView(props) {
           filters
           entryType={"Form"}
           actions={actions}
+          disableTopPagination
         />
       </CardContent>
     </Card>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -74,7 +74,7 @@ function FormView(props) {
         avatar={<Avatar className={classes.formViewAvatar}><DescriptionIcon/></Avatar>}
         title={<Typography variant="h6">Forms</Typography>}
         action={
-          <Tooltip title="See more">
+          <Tooltip title="Expand">
             <Link to={"/content.html/Forms"}>
               <IconButton>
                 <MoreHorizIcon/>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -94,6 +94,7 @@ function FormView(props) {
           columns={columns}
           customUrl={`/Forms.paginate?descending=true${activeTab == tabs.indexOf("Draft") ? '&fieldname=statusFlags&fieldvalue=INCOMPLETE' : ''}`}
           defaultLimit={10}
+          joinChildren="lfs:Answer"
           filters
           entryType={"Form"}
           actions={actions}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -21,7 +21,7 @@ import LiveTable from "./LiveTable.jsx";
 
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 
-import { Button, Card, CardContent, CardHeader, Tab, Tabs, withStyles } from "@material-ui/core";
+import { Button, Card, CardContent, CardHeader, Divider, Tab, Tabs, withStyles } from "@material-ui/core";
 import DeleteButton from "./DeleteButton.jsx";
 import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
 
@@ -63,10 +63,11 @@ function FormView(props) {
         }
       />
       <Tabs value={activeTab} onChange={(event, value) => setActiveTab(value)}>
-        {tabs.map(value => {
-          return <Tab label={value} />;
+        {tabs.map((value, index) => {
+          return <Tab label={value}  key={"form-" + index} />;
         })}
       </Tabs>
+      <Divider />
       <CardContent>
         <LiveTable
           columns={columns}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -42,7 +42,7 @@ function LiveTable(props) {
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Define the component's state
 
-  const { customUrl, columns, defaultLimit, joinChildren, updateData, classes, filters, entryType, actions, admin, ...rest } = props;
+  const { customUrl, columns, defaultLimit, joinChildren, updateData, classes, filters, entryType, actions, admin, disableTopPagination, disableBottomPagination, ...rest } = props;
   const [tableData, setTableData] = useState();
   const [cachedFilters, setCachedFilters] = useState(null);
   const [paginationData, setPaginationData] = useState(
@@ -343,9 +343,11 @@ function LiveTable(props) {
     // We wrap everything in a Paper for a nice separation, as a Table has no background or border of its own.
     <Paper elevation={0}>
       {filters && <Filters onChangeFilters={handleChangeFilters} disabled={!Boolean(tableData)} {...rest} />}
+      {!disableTopPagination &&
       <div>
         {paginationControls}
       </div>
+      }
       {/*
       // stickyHeader doesn't really work right now, since the Paper just extends all the way down to fit the table.
       // The whole UI needs to be redesigned so that we can set a maximum height to the Paper,
@@ -394,7 +396,7 @@ function LiveTable(props) {
           }
         </TableBody>
       </Table>
-      {paginationControls}
+      {!disableBottomPagination && paginationControls}
       {!tableData && (<LinearProgress className={classes.progressIndicator}/>)}
     </Paper>
   );

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -39,7 +39,7 @@ export const MODE_DIALOG = 1;
  * @param {presetPath} string The questionnaire to use automatically, if any.
  */
 function NewFormDialog(props) {
-  const { children, classes, presetPath, currentSubject, theme, mode, open } = { mode:MODE_ACTION, open: false, ...props };
+  const { children, classes, presetPath, currentSubject, theme, mode, open, onClose } = { mode:MODE_ACTION, open: false, ...props };
   const [ dialogOpen, setDialogOpen ] = useState(false);
   const [ newSubjectPopperOpen, setNewSubjectPopperOpen ] = useState(false);
   const [ initialized, setInitialized ] = useState(false);
@@ -223,7 +223,15 @@ function NewFormDialog(props) {
 
   return (
     <React.Fragment>
-      <Dialog open={mode === MODE_ACTION ? dialogOpen : open} onClose={() => { setDialogOpen(false); }}>
+      <Dialog
+        open={mode === MODE_ACTION ? dialogOpen : open}
+        onClose={() => {
+          setDialogOpen(false);
+          if (onClose) {
+            onClose();
+          }
+        }}
+      >
         <DialogTitle id="new-form-title">
           {progress === PROGRESS_SELECT_QUESTIONNAIRE ? "Select a questionnaire" : "Select a subject"}
         </DialogTitle>
@@ -334,7 +342,13 @@ function NewFormDialog(props) {
       <NewSubjectDialog
         allowedTypes={parseToArray(selectedQuestionnaire?.["requiredSubjectTypes"])}
         disabled={isFetching}
-        onClose={() => { setNewSubjectPopperOpen(false); setError();}}
+        onClose={() => {
+          setNewSubjectPopperOpen(false);
+          setError();
+          if (onClose) {
+            onClose();
+          }
+        }}
         onChangeSubject={(event) => {setNewSubjectName(event.target.value);}}
         currentSubject={currentSubject}
         onSubmit={createForm}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -30,6 +30,8 @@ import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 
 const PROGRESS_SELECT_QUESTIONNAIRE = 0;
 const PROGRESS_SELECT_SUBJECT = 1;
+export const MODE_ACTION = 0;
+export const MODE_DIALOG = 1;
 
 /**
  * A component that renders a FAB to open a dialog to create a new form.
@@ -37,8 +39,8 @@ const PROGRESS_SELECT_SUBJECT = 1;
  * @param {presetPath} string The questionnaire to use automatically, if any.
  */
 function NewFormDialog(props) {
-  const { children, classes, presetPath, currentSubject, theme } = props;
-  const [ open, setOpen ] = useState(false);
+  const { children, classes, presetPath, currentSubject, theme, mode, open } = { mode:MODE_ACTION, open: false, ...props };
+  const [ dialogOpen, setDialogOpen ] = useState(false);
   const [ newSubjectPopperOpen, setNewSubjectPopperOpen ] = useState(false);
   const [ initialized, setInitialized ] = useState(false);
   const [ selectedQuestionnaire, setSelectedQuestionnaire ] = useState();
@@ -49,6 +51,7 @@ function NewFormDialog(props) {
   const [ relatedForms, setRelatedForms ] = useState();
   const [ disableProgress, setDisableProgress ] = useState(false);
   const [ rowCount, setRowCount ] = useState(5);
+  const [ wasOpen, setWasOpen ] = useState(false);
 
   let createForm = (subject) => {
     setError("");
@@ -89,7 +92,7 @@ function NewFormDialog(props) {
       }
       setInitialized(true);
     }
-    setOpen(true);
+    setDialogOpen(true);
     setError("");
     setProgress(presetPath ? PROGRESS_SELECT_SUBJECT : PROGRESS_SELECT_QUESTIONNAIRE);
   }
@@ -151,7 +154,7 @@ function NewFormDialog(props) {
     setError(false);
     // Exit the dialog if we're at the first page or if there is a preset path
     if (progress === PROGRESS_SELECT_QUESTIONNAIRE || presetPath) {
-      setOpen(false);
+      setDialogOpen(false);
     } else {
       setProgress(PROGRESS_SELECT_QUESTIONNAIRE);
       setSelectedSubject(null);
@@ -197,6 +200,12 @@ function NewFormDialog(props) {
   }, [progress]);
 
   const isFetching = numFetchRequests > 0;
+  if (wasOpen !== open) {
+    setWasOpen(open);
+    if (MODE_DIALOG) {
+      openDialog();
+    }
+  }
 
   useEffect(() => {
     if (currentSubject && selectedQuestionnaire) {
@@ -210,11 +219,11 @@ function NewFormDialog(props) {
         setSelectedSubject(null); // remove selectedsubject so next dialog can open (should not create form right away)
       }
     }
-  }, [selectedQuestionnaire, open])
+  }, [selectedQuestionnaire, dialogOpen])
 
   return (
     <React.Fragment>
-      <Dialog open={open} onClose={() => { setOpen(false); }}>
+      <Dialog open={mode === MODE_ACTION ? dialogOpen : open} onClose={() => { setDialogOpen(false); }}>
         <DialogTitle id="new-form-title">
           {progress === PROGRESS_SELECT_QUESTIONNAIRE ? "Select a questionnaire" : "Select a subject"}
         </DialogTitle>
@@ -331,19 +340,22 @@ function NewFormDialog(props) {
         onSubmit={createForm}
         open={newSubjectPopperOpen}
         />
-      <div className={classes.newFormButtonWrapper}>
-        <Tooltip title={children} aria-label="add">
-          <Fab
-            color="primary"
-            aria-label="add"
-            onClick={openDialog}
-            disabled={!open && isFetching}
-          >
-            <AddIcon />
-          </Fab>
-        </Tooltip>
-        {!open && isFetching && <CircularProgress size={56} className={classes.newFormLoadingIndicator} />}
-      </div>
+      {
+        mode === MODE_ACTION &&
+          <div className={classes.newFormButtonWrapper}>
+            <Tooltip title={children} aria-label="add">
+              <Fab
+                color="primary"
+                aria-label="add"
+                onClick={openDialog}
+                disabled={!dialogOpen && isFetching}
+              >
+                <AddIcon />
+              </Fab>
+            </Tooltip>
+            {!dialogOpen && isFetching && <CircularProgress size={56} className={classes.newFormLoadingIndicator} />}
+          </div>
+      }
     </React.Fragment>
   )
 }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -155,6 +155,9 @@ function NewFormDialog(props) {
     // Exit the dialog if we're at the first page or if there is a preset path
     if (progress === PROGRESS_SELECT_QUESTIONNAIRE || presetPath) {
       setDialogOpen(false);
+      if (onClose) {
+        onClose();
+      }
     } else {
       setProgress(PROGRESS_SELECT_QUESTIONNAIRE);
       setSelectedSubject(null);

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
@@ -22,17 +22,22 @@ import LiveTable from "./LiveTable.jsx";
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 
 import {
-  Button,
+  Avatar,
   Card,
   CardContent,
   CardHeader,
   CircularProgress,
   Divider,
+  IconButton,
   Tab,
   Tabs,
+  Tooltip,
   Typography,
   withStyles
 } from "@material-ui/core";
+import { Link } from 'react-router-dom';
+import AssignmentIndIcon from '@material-ui/icons/AssignmentInd';
+import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import DeleteButton from "./DeleteButton.jsx";
 import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
 
@@ -91,12 +96,18 @@ function SubjectView(props) {
   }
 
   return (
-    <Card>
+    <Card className={classes.subjectView}>
       <CardHeader
-        title={
-          <Button className={classes.cardHeaderButton}>
-            Subjects
-          </Button>
+        avatar={<Avatar className={classes.subjectViewAvatar}><AssignmentIndIcon/></Avatar>}
+        title={<Typography variant="h6">Subjects</Typography>}
+        action={
+          <Tooltip title="See more">
+            <Link to={"/content.html/Subjects"}>
+              <IconButton>
+                <MoreHorizIcon/>
+              </IconButton>
+            </Link>
+          </Tooltip>
         }
       />
       {
@@ -118,6 +129,7 @@ function SubjectView(props) {
               defaultLimit={10}
               entryType={"Subject"}
               actions={actions}
+              disableTopPagination
             />
           : <Typography>No results</Typography>
       }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
@@ -101,7 +101,7 @@ function SubjectView(props) {
         avatar={<Avatar className={classes.subjectViewAvatar}><AssignmentIndIcon/></Avatar>}
         title={<Typography variant="h6">Subjects</Typography>}
         action={
-          <Tooltip title="See more">
+          <Tooltip title="Expand">
             <Link to={"/content.html/Subjects"}>
               <IconButton>
                 <MoreHorizIcon/>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
@@ -27,6 +27,7 @@ import {
   CardContent,
   CardHeader,
   CircularProgress,
+  Divider,
   Tab,
   Tabs,
   Typography,
@@ -67,7 +68,7 @@ function SubjectView(props) {
 
   let fetchSubjectTypes = () => {
     let url = new URL("/query", window.location.origin);
-    url.searchParams.set("query", `SELECT * FROM [lfs:SubjectType] as n`);
+    url.searchParams.set("query", `SELECT * FROM [lfs:SubjectType] as n order by n.'lfs:defaultOrder'`);
     // TODO: Handle pagination?
     url.searchParams.set("limit", 10);
     url.searchParams.set("offset", 0);
@@ -102,11 +103,12 @@ function SubjectView(props) {
         tabsLoading
           ? <CircularProgress/>
           : <Tabs value={activeTab} onChange={(event, value) => setActiveTab(value)}>
-              {subjectTypes.map(subject => {
-                return <Tab label={subject['label'] || subject['@name']} />;
+              {subjectTypes.map((subject, index) => {
+                return <Tab label={subject['label'] || subject['@name']} key={"subject-" + index}/>;
               })}
             </Tabs>
       }
+      <Divider />
       <CardContent>
       {
         hasSubjects

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
@@ -116,7 +116,6 @@ function SubjectView(props) {
               columns={columns}
               customUrl={'/Subjects.paginate?fieldname=type&fieldvalue='+ encodeURIComponent(subjectTypes[activeTab]["jcr:uuid"])}
               defaultLimit={10}
-              filters
               entryType={"Subject"}
               actions={actions}
             />

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
@@ -1,0 +1,128 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+import React, { useState } from "react";
+import LiveTable from "./LiveTable.jsx";
+
+import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
+
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CircularProgress,
+  Tab,
+  Tabs,
+  Typography,
+  withStyles
+} from "@material-ui/core";
+import DeleteButton from "./DeleteButton.jsx";
+import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
+
+function SubjectView(props) {
+  const { classes } = props;
+  const [ activeTab, setActiveTab ] = useState(0);
+  const [ subjectTypes, setSubjectTypes] = useState([])
+  const [ tabsLoading, setTabsLoading ] = useState(null);
+  const hasSubjects = tabsLoading === false && subjectTypes.length > 0;
+
+  // Column configuration for the LiveTables
+  const columns = [
+    {
+      "key": "@name",
+      "label": "Identifier",
+      "format": getEntityIdentifier,
+      "link": "dashboard+path",
+    },
+    {
+      "key": "jcr:created",
+      "label": "Created on",
+      "format": "date:YYYY-MM-DD HH:mm",
+    },
+    {
+      "key": "jcr:createdBy",
+      "label": "Created by",
+      "format": "string",
+    },
+  ]
+  const actions = [
+    DeleteButton
+  ]
+
+  let fetchSubjectTypes = () => {
+    let url = new URL("/query", window.location.origin);
+    url.searchParams.set("query", `SELECT * FROM [lfs:SubjectType] as n`);
+    // TODO: Handle pagination?
+    url.searchParams.set("limit", 10);
+    url.searchParams.set("offset", 0);
+    return fetch(url)
+      .then(response => response.json())
+      .then(result => {
+        setSubjectTypes(result.rows);
+        setTabsLoading(false);
+      })
+  }
+
+  if (tabsLoading == null) {
+    fetchSubjectTypes();
+    setTabsLoading(true);
+  }
+
+  let path;
+  if (hasSubjects) {
+    path = subjectTypes[activeTab]['@path'];
+  }
+
+  return (
+    <Card>
+      <CardHeader
+        title={
+          <Button className={classes.cardHeaderButton}>
+            Subjects
+          </Button>
+        }
+      />
+      {
+        tabsLoading
+          ? <CircularProgress/>
+          : <Tabs value={activeTab} onChange={(event, value) => setActiveTab(value)}>
+              {subjectTypes.map(subject => {
+                return <Tab label={subject['label'] || subject['@name']} />;
+              })}
+            </Tabs>
+      }
+      <CardContent>
+      {
+        hasSubjects
+          ? <LiveTable
+              columns={columns}
+              customUrl={'/Subjects.paginate?fieldname=type&fieldvalue='+ encodeURIComponent(subjectTypes[activeTab]["jcr:uuid"])}
+              defaultLimit={10}
+              filters
+              entryType={"Subject"}
+              actions={actions}
+            />
+          : <Typography>No results</Typography>
+      }
+      </CardContent>
+    </Card>
+  );
+}
+
+export default withStyles(QuestionnaireStyle)(SubjectView);

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -38,7 +38,6 @@ import {
   withStyles
 } from "@material-ui/core";
 import AddIcon from "@material-ui/icons/Add";
-import NewFormDialog from "./NewFormDialog";
 
 async function getDashboardExtensions() {
   return loadExtensions("DashboardViews")
@@ -68,6 +67,12 @@ function UserDashboard(props) {
   let [ open, setOpen ] = useState(false);
   let [ rowCount, setRowCount ] = useState(5);
 
+  let onClose = () => {
+    setSelectedCreation(-1);
+    setSelectedRow(undefined);
+    setOpen(false);
+  }
+
   useEffect(() => {
     getDashboardExtensions()
       .then(extensions => setDashboardExtensions(extensions))
@@ -91,28 +96,27 @@ function UserDashboard(props) {
     <React.Fragment>
       <Grid container spacing={3}>
         {
-          dashboardExtensions.map((extension) => {
+          dashboardExtensions.map((extension, index) => {
             let Extension = extension["lfs:extensionRender"];
-            return <Grid item lg={12} xl={6}>
+            return <Grid item lg={12} xl={6} key={"extension-" + index}>
               <Extension />
             </Grid>
           })
         }
       </Grid>
-      <Dialog open={open} onClose={() => setOpen(false)}>
-        <DialogTitle>
-          <Typography variant="h6" className={classes.dialogTitle}>Add</Typography>
-        </DialogTitle>
-        <DialogContent>
+      <Dialog open={open} onClose={onClose}>
+        <DialogTitle className={classes.dialogTitle}>New</DialogTitle>
+        <DialogContent dividers>
           <MaterialTable
             columns={[
-              { title: 'Type', field: 'lfs:extensionName' },
+              { field: 'lfs:extensionName' },
             ]}
             data={creationExtensions}
             options={{
               search: true,
               pageSize: rowCount,
               showTitle: false,
+              paging: creationExtensions.length > 5,
               rowStyle: rowData => ({
                 // /* It doesn't seem possible to alter the className from here */
                 backgroundColor: (selectedRow && selectedRow["jcr:uuid"] === rowData["jcr:uuid"]) ? theme.palette.grey["200"] : theme.palette.background.default
@@ -130,7 +134,7 @@ function UserDashboard(props) {
           <Button
             variant="contained"
             color="default"
-            onClick={() => setOpen(false)}
+            onClick={onClose}
             >
             Cancel
           </Button>
@@ -141,21 +145,24 @@ function UserDashboard(props) {
               setOpen(false);
               setSelectedCreation(creationExtensions.indexOf(selectedRow));
             }}
+            disabled={typeof(selectedRow) === "undefined"}
             >
             Next
           </Button>
         </DialogActions>
       </Dialog>
       <div className={classes.newFormButtonWrapper}>
-        <Tooltip title={"Add"} aria-label="add">
-          <Fab
-            color="primary"
-            aria-label="add"
-            onClick={() => setOpen(true)}
-            disabled={creationLoading}
-          >
-            <AddIcon />
-          </Fab>
+        <Tooltip title={"New"} aria-label="new">
+          <span>
+            <Fab
+              color="primary"
+              aria-label="new"
+              onClick={() => setOpen(true)}
+              disabled={creationLoading}
+            >
+              <AddIcon />
+            </Fab>
+          </span>
         </Tooltip>
       </div>
       {
@@ -163,12 +170,13 @@ function UserDashboard(props) {
           let Extension = extension["lfs:extensionRender"];
           return <Extension
             open={index === selectedCreation}
-            onClose={() => setSelectedCreation(-1)}
-            onSubmit={() => setSelectedCreation(-1)}
+            onClose={onClose}
+            onSubmit={onClose}
             // NewFormDialog specific argument
             mode={MODE_DIALOG}
             // NewSubjectDialog specific argument
             openNewSubject={true}
+            key={"extensionDialog-" + index}
             />
         })
       }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -98,7 +98,7 @@ function UserDashboard(props) {
         {
           dashboardExtensions.map((extension, index) => {
             let Extension = extension["lfs:extensionRender"];
-            return <Grid item lg={12} xl={6} key={"extension-" + index}>
+            return <Grid item lg={12} xl={6} key={"extension-" + index} className={classes.dashboardEntry}>
               <Extension />
             </Grid>
           })

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -16,161 +16,143 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState } from "react";
-import LiveTable from "./LiveTable.jsx";
+import React, { useState, useEffect } from "react";
 
+import { loadExtensions } from "../uiextension/extensionManager";
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
+import { MODE_DIALOG } from "../dataHomepage/NewFormDialog.jsx"
 
-import { Button, Card, CardContent, CardHeader, Grid, Link, Typography, withStyles } from "@material-ui/core";
-import NewFormDialog from "./NewFormDialog.jsx";
-import DeleteButton from "./DeleteButton.jsx";
-import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Fab,
+  Grid,
+  Tooltip,
+  Typography,
+  withStyles
+} from "@material-ui/core";
+import AddIcon from "@material-ui/icons/Add";
+import NewFormDialog from "./NewFormDialog";
+
+async function getDashboardExtensions() {
+  return loadExtensions("DashboardViews")
+    .then(extensions => extensions.slice()
+      .sort((a, b) => a["lfs:defaultOrder"] - b["lfs:defaultOrder"])
+    )
+}
+
+async function getDashboardCreations() {
+  return loadExtensions("DashboardCreation")
+    .then(extensions => extensions.slice()
+      .sort((a, b) => a["lfs:defaultOrder"] - b["lfs:defaultOrder"])
+    )
+}
 
 // Component that renders the user's dashboard, with one LiveTable per questionnaire
 // visible by the user. Each LiveTable contains all forms that use the given
 // questionnaire.
 function UserDashboard(props) {
   const { classes } = props;
-  // Store information about each questionnaire and whether or not we have
-  // initialized
-  let [questionnaires, setQuestionnaires] = useState([]);
-  let [initialized, setInitialized] = useState(false);
-  let [numberForms, setNumberForms] = useState();
-  // Error message set when fetching the data from the server fails
-  let [ error, setError ] = useState();
+  let [ dashboardExtensions, setDashboardExtensions ] = useState([]);
+  let [ creationExtensions, setCreationExtensions ] = useState([]);
+  let [ loading, setLoading ] = useState(true);
+  let [ creationLoading, setCreationLoading ] = useState(true);
+  let [ selectedCreation, setSelectedCreation ] = useState(-1);
+  let [ open, setOpen ] = useState(false);
 
-  // Column configuration for the LiveTables
-  const columns = [
-    {
-      "key": "@name",
-      "label": "Identifier",
-      "format": getEntityIdentifier,
-      "link": "dashboard+path",
-    },
-    {
-      "key": "jcr:created",
-      "label": "Created on",
-      "format": "date:YYYY-MM-DD HH:mm",
-    },
-    {
-      "key": "jcr:createdBy",
-      "label": "Created by",
-      "format": "string",
-    },
-  ]
-  const actions = [
-    DeleteButton
-  ]
-
-  // Obtain information about the questionnaires available to the user
-  let initialize = () => {
-    setInitialized(true);
-
-    // Fetch the questionnaires
-    fetch(`/query?${numberForms ? `limit=${numberForms}&`:""}query=select * from [lfs:Questionnaire]`)
-      .then((response) => response.ok ? response.json() : Promise.reject(response))
-      .then((response) => {
-        if (response.totalrows == 0) {
-          setError("Access to data is pending the approval of your account");
-        }
-        if (response.returnedrows < response.totalrows) {
-          setNumberForms(response.totalrows);
-          setInitialized(false);
-        } else {
-          setQuestionnaires(response["rows"]);
-        }
+  useEffect(() => {
+    getDashboardExtensions()
+      .then(extensions => setDashboardExtensions(extensions))
+      .catch(err => console.log("Something went wrong loading the user dashboard", err))
+      .finally(() => setLoading(false));
+    getDashboardCreations()
+      .then(creations => {
+        setCreationExtensions(creations);
       })
-      .catch(handleError);
-  }
+      .catch(err => console.log("Something went wrong loading the user dashboard", err))
+      .finally(() => setCreationLoading(false));
+  }, [])
 
-  // Callback method for the `fetchData` method, invoked when the request failed.
-  let handleError = (response) => {
-    setError(response.statusText ? response.statusText : response.toString());
-    setQuestionnaires([]);  // Prevent an infinite loop if data was not set
-  };
-
-  // If no forms can be obtained, we do not want to keep on re-obtaining questionnaires
-  if (!initialized) {
-    initialize();
-  }
-
-  // If an error was returned, report the error
-  if (error) {
+  if (loading) {
     return (
-      <Card>
-        <CardHeader title="Error"/>
-        <CardContent>
-          <Typography>{error}</Typography>
-        </CardContent>
-      </Card>
+      <Grid container justify="center"><Grid item><CircularProgress/></Grid></Grid>
     );
   }
 
   return (
     <React.Fragment>
       <Grid container spacing={3}>
-        <Grid item lg={12} xl={6}>
-          <Card>
-            <CardHeader
-              title={
-                  <Button className={classes.cardHeaderButton}>
-                    Incomplete Forms
-                  </Button>
-              }
-            />
-            <CardContent>
-              <LiveTable
-                columns={columns}
-                customUrl='/Forms.paginate?fieldname=statusFlags&fieldvalue=INCOMPLETE'
-                defaultLimit={10}
-                joinChildren="lfs:Answer"
-                filters
-                entryType={"Form"}
-                actions={actions}
-              />
-            </CardContent>
-          </Card>
-        </Grid>
-        {questionnaires.map( (questionnaire) => {
-          const customUrl='/Forms.paginate?fieldname=questionnaire&fieldvalue='
-            + encodeURIComponent(questionnaire["jcr:uuid"]);
-          return(
-            <Grid item lg={12} xl={6} key={questionnaire["jcr:uuid"]}>
-              <Card>
-                <CardHeader
-                  title={
-                    <Link href={`/content.html/Forms?questionnaire=${questionnaire["jcr:uuid"]}`}>
-                      <Button className={classes.cardHeaderButton}>
-                        {questionnaire["title"]}
-                      </Button>
-                    </Link>
-                  }
-                  action={
-                    <NewFormDialog presetPath={questionnaire["@path"]}>
-                      New form
-                    </NewFormDialog>
-                  }
-                  classes={{
-                    action: classes.newFormButtonHeader
-                  }}
-                />
-                <CardContent>
-                  <LiveTable
-                    columns={columns}
-                    customUrl={customUrl}
-                    defaultLimit={10}
-                    joinChildren="lfs:Answer"
-                    questionnaire={questionnaire["@path"]}
-                    entryType={questionnaire["title"]}
-                    filters
-                    actions={actions}
-                    />
-                </CardContent>
-              </Card>
+        {
+          dashboardExtensions.map((extension) => {
+            let Extension = extension["lfs:extensionRender"];
+            return <Grid item lg={12} xl={6}>
+              <Extension />
             </Grid>
-          )
-        })}
+          })
+        }
       </Grid>
+      <Dialog open={open} onClose={() => setOpen(false)}>
+        <DialogTitle disableTypography>
+          <Typography variant="h6" color="error" className={classes.dialogTitle}>Add</Typography>
+        </DialogTitle>
+        <DialogActions>
+          <Button
+            variant="contained"
+            color="default"
+            onClick={() => setOpen(false)}
+            >
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={ () => {
+              setOpen(false);
+              setSelectedCreation(0);
+            }}
+            >
+            Create Subject
+          </Button>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={ () => {
+              setOpen(false);
+              setSelectedCreation(1);
+            }}
+            >
+            Create Form
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Tooltip title={"Add"} aria-label="add">
+        <Fab
+          color="primary"
+          aria-label="add"
+          onClick={() => setOpen(true)}
+          disabled={creationLoading}
+        >
+          <AddIcon />
+        </Fab>
+      </Tooltip>
+      {
+        creationExtensions.map((extension, index) => {
+          let Extension = extension["lfs:extensionRender"];
+          return <Extension
+            open={index === selectedCreation}
+            onClose={() => setSelectedCreation(-1)}
+            onSubmit={() => setSelectedCreation(-1)}
+            // NewFormDialog specific argument
+            mode={MODE_DIALOG}
+            // NewSubjectDialog specific argument
+            openNewSubject={true}
+            />
+        })
+      }
     </React.Fragment>
   );
 }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -18,6 +18,8 @@
 //
 import React, { useState, useEffect } from "react";
 
+import MaterialTable from "material-table";
+
 import { loadExtensions } from "../uiextension/extensionManager";
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 import { MODE_DIALOG } from "../dataHomepage/NewFormDialog.jsx"
@@ -56,13 +58,15 @@ async function getDashboardCreations() {
 // visible by the user. Each LiveTable contains all forms that use the given
 // questionnaire.
 function UserDashboard(props) {
-  const { classes } = props;
+  const { classes, theme } = props;
   let [ dashboardExtensions, setDashboardExtensions ] = useState([]);
   let [ creationExtensions, setCreationExtensions ] = useState([]);
   let [ loading, setLoading ] = useState(true);
   let [ creationLoading, setCreationLoading ] = useState(true);
   let [ selectedCreation, setSelectedCreation ] = useState(-1);
+  let [ selectedRow, setSelectedRow ] = useState(undefined);
   let [ open, setOpen ] = useState(false);
+  let [ rowCount, setRowCount ] = useState(5);
 
   useEffect(() => {
     getDashboardExtensions()
@@ -96,9 +100,31 @@ function UserDashboard(props) {
         }
       </Grid>
       <Dialog open={open} onClose={() => setOpen(false)}>
-        <DialogTitle disableTypography>
-          <Typography variant="h6" color="error" className={classes.dialogTitle}>Add</Typography>
+        <DialogTitle>
+          <Typography variant="h6" className={classes.dialogTitle}>Add</Typography>
         </DialogTitle>
+        <DialogContent>
+          <MaterialTable
+            columns={[
+              { title: 'Type', field: 'lfs:extensionName' },
+            ]}
+            data={creationExtensions}
+            options={{
+              search: true,
+              pageSize: rowCount,
+              rowStyle: rowData => ({
+                // /* It doesn't seem possible to alter the className from here */
+                backgroundColor: (selectedRow && selectedRow["jcr:uuid"] === rowData["jcr:uuid"]) ? theme.palette.grey["200"] : theme.palette.background.default
+              })
+            }}
+            onRowClick={(event, rowData) => {
+              setSelectedRow(rowData);
+            }}
+            onChangeRowsPerPage={pageSize => {
+              setRowCount(pageSize);
+            }}
+            />
+        </DialogContent>
         <DialogActions>
           <Button
             variant="contained"
@@ -112,33 +138,25 @@ function UserDashboard(props) {
             color="primary"
             onClick={ () => {
               setOpen(false);
-              setSelectedCreation(0);
+              setSelectedCreation(creationExtensions.indexOf(selectedRow));
             }}
             >
-            Create Subject
-          </Button>
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={ () => {
-              setOpen(false);
-              setSelectedCreation(1);
-            }}
-            >
-            Create Form
+            Next
           </Button>
         </DialogActions>
       </Dialog>
-      <Tooltip title={"Add"} aria-label="add">
-        <Fab
-          color="primary"
-          aria-label="add"
-          onClick={() => setOpen(true)}
-          disabled={creationLoading}
-        >
-          <AddIcon />
-        </Fab>
-      </Tooltip>
+      <div className={classes.newFormButtonWrapper}>
+        <Tooltip title={"Add"} aria-label="add">
+          <Fab
+            color="primary"
+            aria-label="add"
+            onClick={() => setOpen(true)}
+            disabled={creationLoading}
+          >
+            <AddIcon />
+          </Fab>
+        </Tooltip>
+      </div>
       {
         creationExtensions.map((extension, index) => {
           let Extension = extension["lfs:extensionRender"];
@@ -157,4 +175,4 @@ function UserDashboard(props) {
   );
 }
 
-export default withStyles(QuestionnaireStyle)(UserDashboard);
+export default withStyles(QuestionnaireStyle, {withTheme: true})(UserDashboard);

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -46,8 +46,8 @@ async function getDashboardExtensions() {
     )
 }
 
-async function getDashboardCreations() {
-  return loadExtensions("DashboardCreation")
+async function getMenuItems() {
+  return loadExtensions("DashboardMenuItems")
     .then(extensions => extensions.slice()
       .sort((a, b) => a["lfs:defaultOrder"] - b["lfs:defaultOrder"])
     )
@@ -78,7 +78,7 @@ function UserDashboard(props) {
       .then(extensions => setDashboardExtensions(extensions))
       .catch(err => console.log("Something went wrong loading the user dashboard", err))
       .finally(() => setLoading(false));
-    getDashboardCreations()
+    getMenuItems()
       .then(creations => {
         setCreationExtensions(creations);
       })

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -112,6 +112,7 @@ function UserDashboard(props) {
             options={{
               search: true,
               pageSize: rowCount,
+              showTitle: false,
               rowStyle: rowData => ({
                 // /* It doesn't seem possible to alter the className from here */
                 backgroundColor: (selectedRow && selectedRow["jcr:uuid"] === rowData["jcr:uuid"]) ? theme.palette.grey["200"] : theme.palette.background.default

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -104,7 +104,7 @@ function UserDashboard(props) {
           })
         }
       </Grid>
-      <Dialog open={open} onClose={onClose}>
+      <Dialog fullWidth maxWidth="xs" open={open} onClose={onClose}>
         <DialogTitle className={classes.dialogTitle}>New</DialogTitle>
         <DialogContent dividers>
           <MaterialTable
@@ -113,9 +113,9 @@ function UserDashboard(props) {
             ]}
             data={creationExtensions}
             options={{
-              search: true,
+              toolbar: false,
+              header: false,
               pageSize: rowCount,
-              showTitle: false,
               paging: creationExtensions.length > 5,
               rowStyle: rowData => ({
                 // /* It doesn't seem possible to alter the className from here */

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/tableStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/tableStyle.jsx
@@ -28,7 +28,7 @@ const liveTableStyle = theme => ({
         margin: theme.spacing(0, 1, 0, 0)
     },
     filterContainer: {
-        padding: theme.spacing(0, 1),
+        padding: theme.spacing(0, 2),
     },
     addFilterButton: {
         minWidth: 0,

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -105,6 +105,11 @@ const questionnaireStyle = theme => ({
         bottom: theme.spacing(1),
         right: theme.spacing(6.5)
     },
+    dashboardEntry: {
+      "& > *": {
+        height: "100%",
+      },
+    },
     newFormButtonWrapper: {
         margin: theme.spacing(1),
         position: "fixed",

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -106,9 +106,10 @@ const questionnaireStyle = theme => ({
         right: theme.spacing(6.5)
     },
     newFormButtonWrapper: {
-        height: "0px",
         margin: theme.spacing(1),
-        position: "relative"
+        position: "fixed",
+        bottom: theme.spacing(2),
+        right: theme.spacing(2),
     },
     newFormTypePlaceholder: {
         position: 'relative',

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -106,9 +106,39 @@ const questionnaireStyle = theme => ({
         right: theme.spacing(6.5)
     },
     dashboardEntry: {
-      "& > *": {
-        height: "100%",
-      },
+        "& > *": {
+            height: "100%",
+            marginTop: theme.spacing(4),
+        },
+        "& .MuiTab-root": {
+            width: "auto",
+            minWidth: theme.spacing(10),
+            paddingLeft: theme.spacing(2),
+            paddingRight: theme.spacing(2),
+            textTransform: "none",
+         },
+         "& .MuiCardContent-root": {
+            padding: theme.spacing(3, 0),
+         },
+         "& .MuiTableCell-body": {
+            padding: theme.spacing(0, 2),
+         },
+    },
+    subjectView : {
+        "& .MuiTabs-indicator": {
+            background: "orange",
+        },
+    },
+    subjectViewAvatar: {
+        background: "orange",
+    },
+    formView: {
+        "& .MuiTabs-indicator": {
+            background: theme.palette.info.main,
+        },
+    },
+    formViewAvatar: {
+        background: theme.palette.info.main,
     },
     newFormButtonWrapper: {
         margin: theme.spacing(1),

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -324,7 +324,7 @@ export function NewSubjectDialog (props) {
       let subjectId = getSubjectIdFromPath(subject);
       if (openNewSubject && subjectId) {
         history.push({
-          pathname: window.location.pathname + "/" + subjectId
+          pathname: "/content.html/Subjects/" + subjectId
         });
         return;
       } else {

--- a/modules/data-entry/src/main/frontend/webpack.config.js
+++ b/modules/data-entry/src/main/frontend/webpack.config.js
@@ -26,6 +26,10 @@ module.exports = {
     [module_name + 'dateQuestion']: './src/questionnaire/DateQuestion.jsx',
     [module_name + 'userDashboard']: './src/dataHomepage/UserDashboard.jsx',
     [module_name + 'SubjectType']: './src/dataHomepage/SubjectType.jsx',
+    [module_name + 'FormView']: './src/dataHomepage/FormView.jsx',
+    [module_name + 'SubjectView']: './src/dataHomepage/SubjectView.jsx',
+    [module_name + 'NewFormDialog']: './src/dataHomepage/NewFormDialog.jsx',
+    [module_name + 'SubjectSelector']: './src/questionnaire/SubjectSelector.jsx',
   },
   plugins: [
     new CleanWebpackPlugin(),

--- a/modules/data-entry/src/main/resources/SLING-INF/content/Extensions.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/Extensions.json
@@ -106,14 +106,14 @@
         "NewFormDialog": {
             "jcr:primaryType": "lfs:Extension",
             "lfs:extensionPointId": "lfs/coreUI/dashboardcreation/entry",
-            "lfs:extensionName": "New Form",
+            "lfs:extensionName": "Form",
             "lfs:extensionRenderURL": "asset:lfs-dataentry.NewFormDialog.js",
             "lfs:defaultOrder": 2
         },
         "NewSubjectDialog": {
             "jcr:primaryType": "lfs:Extension",
             "lfs:extensionPointId": "lfs/coreUI/dashboardcreation/entry",
-            "lfs:extensionName": "New Subject",
+            "lfs:extensionName": "Subject",
             "lfs:extensionRenderURL": "asset:lfs-dataentry.SubjectSelector.js?component=NewSubjectDialog",
             "lfs:defaultOrder": 1
         }

--- a/modules/data-entry/src/main/resources/SLING-INF/content/Extensions.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/Extensions.json
@@ -83,5 +83,39 @@
             "lfs:icon": "asset:lfs-dataentry.formsIcon.js",
             "lfs:defaultOrder": 3
         }
+    },
+    "DashboardViews": {
+        "jcr:primaryType": "sling:Folder",
+        "FormView": {
+            "jcr:primaryType": "lfs:Extension",
+            "lfs:extensionPointId": "lfs/coreUI/dashboardviews/entry",
+            "lfs:extensionName": "Form View",
+            "lfs:extensionRenderURL": "asset:lfs-dataentry.FormView.js",
+            "lfs:defaultOrder": 2
+        },
+        "SubjectView": {
+            "jcr:primaryType": "lfs:Extension",
+            "lfs:extensionPointId": "lfs/coreUI/dashboardviews/entry",
+            "lfs:extensionName": "Subject View",
+            "lfs:extensionRenderURL": "asset:lfs-dataentry.SubjectView.js",
+            "lfs:defaultOrder": 1
+        }
+    },
+    "DashboardCreation": {
+        "jcr:primaryType": "sling:Folder",
+        "NewFormDialog": {
+            "jcr:primaryType": "lfs:Extension",
+            "lfs:extensionPointId": "lfs/coreUI/dashboardcreation/entry",
+            "lfs:extensionName": "New Form",
+            "lfs:extensionRenderURL": "asset:lfs-dataentry.NewFormDialog.js",
+            "lfs:defaultOrder": 2
+        },
+        "NewSubjectDialog": {
+            "jcr:primaryType": "lfs:Extension",
+            "lfs:extensionPointId": "lfs/coreUI/dashboardcreation/entry",
+            "lfs:extensionName": "New Subject",
+            "lfs:extensionRenderURL": "asset:lfs-dataentry.SubjectSelector.js?component=NewSubjectDialog",
+            "lfs:defaultOrder": 1
+        }
     }
 }

--- a/modules/data-entry/src/main/resources/SLING-INF/content/Extensions.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/Extensions.json
@@ -101,18 +101,18 @@
             "lfs:defaultOrder": 1
         }
     },
-    "DashboardCreation": {
+    "DashboardMenuItems": {
         "jcr:primaryType": "sling:Folder",
         "NewFormDialog": {
             "jcr:primaryType": "lfs:Extension",
-            "lfs:extensionPointId": "lfs/coreUI/dashboardcreation/entry",
+            "lfs:extensionPointId": "lfs/coreUI/dashboardmenuitems/entry",
             "lfs:extensionName": "Form",
             "lfs:extensionRenderURL": "asset:lfs-dataentry.NewFormDialog.js",
             "lfs:defaultOrder": 2
         },
         "NewSubjectDialog": {
             "jcr:primaryType": "lfs:Extension",
-            "lfs:extensionPointId": "lfs/coreUI/dashboardcreation/entry",
+            "lfs:extensionPointId": "lfs/coreUI/dashboardmenuitems/entry",
             "lfs:extensionName": "Subject",
             "lfs:extensionRenderURL": "asset:lfs-dataentry.SubjectSelector.js?component=NewSubjectDialog",
             "lfs:defaultOrder": 1

--- a/modules/data-entry/src/main/resources/SLING-INF/content/Extensions.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/Extensions.json
@@ -5,7 +5,7 @@
         "UserDashboard": {
             "jcr:primaryType": "lfs:Extension",
             "lfs:extensionPointId": "lfs/coreUI/view",
-            "lfs:extensionName": "User dashboard",
+            "lfs:extensionName": "Dashboard",
             "lfs:targetURL": "/content.html/Questionnaires/User",
             "lfs:extensionRenderURL": "asset:lfs-dataentry.userDashboard.js"
         },
@@ -62,7 +62,7 @@
         "UserDashboard": {
             "jcr:primaryType": "lfs:Extension",
             "lfs:extensionPointId": "lfs/coreUI/sidebar/entry",
-            "lfs:extensionName": "User dashboard",
+            "lfs:extensionName": "Dashboard",
             "lfs:targetURL": "/content.html/Questionnaires/User",
             "lfs:icon": "asset:lfs-dataentry.formsIcon.js",
             "lfs:defaultOrder": 0

--- a/modules/homepage/src/main/resources/SLING-INF/content/apps/lfs/ExtensionPoints/DashboardCreation.json
+++ b/modules/homepage/src/main/resources/SLING-INF/content/apps/lfs/ExtensionPoints/DashboardCreation.json
@@ -1,5 +1,0 @@
-{
-  "jcr:primaryType": "lfs:ExtensionPoint",
-  "lfs:extensionPointId": "lfs/coreUI/dashboardcreation/entry",
-  "lfs:extensionPointName": "Entries creatable from the user dashboard"
-}

--- a/modules/homepage/src/main/resources/SLING-INF/content/apps/lfs/ExtensionPoints/DashboardCreation.json
+++ b/modules/homepage/src/main/resources/SLING-INF/content/apps/lfs/ExtensionPoints/DashboardCreation.json
@@ -1,0 +1,5 @@
+{
+  "jcr:primaryType": "lfs:ExtensionPoint",
+  "lfs:extensionPointId": "lfs/coreUI/dashboardcreation/entry",
+  "lfs:extensionPointName": "Entries creatable from the user dashboard"
+}

--- a/modules/homepage/src/main/resources/SLING-INF/content/apps/lfs/ExtensionPoints/DashboardMenuItems.json
+++ b/modules/homepage/src/main/resources/SLING-INF/content/apps/lfs/ExtensionPoints/DashboardMenuItems.json
@@ -1,0 +1,5 @@
+{
+  "jcr:primaryType": "lfs:ExtensionPoint",
+  "lfs:extensionPointId": "lfs/coreUI/dashboardmenuitems/entry",
+  "lfs:extensionPointName": "Entries for the create item menu on the user dashboard"
+}

--- a/modules/homepage/src/main/resources/SLING-INF/content/apps/lfs/ExtensionPoints/DashboardViews.json
+++ b/modules/homepage/src/main/resources/SLING-INF/content/apps/lfs/ExtensionPoints/DashboardViews.json
@@ -1,0 +1,5 @@
+{
+  "jcr:primaryType": "lfs:ExtensionPoint",
+  "lfs:extensionPointId": "lfs/coreUI/dashboardviews/entry",
+  "lfs:extensionPointName": "Views for the user dashboard"
+}


### PR DESCRIPTION
Replace userdashboard with extension based grid
- Reduces number of + buttons
- Allows access to subjects from homepage
- Allows extensibility on a per-project basis
    
Default displayed items:
- Forms list, with tabs for completed forms and draft forms
- Subject list, with tabs for subject type
    
Default creatable items:
- Forms
- Subjects

Reuses existing components for creating forms and subjects
- Added ability to specify component from an extensionRenderURL, so NewSubjectDialog could be used instead of the SubjectSelector default
- Adjusted NewFormDialog to add a dialog only mode 