### PR TITLE
LFS-816: Handle re-login globally (continued)

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { withRouter, useHistory } from "react-router-dom";
 
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton } from "@material-ui/core";
@@ -24,6 +24,7 @@ import { Tooltip, Typography, withStyles } from "@material-ui/core";
 import { Delete, Close } from "@material-ui/icons";
 
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
+import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
 
 /**
  * A component that renders an icon to open a dialog to delete an entry.
@@ -43,6 +44,8 @@ function DeleteButton(props) {
   const defaultDialogAction = `Are you sure you want to delete ${entryName}?`;
   const defaultErrorMessage = entryName + " could not be removed.";
   const history = useHistory();
+
+  const globalLoginDisplay = useContext(GlobalLoginContext);
 
   let openDialog = () => {
     closeError();
@@ -137,7 +140,7 @@ function DeleteButton(props) {
     if (deleteRecursive) {
       url.searchParams.set("recursive", true);
     }
-    fetch( url, {
+    fetchWithReLogin(globalLoginDisplay, url, {
       method: 'DELETE',
       headers: {
         Accept: "application/json"

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
@@ -39,7 +39,6 @@ function DeleteButton(props) {
   const [ dialogAction, setDialogAction ] = useState("");
   const [ deleteRecursive, setDeleteRecursive ] = useState(false);
   const [ entryNotFound, setEntryNotFound ] = useState(false);
-  const [ deletionStatus, setDeletionStatus ] = useState(undefined);
 
   const defaultDialogAction = `Are you sure you want to delete ${entryName}?`;
   const defaultErrorMessage = entryName + " could not be removed.";
@@ -73,16 +72,7 @@ function DeleteButton(props) {
   }
 
   let handleError = (status, response) => {
-    // If the user is not logged in, offer to log in
-    const sessionInfo = window.Sling.getSessionInfo();
-    if (sessionInfo === null || sessionInfo.userID === 'anonymous') {
-      // On first attempt to save while logged out, set status to false to make button text inform user
-      setDeletionStatus(false);
-      setDialogAction(defaultErrorMessage);
-    } else if (status === 401) {
-      setErrorMessage(`${defaultErrorMessage} You are not permitted to perform that action.`);
-      openError();
-    } else if (status === 404) {
+    if (status === 404) {
       setErrorMessage(`${entryName} could not be found. This ${entryType ? entryType : "item"} may have already been deleted.`);
       setEntryNotFound(true);
       openError();
@@ -115,26 +105,6 @@ function DeleteButton(props) {
     }
   }
 
-  let handleDeleteButtonClicked = () => {
-    if (deletionStatus === false) {
-      handleLogin();
-    } else {
-      handleDelete();
-    }
-  }
-
-  let handleLogin = () => {
-    const width = 600;
-    const height = 800;
-    const top = window.top.outerHeight / 2 + window.top.screenY - (height / 2);
-    const left = window.top.outerWidth / 2 + window.top.screenX - (width / 2);
-    // After a successful log in, the login dialog code will "open" the specified resource, which results in executing the specified javascript code
-    window.open("/login.html?resource=javascript%3Awindow.close()", "loginPopup", `width=${width}, height=${height}, top=${top}, left=${left}`);
-    // Reset the dialog message and log in button
-    setDeletionStatus(undefined);
-    setDialogAction(defaultDialogAction);
-  }
-
   let handleDelete = () => {
     let url = new URL(entryPath, window.location.origin);
     if (deleteRecursive) {
@@ -147,7 +117,6 @@ function DeleteButton(props) {
       }
     }).then((response) => {
       if (response.ok)  {
-        setDeletionStatus(true);
         closeDialog();
         if (onComplete) {onComplete();}
         if (shouldGoBack) {goBack();}
@@ -194,8 +163,8 @@ function DeleteButton(props) {
             <Typography variant="body1">{dialogAction}</Typography>
         </DialogContent>
         <DialogActions className={classes.dialogActions}>
-            <Button variant="contained" color="secondary" size="small" onClick={() => handleDeleteButtonClicked()}>
-              { deletionStatus === false ? "Log in and Try Again?" : (deleteRecursive ? "Delete All" : "Delete")}
+            <Button variant="contained" color="secondary" size="small" onClick={() => handleDelete()}>
+              { deleteRecursive ? "Delete All" : "Delete" }
             </Button>
             <Button variant="contained" size="small" onClick={closeDialog}>Close</Button>
         </DialogActions>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -89,7 +89,7 @@ function UserDashboard(props) {
       .finally(() => setCreationLoading(false));
   }, [])
 
-  if (loading || globalLoginDisplay.getDialogOpenStatus()) {
+  if (loading) {
     return (
       <Grid container justify="center"><Grid item><CircularProgress/></Grid></Grid>
     );

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -16,14 +16,13 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useContext, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 
 import MaterialTable from "material-table";
 
 import { loadExtensions } from "../uiextension/extensionManager";
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
-import { MODE_DIALOG } from "../dataHomepage/NewFormDialog.jsx"
-import { GlobalLoginContext } from "../login/loginDialogue.js";
+import { MODE_DIALOG } from "../dataHomepage/NewFormDialog.jsx";
 
 import {
   Button,
@@ -73,8 +72,6 @@ function UserDashboard(props) {
     setSelectedRow(undefined);
     setOpen(false);
   }
-
-  let globalLoginDisplay = useContext(GlobalLoginContext);
 
   useEffect(() => {
     getDashboardExtensions()

--- a/modules/homepage/src/main/frontend/src/themePage/index.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/index.jsx
@@ -114,7 +114,8 @@ class Main extends React.Component {
             (!this.state.loginDialogOpen) && this.setState({
               loginDialogOpen: true
             });
-            (!noQueue) && this.setState({
+            let shouldAddHandler = (!noQueue) || (this.state.loginHandler.length < 1);
+            shouldAddHandler && this.setState({
               loginHandler: this.state.loginHandler.concat(handler)
             });
           },

--- a/modules/homepage/src/main/frontend/src/themePage/index.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/index.jsx
@@ -45,7 +45,7 @@ class Main extends React.Component {
       title: document.querySelector('meta[name="title"]').content,
       color: document.querySelector('meta[name="themeColor"]')?.content || "blue",
       loginDialogOpen: false,
-      loginHandler: [],
+      loginHandlers: [],
     };
 
     getRoutes().then(routes => this.setState({routes: routes}));
@@ -104,7 +104,7 @@ class Main extends React.Component {
       <React.Fragment>
       <GlobalLoginContext.Provider
         value={{
-          dialogOpen: (loginHandlerFcn, noQueue) => {
+          dialogOpen: (loginHandlerFcn, discardOnFailure) => {
             let handler = ((success) => {
               success && this.state.loginDialogOpen && this.setState({
                 loginDialogOpen: false
@@ -114,9 +114,9 @@ class Main extends React.Component {
             (!this.state.loginDialogOpen) && this.setState({
               loginDialogOpen: true
             });
-            let shouldAddHandler = (!noQueue) || (this.state.loginHandler.length < 1);
+            let shouldAddHandler = (!discardOnFailure) || (this.state.loginHandlers.length < 1);
             shouldAddHandler && this.setState({
-              loginHandler: this.state.loginHandler.concat(handler)
+              loginHandlers: this.state.loginHandlers.concat(handler)
             });
           },
           getDialogOpenStatus: () => {
@@ -136,10 +136,10 @@ class Main extends React.Component {
           isOpen={this.state.loginDialogOpen}
           handleLogin={(success) => {
             if (success) {
-              for (let i = 0; i < this.state.loginHandler.length; i++) {
-                this.state.loginHandler[i](success);
+              for (let i = 0; i < this.state.loginHandlers.length; i++) {
+                this.state.loginHandlers[i](success);
               }
-              this.setState({loginHandler: []});
+              this.setState({loginHandlers: []});
             }
           }}
         />

--- a/modules/homepage/src/main/frontend/src/themePage/index.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/index.jsx
@@ -106,7 +106,7 @@ class Main extends React.Component {
         value={{
           dialogOpen: (loginHandlerFcn, discardOnFailure) => {
             let handler = ((success) => {
-              success && this.state.loginDialogOpen && this.setState({
+              success && this.setState({
                 loginDialogOpen: false
               });
               success && loginHandlerFcn();

--- a/modules/login/src/main/frontend/src/login/loginDialogue.js
+++ b/modules/login/src/main/frontend/src/login/loginDialogue.js
@@ -23,16 +23,16 @@ import MainLoginComponent from './loginMainComponent';
 
 export const GlobalLoginContext = React.createContext();
 
-export function fetchWithReLogin(displayLoginCtx, url, fetchArgs) {
+export function fetchWithReLogin(displayLoginCtx, url, fetchArgs, noQueue) {
     return new Promise(function(resolve, reject) {
       function fetchFunc() {
         fetch(url, fetchArgs)
         .then((response) => {
           if (response.status == 401 || response.status == 500) {
-              displayLoginCtx.dialogOpen(fetchFunc);
+              displayLoginCtx.dialogOpen(fetchFunc, noQueue);
           } else if (response.ok && response.url.startsWith(window.location.origin + "/login")) {
-              displayLoginCtx.dialogOpen(fetchFunc);
-          } else if (response.ok) {
+              displayLoginCtx.dialogOpen(fetchFunc, noQueue);
+          } else if (response.ok || response.status == 404 || response.status == 409) {
               resolve(response);
           } else {
               reject(response);

--- a/modules/login/src/main/frontend/src/login/loginDialogue.js
+++ b/modules/login/src/main/frontend/src/login/loginDialogue.js
@@ -32,10 +32,8 @@ export function fetchWithReLogin(displayLoginCtx, url, fetchArgs, discardOnFailu
               displayLoginCtx.dialogOpen(fetchFunc, discardOnFailure);
           } else if (response.ok && response.url.startsWith(window.location.origin + "/login")) {
               displayLoginCtx.dialogOpen(fetchFunc, discardOnFailure);
-          } else if (response.ok || response.status == 404 || response.status == 409) {
-              resolve(response);
           } else {
-              reject(response);
+              resolve(response);
           }
         })
         .catch((err) => {reject(err)});

--- a/modules/login/src/main/frontend/src/login/loginDialogue.js
+++ b/modules/login/src/main/frontend/src/login/loginDialogue.js
@@ -23,15 +23,15 @@ import MainLoginComponent from './loginMainComponent';
 
 export const GlobalLoginContext = React.createContext();
 
-export function fetchWithReLogin(displayLoginCtx, url, fetchArgs, noQueue) {
+export function fetchWithReLogin(displayLoginCtx, url, fetchArgs, discardOnFailure) {
     return new Promise(function(resolve, reject) {
       function fetchFunc() {
         fetch(url, fetchArgs)
         .then((response) => {
           if (response.status == 401 || response.status == 500) {
-              displayLoginCtx.dialogOpen(fetchFunc, noQueue);
+              displayLoginCtx.dialogOpen(fetchFunc, discardOnFailure);
           } else if (response.ok && response.url.startsWith(window.location.origin + "/login")) {
-              displayLoginCtx.dialogOpen(fetchFunc, noQueue);
+              displayLoginCtx.dialogOpen(fetchFunc, discardOnFailure);
           } else if (response.ok || response.status == 404 || response.status == 409) {
               resolve(response);
           } else {


### PR DESCRIPTION
If these changes are acceptable, please merge the `LFS-816` branch into `dev` but do not close this Pull Request or delete the `LFS-816` branch as `fetchWithReLogin()` needs to be added to various other places. I have opened this pull request now so as to keep the `LFS-816` and `dev` branches from drifting too far apart and causing merge conflicts.

- Upgrades DeleteButton.jsx from using `fetch()` to using `fetchWithReLogin()`
  - To test:
    - Build the LFS-816 branch
    - Create a new _Demographics_ Form
    - Enter some data and save the Form
    - Open a new browser tab, visit `http://localhost:8080` and logout.
    - Return to the original browser tab
    - Click the _Trash Can_ icon to delete the Form
    - Confirm Form deletion
    - You should be prompted with a login dialog
    - After properly logging in, the Form should be deleted