### PR TITLE
LFS-841: Refactor the pedigree data type

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -83,7 +83,7 @@ function Answer (props) {
               );
           })}
           {
-            answerMetadata ?
+            answerMetadata &&
               Array.from(answerMetadata.entries()).map(([key, value], index) => {
                 return (
                   <input
@@ -93,7 +93,6 @@ function Answer (props) {
                     value={value}></input>
                 );
               })
-            : []
           }
         </React.Fragment>)
       :

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -30,7 +30,7 @@ export const VALUE_POS = 1;
 // Holds answers and automatically generates hidden inputs
 // for form submission
 function Answer (props) {
-  let { answers, answerMap, answerNodeType, existingAnswer, path, questionName, questionDefinition, valueType, onChangeNote, noteComponent, noteProps, onAddedAnswerPath, onDecidedOutputPath, sectionAnswersState } = props;
+  let { answers, answerMetadata, answerNodeType, existingAnswer, path, questionName, questionDefinition, valueType, onChangeNote, noteComponent, noteProps, onAddedAnswerPath, onDecidedOutputPath, sectionAnswersState } = props;
   let { enableNotes } = { ...props, ...questionDefinition };
   let [ answerID ] = useState((existingAnswer && existingAnswer[0]) || uuidv4());
   let answerPath = path + "/" + answerID;
@@ -83,8 +83,8 @@ function Answer (props) {
               );
           })}
           {
-            answerMap ?
-              Array.from(answerMap.entries()).map(([key, value], index) => {
+            answerMetadata ?
+              Array.from(answerMetadata.entries()).map(([key, value], index) => {
                 return (
                   <input
                     type="hidden"

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -30,7 +30,7 @@ export const VALUE_POS = 1;
 // Holds answers and automatically generates hidden inputs
 // for form submission
 function Answer (props) {
-  let { answers, answerNodeType, existingAnswer, path, questionName, questionDefinition, valueType, onChangeNote, noteComponent, noteProps, onAddedAnswerPath, onDecidedOutputPath, sectionAnswersState } = props;
+  let { answers, answerMap, answerNodeType, existingAnswer, path, questionName, questionDefinition, valueType, onChangeNote, noteComponent, noteProps, onAddedAnswerPath, onDecidedOutputPath, sectionAnswersState } = props;
   let { enableNotes } = { ...props, ...questionDefinition };
   let [ answerID ] = useState((existingAnswer && existingAnswer[0]) || uuidv4());
   let answerPath = path + "/" + answerID;
@@ -82,6 +82,19 @@ function Answer (props) {
               <input type="hidden" name={`${answerPath}/value`} key={element[VALUE_POS] === undefined ? index : element[VALUE_POS]} value={element[VALUE_POS]}></input>
               );
           })}
+          {
+            answerMap ?
+              Array.from(answerMap.entries()).map(([key, value], index) => {
+                return (
+                  <input
+                    type="hidden"
+                    name={`${answerPath}/${key}`}
+                    key={value === undefined ? index + (answers ? answers.length : 0) : value}
+                    value={value}></input>
+                );
+              })
+            : []
+          }
         </React.Fragment>)
       :
         <input type="hidden" name={`${answerPath}/value@Delete`} value="0"></input>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
@@ -115,7 +115,7 @@ function PedigreeQuestion(props) {
   }
 
   let outputAnswers = pedigreeJSON ? [["value", pedigreeJSON], "image", pedigreeSVG] : [];
-  let answerMap = pedigreeSVG ? new Map().set("image", pedigreeSVG) : null;
+  let answerMetadata = pedigreeSVG ? new Map().set("image", pedigreeSVG) : null;
 
   return (
     <Question
@@ -138,7 +138,7 @@ function PedigreeQuestion(props) {
       </Dialog>
       <Answer
         answers={outputAnswers}
-        answerMap={answerMap}
+        answerMetadata={answerMetadata}
         questionDefinition={props.questionDefinition}
         existingAnswer={existingAnswer}
         answerNodeType="lfs:PedigreeAnswer"

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
@@ -50,7 +50,7 @@ function PedigreeQuestion(props) {
   const [ expanded, setExpanded ] = useState(false);
   // default pedigreeData state variable to the pedigree saved in LFS:
   const [ pedigreeData, setPedigree ] = useState(existingAnswer && existingAnswer.length > 1 && existingAnswer[1].value
-                                        ? {"image": existingAnswer[1].image, "pedigreeJSON": existingAnswer[1].value[0]}
+                                        ? {"image": existingAnswer[1].image, "pedigreeJSON": existingAnswer[1].value}
                                         : {});
 
   // TODO: use another placeholder image? load from resources?
@@ -114,7 +114,7 @@ function PedigreeQuestion(props) {
     return image_div || "";
   }
 
-  let outputAnswers = pedigreeJSON ? [["value", pedigreeJSON], "image", pedigreeSVG] : [];
+  let outputAnswers = pedigreeJSON ? [["value", pedigreeJSON]] : [];
   let answerMetadata = pedigreeSVG ? new Map().set("image", pedigreeSVG) : null;
 
   return (

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
@@ -46,11 +46,11 @@ import PedigreeEditor from "../pedigree/pedigree";
 //      }}
 //    />
 function PedigreeQuestion(props) {
-  const { existingAnswer, isEdit, classes, ...rest } = props;
+  const { existingAnswer, classes, ...rest } = props;
   const [ expanded, setExpanded ] = useState(false);
   // default pedigreeData state variable to the pedigree saved in LFS:
   const [ pedigreeData, setPedigree ] = useState(existingAnswer && existingAnswer.length > 1 && existingAnswer[1].value
-                                        ? {"image": existingAnswer[1].value[1], "pedigreeJSON": existingAnswer[1].value[0]}
+                                        ? {"image": existingAnswer[1].image, "pedigreeJSON": existingAnswer[1].value[0]}
                                         : {});
 
   // TODO: use another placeholder image? load from resources?
@@ -110,20 +110,24 @@ function PedigreeQuestion(props) {
     setPedigree({"image": pedigreeSVG, "pedigreeJSON": pedigreeJSON});
   };
 
-  let outputAnswers = pedigreeJSON ? [["value", pedigreeJSON], ["image", pedigreeSVG]] : [];
+  let defaultDisplayFormatter = function(label, idx) {
+    return image_div || "";
+  }
+
+  let outputAnswers = pedigreeJSON ? [["value", pedigreeJSON], "image", pedigreeSVG] : [];
+  let answerMap = pedigreeSVG ? new Map().set("image", pedigreeSVG) : null;
 
   return (
     <Question
-      preventDefaultView={true}
+      existingAnswer={existingAnswer}
+      defaultDisplayFormatter={defaultDisplayFormatter}
       {...rest}
       >
-      {image_div && (
-        isEdit ?
+      {image_div &&
         <Link onClick={() => {setExpanded(true);}}>
           {image_div}
         </Link>
-        : <span> {image_div} </span>
-      )}
+      }
       <Dialog fullScreen open={expanded}
         onEntering={() => { openPedigree(); }}
         onExit={() => { closePedigree(); }}
@@ -134,6 +138,7 @@ function PedigreeQuestion(props) {
       </Dialog>
       <Answer
         answers={outputAnswers}
+        answerMap={answerMap}
         questionDefinition={props.questionDefinition}
         existingAnswer={existingAnswer}
         answerNodeType="lfs:PedigreeAnswer"
@@ -150,7 +155,6 @@ PedigreeQuestion.propTypes = {
     description: PropTypes.string
   }).isRequired,
   existingAnswer: PropTypes.array,
-  isEdit: PropTypes.bool,
 }
 
 const StyledPedigreeQuestion = withStyles(QuestionnaireStyle)(PedigreeQuestion)

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/labels/PedigreeLabelProcessor.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/labels/PedigreeLabelProcessor.java
@@ -54,7 +54,7 @@ public class PedigreeLabelProcessor extends SimpleAnswerLabelProcessor implement
     public JsonValue getAnswerLabel(final Node node, final Node question)
     {
         try {
-            return Json.createValue(node.getProperty(PROP_VALUE).getValues()[1].toString());
+            return Json.createValue(node.getProperty("image").getValue().toString());
         } catch (RepositoryException e) {
             // Really shouldn't happen
         }


### PR DESCRIPTION
- Add answerMetadata property to Answer component, enabling answer to be stored keyed, rather than in the value array if desired
- Move pedigree svg from sling value array to image property
- Change PedigreeQuestion to use defaultDisplayFormatter when not editing