### PR TITLE
LFS-758: Create a JSON processor for obfuscating dates

### DIFF
--- a/cardiac-rehab-resources/backend/pom.xml
+++ b/cardiac-rehab-resources/backend/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>ca.sickkids.ccm.lfs</groupId>
+    <artifactId>cardiac-rehab-resources</artifactId>
+    <version>0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>cardiac-rehab-backend</artifactId>
+  <packaging>bundle</packaging>
+  <name>Cardiac Rehab Resources - Backend code</name>
+
+  <build>
+    <plugins>
+      <!-- This is an OSGi bundle -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax.json</groupId>
+      <artifactId>javax.json-api</artifactId>
+      <version>1.1.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.api</artifactId>
+      <version>2.18.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+      <version>1.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.jcr</groupId>
+      <artifactId>jcr</artifactId>
+      <version>2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>lfs-utils</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/serialize/DateObfuscationProcessor.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/serialize/DateObfuscationProcessor.java
@@ -152,11 +152,7 @@ public class DateObfuscationProcessor implements ResourceJsonProcessor
                         value != null ? Json.createValue(value) : JsonValue.NULL);
                 }
             }
-            if (this.bareExport.get() && this.rootNode.get().equals(node.getPath())) {
-                json.remove("created");
-                json.add("@created_differential", this.baseDate == null ? JsonValue.NULL : Json.createValue(
-                    this.baseDate.until(node.getProperty("jcr:created").getDate().toInstant(), ChronoUnit.DAYS)));
-            }
+            json.remove("created");
         } catch (RepositoryException e) {
             LOGGER.warn("Failed to access properties of {}: {}", node, e.getMessage(), e);
         }

--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/serialize/DateObfuscationProcessor.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/serialize/DateObfuscationProcessor.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package ca.sickkids.ccm.lfs.cardiacrehab.internal.serialize;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.PropertyIterator;
+import javax.jcr.PropertyType;
+import javax.jcr.RepositoryException;
+import javax.json.Json;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonValue;
+
+import org.apache.sling.api.resource.Resource;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ca.sickkids.ccm.lfs.serialize.spi.ResourceJsonProcessor;
+
+/**
+ * Obfuscate all date fields by serializing them as a relative offset from a specific reference date. The reference date
+ * is defined in an environment variable called {@code REFERENCE_DATE}. The The name of this processor is
+ * {@code relativeDates}.
+ *
+ * @version $Id$
+ */
+@Component(immediate = true)
+public class DateObfuscationProcessor implements ResourceJsonProcessor
+{
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DateObfuscationProcessor.class);
+
+    private final ThreadLocal<Map<String, Long>> dates = ThreadLocal.withInitial(HashMap::new);
+
+    private ThreadLocal<Boolean> bareExport = new ThreadLocal<>();
+
+    private ThreadLocal<String> rootNode = new ThreadLocal<>();
+
+    private Instant baseDate;
+
+    @Override
+    public String getName()
+    {
+        return "relativeDates";
+    }
+
+    @Override
+    public int getPriority()
+    {
+        return 100;
+    }
+
+    @Override
+    public boolean canProcess(Resource resource)
+    {
+        return true;
+    }
+
+    @Activate
+    public void activate()
+    {
+        String env = System.getenv("REFERENCE_DATE");
+        if (env != null) {
+            try {
+                this.baseDate = DATE_FORMAT.parse(env).toInstant();
+            } catch (ParseException e) {
+                LOGGER.error("Reference date is invalid, expected format is yyyy-MM-dd, found {}", env);
+            }
+        } else {
+            LOGGER.error("No reference date is set, dates will not be included in the JSON export");
+        }
+
+    }
+
+    @Override
+    public void start(Resource resource)
+    {
+        // It is not nice to explicitly overlap another JSON processor, but this one is very special:
+        // if this is a bare export, we must replace the "created" field added by the bare processor with a differential
+        this.bareExport.set(
+            Arrays.asList(resource.getResourceMetadata().getResolutionPathInfo().split("(?<!\\\\)(?:\\\\\\\\)*\\."))
+                .contains("bare"));
+        this.rootNode.set(resource.getPath());
+    }
+
+    @Override
+    public JsonValue processProperty(Node node, Property property, JsonValue input,
+        Function<Node, JsonValue> serializeNode)
+    {
+        try {
+            if (input != null && property.getType() == PropertyType.DATE && property.getDate() != null) {
+                if (this.baseDate != null) {
+                    this.dates.get().put(property.getPath(),
+                        this.baseDate.until(property.getValue().getDate().toInstant(), ChronoUnit.DAYS));
+                } else {
+                    this.dates.get().put(property.getPath(), null);
+                }
+                return null;
+            }
+        } catch (RepositoryException e) {
+            LOGGER.warn("Failed to access property {}: {}", property, e.getMessage(), e);
+        }
+        return input;
+    }
+
+    @Override
+    public void leave(Node node, JsonObjectBuilder json, Function<Node, JsonValue> serializeNode)
+    {
+        try {
+            final PropertyIterator properties = node.getProperties();
+            while (properties.hasNext()) {
+                Property property = properties.nextProperty();
+                if (property.getType() == PropertyType.DATE && this.dates.get().containsKey(property.getPath())) {
+                    Long value = this.dates.get().get(property.getPath());
+                    json.add("@" + property.getName() + "_differential",
+                        value != null ? Json.createValue(value) : JsonValue.NULL);
+                }
+            }
+            if (this.bareExport.get() && this.rootNode.get().equals(node.getPath())) {
+                json.remove("created");
+                json.add("@created_differential", this.baseDate
+                    .until(node.getProperty("jcr:created").getValue().getDate().toInstant(), ChronoUnit.DAYS));
+            }
+        } catch (RepositoryException e) {
+            LOGGER.warn("Failed to access properties of {}: {}", node, e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void end(Resource resource)
+    {
+        this.dates.remove();
+        this.rootNode.remove();
+        this.bareExport.remove();
+    }
+}

--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/serialize/DateObfuscationProcessor.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/serialize/DateObfuscationProcessor.java
@@ -154,8 +154,8 @@ public class DateObfuscationProcessor implements ResourceJsonProcessor
             }
             if (this.bareExport.get() && this.rootNode.get().equals(node.getPath())) {
                 json.remove("created");
-                json.add("@created_differential", this.baseDate == null ? null : this.baseDate
-                    .until(node.getProperty("jcr:created").getDate().toInstant(), ChronoUnit.DAYS));
+                json.add("@created_differential", this.baseDate == null ? JsonValue.NULL : Json.createValue(
+                    this.baseDate.until(node.getProperty("jcr:created").getDate().toInstant(), ChronoUnit.DAYS)));
             }
         } catch (RepositoryException e) {
             LOGGER.warn("Failed to access properties of {}: {}", node, e.getMessage(), e);

--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/serialize/DateObfuscationProcessor.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/serialize/DateObfuscationProcessor.java
@@ -46,7 +46,7 @@ import ca.sickkids.ccm.lfs.serialize.spi.ResourceJsonProcessor;
 
 /**
  * Obfuscate all date fields by serializing them as a relative offset from a specific reference date. The reference date
- * is defined in an environment variable called {@code REFERENCE_DATE}. The The name of this processor is
+ * is defined in an environment variable called {@code REFERENCE_DATE}. The name of this processor is
  * {@code relativeDates}.
  *
  * @version $Id$
@@ -60,9 +60,9 @@ public class DateObfuscationProcessor implements ResourceJsonProcessor
 
     private final ThreadLocal<Map<String, Long>> dates = ThreadLocal.withInitial(HashMap::new);
 
-    private ThreadLocal<Boolean> bareExport = new ThreadLocal<>();
+    private final ThreadLocal<Boolean> bareExport = new ThreadLocal<>();
 
-    private ThreadLocal<String> rootNode = new ThreadLocal<>();
+    private final ThreadLocal<String> rootNode = new ThreadLocal<>();
 
     private Instant baseDate;
 
@@ -119,7 +119,7 @@ public class DateObfuscationProcessor implements ResourceJsonProcessor
             if (input != null && property.getType() == PropertyType.DATE && property.getDate() != null) {
                 if (this.baseDate != null) {
                     this.dates.get().put(property.getPath(),
-                        this.baseDate.until(property.getValue().getDate().toInstant(), ChronoUnit.DAYS));
+                        this.baseDate.until(property.getDate().toInstant(), ChronoUnit.DAYS));
                 } else {
                     this.dates.get().put(property.getPath(), null);
                 }
@@ -146,8 +146,8 @@ public class DateObfuscationProcessor implements ResourceJsonProcessor
             }
             if (this.bareExport.get() && this.rootNode.get().equals(node.getPath())) {
                 json.remove("created");
-                json.add("@created_differential", this.baseDate
-                    .until(node.getProperty("jcr:created").getValue().getDate().toInstant(), ChronoUnit.DAYS));
+                json.add("@created_differential", this.baseDate == null ? null : this.baseDate
+                    .until(node.getProperty("jcr:created").getDate().toInstant(), ChronoUnit.DAYS));
             }
         } catch (RepositoryException e) {
             LOGGER.warn("Failed to access properties of {}: {}", node, e.getMessage(), e);

--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/serialize/DateObfuscationProcessor.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/serialize/DateObfuscationProcessor.java
@@ -56,6 +56,8 @@ public class DateObfuscationProcessor implements ResourceJsonProcessor
 {
     private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
 
+    private static final SimpleDateFormat MONTH_YEAR_DATE_FORMAT = new SimpleDateFormat("MM-yyyy");
+
     private static final Logger LOGGER = LoggerFactory.getLogger(DateObfuscationProcessor.class);
 
     private final ThreadLocal<Map<String, Long>> dates = ThreadLocal.withInitial(HashMap::new);
@@ -117,6 +119,12 @@ public class DateObfuscationProcessor implements ResourceJsonProcessor
     {
         try {
             if (input != null && property.getType() == PropertyType.DATE && property.getDate() != null) {
+                // The date of birth gets special treatment: instead of obfuscating it, just output month and year
+                if (node.hasProperty("question") && "/Questionnaires/Participant Status/Demographics/date of birth"
+                    .equals(node.getProperty("question").getNode().getPath()) && "value".equals(property.getName())) {
+                    return Json.createValue(MONTH_YEAR_DATE_FORMAT.format(property.getDate().getTime()));
+                }
+
                 if (this.baseDate != null) {
                     this.dates.get().put(property.getPath(),
                         this.baseDate.until(property.getDate().toInstant(), ChronoUnit.DAYS));

--- a/cardiac-rehab-resources/pom.xml
+++ b/cardiac-rehab-resources/pom.xml
@@ -33,5 +33,6 @@
 
   <modules>
     <module>clinical-data</module>
+    <module>backend</module>
   </modules>
 </project>

--- a/distribution/src/main/provisioning/62-cardiac-rehab-resources.txt
+++ b/distribution/src/main/provisioning/62-cardiac-rehab-resources.txt
@@ -25,3 +25,4 @@
 
 [artifacts runModes=cardiac_rehab]
     ca.sickkids.ccm.lfs/cardiac-rehab-resources-clinical-data/${lfs.version}
+    ca.sickkids.ccm.lfs/cardiac-rehab-backend/${lfs.version}


### PR DESCRIPTION
To test, start with the `cardiac_rehab` runmode, create a subject and some forms containing at least one date field, then export them using different combinations of json processors:
* first without the environment variable, access
```http://localhost:8080/Subjects/[uuid].data.deep.bare.-identify.relativeDates.dataFilter:createdAfter=2020-12-08.dataFilter:createdBy=admin.json```
all dates should be null
* with envirionment variable - set the environment variable `REFERENCE_DATE` to be, for example, 2020-12-12, then access the same subject path as above -> the dates should turn into number of days relative to December 1st.