### PR TITLE
LFS-680 + LFS-681: When clicking (+) on a subject child chart to add a form, do not offer irrelevant subjects and questionnaires

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -264,7 +264,34 @@ function NewFormDialog(props) {
                 ]}
                 data={query => {
                   let url = new URL("/query", window.location.origin);
-                  url.searchParams.set("query", `select * from [lfs:Questionnaire] as n${query.search ? ` WHERE CONTAINS(n.'title', '*${query.search}*')` : ""} order by n.'title'`);
+                  let sql = `select * from [lfs:Questionnaire] as n `;
+                  let conditions = [];
+                  if (query.search) {
+                    conditions.push(`CONTAINS(n.'title', '*${query.search}*')`);
+                  }
+                  // If we're on the patient chart, only allow the current subjects whose type is:
+                  // a) the type of the current subject
+                  // b) the type of any progeny of the current subject
+                  if (currentSubject) {
+                    // Join the UUIDs of the progeny types, and convert them into conditions
+                    // These conditions will be n.'requiredSubjectTypes' (IS NULL or ='<uuid>')
+                    let acceptableSubjectTypes = [" IS NULL", `='${currentSubject["type"]["jcr:uuid"]}'`];
+                    if ("progeny" in currentSubject["type"]) {
+                      acceptableSubjectTypes.concat(currentSubject["type"]["progeny"].map((subject) => `='${subject["jcr:uuid"]}'`));
+                    }
+                    // Join the conditions together with an OR, and wrap it in brackets
+                    conditions.push(
+                      "(" + acceptableSubjectTypes.map((condition) => `n.'requiredSubjectTypes'${condition}`).join(" OR ") + ")"
+                    );
+                  }
+
+                  if (conditions.length > 0) {
+                    sql += "WHERE " + conditions.join(" AND ");
+                  }
+
+                  sql += " order by n.'title'";
+
+                  url.searchParams.set("query", sql);
                   url.searchParams.set("limit", query.pageSize);
                   url.searchParams.set("offset", query.page*query.pageSize);
                   return fetchWithReLogin(globalLoginDisplay, url)

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -831,7 +831,7 @@ function SubjectSelectorList(props) {
             }
             if (currentSubject) {
               let subjectID = currentSubject["jcr:uuid"];
-              conditions.push(`(n.'ancestors'='${subjectID}' OR n.'progeny'='${subjectID}' OR n.'jcr:uuid'='${subjectID}')`);
+              conditions.push(`(n.'ancestors'='${subjectID}' OR isdescendantnode(n,'${currentSubject["@path"]}') OR n.'jcr:uuid'='${subjectID}')`);
             }
             let condition = (conditions.length === 0) ? "" : ` WHERE ${conditions.join(" AND ")}`
 

--- a/modules/subjects/src/main/java/ca/sickkids/ccm/lfs/subjects/internal/SubjectAncestryEditor.java
+++ b/modules/subjects/src/main/java/ca/sickkids/ccm/lfs/subjects/internal/SubjectAncestryEditor.java
@@ -119,6 +119,14 @@ public class SubjectAncestryEditor extends DefaultEditor
         if (identifiers.size() > 0) {
             this.currentNodeBuilder.setProperty(PROP_PARENTS, identifiers.get(0), Type.WEAKREFERENCE);
             this.currentNodeBuilder.setProperty(PROP_ANCESTORS, identifiers, Type.WEAKREFERENCES);
+        } else {
+            // Remove the old properties if they exist
+            if (this.currentNodeBuilder.hasProperty(PROP_ANCESTORS)) {
+                this.currentNodeBuilder.removeProperty(PROP_ANCESTORS);
+            }
+            if (this.currentNodeBuilder.hasProperty(PROP_PARENTS)) {
+                this.currentNodeBuilder.removeProperty(PROP_PARENTS);
+            }
         }
     }
 

--- a/modules/subjects/src/main/java/ca/sickkids/ccm/lfs/subjects/internal/SubjectProgenyEditor.java
+++ b/modules/subjects/src/main/java/ca/sickkids/ccm/lfs/subjects/internal/SubjectProgenyEditor.java
@@ -102,8 +102,11 @@ public class SubjectProgenyEditor extends DefaultEditor
         final List<String> identifiers = getProgeny(this.currentNodeBuilder);
 
         // Get&write progeny to the JCR repo
+        // NB: Empty properties cause errors in JCR-SQL2 queries, so we remove the property altogether if it is empty
         if (identifiers.size() > 0) {
             this.currentNodeBuilder.setProperty(PROP_PROGENY, identifiers, Type.WEAKREFERENCES);
+        } else if (this.currentNodeBuilder.hasProperty(PROP_PROGENY)) {
+            this.currentNodeBuilder.removeProperty(PROP_PROGENY);
         }
     }
 

--- a/modules/subjects/src/main/java/ca/sickkids/ccm/lfs/subjects/internal/SubjectProgenyEditor.java
+++ b/modules/subjects/src/main/java/ca/sickkids/ccm/lfs/subjects/internal/SubjectProgenyEditor.java
@@ -102,7 +102,9 @@ public class SubjectProgenyEditor extends DefaultEditor
         final List<String> identifiers = getProgeny(this.currentNodeBuilder);
 
         // Get&write progeny to the JCR repo
-        this.currentNodeBuilder.setProperty(PROP_PROGENY, identifiers, Type.WEAKREFERENCES);
+        if (identifiers.size() > 0) {
+            this.currentNodeBuilder.setProperty(PROP_PROGENY, identifiers, Type.WEAKREFERENCES);
+        }
     }
 
     /**

--- a/modules/variants/src/main/resources/SLING-INF/content/Questionnaires/SomaticVariants.xml
+++ b/modules/variants/src/main/resources/SLING-INF/content/Questionnaires/SomaticVariants.xml
@@ -28,8 +28,8 @@
 	<property>
 		<name>requiredSubjectTypes</name>
 		<values>
-			<value>/SubjectTypes/Tumor</value>
-			<value>/SubjectTypes/TumorRegion</value>
+			<value>/SubjectTypes/Patient/Tumor</value>
+			<value>/SubjectTypes/Patient/Tumor/TumorRegion</value>
 		</values>
 		<type>Reference</type>
 	</property>


### PR DESCRIPTION
### [LFS-680](https://phenotips.atlassian.net/browse/LFS-680): When clicking (+) on a subject chart to add a form, provide list of forms that take this type of subject and its children only

This work also includes the ProgenyProcessor, which allows for a new .json selector (.progeny) which recursively finds the children of a given node (via recursively looking for nodes whose parent is the given node).

To test: When viewing the patient chart for a Tumour, trying to create a new form from that page will no longer show Questionnaires like Demographics, which cannot be used for a Tumour.

### [LFS-681](https://phenotips.atlassian.net/browse/LFS-681): When clicking (+) on a subject child chart to add a form, do not show parent subject in the subject selection dialog

**To test**: When creating a new form **from a patient chart**, the following behaviours should occur:
- If you try to create a form whose subject can be the patient you're looking at, it automatically chooses the patient as the subject for your new form. E.g., create a new patient, go to its chart, and then try creating a Demographics form. It should automatically choose the patient you're looking at as the subject for that form.
- If you try to create a form for a new subject, and the parent of that subject can be the patient you're looking at, the patient is automatically chosen as its parent. For example, create a Patient, then go to its chart and create a Tumour form. It will prompt you to create a new Tumour, which should then **automatically* choose the patient you're looking at as its parent. 
