### PR TITLE
LFS-722: Fields at the bottom of the form are inaccessible

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -383,13 +383,14 @@ function Form (props) {
             />
         </Grid>
         :
-        <Grid item xs={false}>
+        <Grid item xs={false} className={classes.formBottom}>
           <div className={classes.mainPageAction}>
             <Fab
               variant="extended"
               color={saveInProgress ? "default" : lastSaveStatus === false ? "secondary" : "primary"}
               disabled={saveInProgress}
               onClick={handleSubmit}
+              className={classes.saveButton}
             >
             {
               saveInProgress ? <><CloudUploadIcon /> Saving...</> :

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -172,17 +172,14 @@ function Form (props) {
             openErrorDialog();
         })
         setLastSaveStatus(undefined);
-      } else {
-        // If the user is not logged in, offer to log in
-        const sessionInfo = window.Sling.getSessionInfo();
-        if (sessionInfo === null || sessionInfo.userID === 'anonymous') {
-          // On first attempt to save while logged out, set status to false to make button text inform user
-          setLastSaveStatus(false);
-
-        }
       }
-      })
-      .finally(() => {formNode?.current && setSaveInProgress(false)});
+    }).catch((err) => {
+        setErrorCode(0);
+        setErrorMessage(err?.message);
+        openErrorDialog();
+        setLastSaveStatus(undefined);
+    })
+    .finally(() => {formNode?.current && setSaveInProgress(false)});
   }
 
   // Handle when the subject of the form changes
@@ -410,7 +407,11 @@ function Form (props) {
           </IconButton>
         </DialogTitle>
         <DialogContent>
-            <Typography variant="body1">Server responded with response code {errorCode}:<br />{errorMessage}</Typography>
+            <Typography variant="h6">Your changes were not saved.</Typography>
+            <Typography variant="body1" paragraph>Server responded with response code {errorCode}: {errorMessage}</Typography>
+            {lastSaveTimestamp &&
+            <Typography variant="body1" paragraph>Time of the last successful save: {moment(lastSaveTimestamp.toISOString()).calendar()}</Typography>
+            }
         </DialogContent>
       </Dialog>
     </form>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -24,6 +24,7 @@ import {
   Breadcrumbs,
   Button,
   CircularProgress,
+  Fab,
   Grid,
   Link,
   Typography,
@@ -35,6 +36,9 @@ import {
 } from "@material-ui/core";
 import CloseIcon from "@material-ui/icons/Close";
 import EditIcon from '@material-ui/icons/Edit';
+import CloudUploadIcon from "@material-ui/icons/CloudUpload";
+import DoneIcon from "@material-ui/icons/Done";
+import WarningIcon from '@material-ui/icons/Warning';
 
 import QuestionnaireStyle, { FORM_ENTRY_CONTAINER_PROPS } from "./QuestionnaireStyle";
 import FormEntry, { QUESTION_TYPES, ENTRY_TYPES } from "./FormEntry";
@@ -368,6 +372,7 @@ function Form (props) {
               })
           }
         </FormProvider>
+        {paginationEnabled ?
         <Grid item xs={12} className={classes.formFooter}>
           <FormPagination
             lastPage={lastValidPage}
@@ -377,6 +382,24 @@ function Form (props) {
             handlePageChange={handlePageChange}
             />
         </Grid>
+        :
+        <Grid item xs={false}>
+          <div className={classes.mainPageAction}>
+            <Fab
+              variant="extended"
+              color={saveInProgress ? "default" : lastSaveStatus === false ? "secondary" : "primary"}
+              disabled={saveInProgress}
+              onClick={handleSubmit}
+            >
+            {
+              saveInProgress ? <><CloudUploadIcon /> Saving...</> :
+              lastSaveStatus === false ? <><WarningIcon /> Save failed</> :
+              <><DoneIcon /> {lastSaveStatus ? "Saved" : "Save"}</>
+            }
+            </Fab>
+          </div>
+        </Grid>
+        }
       </Grid>
       <Dialog open={errorDialogDisplayed} onClose={closeErrorDialog}>
         <DialogTitle disableTypography>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -101,11 +101,17 @@ const questionnaireStyle = theme => ({
         border: "1px solid",
         display: "inline-block"
     },
+    formBottom: {
+        minHeight: theme.spacing(8),
+    },
     saveButton: {
-        position: "fixed",
-        top: 'auto',
-        bottom: theme.spacing(1),
-        right: theme.spacing(6.5)
+        marginTop: theme.spacing(1),
+        "& .MuiFab-label" : {
+          marginRight: theme.spacing(1),
+        },
+        "& .MuiSvgIcon-root" : {
+          marginRight: theme.spacing(1),
+        },
     },
     dashboardEntry: {
         "& > *": {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -296,7 +296,7 @@ const questionnaireStyle = theme => ({
         width: "100%",
         top: 0,
         paddingTop: theme.spacing(4) + 'px !important',
-        backgroundColor: "white",
+        backgroundColor: theme.palette.background.paper,
         opacity: 1,
         zIndex: "1010",
         margin: theme.spacing(2),


### PR DESCRIPTION
Introduced a separate save button, outside of the pagination component, styled similarly to the main action buttons on Dashboard, Forms, Subjects.
![image](https://user-images.githubusercontent.com/651980/102018301-7da07f80-3d3a-11eb-8f80-e9a1a95acf3e.png)

Additionally, for LFS-783 (As a user filling out a form, I can see when the data was last saved in the current session improved feedback displayed to the user): when pressing the save button fails to save the data, display an error dialog which includes the time of the last save.
![image](https://user-images.githubusercontent.com/651980/102018243-37e3b700-3d3a-11eb-92d8-e79e938e666f.png)
