### PR TITLE
Quick fix for regression introduced by LFS-655, where user is no longer informed if save failed

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -169,13 +169,9 @@ function Form (props) {
         })
         setLastSaveStatus(undefined);
       } else {
-        // If the user is not logged in, offer to log in
-        const sessionInfo = window.Sling.getSessionInfo();
-        if (sessionInfo === null || sessionInfo.userID === 'anonymous') {
-          // On first attempt to save while logged out, set status to false to make button text inform user
-          setLastSaveStatus(false);
-
-        }
+        setErrorMessage("Saving the data failed");
+        openErrorDialog();
+        setLastSaveStatus(false);
       }
       })
       .finally(() => {formNode?.current && setSaveInProgress(false)});
@@ -386,7 +382,7 @@ function Form (props) {
           </IconButton>
         </DialogTitle>
         <DialogContent>
-            <Typography variant="body1">Server responded with response code {errorCode}:<br />{errorMessage}</Typography>
+            <Typography variant="body1">{errorMessage}</Typography>
         </DialogContent>
       </Dialog>
     </form>

--- a/modules/login/src/main/frontend/src/login/loginDialogue.js
+++ b/modules/login/src/main/frontend/src/login/loginDialogue.js
@@ -38,7 +38,15 @@ export function fetchWithReLogin(displayLoginCtx, url, fetchArgs) {
               reject(response);
           }
         })
-        .catch((err) => {reject(err)});
+        .catch((err) => {
+          if (!(fetchArgs?.method?.toUpperCase() == 'GET')) {
+             // Forward the errors to non-GET requests for customized feedback to the user
+             resolve(err)
+          } else {
+             // silently catch errors for GET requests
+             reject(err)
+          }
+        });
       }
       fetchFunc();
     });


### PR DESCRIPTION
Quick fix for regression introduced by LFS-655: when offline, saving a form fails silently and the user has no idea their data is not saved.
Forwarding the exception to the function whicj called fetchWithRelogin, which usually already had code for informinf the user of the failure.

A better fix for the future: fetchWithRelogin should trigger displaying the error itself.