### PR TITLE
LFS-581: Livetable pagination should go back to page 1 when changing the search criteria

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -99,13 +99,17 @@ function LiveTable(props) {
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Define the component's behavior
 
-  let fetchData = (newPage) => {
+  let fetchData = (newPage, goToStart) => {
     if (fetchStatus.currentFetch) {
       // TODO: abort previous request
     }
 
     let url = new URL(urlBase);
-    url.searchParams.set("offset", newPage.offset);
+    let queryOffset = newPage.offset;
+    if (goToStart) {
+      queryOffset = 0;
+    }
+    url.searchParams.set("offset", queryOffset);
     url.searchParams.set("limit", newPage.limit || paginationData.limit);
     url.searchParams.set("req", ++fetchStatus.currentRequestNumber);
 
@@ -321,7 +325,7 @@ function LiveTable(props) {
   // Initialize the component: if there's no data loaded yet, fetch the first page
 
   if (fetchStatus.currentRequestNumber == -1) {
-    fetchData(paginationData);
+    fetchData(paginationData, true);
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -105,11 +105,7 @@ function LiveTable(props) {
     }
 
     let url = new URL(urlBase);
-    let queryOffset = newPage.offset;
-    if (goToStart) {
-      queryOffset = 0;
-    }
-    url.searchParams.set("offset", queryOffset);
+    url.searchParams.set("offset", goToStart ? 0 : newPage.offset);
     url.searchParams.set("limit", newPage.limit || paginationData.limit);
     url.searchParams.set("req", ++fetchStatus.currentRequestNumber);
 


### PR DESCRIPTION
This Pull Request addresses the issue described in LFS-581 where the _page_ of a Livetable is not reset to zero upon search criteria change.

To test this Pull Request:

1. Build the `LFS-581_test` branch
2. Start CARDS.
3. Once CARDS has finished loading, load the sample demographics data with `./load_sample_demographics.sh`
4. In the _Quick Search bar_, enter _2021_
5. Click _7 more results_
6. Navigate to the 2nd page of the LiveTable
7. In the _Quick Search bar_, enter _2021-01-01_
8. Click _3 more results_
9. The LiveTable should display _1-8 of 8_