### PR TITLE
LFS-776: IDs instead of values are displayed for terms added via NCR

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/NCRNote.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/NCRNote.jsx
@@ -60,7 +60,7 @@ function ParsedNoteSection (props) {
   // Handle the user clicking on a link which corresponds to a suggestion
   let addSuggestion = (event) => {
     event.preventDefault();
-    onAddSuggestion(firstMatch[ONTOLOGY_KEY], firstMatch["names"][0])
+    onAddSuggestion(firstMatch[ONTOLOGY_KEY].replace(/:/g, ""), firstMatch["names"][0])
   }
 
   return (<React.Fragment>


### PR DESCRIPTION
Remove all instances of the colon ":" character when handling `hp_id` values from NCR so that these identifiers may point to ontological entities under the JCR path `/Vocabularies/`