### PR TITLE
LFS-796: Allow for an external MongoDB instance (and its credentials) to be defined when generating a docker-compose environment

### DIFF
--- a/compose-cluster/.gitignore
+++ b/compose-cluster/.gitignore
@@ -3,3 +3,4 @@ initializer/initialize_all.sh
 mongos/mongo-router.conf
 shard*
 NCR_MODEL
+secrets

--- a/compose-cluster/cleanup.sh
+++ b/compose-cluster/cleanup.sh
@@ -29,4 +29,7 @@ rm initializer/initialize_all.sh
 echo "Removing mongos/mongo-router.conf"
 rm mongos/mongo-router.conf
 
+echo "Removing secrets"
+rm -r secrets
+
 echo "Done"

--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -227,7 +227,7 @@ yaml_obj['services']['lfsinitial']['environment'].append("LFS_RELOAD=${LFS_RELOA
 if args.oak_filesystem:
     yaml_obj['services']['lfsinitial']['environment'].append("OAK_FILESYSTEM=true")
 
-if not args.oak_filesystem:
+if not (args.oak_filesystem or args.external_mongo):
     yaml_obj['services']['lfsinitial']['depends_on'] = ['router']
 
 #Configure the NCR container (if enabled) - only one for now

--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -243,9 +243,9 @@ if ENABLE_NCR:
 	yaml_obj['services']['neuralcr']['networks']['internalnetwork']['aliases'] = ['neuralcr']
 
 if args.external_mongo:
-	ext_mongo_address = input("Enter the address of the MongoDB server: ")
+	ext_mongo_address = input("Enter the address of the MongoDB server (ip, hostname, or domain name, optionally followed by port, e.g. mongo.localdomain:27017): ")
 	ext_mongo_credentials = input("Enter the username:password for the MongoDB server (leave blank for no password): ")
-	ext_mongo_db_name = input("Enter the Sling storage database name on the MongoDB server (default: db): ")
+	ext_mongo_db_name = input("Enter the Sling storage database name on the MongoDB server (default: sling): ")
 	yaml_obj['services']['lfsinitial']['environment'].append("EXTERNAL_MONGO_ADDRESS={}".format(ext_mongo_address))
 	if len(ext_mongo_credentials) != 0:
 		#Create the secrets directory if it does not exist

--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -221,7 +221,7 @@ yaml_obj['services']['lfsinitial']['networks']['internalnetwork']['aliases'] = [
 
 yaml_obj['services']['lfsinitial']['environment'] = []
 yaml_obj['services']['lfsinitial']['environment'].append("INITIAL_SLING_NODE=true")
-if not args.oak_filesystem:
+if not (args.oak_filesystem or args.external_mongo):
     yaml_obj['services']['lfsinitial']['environment'].append("INSIDE_DOCKER_COMPOSE=true")
 yaml_obj['services']['lfsinitial']['environment'].append("LFS_RELOAD=${LFS_RELOAD:-}")
 if args.oak_filesystem:

--- a/distribution/Dockerfile
+++ b/distribution/Dockerfile
@@ -18,6 +18,11 @@
 # Start from a small JRE8 base image
 FROM openjdk:8-jre-alpine
 
+# Install utilities for patching the JAR file, if such is necessary
+RUN apk add \
+  unzip \
+  zip
+
 # Optional: enable remote debugging at port 5005
 ENV DEBUG=
 

--- a/pom.xml
+++ b/pom.xml
@@ -381,6 +381,7 @@
             <exclude>compose-cluster/initializer/initialize_all.sh</exclude>
             <exclude>compose-cluster/mongos/mongo-router.conf</exclude>
             <exclude>compose-cluster/shard*/**</exclude>
+            <exclude>compose-cluster/secrets/**</exclude>
           </excludes>
         </configuration>
         <executions>


### PR DESCRIPTION
Adds the `--external_mongo` flag to the `generate_compose_yaml.py` utility so that an external MongoDB instance can be used for Apache Sling data storage. Modifies the LFS Docker image so that the LFS JAR file is appropriately patched with these updated external MongoDB configuration settings.