### PR TITLE
[misc] Remove patient view from non-lfs runmodes

### DIFF
--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Extensions.json
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Extensions.json
@@ -8,6 +8,13 @@
             "lfs:extensionName": "Tumors",
             "lfs:targetURL": "/content.html/Tumor",
             "lfs:extensionRenderURL": "asset:lfs-dataentry.SubjectType.js"
+        },
+        "Patients": {
+            "jcr:primaryType": "lfs:Extension",
+            "lfs:extensionPointId": "lfs/coreUI/view",
+            "lfs:extensionName": "Patients",
+            "lfs:targetURL": "/content.html/Patient",
+            "lfs:extensionRenderURL": "asset:lfs-dataentry.SubjectType.js"
         }
     },
     "Sidebar": {
@@ -19,6 +26,14 @@
             "lfs:targetURL": "/content.html/Tumor",
             "lfs:icon": "asset:lfs-dataentry.subjectsIcon.js",
             "lfs:defaultOrder": 6
+        },
+        "Patients": {
+            "jcr:primaryType": "lfs:Extension",
+            "lfs:extensionPointId": "lfs/coreUI/sidebar/entry",
+            "lfs:extensionName": "Patients",
+            "lfs:targetURL": "/content.html/Patient",
+            "lfs:icon": "asset:lfs-dataentry.subjectsIcon.js",
+            "lfs:defaultOrder": 5
         }
     }
 }

--- a/modules/data-entry/src/main/resources/SLING-INF/content/Extensions.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/Extensions.json
@@ -36,13 +36,6 @@
             "lfs:extensionName": "Subjects",
             "lfs:targetURL": "/content.html/Subjects",
             "lfs:extensionRenderURL": "asset:lfs-dataentry.Subjects.js"
-        },
-        "Patients": {
-            "jcr:primaryType": "lfs:Extension",
-            "lfs:extensionPointId": "lfs/coreUI/view",
-            "lfs:extensionName": "Patients",
-            "lfs:targetURL": "/content.html/Patient",
-            "lfs:extensionRenderURL": "asset:lfs-dataentry.SubjectType.js"
         }
     },
     "AdminDashboard": {
@@ -89,14 +82,6 @@
             "lfs:targetURL": "/content.html/Forms",
             "lfs:icon": "asset:lfs-dataentry.formsIcon.js",
             "lfs:defaultOrder": 3
-        },
-        "Patients": {
-            "jcr:primaryType": "lfs:Extension",
-            "lfs:extensionPointId": "lfs/coreUI/sidebar/entry",
-            "lfs:extensionName": "Patients",
-            "lfs:targetURL": "/content.html/Patient",
-            "lfs:icon": "asset:lfs-dataentry.subjectsIcon.js",
-            "lfs:defaultOrder": 5
         }
     }
 }


### PR DESCRIPTION
Removed from runmodes `cardiac` and `cardiac_rehab`
- Removed side bar entry and view