### PR TITLE
LFS-789: Browser-native login prompts appear when attempting to save forms with an invalid session

### DIFF
--- a/compose-cluster/proxy/000-default.conf
+++ b/compose-cluster/proxy/000-default.conf
@@ -16,6 +16,7 @@
 # under the License.
 
 <VirtualHost *:80>
+	Header unset WWW-Authenticate
 	ProxyPreserveHost On
 	
 	ProxyPass /ncr/ http://127.0.0.1:8600/

--- a/compose-cluster/proxy/Dockerfile
+++ b/compose-cluster/proxy/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get -y install \
 
 RUN a2enmod proxy
 RUN a2enmod proxy_http
+RUN a2enmod headers
 
 COPY 000-default.conf /etc/apache2/sites-enabled/000-default.conf
 


### PR DESCRIPTION
To test:

1. Ensure that Docker is installed and build LFS with `mvn clean install`.
2. Create a simple docker-compose deployment `cd compose-cluster`, `python3 generate_compose_yaml.py --oak_filesystem`, `docker-compose up -d`.
3. Visit `http://localhost:8080`.
4. Create a new Demographics form and add some data, but do not click _Save_.
5. Open in a new browser tab `http://localhost:8080` and logout. Return back to the first browser tab.
6. Click _Save_.
7. The themed login dialog should appear but at no point should a browser-native login prompt ever appear.
8. To stop everything after the test, in the `docker-compose` directory, run `docker-compose down`.