### PR TITLE
LFS-803: Set the correct timezone within the LFS Docker container

### DIFF
--- a/distribution/Dockerfile
+++ b/distribution/Dockerfile
@@ -21,7 +21,8 @@ FROM openjdk:8-jre-alpine
 # Install utilities for patching the JAR file, if such is necessary
 RUN apk add \
   unzip \
-  zip
+  zip \
+  tzdata
 
 # Optional: enable remote debugging at port 5005
 ENV DEBUG=


### PR DESCRIPTION
This pull request allows for the environment variable `TZ` to be set to the deployment timezone so that all dates within the container will be based on the local time and not UTC.

To test, when running via docker-compose, add the environment variable `TZ=America/Toronto` to the `lfsinitial` container and start (`docker-compose up -d`). Obtain a shell to the `lfsinitial` container (`docker-compose exec lfsinitial /bin/sh`) and run `date`. The displayed date/time should be the local date/time and not UTC.