### PR TITLE
LFS-823: As a user, I am stuck in a relogin cycle when deleting a form while editing that form

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
@@ -29,7 +29,7 @@ import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
  * A component that renders an icon to open a dialog to delete an entry.
  */
 function DeleteButton(props) {
-  const { classes, entryPath, entryName, onComplete, entryType, entryLabel, size, shouldGoBack, buttonClass, removeWindowHandlers } = props;
+  const { classes, entryPath, entryName, onComplete, entryType, entryLabel, size, shouldGoBack, buttonClass } = props;
 
   const [ open, setOpen ] = useState(false);
   const [ errorOpen, setErrorOpen ] = useState(false);
@@ -137,7 +137,6 @@ function DeleteButton(props) {
     if (deleteRecursive) {
       url.searchParams.set("recursive", true);
     }
-    if (removeWindowHandlers) {removeWindowHandlers();}
     fetch( url, {
       method: 'DELETE',
       headers: {

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
@@ -29,7 +29,7 @@ import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
  * A component that renders an icon to open a dialog to delete an entry.
  */
 function DeleteButton(props) {
-  const { classes, entryPath, entryName, onComplete, entryType, entryLabel, size, shouldGoBack, buttonClass } = props;
+  const { classes, entryPath, entryName, onComplete, entryType, entryLabel, size, shouldGoBack, buttonClass, removeWindowHandlers } = props;
 
   const [ open, setOpen ] = useState(false);
   const [ errorOpen, setErrorOpen ] = useState(false);
@@ -137,6 +137,7 @@ function DeleteButton(props) {
     if (deleteRecursive) {
       url.searchParams.set("recursive", true);
     }
+    if (removeWindowHandlers) {removeWindowHandlers();}
     fetch( url, {
       method: 'DELETE',
       headers: {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -109,10 +109,10 @@ function Form (props) {
   const formURL = `/Forms/${id}`;
 
   useEffect(() => {
-    function removeThisHandler() {
+    function removeSaveDataHandler() {
       window.removeEventListener("beforeunload", saveData);
     }
-    setRemoveWindowHandlers(() => removeThisHandler);
+    setRemoveWindowHandlers(() => removeSaveDataHandler);
     window.addEventListener("beforeunload", saveData);
     // When component unmounts:
     return (() => {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -228,9 +228,13 @@ function Form (props) {
     pageNameWriter((subjectName ? subjectName + ": " : "") + title);
   }, [subjectName, title])
 
+  // Load the Form, only once, upon initialization
+  useEffect(() => {
+    fetchData();
+  }, []);
+
   // If the data has not yet been fetched, return an in-progress symbol
   if (!data) {
-    fetchData();
     return (
       <Grid container justify="center"><Grid item><CircularProgress/></Grid></Grid>
     );

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -323,7 +323,7 @@ function Form (props) {
               entryType={data?.questionnaire?.title || "Form"}
               shouldGoBack={true}
               buttonClass={classes.titleButton}
-              removeWindowHandlers={removeWindowHandlers}
+              onComplete={removeWindowHandlers}
             />
           </Typography>
           <Breadcrumbs separator="·">

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -102,17 +102,21 @@ function Form (props) {
   let [ activePage, setActivePage ] = useState(0);
   let [ pages, setPages ] = useState([]);
   let [ paginationEnabled, setPaginationEnabled ] = useState(false);
+  let [ removeWindowHandlers, setRemoveWindowHandlers ] = useState();
 
   let formNode = React.useRef();
   let pageNameWriter = usePageNameWriterContext();
   const formURL = `/Forms/${id}`;
 
   useEffect(() => {
+    function removeThisHandler() {
+      window.removeEventListener("beforeunload", saveData);
+    }
+    setRemoveWindowHandlers(() => removeThisHandler);
     window.addEventListener("beforeunload", saveData);
     // When component unmounts:
     return (() => {
-      // always save when navigating away
-      saveData();
+      // cleanup event handler
       window.removeEventListener("beforeunload", saveData);
     });
   }, []);
@@ -319,6 +323,7 @@ function Form (props) {
               entryType={data?.questionnaire?.title || "Form"}
               shouldGoBack={true}
               buttonClass={classes.titleButton}
+              removeWindowHandlers={removeWindowHandlers}
             />
           </Typography>
           <Breadcrumbs separator="·">

--- a/modules/homepage/src/main/frontend/src/themePage/index.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/index.jsx
@@ -165,6 +165,7 @@ Main.propTypes = {
 const MainComponent = (withStyles(IndexStyle, {withTheme: true})(Main));
 
 const hist = createBrowserHistory();
+hist.listen(({action, location}) => window.dispatchEvent(new Event("beforeunload")));
 ReactDOM.render(
   <Router history={hist}>
     <Switch>


### PR DESCRIPTION
Fixes the bug present on the `dev` branch described by LFS-823

To reproduce that bug on the `dev` branch:

1. Create any form
2. While in the form, click the trash can icon to delete the form and confirm
3. You are prompted to login, logging in reopens the same login screen - this continues without end
4. To get out of the loop, you must clear the URL and return home

To test this PR:

1. Build the `LFS-823` branch
2. Create a new _Demographics_ form, enter some data, and close that browser tab without clicking the _Save_ button.
3. Open CARDS again and this _Demographics_ form should be present with the data entered from the previous step
4. Enter some more data in this same _Demographics_ form and click on one of the sidebar links (don't click _Save_)
5. Open this _Demographics_ form again - the data from the previous step should be present
6. Delete this form - you should not be prompted to re-login