### PR TITLE
[cardiac_rehab] Remove the Participant Id question

### DIFF
--- a/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/6MWT.xml
+++ b/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/6MWT.xml
@@ -67,34 +67,6 @@
 		</property>
 	</node>
 	<node>
-		<name>Participant ID</name>
-		<primaryNodeType>lfs:Section</primaryNodeType>
-		<property>
-			<name>label</name>
-			<value>Participant ID</value>
-			<type>String</type>
-		</property>
-		<node>
-			<name>participant_id</name>
-			<primaryNodeType>lfs:Question</primaryNodeType>
-			<property>
-				<name>text</name>
-				<value>Participant ID</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>dataType</name>
-				<value>long</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>minAnswers</name>
-				<value>1</value>
-				<type>Long</type>
-			</property>
-		</node>
-	</node>
-	<node>
 		<name>Date</name>
 		<primaryNodeType>lfs:Section</primaryNodeType>
 		<property>


### PR DESCRIPTION
Participant id is not needed, the participant Id is always the id of the subject of the form.