### PR TITLE
LFS-747 / LFS-802: Multiple choice questions should support the "None of the above" option

### DIFF
--- a/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/6MWT.xml
+++ b/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/6MWT.xml
@@ -1029,7 +1029,7 @@
 					<type>String</type>
 				</property>
 				<property>
-					<name>noneOfTheAbove</name>
+					<name>notApplicable</name>
 					<value>true</value>
 					<type>Boolean</type>
 				</property>
@@ -1290,7 +1290,7 @@
 					<type>String</type>
 				</property>
 				<property>
-					<name>noneOfTheAbove</name>
+					<name>notApplicable</name>
 					<value>true</value>
 					<type>Boolean</type>
 				</property>
@@ -1479,7 +1479,7 @@
 					<type>String</type>
 				</property>
 				<property>
-					<name>noneOfTheAbove</name>
+					<name>notApplicable</name>
 					<value>true</value>
 					<type>Boolean</type>
 				</property>
@@ -1620,7 +1620,7 @@
 					<type>String</type>
 				</property>
 				<property>
-					<name>noneOfTheAbove</name>
+					<name>notApplicable</name>
 					<value>true</value>
 					<type>Boolean</type>
 				</property>

--- a/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/6MWT.xml
+++ b/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/6MWT.xml
@@ -1028,6 +1028,11 @@
 					<value>N/A</value>
 					<type>String</type>
 				</property>
+				<property>
+					<name>noneOfTheAbove</name>
+					<value>true</value>
+					<type>Boolean</type>
+				</property>
 			</node>
 			<node>
 				<name>Cane (right)</name>
@@ -1284,6 +1289,11 @@
 					<value>N/A</value>
 					<type>String</type>
 				</property>
+				<property>
+					<name>noneOfTheAbove</name>
+					<value>true</value>
+					<type>Boolean</type>
+				</property>
 			</node>
 			<node>
 				<name>Chest pain</name>
@@ -1468,6 +1478,11 @@
 					<value>N/A</value>
 					<type>String</type>
 				</property>
+				<property>
+					<name>noneOfTheAbove</name>
+					<value>true</value>
+					<type>Boolean</type>
+				</property>
 			</node>
 			<node>
 				<name>Muscular Fatigue</name>
@@ -1603,6 +1618,11 @@
 					<name>value</name>
 					<value>N/A</value>
 					<type>String</type>
+				</property>
+				<property>
+					<name>noneOfTheAbove</name>
+					<value>true</value>
+					<type>Boolean</type>
 				</property>
 			</node>
 			<node>

--- a/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Baseline Health Information - Medications.xml
+++ b/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Baseline Health Information - Medications.xml
@@ -274,6 +274,11 @@
 					<value>None of the above</value>
 					<type>String</type>
 				</property>
+				<property>
+					<name>noneOfTheAbove</name>
+					<value>true</value>
+					<type>Boolean</type>
+				</property>
 			</node>
 		</node>
 		<node>

--- a/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Baseline Health Information.xml
+++ b/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Baseline Health Information.xml
@@ -2346,6 +2346,11 @@
 					<value>None of the above</value>
 					<type>String</type>
 				</property>
+				<property>
+					<name>noneOfTheAbove</name>
+					<value>true</value>
+					<type>Boolean</type>
+				</property>
 			</node>
 		</node>
 		<node>
@@ -2510,6 +2515,11 @@
 					<value>None of the above</value>
 					<type>String</type>
 				</property>
+				<property>
+					<name>noneOfTheAbove</name>
+					<value>true</value>
+					<type>Boolean</type>
+				</property>
 			</node>
 		</node>
 		<node>
@@ -2590,6 +2600,11 @@
 					<value>No cancer history</value>
 					<type>String</type>
 				</property>
+				<property>
+					<name>noneOfTheAbove</name>
+					<value>true</value>
+					<type>Boolean</type>
+				</property>
 			</node>
 		</node>
 		<node>
@@ -2669,6 +2684,11 @@
 					<name>value</name>
 					<value>None of the above</value>
 					<type>String</type>
+				</property>
+				<property>
+					<name>noneOfTheAbove</name>
+					<value>true</value>
+					<type>Boolean</type>
 				</property>
 			</node>
 		</node>
@@ -3259,6 +3279,11 @@
 					<name>value</name>
 					<value>None of the above</value>
 					<type>String</type>
+				</property>
+				<property>
+					<name>noneOfTheAbove</name>
+					<value>true</value>
+					<type>Boolean</type>
 				</property>
 			</node>
 		</node>

--- a/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Events.xml
+++ b/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Events.xml
@@ -1361,7 +1361,7 @@
 						<type>String</type>
 					</property>
 					<property>
-						<name>noneOfTheAbove</name>
+						<name>notApplicable</name>
 						<value>true</value>
 						<type>Boolean</type>
 					</property>
@@ -1657,7 +1657,7 @@
 						<type>String</type>
 					</property>
 					<property>
-						<name>noneOfTheAbove</name>
+						<name>notApplicable</name>
 						<value>true</value>
 						<type>Boolean</type>
 					</property>
@@ -1963,7 +1963,7 @@
 						<type>String</type>
 					</property>
 					<property>
-						<name>noneOfTheAbove</name>
+						<name>notApplicable</name>
 						<value>true</value>
 						<type>Boolean</type>
 					</property>

--- a/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Events.xml
+++ b/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Events.xml
@@ -1360,6 +1360,11 @@
 						<value>None</value>
 						<type>String</type>
 					</property>
+					<property>
+						<name>noneOfTheAbove</name>
+						<value>true</value>
+						<type>Boolean</type>
+					</property>
 				</node>
 			</node>
 			<node>
@@ -1650,6 +1655,11 @@
 						<name>value</name>
 						<value>None</value>
 						<type>String</type>
+					</property>
+					<property>
+						<name>noneOfTheAbove</name>
+						<value>true</value>
+						<type>Boolean</type>
 					</property>
 				</node>
 			</node>
@@ -1951,6 +1961,11 @@
 						<name>value</name>
 						<value>None</value>
 						<type>String</type>
+					</property>
+					<property>
+						<name>noneOfTheAbove</name>
+						<value>true</value>
+						<type>Boolean</type>
 					</property>
 				</node>
 			</node>

--- a/cardiac-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/0-5NDVariables.xml
+++ b/cardiac-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/0-5NDVariables.xml
@@ -66,6 +66,11 @@
 				<value>None</value>
 				<type>String</type>
 			</property>
+			<property>
+				<name>notApplicable</name>
+				<value>true</value>
+				<type>Boolean</type>
+			</property>
 		</node>
 		<node>
 			<name>ABAS</name>

--- a/cardiac-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/6-21NDVariables.xml
+++ b/cardiac-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/6-21NDVariables.xml
@@ -361,6 +361,11 @@
 				<value>None</value>
 				<type>String</type>
 			</property>
+			<property>
+				<name>notApplicable</name>
+				<value>true</value>
+				<type>Boolean</type>
+			</property>
 		</node>
 		<node>
 			<name>ABAS</name>
@@ -2261,6 +2266,11 @@
 				<name>value</name>
 				<value>None</value>
 				<type>String</type>
+			</property>
+			<property>
+				<name>notApplicable</name>
+				<value>true</value>
+				<type>Boolean</type>
 			</property>
 		</node>
 		<node>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Demographics.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Demographics.xml
@@ -844,6 +844,11 @@
 				<value>N/A</value>
 				<type>String</type>
 			</property>
+			<property>
+				<name>notApplicable</name>
+				<value>true</value>
+				<type>Boolean</type>
+			</property>
 		</node>
 	</node>
 	<node>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -42,10 +42,11 @@ const GHOST_SENTINEL = "custom-input";
   * @param {func} onChange Callback for when an option is removed, receives as argument the value of the removed option
   * @param {Object} additionalInputProps additional props to be set on the input element
   * @param {Object} muiInputProps additional props to be forwarded to the MUI input element
+  * @param {Object} naValue if provided, any answer with this value will de-select all other selected options, and will be unselected if any other option is selected
   * @param {bool} error indicates if the current selection is in a state of error
   */
 function MultipleChoice(props) {
-  let { classes, existingAnswer, input, textbox, onUpdate, onChange, additionalInputProps, muiInputProps, error, questionName, ...rest } = props;
+  let { classes, existingAnswer, input, textbox, onUpdate, onChange, additionalInputProps, muiInputProps, naValue, error, questionName, ...rest } = props;
   let { maxAnswers, minAnswers, displayMode } = {...props.questionDefinition, ...props};
   let defaults = props.defaults || Object.values(props.questionDefinition)
     // Keep only answer options
@@ -53,6 +54,9 @@ function MultipleChoice(props) {
     .filter(value => value['jcr:primaryType'] == 'lfs:AnswerOption')
     // Only extract the labels and internal values from the node
     .map(value => [value.label || value.value, value.value, true]);
+  // Locate an option referring to the "none of the above", if it exists
+  let naOption = naValue || Object.values(props.questionDefinition)
+    .find((value) => value['noneOfTheAbove'])?.["value"];
   const isBare = defaults.length === 0 && maxAnswers === 1;
   const isRadio = defaults.length > 0 && maxAnswers === 1;
   const isSelect = displayMode === "select";
@@ -86,7 +90,7 @@ function MultipleChoice(props) {
   let inputEl = null;
 
   let selectOption = (id, name, checked = false) => {
-    // When selecting a new option, remove the ["",""] answer, as it no longer has a purpose
+    // Selecting a radio button option will select only that option
     if (isRadio) {
       let defaultOption = defaults.filter((option) => {return option[VALUE_POS] === name || option[LABEL_POS] === name})[0];
       if (defaultOption) {
@@ -105,6 +109,13 @@ function MultipleChoice(props) {
       return unselect(id, name);
     }
 
+    // If the naOption is selected, all other elements are deselected
+    if (naOption == id) {
+      setSelection([[name, id]]);
+      // OK to clear input, since they're removing everything else
+      return false;
+    }
+
     // Do not add anything if we are at our maximum number of selections
     if (maxAnswers > 0 && selection.length >= maxAnswers) {
       return;
@@ -120,6 +131,8 @@ function MultipleChoice(props) {
     // If we're inserting a new entry, we should never add the empty tracker
     newSelection = newSelection.filter((option) => {
       return (option[VALUE_POS] !== "" && option[LABEL_POS] !== "")
+        // And if we've gotten here and there's a "none of the above" option, we remove it from the selection
+        && (!naOption || option[VALUE_POS] != naOption)
     });
 
     // Check if any of the predefined options matches the user input. If yes, select it instead of adding a new entry

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -112,6 +112,8 @@ function MultipleChoice(props) {
     // If the naOption is selected, all other elements are deselected
     if (naOption == id) {
       setSelection([[name, id]]);
+      // Clear any user-input options
+      setOptions(all_options);
       // OK to clear input, since they're removing everything else
       return false;
     }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -121,7 +121,14 @@ function MultipleChoice(props) {
       return false;
     } else if (noneOfTheAboveOption == id) {
       // If the noneOfTheAboveOption is selected, other elements are deselected but user-input options remain
-      setSelection([[name, id]]);
+      setSelection((old) => {
+        // Only keep options that are user-input
+        let defaultOptions = defaults.filter(option => option[IS_DEFAULT_POS]).map((option) => option[VALUE_POS]);
+        let newSelection = old.slice().filter((option) => !defaultOptions.includes(option[VALUE_POS]));
+        newSelection.push([name, id]);
+        console.log(newSelection);
+        return newSelection;
+      });
       // OK to clear input (we more-or-less should never get here via a user-entered input)
       // The only instance where the user input something but we trigger a "none of the above" is when they type
       // the value corresponding to the "none of the above", which should clear the input anyway

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -43,10 +43,11 @@ const GHOST_SENTINEL = "custom-input";
   * @param {Object} additionalInputProps additional props to be set on the input element
   * @param {Object} muiInputProps additional props to be forwarded to the MUI input element
   * @param {Object} naValue if provided, any answer with this value will de-select all other selected options, and will be unselected if any other option is selected
+  * @param {Object} noneOfTheAboveValue if provided, any answer with this value will de-select all other pre-defined options, and will be unselected if any other option is selected
   * @param {bool} error indicates if the current selection is in a state of error
   */
 function MultipleChoice(props) {
-  let { classes, existingAnswer, input, textbox, onUpdate, onChange, additionalInputProps, muiInputProps, naValue, error, questionName, ...rest } = props;
+  let { classes, existingAnswer, input, textbox, onUpdate, onChange, additionalInputProps, muiInputProps, naValue, noneOfTheAboveValue, error, questionName, ...rest } = props;
   let { maxAnswers, minAnswers, displayMode } = {...props.questionDefinition, ...props};
   let defaults = props.defaults || Object.values(props.questionDefinition)
     // Keep only answer options
@@ -56,6 +57,8 @@ function MultipleChoice(props) {
     .map(value => [value.label || value.value, value.value, true]);
   // Locate an option referring to the "none of the above", if it exists
   let naOption = naValue || Object.values(props.questionDefinition)
+    .find((value) => value['notApplicable'])?.["value"];
+  let noneOfTheAboveOption = noneOfTheAboveValue || Object.values(props.questionDefinition)
     .find((value) => value['noneOfTheAbove'])?.["value"];
   const isBare = defaults.length === 0 && maxAnswers === 1;
   const isRadio = defaults.length > 0 && maxAnswers === 1;
@@ -109,12 +112,19 @@ function MultipleChoice(props) {
       return unselect(id, name);
     }
 
-    // If the naOption is selected, all other elements are deselected
+    // If the naOption is selected, all other elements are deselected and user-input options are cleared
     if (naOption == id) {
       setSelection([[name, id]]);
       // Clear any user-input options
       setOptions(all_options);
       // OK to clear input, since they're removing everything else
+      return false;
+    } else if (noneOfTheAboveOption == id) {
+      // If the noneOfTheAboveOption is selected, other elements are deselected but user-input options remain
+      setSelection([[name, id]]);
+      // OK to clear input (we more-or-less should never get here via a user-entered input)
+      // The only instance where the user input something but we trigger a "none of the above" is when they type
+      // the value corresponding to the "none of the above", which should clear the input anyway
       return false;
     }
 
@@ -133,8 +143,10 @@ function MultipleChoice(props) {
     // If we're inserting a new entry, we should never add the empty tracker
     newSelection = newSelection.filter((option) => {
       return (option[VALUE_POS] !== "" && option[LABEL_POS] !== "")
-        // And if we've gotten here and there's a "none of the above" option, we remove it from the selection
+        // And if we've gotten here and there's an "na" option, we remove it from the selection
         && (!naOption || option[VALUE_POS] != naOption)
+        // The same goes for a "none of the above" option
+        && (!noneOfTheAboveOption || option[VALUE_POS] != noneOfTheAboveOption)
     });
 
     // Check if any of the predefined options matches the user input. If yes, select it instead of adding a new entry

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -83,6 +83,10 @@
   // Mandatory, every option needs a stored value.
   - value (string) mandatory
 
+  // If set, selecting this answer in a multiple choice question will remove _all other options_ (as in a "none of the above" option)
+  // In addition, selecting any other answer will unselect this option
+  - noneOfTheAbove (boolean)
+
   // Children
 
   // Answer options can be hierarchical, so an option may have suboptions.

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -83,9 +83,13 @@
   // Mandatory, every option needs a stored value.
   - value (string) mandatory
 
-  // If set, selecting this answer in a multiple choice question will remove _all other options_ (as in a "none of the above" option)
-  // In addition, selecting any other answer will unselect this option
+  // If set, selecting this answer in a multiple choice question will remove _all other non-user-entered options_
+  // (as in a "none of the above" option). In addition, selecting any other answer will unselect this option
   - noneOfTheAbove (boolean)
+
+  // If set, selecting this answer in a multiple choice question will remove _all other options, including user-entered ones_
+  // (as in a "not applicable" option) In addition, selecting any other answer will unselect this option
+  - notApplicable (boolean)
 
   // Children
 

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -84,11 +84,11 @@
   - value (string) mandatory
 
   // If set, selecting this answer in a multiple choice question will remove _all other non-user-entered options_
-  // (as in a "none of the above" option). In addition, selecting any other answer will unselect this option
+  // (as in a "none of the above" option). In addition, selecting any other answer will unselect this option.
   - noneOfTheAbove (boolean)
 
   // If set, selecting this answer in a multiple choice question will remove _all other options, including user-entered ones_
-  // (as in a "not applicable" option) In addition, selecting any other answer will unselect this option
+  // (as in a "not applicable" option). In addition, selecting any other answer will unselect this option.
   - notApplicable (boolean)
 
   // Children


### PR DESCRIPTION
[Jira link for the base functionality](https://phenotips.atlassian.net/browse/LFS-747) 

[Jira link for the questionnaire changes](https://phenotips.atlassian.net/browse/LFS-802)

**Test branch:** Running the multiple choice in `cardiac_rehab` runmode (`java -jar distribution/target/lfs-0.1-SNAPSHOT.jar -Dsling.run.modes=nolfs,cardiac_rehab,dev`),
- create a form for `6MWT` and check the behaviour of `Reason for pausing during the test`. The NA option should deselect everything, including user-input ones.
- create a form for `Baseline Health Information`, and check the behaviour of `Diseases of the musculoskeletal system or connective tissue: check all that apply`. The "None of the above" option should deselect everything except for anything you enter in the input box.

This adds another option to an lfs:AnswerOption that allows you to make an answer option a "none of the above". This isn't yet added to the editor.

