### PR TITLE
LFS-865: When loading a patient chart, an unnecessarily large amount of fetch calls to /Subjects/<UUID>.deep.json are made

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -186,9 +186,13 @@ function SubjectContainer(props) {
     setData([]);  // Prevent an infinite loop if data was not set
   };
 
+  // Fetch this Subject's data
+  useEffect(() => {
+    fetchData();
+  }, []);
+
   // If the data has not yet been fetched, return an in-progress symbol
   if (!data) {
-    fetchData();
     return (
       <Grid container justify="center"><Grid item><CircularProgress/></Grid></Grid>
     );


### PR DESCRIPTION
To test:

1. Build the `LFS-865` branch
2. Create a new Demographics Form and associated Subject
3. Enter some values for the Demographics Form and save
4. Visit the Dashboard
5. Open the browser's Network Inspector and filter for URLs containing `/Subjects/`
6. Click on the link for the newly created Subject to open the patient chart
7. Only one request in the browser's Network Inspector should be displayed with the `/Subjects/` URL filter in effect