### PR TITLE
LFS-787: After a form is saved with an unanswered MM/yyyy date question, it can no longer be re-rendered

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx
@@ -236,7 +236,7 @@ function DateQuestion(props) {
     isDate ? "date" :
     "datetime-local";
 
-  if (isMonth && monthDateString == "" && existingAnswer) {
+  if (isMonth && monthDateString == "" && currentStartValue) {
     setMonthDateString(momentStringToDisplayMonth(currentStartValue));
   }
 


### PR DESCRIPTION
To test (before and after), go to the Participant status form in cardiac_rehab runmode and save the form without filling out the Date of birth (MM/yyyy) field.