### PR TITLE
LFS-818: Display an estimate of the total number of results in the livetable

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -53,7 +53,7 @@ function LiveTable(props) {
       "displayed": 0,
       "total": -1,
       "page": 0,
-      "isApprox": false,
+      "totalIsApproximate": false,
     }
   );
   const [fetchStatus, setFetchStatus] = useState(
@@ -146,7 +146,7 @@ function LiveTable(props) {
         "displayed": json.returnedrows,
         "total": json.totalrows,
         "page": Math.floor(json.offset / json.limit),
-        "isApprox": json.isApprox,
+        "totalIsApproximate": json.totalIsApproximate,
       }
     );
   };
@@ -335,13 +335,13 @@ function LiveTable(props) {
     <TablePagination
       component="div"
       rowsPerPageOptions={[10, 50, 100, 1000]}
-      count={paginationData.isApprox ? -1 : paginationData.total}
+      count={paginationData.totalIsApproximate ? -1 : paginationData.total}
       rowsPerPage={paginationData.limit}
       page={paginationData.page}
       onChangePage={handleChangePage}
       onChangeRowsPerPage={handleChangeRowsPerPage}
       labelDisplayedRows={({from, to, count}) =>
-          `${from}-${to} of ${paginationData.isApprox ? `more than ${paginationData.total}` : count}`
+          `${from}-${to} of ${paginationData.totalIsApproximate ? `more than ${paginationData.total}` : count}`
       }
     />
   )

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -53,6 +53,7 @@ function LiveTable(props) {
       "displayed": 0,
       "total": -1,
       "page": 0,
+      "isApprox": false,
     }
   );
   const [fetchStatus, setFetchStatus] = useState(
@@ -145,6 +146,7 @@ function LiveTable(props) {
         "displayed": json.returnedrows,
         "total": json.totalrows,
         "page": Math.floor(json.offset / json.limit),
+        "isApprox": json.isApprox,
       }
     );
   };
@@ -333,12 +335,14 @@ function LiveTable(props) {
     <TablePagination
       component="div"
       rowsPerPageOptions={[10, 50, 100, 1000]}
-      count={paginationData.total >= 0 ? paginationData.total : -1}
+      count={paginationData.isApprox ? -1 : paginationData.total}
       rowsPerPage={paginationData.limit}
       page={paginationData.page}
       onChangePage={handleChangePage}
       onChangeRowsPerPage={handleChangeRowsPerPage}
-      labelDisplayedRows={({from, to, count}) => `${from}-${to} of ${count >= 0 ? count : `more than ${-1 * paginationData.total}`}`}
+      labelDisplayedRows={({from, to, count}) =>
+          `${from}-${to} of ${paginationData.isApprox ? `more than ${paginationData.total}` : count}`
+      }
     />
   )
 

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -333,11 +333,12 @@ function LiveTable(props) {
     <TablePagination
       component="div"
       rowsPerPageOptions={[10, 50, 100, 1000]}
-      count={paginationData.total}
+      count={paginationData.total >= 0 ? paginationData.total : -1}
       rowsPerPage={paginationData.limit}
       page={paginationData.page}
       onChangePage={handleChangePage}
       onChangeRowsPerPage={handleChangeRowsPerPage}
+      labelDisplayedRows={({from, to, count}) => `${from}-${to} of ${count >= 0 ? count : `more than ${-1 * paginationData.total}`}`}
     />
   )
 

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
@@ -76,6 +76,8 @@ public class PaginationServlet extends SlingSafeMethodsServlet
 
     private static final long serialVersionUID = -6068156942302219324L;
 
+    private static final int QUERY_SIZE_MULTIPLIER = 10;
+
     // Allowed JCR-SQL2 operators (from https://docs.adobe.com/docs/en/spec/jcr/2.0/6_Query.html#6.7.17%20Operator)
     private static final List<String> COMPARATORS =
         Arrays.asList("=", "<>", "<", "<=", ">", ">=", "LIKE", "notes contain");
@@ -108,7 +110,7 @@ public class PaginationServlet extends SlingSafeMethodsServlet
             Query filterQuery = queryManager.createQuery(finalquery, "JCR-SQL2");
 
             //Set the limit and offset here to improve query performance
-            filterQuery.setLimit((10 * limit) + 1);
+            filterQuery.setLimit((QUERY_SIZE_MULTIPLIER * limit) + 1);
             filterQuery.setOffset(offset);
 
             //Execute the query
@@ -488,8 +490,8 @@ public class PaginationServlet extends SlingSafeMethodsServlet
         jsonGen.write("offset", limits[0]);
         jsonGen.write("limit", limits[1]);
         jsonGen.write("returnedrows", limits[2]);
-        jsonGen.write("totalrows", (limits[3] > (10 * limits[1]))
-            ? ((-10 * limits[1]) - limits[0]) : (limits[0] + limits[3]));
+        jsonGen.write("totalrows", (limits[3] > (QUERY_SIZE_MULTIPLIER * limits[1]))
+            ? ((-1 * QUERY_SIZE_MULTIPLIER * limits[1]) - limits[0]) : (limits[0] + limits[3]));
     }
 
     private long[] writeResources(final JsonGenerator jsonGen, final Iterator<Resource> nodes,

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
@@ -486,14 +486,14 @@ public class PaginationServlet extends SlingSafeMethodsServlet
      */
     private void writeSummary(final JsonGenerator jsonGen, final SlingHttpServletRequest request, final long[] limits)
     {
-        final boolean isApprox = (limits[3] > (QUERY_SIZE_MULTIPLIER * limits[1]));
+        final boolean totalIsApproximate = (limits[3] > (QUERY_SIZE_MULTIPLIER * limits[1]));
         jsonGen.write("req", request.getParameter("req"));
         jsonGen.write("offset", limits[0]);
         jsonGen.write("limit", limits[1]);
         jsonGen.write("returnedrows", limits[2]);
-        jsonGen.write("totalrows", isApprox
+        jsonGen.write("totalrows", totalIsApproximate
             ? ((QUERY_SIZE_MULTIPLIER * limits[1]) + limits[0]) : (limits[0] + limits[3]));
-        jsonGen.write("isApprox", isApprox);
+        jsonGen.write("totalIsApproximate", totalIsApproximate);
     }
 
     private long[] writeResources(final JsonGenerator jsonGen, final Iterator<Resource> nodes,

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
@@ -108,7 +108,7 @@ public class PaginationServlet extends SlingSafeMethodsServlet
             Query filterQuery = queryManager.createQuery(finalquery, "JCR-SQL2");
 
             //Set the limit and offset here to improve query performance
-            filterQuery.setLimit(limit + 1);
+            filterQuery.setLimit((10 * limit) + 1);
             filterQuery.setOffset(offset);
 
             //Execute the query
@@ -488,7 +488,8 @@ public class PaginationServlet extends SlingSafeMethodsServlet
         jsonGen.write("offset", limits[0]);
         jsonGen.write("limit", limits[1]);
         jsonGen.write("returnedrows", limits[2]);
-        jsonGen.write("totalrows", (limits[3] > limits[1]) ? -1 : (limits[0] + limits[2]));
+        jsonGen.write("totalrows", (limits[3] > (10 * limits[1]))
+            ? ((-10 * limits[1]) - limits[0]) : (limits[0] + limits[3]));
     }
 
     private long[] writeResources(final JsonGenerator jsonGen, final Iterator<Resource> nodes,

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
@@ -486,12 +486,14 @@ public class PaginationServlet extends SlingSafeMethodsServlet
      */
     private void writeSummary(final JsonGenerator jsonGen, final SlingHttpServletRequest request, final long[] limits)
     {
+        final boolean isApprox = (limits[3] > (QUERY_SIZE_MULTIPLIER * limits[1]));
         jsonGen.write("req", request.getParameter("req"));
         jsonGen.write("offset", limits[0]);
         jsonGen.write("limit", limits[1]);
         jsonGen.write("returnedrows", limits[2]);
-        jsonGen.write("totalrows", (limits[3] > (QUERY_SIZE_MULTIPLIER * limits[1]))
-            ? ((-1 * QUERY_SIZE_MULTIPLIER * limits[1]) - limits[0]) : (limits[0] + limits[3]));
+        jsonGen.write("totalrows", isApprox
+            ? ((QUERY_SIZE_MULTIPLIER * limits[1]) + limits[0]) : (limits[0] + limits[3]));
+        jsonGen.write("isApprox", isApprox);
     }
 
     private long[] writeResources(final JsonGenerator jsonGen, final Iterator<Resource> nodes,


### PR DESCRIPTION
This PR causes the `PaginationServlet` to check if at least ten times the number of results per LiveTable page match the given query. If the number of matches exceeds this number, the total number of matches is approximated with _"of more than"_, otherwise the exact number of matches is displayed.

For example, suppose that 55 forms match a query. If we are looking at _10_ results per page, the PaginationServlet will check if at least _100_ results can be found. As the amount of found results does _not_ exceed _100_, the _TablePagination_ controls will display `1-10 of 55`, `11-20 of 55`, etc...

Now, suppose that there were 135 matches. The _TablePagination_ controls would display, `1-10 of more than 100`, `11-20 of more than 110`, `21-30 of more than 120`, `31-40 of more than 130`, `41-50 of 135`, `51-60 of 135`, `61-70 of 135`, etc...

To test, build the `LFS-818_test` branch and generate _130_ fake tumor forms with `./generate_fake_tumors.sh`. Test moving between LiveTable pages and applying filters (eg. `Lesion Number > 6500`).