### PR TITLE
LFS-730: Set up sending data via the S3 ingest API

### DIFF
--- a/cardiac-rehab-resources/backend/pom.xml
+++ b/cardiac-rehab-resources/backend/pom.xml
@@ -106,5 +106,11 @@
       <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-osgi</artifactId>
+      <version>1.11.383</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/cardiac-rehab-resources/backend/pom.xml
+++ b/cardiac-rehab-resources/backend/pom.xml
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-osgi</artifactId>
-      <version>1.11.383</version>
+      <version>1.11.924</version>
     </dependency>
   </dependencies>
 </project>

--- a/cardiac-rehab-resources/backend/pom.xml
+++ b/cardiac-rehab-resources/backend/pom.xml
@@ -50,12 +50,6 @@
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <!-- This will automatically add an [artifacts] entry with the jar produced by this module in the provisioning file -->
-          <attach>
-            <type>jar</type>
-          </attach>
-        </configuration>
       </plugin>
     </plugins>
   </build>
@@ -110,7 +104,6 @@
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-osgi</artifactId>
       <version>1.11.383</version>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/NightlyExport.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/NightlyExport.java
@@ -47,7 +47,8 @@ public class NightlyExport
     protected void activate(ComponentContext componentContext) throws Exception
     {
         LOGGER.info("NightlyExport activating");
-        ScheduleOptions options = this.scheduler.EXPR("30 23 * * * ?");
+        final String nightlyExportSchedule = System.getenv("NIGHTLY_EXPORT_SCHEDULE");
+        ScheduleOptions options = this.scheduler.EXPR(nightlyExportSchedule);
         options.name("NightlyExport");
         options.canRunConcurrently(true);
 

--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/NightlyExport.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/NightlyExport.java
@@ -47,7 +47,7 @@ public class NightlyExport
     protected void activate(ComponentContext componentContext) throws Exception
     {
         LOGGER.info("NightlyExport activating");
-        ScheduleOptions options = this.scheduler.EXPR("30 23 * * * ?");
+        ScheduleOptions options = this.scheduler.EXPR("0 * * * * ?");
         options.name("NightlyExport");
         options.canRunConcurrently(true);
 

--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/NightlyExport.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/NightlyExport.java
@@ -47,7 +47,7 @@ public class NightlyExport
     protected void activate(ComponentContext componentContext) throws Exception
     {
         LOGGER.info("NightlyExport activating");
-        ScheduleOptions options = this.scheduler.EXPR("0 * * * * ?");
+        ScheduleOptions options = this.scheduler.EXPR("30 23 * * * ?");
         options.name("NightlyExport");
         options.canRunConcurrently(true);
 

--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/NightlyExportTask.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/NightlyExportTask.java
@@ -37,6 +37,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
@@ -71,7 +74,7 @@ public class NightlyExportTask implements Runnable
                     "%s_formData_%s.json",
                     cleanString(identifier.getParticipantId()),
                     fileDateString);
-                this.output(subjectContents, filename, fileDateString);
+                this.output(subjectContents, filename);
             }
         }
     }
@@ -193,28 +196,24 @@ public class NightlyExportTask implements Runnable
         }
     }
 
-    private void output(SubjectContents input, String filename, String dateString)
+    private void output(SubjectContents input, String filename)
     {
-        /*
-        String path = String.format("%s/cards-exports/%s/", System.getProperty("user.home"), dateString);
-        File directory = new File(path);
-        directory.mkdirs();
-        try (FileWriter file = new FileWriter(path + filename)) {
-            file.write(input.getData());
-            LOGGER.info("Exported {} to {}", input.getUrl(), path + filename);
-        } catch (IOException e) {
-            LOGGER.error("Failed to perform the nightly export", e.getMessage(), e);
-        }
-        */
-        LOGGER.warn("Setting up EndpointConfiguration");
-        final EndpointConfiguration endpointConfig = new EndpointConfiguration("http://localhost:9000/", "us-west-1");
+        final String s3EndpointUrl = System.getenv("S3_ENDPOINT_URL");
+        final String s3EndpointRegion = System.getenv("S3_ENDPOINT_REGION");
+        final String s3BucketName = System.getenv("S3_BUCKET_NAME");
+        final String awsKey = System.getenv("AWS_KEY");
+        final String awsSecret = System.getenv("AWS_SECRET");
+        final EndpointConfiguration endpointConfig =
+            new EndpointConfiguration(s3EndpointUrl, s3EndpointRegion);
+        final AWSCredentials credentials = new BasicAWSCredentials(awsKey, awsSecret);
         final AmazonS3 s3 = AmazonS3ClientBuilder.standard()
             .withEndpointConfiguration(endpointConfig)
+            .withPathStyleAccessEnabled(true)
+            .withCredentials(new AWSStaticCredentialsProvider(credentials))
             .build();
         try {
-            LOGGER.warn("START: s3.putObject()");
-            s3.putObject("sample", "test.txt", input.getData());
-            LOGGER.warn("END: s3.putObject()");
+            s3.putObject(s3BucketName, filename, input.getData());
+            LOGGER.info("Exported {} to {}", input.getUrl(), filename);
         } catch (AmazonServiceException e) {
             LOGGER.error("Failed to perform the nightly export", e.getMessage(), e);
         }

--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/NightlyExportTask.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/NightlyExportTask.java
@@ -19,9 +19,6 @@
 
 package ca.sickkids.ccm.lfs.cardiacrehab.internal.export;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
@@ -38,6 +35,11 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
 public class NightlyExportTask implements Runnable
 {
@@ -193,6 +195,7 @@ public class NightlyExportTask implements Runnable
 
     private void output(SubjectContents input, String filename, String dateString)
     {
+        /*
         String path = String.format("%s/cards-exports/%s/", System.getProperty("user.home"), dateString);
         File directory = new File(path);
         directory.mkdirs();
@@ -200,6 +203,19 @@ public class NightlyExportTask implements Runnable
             file.write(input.getData());
             LOGGER.info("Exported {} to {}", input.getUrl(), path + filename);
         } catch (IOException e) {
+            LOGGER.error("Failed to perform the nightly export", e.getMessage(), e);
+        }
+        */
+        LOGGER.warn("Setting up EndpointConfiguration");
+        final EndpointConfiguration endpointConfig = new EndpointConfiguration("http://localhost:9000/", "us-west-1");
+        final AmazonS3 s3 = AmazonS3ClientBuilder.standard()
+            .withEndpointConfiguration(endpointConfig)
+            .build();
+        try {
+            LOGGER.warn("START: s3.putObject()");
+            s3.putObject("sample", "test.txt", input.getData());
+            LOGGER.warn("END: s3.putObject()");
+        } catch (AmazonServiceException e) {
             LOGGER.error("Failed to perform the nightly export", e.getMessage(), e);
         }
     }

--- a/cardiac-rehab-resources/backend/src/main/provisioning/model.txt
+++ b/cardiac-rehab-resources/backend/src/main/provisioning/model.txt
@@ -21,6 +21,18 @@
 [feature name=cardiac-rehab-backend]
 
 [artifacts runModes=cardiac_rehab startLevel=10]
+    ca.sickkids.ccm.lfs/cardiac-rehab-backend
+    com.amazonaws/aws-java-sdk-osgi
+    com.fasterxml.jackson.dataformat/jackson-dataformat-cbor/2.6.7
+    io.netty/netty-codec-http/4.1.17.Final
+    io.netty/netty-codec/4.1.17.Final
+    io.netty/netty-handler/4.1.17.Final
+    io.netty/netty-buffer/4.1.17.Final
+    io.netty/netty-common/4.1.17.Final
+    io.netty/netty-transport/4.1.17.Final
+    io.netty/netty-resolver/4.1.17.Final
+    software.amazon.ion/ion-java/1.0.2
+    joda-time/joda-time/2.8.1
 
 [configurations]
   org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-lfs-export


### PR DESCRIPTION
This pull request modifies the functionality introduced in LFS-752 which performs a nightly export of data entered that day and writes it to JSON files on the file system when run in the `cardiac_rehab` runmode. This pull request replaces the writes to the file system with writes to an S3 bucket defined by the environment variables:

- `S3_ENDPOINT_URL`: URL of the S3 service
- `S3_ENDPOINT_REGION`: Region
- `S3_BUCKET_NAME`: Bucket name
- `AWS_KEY`: AWS access key ID
- `AWS_SECRET`: AWS access key secret
- `AWS_CA_BUNDLE`: Path to the SSL/TLS certificate for making a secure connection to the S3 bucket