### PR TITLE
LFS-859: Make the color of sidebar menu items configurable

### DIFF
--- a/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/libs/lfs/conf.json
+++ b/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/libs/lfs/conf.json
@@ -3,5 +3,9 @@
   "AppName": {
     "jcr:primaryType": "nt:unstructured",
     "AppName": "Cards 4 CaRe"
+  },
+  "ThemeColor": {
+    "jcr:primaryType": "nt:unstructured",
+    "ThemeColor": "orange"
   }
 }

--- a/cardiac-resources/clinical-data/src/main/resources/SLING-INF/content/libs/lfs/conf.json
+++ b/cardiac-resources/clinical-data/src/main/resources/SLING-INF/content/libs/lfs/conf.json
@@ -3,5 +3,9 @@
   "AppName": {
     "jcr:primaryType": "nt:unstructured",
     "AppName": "Cards 4 Kids"
+  },
+  "ThemeColor": {
+    "jcr:primaryType": "nt:unstructured",
+    "ThemeColor": "purple"
   }
 }

--- a/cardiac-resources/clinical-data/src/main/resources/SLING-INF/content/libs/lfs/conf.json
+++ b/cardiac-resources/clinical-data/src/main/resources/SLING-INF/content/libs/lfs/conf.json
@@ -6,6 +6,6 @@
   },
   "ThemeColor": {
     "jcr:primaryType": "nt:unstructured",
-    "ThemeColor": "purple"
+    "ThemeColor": "rose"
   }
 }

--- a/modules/commons/src/main/frontend/src/themeStyle.jsx
+++ b/modules/commons/src/main/frontend/src/themeStyle.jsx
@@ -68,7 +68,8 @@ const primaryColor = ["#9c27b0", "#ab47bc", "#8e24aa", "#af2cc5"];
 const warningColor = ["#ff9800", "#ffa726", "#fb8c00", "#ffa21a"];
 const dangerColor = ["#f44336", "#ef5350", "#e53935", "#f55a4e"];
 const successColor = ["#4caf50", "#66bb6a", "#43a047", "#5cb860"];
-const infoColor = ["#00acc1", "#26c6da", "#00acc1", "#00d3ee"];
+const infoColor = ["#2196f3", "#64b5f6", "#2196f3", "#1976d2"];
+const tealColor = ["#00acc1", "#26c6da", "#00acc1", "#00d3ee"];
 const roseColor = ["#e91e63", "#ec407a", "#d81b60", "#eb3573"];
 const grayColor = [
   "#999",
@@ -267,6 +268,7 @@ export {
   dangerColor,
   successColor,
   infoColor,
+  tealColor,
   roseColor,
   grayColor,
   blackColor,

--- a/modules/commons/src/main/resources/SLING-INF/content/libs/lfs/Resource/header.html
+++ b/modules/commons/src/main/resources/SLING-INF/content/libs/lfs/Resource/header.html
@@ -32,6 +32,9 @@
       <meta name="title" content="${config['AppName']}">
       <title>${config.AppName}</title>
     </sly>
+    <sly data-sly-use.config="/libs/lfs/conf/ThemeColor">
+      <meta name="themeColor" content="${config['ThemeColor']}">
+    </sly>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&amp;display=swap" class="next-head"/>
     <script src="/system/sling.js"></script>

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/AdminNavbarLinks.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/AdminNavbarLinks.jsx
@@ -39,7 +39,7 @@ import ChangeUserPasswordDialogue from "../../Userboard/Users/changeuserpassword
 import { fetchWithReLogin, GlobalLoginContext } from "../../login/loginDialogue.js";
 
 function HeaderLinks (props) {
-  const { classes, closeSidebar, theme } = props;
+  const { classes, closeSidebar, theme, color } = props;
   const [ popperOpen, setPopperOpen ] = useState(false);
   const [ passwordDialogOpen, setPasswordDialogOpen ] = useState(false);
   const [ pwdResetSuccessSnackbarOpen, setPwdResetSuccessSnackbarOpen ] = useState(false);
@@ -112,7 +112,7 @@ function HeaderLinks (props) {
             onClick={() => setPopperOpen((open) => !open)}
             ref={avatarRef}
             >
-            <Avatar className={classes.avatar}>{initials}</Avatar>
+            <Avatar className={classes[color]}>{initials}</Avatar>
           </IconButton>
         </Tooltip>
       </Hidden>

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/Navbar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/Navbar.jsx
@@ -34,7 +34,7 @@ function Header({ ...props }) {
         <div className={classes.flex} />
         {/* While the screen is wide enough, display the navbar at the topright */}
         <Hidden smDown implementation="css">
-          <AdminNavbarLinks closeSidebar={props.handleDrawerToggle} />
+          <AdminNavbarLinks closeSidebar={props.handleDrawerToggle} color={color} />
         </Hidden>
         {/* While the screen is too narrow, display the mini sidebar control */}
         <Hidden mdUp implementation="css">
@@ -53,7 +53,7 @@ function Header({ ...props }) {
 
 Header.propTypes = {
   classes: PropTypes.object.isRequired,
-  color: PropTypes.oneOf(["primary", "info", "success", "warning", "danger"])
+  color: PropTypes.oneOf(["primary", "info", "success", "warning", "danger", "blue", "teal", "rose", "red", "orange", "green", "purple"])
 };
 
 export default withStyles(headerStyle)(Header);

--- a/modules/homepage/src/main/frontend/src/themePage/Sidebar/sidebarStyle.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Sidebar/sidebarStyle.jsx
@@ -354,9 +354,6 @@ import {
     aboveBackground: {
       zIndex: "1200"
     },
-    avatar: {
-      backgroundColor: theme.palette.info.main
-    },
     successSnackbar: {
       backgroundColor: theme.palette.success.main
     },

--- a/modules/homepage/src/main/frontend/src/themePage/Sidebar/sidebarStyle.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Sidebar/sidebarStyle.jsx
@@ -295,24 +295,24 @@ import {
       }
     },
     rose: {
-      backgroundColor: roseColor[0],
+      backgroundColor: roseColor[2],
       boxShadow:
         "0 12px 20px -10px rgba(" +
-        hexToRgb(roseColor[0]) +
+        hexToRgb(roseColor[2]) +
         ",.28), 0 4px 20px 0 rgba(" +
         hexToRgb(blackColor) +
         ",.12), 0 7px 8px -5px rgba(" +
-        hexToRgb(roseColor[0]) +
+        hexToRgb(roseColor[2]) +
         ",.2)",
       "&:hover": {
-        backgroundColor: roseColor[0],
+        backgroundColor: roseColor[2],
         boxShadow:
           "0 12px 20px -10px rgba(" +
-          hexToRgb(roseColor[0]) +
+          hexToRgb(roseColor[2]) +
           ",.28), 0 4px 20px 0 rgba(" +
           hexToRgb(blackColor) +
           ",.12), 0 7px 8px -5px rgba(" +
-          hexToRgb(roseColor[0]) +
+          hexToRgb(roseColor[2]) +
           ",.2)"
       }
     },

--- a/modules/homepage/src/main/frontend/src/themePage/Sidebar/sidebarStyle.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Sidebar/sidebarStyle.jsx
@@ -16,6 +16,8 @@ import {
     primaryColor,
     primaryBoxShadow,
     infoColor,
+    tealColor,
+    roseColor,
     successColor,
     warningColor,
     dangerColor,
@@ -204,6 +206,28 @@ import {
           ",.2)"
       }
     },
+    teal: {
+      backgroundColor: tealColor[0],
+      boxShadow:
+        "0 12px 20px -10px rgba(" +
+        hexToRgb(tealColor[0]) +
+        ",.28), 0 4px 20px 0 rgba(" +
+        hexToRgb(blackColor) +
+        ",.12), 0 7px 8px -5px rgba(" +
+        hexToRgb(tealColor[0]) +
+        ",.2)",
+      "&:hover": {
+        backgroundColor: tealColor[0],
+        boxShadow:
+          "0 12px 20px -10px rgba(" +
+          hexToRgb(tealColor[0]) +
+          ",.28), 0 4px 20px 0 rgba(" +
+          hexToRgb(blackColor) +
+          ",.12), 0 7px 8px -5px rgba(" +
+          hexToRgb(tealColor[0]) +
+          ",.2)"
+      }
+    },
     green: {
       backgroundColor: successColor[0],
       boxShadow:
@@ -267,6 +291,28 @@ import {
           hexToRgb(blackColor) +
           ",.12), 0 7px 8px -5px rgba(" +
           hexToRgb(dangerColor[0]) +
+          ",.2)"
+      }
+    },
+    rose: {
+      backgroundColor: roseColor[0],
+      boxShadow:
+        "0 12px 20px -10px rgba(" +
+        hexToRgb(roseColor[0]) +
+        ",.28), 0 4px 20px 0 rgba(" +
+        hexToRgb(blackColor) +
+        ",.12), 0 7px 8px -5px rgba(" +
+        hexToRgb(roseColor[0]) +
+        ",.2)",
+      "&:hover": {
+        backgroundColor: roseColor[0],
+        boxShadow:
+          "0 12px 20px -10px rgba(" +
+          hexToRgb(roseColor[0]) +
+          ",.28), 0 4px 20px 0 rgba(" +
+          hexToRgb(blackColor) +
+          ",.12), 0 7px 8px -5px rgba(" +
+          hexToRgb(roseColor[0]) +
           ",.2)"
       }
     },

--- a/modules/homepage/src/main/frontend/src/themePage/index.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/index.jsx
@@ -43,6 +43,7 @@ class Main extends React.Component {
       routes: [],
       contentOffset: 0,
       title: document.querySelector('meta[name="title"]').content,
+      color: document.querySelector('meta[name="themeColor"]')?.content || "blue",
       loginDialogOpen: false,
       loginHandler: undefined,
     };
@@ -138,7 +139,7 @@ class Main extends React.Component {
               image={this.state.image}
               handleDrawerToggle={this.handleDrawerToggle}
               open={this.state.mobileOpen}
-              color={ document.querySelector('meta[name="themeColor"]')?.content || "blue" }
+              color={ this.state.color }
               {...rest}
             />
             <div className={classes.mainPanel} ref={this.mainPanel} id="main-panel">
@@ -148,6 +149,7 @@ class Main extends React.Component {
               <Navbar
                 routes={ this.state.routes }
                 handleDrawerToggle={this.handleDrawerToggle}
+                color={ this.state.color }
                 {...rest}
               />
             </div>

--- a/modules/homepage/src/main/frontend/src/themePage/index.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/index.jsx
@@ -138,7 +138,7 @@ class Main extends React.Component {
               image={this.state.image}
               handleDrawerToggle={this.handleDrawerToggle}
               open={this.state.mobileOpen}
-              color={ "blue" }
+              color={ document.querySelector('meta[name="themeColor"]')?.content || "blue" }
               {...rest}
             />
             <div className={classes.mainPanel} ref={this.mainPanel} id="main-panel">

--- a/modules/utils/src/main/resources/SLING-INF/libs/lfs/conf.json
+++ b/modules/utils/src/main/resources/SLING-INF/libs/lfs/conf.json
@@ -11,5 +11,9 @@
   "PlatformName": {
     "jcr:primaryType": "nt:unstructured",
     "PlatformName": "${platform.name}"
+  },
+  "ThemeColor": {
+    "jcr:primaryType": "nt:unstructured",
+    "ThemeColor": "${theme.color}"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
     <lfs.version>${project.version}</lfs.version>
     <app.name>LFS Data Core</app.name>
     <platform.name>CARDS</platform.name>
+    <theme.color>blue</theme.color>
     <slf4j.version>1.7.26</slf4j.version>
     <jackrabbit.version>2.16.3</jackrabbit.version>
     <oak.version>1.8.8</oak.version>


### PR DESCRIPTION
The color is specified similarly to the app name and version, and is accessible to the frontend code via a meta tag.
Also added support for a more versatile shade of blue to replace the default teal, and for a shade a pink.
The colors for each project were set as follows:
* LFS - blue (new shade)
* Cards4Care - orange
* Cards4kids - purple