### PR TITLE
LFS-850: When loading a patient chart, an unnecessarily large amount of fetch calls to /Forms/<UUID>.deep.json are made

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -466,9 +466,13 @@ function FormData(props) {
     setData([]);  // Prevent an infinite loop if data was not set
   };
 
+  // Fetch this Form's data
+  useEffect(() => {
+    getFormData(formID);
+  }, []);
+
   // If the data has not yet been fetched, return an in-progress symbol
   if (!data) {
-    getFormData(formID);
     return (
       <Grid container justify="center"><Grid item><CircularProgress/></Grid></Grid>
     );

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -469,7 +469,7 @@ function FormData(props) {
   // Fetch this Form's data
   useEffect(() => {
     getFormData(formID);
-  }, []);
+  }, [formID]);
 
   // If the data has not yet been fetched, return an in-progress symbol
   if (!data) {


### PR DESCRIPTION
To test:

1. Build the `LFS-850` branch
2. Create a new Demographics Form and associated Subject
3. Enter some values for the Demographics Form and save
4. Visit the Dashboard
5. Open the browser's Network Inspector and filter for URLs containing `/Forms/`
6. Click on the link for the newly created Subject to open the patient chart
7. Only one request in the browser's Network Inspector should be displayed with the `/Forms/` URL filter in effect