### PR TITLE
LFS-774: Some fields in Cardiac rehab should be switched to single entry numeric fields

### DIFF
--- a/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/6MWT.xml
+++ b/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/6MWT.xml
@@ -763,16 +763,16 @@
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>unitOfMeasurement</name>
-				<value>N</value>
+				<value>long</value>
 				<type>String</type>
 			</property>
 			<property>
 				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
 				<value>1</value>
 				<type>Long</type>
 			</property>
@@ -800,6 +800,11 @@
 				<value>1</value>
 				<type>Long</type>
 			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
 		</node>
 		<node>
 			<name>wd_part_lap</name>
@@ -811,7 +816,7 @@
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>decimal</value>
 				<type>String</type>
 			</property>
 			<property>
@@ -821,6 +826,11 @@
 			</property>
 			<property>
 				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
 				<value>1</value>
 				<type>Long</type>
 			</property>
@@ -834,13 +844,8 @@
 				<type>String</type>
 			</property>
 			<property>
-				<name>description</name>
-				<value>m</value>
-				<type>String</type>
-			</property>
-			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>decimal</value>
 				<type>String</type>
 			</property>
 			<property>
@@ -850,6 +855,11 @@
 			</property>
 			<property>
 				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
 				<value>1</value>
 				<type>Long</type>
 			</property>

--- a/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Cardiac Rehab Exercise Diary.xml
+++ b/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Cardiac Rehab Exercise Diary.xml
@@ -336,12 +336,12 @@
 			<primaryNodeType>lfs:Question</primaryNodeType>
 			<property>
 				<name>text</name>
-				<value>What was the 6MWT total distance?</value>
+				<value>What was the exercise total distance?</value>
 				<type>String</type>
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>decimal</value>
 				<type>String</type>
 			</property>
 			<property>
@@ -351,6 +351,11 @@
 			</property>
 			<property>
 				<name>minAnswers</name>
+				<value>0</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
 				<value>1</value>
 				<type>Long</type>
 			</property>

--- a/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Participant Status.xml
+++ b/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Participant Status.xml
@@ -375,6 +375,11 @@
 				<value>1</value>
 				<type>Long</type>
 			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
 		</node>
 	</node>
 	<node>


### PR DESCRIPTION
* Participant Status - Device ID
Also changed data type from string to long or decimal:
* 6MWT - Whole laps completed (long, removed unit), Partial Lap distance (dec), total lap distance (dec), total distance (dec)
* Cardiac Rehab Exercise Diary - What was the 6MWT total distance? (dec)