### PR TITLE
LFS-573: Values displayed in patient charts are the raw stored values, not the user-friendly ones

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx
@@ -55,7 +55,7 @@ const ALLOWABLE_DATETIME_FORMATS = DATE_FORMATS.concat(DATETIME_FORMATS)
 
 // Truncates fields in the given moment object or date string
 // according to the given format string
-function amendMoment(date, format) {
+export function amendMoment(date, format) {
   let new_date = date;
   if (typeof new_date === "string") {
     new_date = moment(new_date);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -21,6 +21,8 @@ import React, { useState, useContext, useEffect } from "react";
 import { Link, useLocation } from 'react-router-dom';
 import PropTypes from "prop-types";
 import moment from "moment";
+
+import { amendMoment, MONTH_FORMATS, DATE_FORMATS } from "./DateQuestion.jsx";
 import QuestionnaireStyle from "./QuestionnaireStyle.jsx";
 import NewFormDialog from "../dataHomepage/NewFormDialog";
 import { usePageNameWriterContext } from "../themePage/Page.jsx";
@@ -516,12 +518,31 @@ function FormData(props) {
             })}
             </>
           break;
+        case "date":
+          let date = amendMoment(moment(existingAnswerValue), entryDefinition?.["dateFormat"]);
+          // NB: This code is ripped from DateQuestion, and will need to change if DateQuestion changes its method of displaying dates
+          let isMonth = MONTH_FORMATS.includes(entryDefinition?.["dateFormat"]);
+          let isDate = DATE_FORMATS.includes(entryDefinition?.["dateFormat"]);
+          content = !date.isValid() ? "" :
+            isMonth ? date.format(moment.HTML5_FMT.MONTH) :
+            isDate ? date.format(moment.HTML5_FMT.DATE) :
+            date.format(moment.HTML5_FMT.DATETIME_LOCAL);
+          break;
+        case "boolean":
+          content = existingAnswerValue == 1 ? (entryDefinition?.["yesLabel"] || "Yes")
+                  : existingAnswerValue == 0 ? (entryDefinition?.["noLabel"] || "No")
+                  : (entryDefinition?.["unknownLabel"] || "Unknown")
+          break;
+        case "pedigree":
+          // These are skipped
+          return <></>;
         default:
           // Check for a label and use the label instead of the value, if present
           let answerValue = entryDefinition[existingAnswerValue]?.["label"]
             ? entryDefinition[existingAnswerValue]["label"]
             : existingAnswerValue;
-          content = `${answerValue}`;
+          let units = entryDefinition?.unitOfMeasurement ? (" " + entryDefinition.unitOfMeasurement) : "";
+          content = `${answerValue} ${units}`;
           break;
       }
       // If count of displayed <= max, increase count of displayed

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -502,7 +502,7 @@ function FormData(props) {
     // question title, to be used when 'previewing' the form
     const questionTitle = entryDefinition["text"];
 
-    if (existingQuestionAnswer && existingQuestionAnswer[1]["value"] && (displayed < maxDisplayed)) {
+    if (typeof(existingQuestionAnswer?.[1]?.value) != "undefined" && (displayed < maxDisplayed)) {
       let existingAnswerValue = existingQuestionAnswer[1]["value"];
       // TODO: Other question types will need to be handled as well
       let content = "";

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -534,8 +534,14 @@ function FormData(props) {
                   : (entryDefinition?.["unknownLabel"] || "Unknown")
           break;
         case "pedigree":
-          // These are skipped
-          return <></>;
+          if (!existingAnswerValue) {
+            // Display absolutely nothing if the value does not exist
+            return <></>;
+          } else {
+            // Display Pedigree: yes if the value does exist
+            content = "Yes";
+          }
+          break;
         default:
           // Check for a label and use the label instead of the value, if present
           let answerValue = entryDefinition[existingAnswerValue]?.["label"]


### PR DESCRIPTION
The main type that this PR can't yet handle is vocabulary question types.

To test: start up a cardiac rehab LFS, fill out a form, go to the Patient page. ALl of the values should include units, boolean answers should look nice, date formats should be properly formatted (though saving them is currently bugged in `dev`)