### PR TITLE
LFS-780: Forms and Subjects views should be consistent with the corresponding Dashboard boxes

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -42,7 +42,7 @@ import NewFormDialog from "./NewFormDialog.jsx";
 import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
 
 function FormView(props) {
-  const { questionnaire, classes } = props;
+  const { questionnaire, expanded, disableHeader, disableAvatar, topPagination, classes } = props;
   const [ activeTab, setActiveTab ] = useState(0);
   const [ title, setTitle ] = useState(typeof(props.title) != 'undefined' ? props.title : "Forms");
   const [ subtitle, setSubtitle ] = useState();
@@ -96,9 +96,9 @@ function FormView(props) {
 
   return (
     <Card className={classes.formView}>
-      {(!props.expanded || !props.disableHeader && !props.disableAvatar && title) &&
+      {(!expanded || !disableHeader && !disableAvatar && (title || questionnaire)) &&
       <CardHeader
-        avatar={!props.disableAvatar && <Avatar className={classes.formViewAvatar}><DescriptionIcon/></Avatar>}
+        avatar={!disableAvatar && <Avatar className={classes.formViewAvatar}><DescriptionIcon/></Avatar>}
         title={
           <>
             <Typography variant="h6">{title}</Typography>
@@ -106,7 +106,7 @@ function FormView(props) {
           </>
         }
         action={
-          !props.expanded &&
+          !expanded &&
           <Tooltip title="Expand">
             <Link to={"/content.html/Forms"}>
               <IconButton>
@@ -132,9 +132,9 @@ function FormView(props) {
           filters
           entryType={"Form"}
           actions={actions}
-          disableTopPagination={!props.topPagination}
+          disableTopPagination={!topPagination}
         />
-      {props.expanded &&
+      {expanded &&
         <div className={classes.mainPageAction}>
           <NewFormDialog presetPath={questionnairePath}>
             New form

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -46,7 +46,7 @@ function FormView(props) {
   const [ activeTab, setActiveTab ] = useState(0);
   const [ title, setTitle ] = useState(typeof(props.title) != 'undefined' ? props.title : "Forms");
   const [ subtitle, setSubtitle ] = useState();
-  const [ questionnairePath, SetQuestionnairePath ] = useState();
+  const [ questionnairePath, setQuestionnairePath ] = useState();
   const [ qFetchSent, setQFetchStatus ] = useState(false);
 
   // Column configuration for the LiveTables
@@ -88,7 +88,7 @@ function FormView(props) {
         if (qData) {
           setTitle(qData["title"]);
           setSubtitle(qData["description"]);
-          setQuesionnairePath(qData["@path"]);
+          setQuestionnairePath(qData["@path"]);
         }
       });
     }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -38,11 +38,16 @@ import { Link } from 'react-router-dom';
 import DescriptionIcon from '@material-ui/icons/Description';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import DeleteButton from "./DeleteButton.jsx";
+import NewFormDialog from "./NewFormDialog.jsx";
 import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
 
 function FormView(props) {
-  const { classes } = props;
+  const { questionnaire, classes } = props;
   const [ activeTab, setActiveTab ] = useState(0);
+  const [ title, setTitle ] = useState(typeof(props.title) != 'undefined' ? props.title : "Forms");
+  const [ subtitle, setSubtitle ] = useState();
+  const [ questionnairePath, SetQuestionnairePath ] = useState();
+  const [ qFetchSent, setQFetchStatus ] = useState(false);
 
   // Column configuration for the LiveTables
   const columns = [
@@ -68,12 +73,40 @@ function FormView(props) {
   ]
   const tabs = ["Completed", "Draft"];
 
+  let qFilter = undefined;
+
+  if (questionnaire) {
+    // Set the questionnaire filter for displayed forms
+    qFilter = '&fieldname=questionnaire&fieldvalue=' + encodeURIComponent(questionnaire);
+    // Also fetch the title and other info if we haven't yet
+    if (!qFetchSent) {
+      setQFetchStatus(true);
+      fetch('/query?query=' + encodeURIComponent(`select * from [lfs:Questionnaire] as n WHERE n.'jcr:uuid'='${questionnaire}'`))
+      .then((response) => response.ok ? response.json() : Promise.reject(response))
+      .then((json) => {
+        let qData = json["rows"][0];
+        if (qData) {
+          setTitle(qData["title"]);
+          setSubtitle(qData["description"]);
+          setQuesionnairePath(qData["@path"]);
+        }
+      });
+    }
+  }
+
   return (
     <Card className={classes.formView}>
+      {(!props.expanded || !props.disableHeader && !props.disableAvatar && title) &&
       <CardHeader
-        avatar={<Avatar className={classes.formViewAvatar}><DescriptionIcon/></Avatar>}
-        title={<Typography variant="h6">Forms</Typography>}
+        avatar={!props.disableAvatar && <Avatar className={classes.formViewAvatar}><DescriptionIcon/></Avatar>}
+        title={
+          <>
+            <Typography variant="h6">{title}</Typography>
+            <Typography variant="subtitle1">{subtitle}</Typography>
+          </>
+        }
         action={
+          !props.expanded &&
           <Tooltip title="Expand">
             <Link to={"/content.html/Forms"}>
               <IconButton>
@@ -83,6 +116,7 @@ function FormView(props) {
           </Tooltip>
         }
       />
+      }
       <Tabs value={activeTab} onChange={(event, value) => setActiveTab(value)}>
         {tabs.map((value, index) => {
           return <Tab label={value}  key={"form-" + index} />;
@@ -91,15 +125,22 @@ function FormView(props) {
       <Divider />
       <CardContent>
         <LiveTable
-          columns={columns}
-          customUrl={`/Forms.paginate?descending=true${activeTab == tabs.indexOf("Draft") ? '&fieldname=statusFlags&fieldvalue=INCOMPLETE' : ''}`}
+          columns={props.columns || columns}
+          customUrl={`/Forms.paginate?descending=true${qFilter}${activeTab == tabs.indexOf("Draft") ? '&fieldname=statusFlags&fieldvalue=INCOMPLETE' : ''}`}
           defaultLimit={10}
           joinChildren="lfs:Answer"
           filters
           entryType={"Form"}
           actions={actions}
-          disableTopPagination
+          disableTopPagination={!props.topPagination}
         />
+      {props.expanded &&
+        <div className={classes.mainPageAction}>
+          <NewFormDialog presetPath={questionnairePath}>
+            New form
+          </NewFormDialog>
+        </div>
+      }
       </CardContent>
     </Card>
   );

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -28,7 +28,7 @@ import { usePageNameWriterContext } from "../themePage/Page.jsx";
 
 function Forms(props) {
   const { location, classes } = props;
-  const questionnaireID = /questionnaire=([^&]+)/.exec(location.search);
+  const questionnaireID = /questionnaire=([^&]+)/.exec(location.search)?.[1];
   const pageNameWriter = usePageNameWriterContext();
 
   const entry = /Forms\/(.+)/.exec(location.pathname);

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -76,13 +76,8 @@ function Forms(props) {
   return (
     <Grid container direction="column" spacing={4}>
       <Grid item className={classes.dashboardEntry}>
-        <Typography variant="h2">Forms</Typography>
-      </Grid>
-      <Grid item>
         <FormView
           expanded
-          disableAvatar
-          title=""
           columns={columns}
           questionnaire={questionnaireID}
         />

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -17,24 +17,17 @@
 //  under the License.
 //
 import React, { useEffect, useState } from "react";
-import LiveTable from "./LiveTable.jsx";
 import Form from "../questionnaire/Form.jsx";
 import { getHierarchy } from "../questionnaire/Subject.jsx";
 
-import { Button, Card, CardContent, CardHeader, Grid, Link, withStyles } from "@material-ui/core";
+import { Grid, Typography, withStyles } from "@material-ui/core";
 import questionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
-import NewFormDialog from "./NewFormDialog.jsx";
-import DeleteButton from "./DeleteButton.jsx";
+import FormView from "./FormView.jsx";
 import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
 import { usePageNameWriterContext } from "../themePage/Page.jsx";
 
 function Forms(props) {
-  const { match, location, classes } = props;
-
-  const [ title, setTitle ] = useState("Forms");
-  const [ titleFetchSent, setFetchStatus ] = useState(false);
-  const [ questionnairePath, setQuestionnairePath ] = useState(undefined);
-  const [ questionnaireDetails, setQuestionnaireDetails ] = useState();
+  const { location, classes } = props;
   const questionnaireID = /questionnaire=([^&]+)/.exec(location.search);
   const pageNameWriter = usePageNameWriterContext();
 
@@ -51,29 +44,6 @@ function Forms(props) {
     return <Form id={entry[1]} key={location.pathname}/>;
   }
 
-  // Convert from a questionnaire ID to the title of the form we're editing
-  let getQuestionnaireTitle = (id) => {
-    setFetchStatus(true);
-    fetch('/query?query=' + encodeURIComponent(`select * from [lfs:Questionnaire] as n WHERE n.'jcr:uuid'='${id}'`))
-      .then((response) => response.ok ? response.json() : Promise.reject(response))
-      .then((json) => {
-        setTitle(json["rows"][0]["title"]);
-        setQuestionnairePath(json["rows"][0]["@path"]);
-        setQuestionnaireDetails(json["rows"][0]);
-      });
-  }
-
-  let customUrl = undefined;
-  // Formulate a custom pagination request if a questionnaire ID is given
-  if (questionnaireID) {
-    customUrl='/Forms.paginate?fieldname=questionnaire&fieldvalue='
-            + encodeURIComponent(questionnaireID[1]);
-
-    // Also fetch the title if we haven't yet
-    if (!titleFetchSent) {
-      getQuestionnaireTitle(questionnaireID[1]);
-    }
-  }
   const columns = [
     {
       "key": "@name",
@@ -102,41 +72,23 @@ function Forms(props) {
       "format": "string",
     },
   ]
-  const actions = [
-    DeleteButton
-  ]
 
   return (
-    <Card>
-      <CardHeader
-        color={"warning"/* Does nothing */}
-        title={
-          <Button className={classes.cardHeaderButton}>
-            {title}
-          </Button>
-        }
-        action={
-        <div className={classes.mainPageAction}>
-          <NewFormDialog presetPath={questionnairePath}>
-            New form
-          </NewFormDialog>
-        </div>
-        }
-        classes={{
-          action: classes.newFormButtonHeader
-        }}
-      />
-      <CardContent>
-        <LiveTable
+    <Grid container direction="column" spacing={4}>
+      <Grid item className={classes.dashboardEntry}>
+        <Typography variant="h2">Forms</Typography>
+      </Grid>
+      <Grid item>
+        <FormView
+          expanded
+          disableAvatar
+          topPagination
+          title=""
           columns={columns}
-          customUrl={customUrl}
-          filters
-          joinChildren="lfs:Answer"
-          actions={actions}
-          entryType="Form"
-          />
-      </CardContent>
-    </Card>
+          questionnaire={questionnaireID}
+        />
+      </Grid>
+    </Grid>
   );
 }
 

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -82,7 +82,6 @@ function Forms(props) {
         <FormView
           expanded
           disableAvatar
-          topPagination
           title=""
           columns={columns}
           questionnaire={questionnaireID}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
@@ -46,7 +46,7 @@ import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js"
 import { NewSubjectDialog } from "../questionnaire/SubjectSelector.jsx";
 
 function SubjectView(props) {
-  const { classes } = props;
+  const { expanded, disableHeader, disableAvatar, topPagination, classes } = props;
   const [ newSubjectPopperOpen, setNewSubjectPopperOpen ] = useState(false);
   const [ activeTab, setActiveTab ] = useState(0);
   const [ subjectTypes, setSubjectTypes] = useState([])
@@ -104,9 +104,9 @@ function SubjectView(props) {
 
   return (
     <Card className={classes.subjectView}>
-      {!props.disableHeader &&
+      {!disableHeader &&
       <CardHeader
-        avatar={!props.disableAvatar && <Avatar className={classes.subjectViewAvatar}><AssignmentIndIcon/></Avatar>}
+        avatar={!disableAvatar && <Avatar className={classes.subjectViewAvatar}><AssignmentIndIcon/></Avatar>}
         title={<Typography variant="h6">Subjects</Typography>}
         action={
           !props.expanded &&
@@ -123,6 +123,8 @@ function SubjectView(props) {
       {
         tabsLoading
           ? <CircularProgress/>
+          : subjectTypes.length <= 1 ?
+          <></>
           : <Tabs value={activeTab} onChange={(event, value) => setActiveTab(value)}>
               {subjectTypes.map((subject, index) => {
                 return <Tab label={subject['label'] || subject['@name']} key={"subject-" + index}/>;
@@ -139,12 +141,12 @@ function SubjectView(props) {
               defaultLimit={10}
               entryType={"Subject"}
               actions={actions}
-              disableTopPagination
+              disableTopPagination={!topPagination}
             />
           : <Typography>No results</Typography>
       }
       </CardContent>
-      {props.expanded &&
+      {expanded &&
       <>
         <div className={classes.mainPageAction}>
           <div className={classes.newFormButtonWrapper}>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
@@ -109,7 +109,7 @@ function SubjectView(props) {
         avatar={!disableAvatar && <Avatar className={classes.subjectViewAvatar}><AssignmentIndIcon/></Avatar>}
         title={<Typography variant="h6">Subjects</Typography>}
         action={
-          !props.expanded &&
+          !expanded &&
           <Tooltip title="Expand">
             <Link to={"/content.html/Subjects"}>
               <IconButton>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
@@ -29,6 +29,7 @@ import {
   CircularProgress,
   Divider,
   IconButton,
+  Fab,
   Tab,
   Tabs,
   Tooltip,
@@ -38,12 +39,15 @@ import {
 import { Link } from 'react-router-dom';
 import AssignmentIndIcon from '@material-ui/icons/AssignmentInd';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
+import AddIcon from '@material-ui/icons/Add';
 import DeleteButton from "./DeleteButton.jsx";
 import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
 import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
+import { NewSubjectDialog } from "../questionnaire/SubjectSelector.jsx";
 
 function SubjectView(props) {
   const { classes } = props;
+  const [ newSubjectPopperOpen, setNewSubjectPopperOpen ] = useState(false);
   const [ activeTab, setActiveTab ] = useState(0);
   const [ subjectTypes, setSubjectTypes] = useState([])
   const [ tabsLoading, setTabsLoading ] = useState(null);
@@ -100,10 +104,12 @@ function SubjectView(props) {
 
   return (
     <Card className={classes.subjectView}>
+      {!props.disableHeader &&
       <CardHeader
-        avatar={<Avatar className={classes.subjectViewAvatar}><AssignmentIndIcon/></Avatar>}
+        avatar={!props.disableAvatar && <Avatar className={classes.subjectViewAvatar}><AssignmentIndIcon/></Avatar>}
         title={<Typography variant="h6">Subjects</Typography>}
         action={
+          !props.expanded &&
           <Tooltip title="Expand">
             <Link to={"/content.html/Subjects"}>
               <IconButton>
@@ -113,6 +119,7 @@ function SubjectView(props) {
           </Tooltip>
         }
       />
+      }
       {
         tabsLoading
           ? <CircularProgress/>
@@ -137,6 +144,29 @@ function SubjectView(props) {
           : <Typography>No results</Typography>
       }
       </CardContent>
+      {props.expanded &&
+      <>
+        <div className={classes.mainPageAction}>
+          <div className={classes.newFormButtonWrapper}>
+            <Tooltip aria-label="add" title="New Subject">
+              <Fab
+                color="primary"
+                aria-label="add"
+                onClick={() => {setNewSubjectPopperOpen(true)}}
+              >
+                <AddIcon />
+              </Fab>
+            </Tooltip>
+          </div>
+        </div>
+        <NewSubjectDialog
+          onClose={() => { setNewSubjectPopperOpen(false);}}
+          onSubmit={() => { setNewSubjectPopperOpen(false);}}
+          openNewSubject={true}
+          open={newSubjectPopperOpen}
+        />
+      </>
+      }
     </Card>
   );
 }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
@@ -98,13 +98,8 @@ function Subjects(props) {
   return (
     <Grid container direction="column" spacing={4}>
       <Grid item className={classes.dashboardEntry}>
-         <Typography variant="h2">Subjects</Typography>
-      </Grid>
-      <Grid item>
         <SubjectView
           expanded
-          disableHeader
-          title=""
           columns={columns}
         />
       </Grid>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
@@ -104,7 +104,6 @@ function Subjects(props) {
         <SubjectView
           expanded
           disableHeader
-          topPagination
           title=""
           columns={columns}
         />

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
@@ -17,16 +17,13 @@
 //  under the License.
 //
 import React, { useEffect, useState } from "react";
-import LiveTable from "./LiveTable.jsx";
 import Subject from "../questionnaire/Subject.jsx";
+import SubjectView from "./SubjectView.jsx";
 import { getHierarchy, getSubjectIdFromPath } from "../questionnaire/Subject.jsx";
-import { NewSubjectDialog } from "../questionnaire/SubjectSelector.jsx";
 import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
 
-import { Button, Card, CardContent, CardHeader, Grid, Link, withStyles, ListItemText, Tooltip, Fab } from "@material-ui/core";
-import AddIcon from "@material-ui/icons/Add";
+import { Button, Grid, Typography, withStyles } from "@material-ui/core";
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
-import DeleteButton from "./DeleteButton.jsx";
 import { usePageNameWriterContext } from "../themePage/Page.jsx";
 
 const tableColumns = [
@@ -63,12 +60,25 @@ function Subjects(props) {
   const { classes } = props;
   // fix issue with classes
 
-  let [ newSubjectPopperOpen, setNewSubjectPopperOpen ] = useState(false);
   // When a new subject is added, state will be updated and trigger a livetable refresh
   const [ requestFetchData, setRequestFetchData ] = useState(0);
   // subject types configured on the system
   let [ subjectTypes, setSubjectTypes ] = React.useState([]);
   let [ columns, setColumns ] = React.useState(tableColumns);
+
+  const entry = getSubjectIdFromPath(location.pathname);
+
+  // Clear the page name overwriting if moving from a specific Subject to the Subjects page
+  const pageNameWriter = usePageNameWriterContext();
+  useEffect(() => {
+    if (!entry) {
+      pageNameWriter("");
+    }
+  }, [entry]);
+
+  if (entry) {
+    return <Subject id={entry} contentOffset={props.contentOffset} />;
+  }
 
   // get subject types configured on the system
   if (subjectTypes.length === 0) {
@@ -85,65 +95,21 @@ function Subjects(props) {
       });
   }
 
-  const actions = [
-    DeleteButton
-  ]
-
-  const entry = getSubjectIdFromPath(location.pathname);
-
-  // Clear the page name overwriting if moving from a specific Subject to the Subjects page
-  const pageNameWriter = usePageNameWriterContext();
-  useEffect(() => {
-    if (!entry) {
-      pageNameWriter("");
-    }
-  }, [entry]);
-
-  if (entry) {
-    return <Subject id={entry} contentOffset={props.contentOffset} />;
-  }
-
   return (
-    <div>
-      <Card>
-        <CardHeader
-          title={
-            <Button className={classes.cardHeaderButton}>
-              Subjects
-            </Button>
-          }
-          action={
-          <div className={classes.mainPageAction}>
-            <div className={classes.newFormButtonWrapper}>
-              <Tooltip aria-label="add" title="New Subject">
-                <Fab
-                  color="primary"
-                  aria-label="add"
-                  onClick={() => {setNewSubjectPopperOpen(true)}}
-                >
-                  <AddIcon />
-                </Fab>
-              </Tooltip>
-            </div>
-          </div>
-          }
+    <Grid container direction="column" spacing={4}>
+      <Grid item className={classes.dashboardEntry}>
+         <Typography variant="h2">Subjects</Typography>
+      </Grid>
+      <Grid item>
+        <SubjectView
+          expanded
+          disableHeader
+          topPagination
+          title=""
+          columns={columns}
         />
-        <CardContent>
-          <LiveTable
-            columns={columns}
-            updateData={requestFetchData}
-            actions={actions}
-            entryType={"Subject"}
-          />
-        </CardContent>
-      </Card>
-      <NewSubjectDialog
-        onClose={() => { setNewSubjectPopperOpen(false);}}
-        onSubmit={() => { setNewSubjectPopperOpen(false);}}
-        openNewSubject={true}
-        open={newSubjectPopperOpen}
-        />
-    </div>
+      </Grid>
+    </Grid>
   );
 }
 


### PR DESCRIPTION
This PR only makes the look of the Forms and Subjects pages consistent with their corresponding dashboard boxes. The form filters are not yet transfered from Dashboard to the Forms page when clicking on "Expand".