### PR TITLE
LFS-849: Nightly pushes should omit incomplete forms

### DIFF
--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/NightlyExportTask.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/NightlyExportTask.java
@@ -162,7 +162,8 @@ public class NightlyExportTask implements Runnable
             Set<SubjectIdentifier> subjects = new HashSet<>();
             String query = String.format(
                 "SELECT subject.* FROM [lfs:Form] AS form INNER JOIN [lfs:Subject] AS subject"
-                    + " ON form.'subject'=subject.[jcr:uuid] WHERE form.[jcr:created] >= '%s'",
+                    + " ON form.'subject'=subject.[jcr:uuid]"
+                    + " WHERE form.[jcr:created] >= '%s' AND NOT CONTAINS(form.[statusFlags], 'INCOMPLETE')",
                 requestDateString
             );
 
@@ -183,7 +184,7 @@ public class NightlyExportTask implements Runnable
     private SubjectContents getSubjectContents(String path, String requestDateString)
     {
         String subjectDataUrl = String.format(
-            "%s.data.deep.bare.-identify.relativeDates.dataFilter:createdAfter=%s",
+            "%s.data.deep.bare.-identify.relativeDates.dataFilter:createdAfter=%s.dataFilter:statusNot=INCOMPLETE",
             path,
             requestDateString
         );

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/DataSubjectProcessor.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/DataSubjectProcessor.java
@@ -165,10 +165,10 @@ public class DataSubjectProcessor implements ResourceJsonProcessor
                     result.append(" and n.[jcr:createdBy] = '").append(value).append('\'');
                     break;
                 case "status":
-                    result.append(" and contains(n.[statusFlags], '").append(value).append("') ");
+                    result.append(" and contains(n.[statusFlags], '").append(value).append("')");
                     break;
                 case "statusNot":
-                    result.append(" and not contains(n.[statusFlags], '").append(value).append("') ");
+                    result.append(" and not contains(n.[statusFlags], '").append(value).append("')");
                     break;
                 default:
                     break;

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/DataSubjectProcessor.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/DataSubjectProcessor.java
@@ -164,6 +164,12 @@ public class DataSubjectProcessor implements ResourceJsonProcessor
                 case "createdBy":
                     result.append(" and n.[jcr:createdBy] = '").append(value).append('\'');
                     break;
+                case "status":
+                    result.append(" and contains(n.[statusFlags], '").append(value).append("') ");
+                    break;
+                case "statusNot":
+                    result.append(" and not contains(n.[statusFlags], '").append(value).append("') ");
+                    break;
                 default:
                     break;
             }


### PR DESCRIPTION
Add `status` and `statusNot` filters to subject export processor
Edit nightly export script to only export subjects containing complete forms
- Filter out subjects where all new forms contain the `INCOMPLETE` status flag
- Use new `statusNot` filter to only export completed forms for each subject

Testing:
As I do not have amazonaws s3 buckets set up for my own testing, testing was performed by logging the json URLS that should be exported (in `sling/logs/error.log`) and manually checking the contents of these URLs. To do this, amazonaws code was commented out to prevent exceptions. This modified code can be found [here](https://github.com/ccmbioinfo/lfs/tree/LFS-849-test).