### PR TITLE
LFS-869: Frontend crashes when deleting a Patient through the Patient Chart UI

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -18,7 +18,7 @@
 //
 
 import React, { useState, useContext, useEffect } from "react";
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, withRouter } from 'react-router-dom';
 import PropTypes from "prop-types";
 import moment from "moment";
 
@@ -265,10 +265,10 @@ function SubjectHeader (props) {
 }
 
 /**
- * Component that displays all forms related to a Subject.
+ * Component that displays all forms related to a Subject. Do not use directly, use SubjectMember instead.
  */
-function SubjectMember (props) {
-  let { id, classes, level, data, maxDisplayed, pageSize, onDelete } = props;
+function SubjectMemberWithoutHistory (props) {
+  let { classes, data, history, id, level, maxDisplayed, onDelete, pageSize } = props;
   // Error message set when fetching the data from the server fails
   let [ error, setError ] = useState();
   // table data: related forms to the subject
@@ -308,6 +308,14 @@ function SubjectMember (props) {
     return word[0].toUpperCase() + word.slice(1).toLowerCase();
   }
 
+  // When the main subject is deleted, if they're our top-level patient we'll redirect to Dashboard
+  let handleDeletion = () => {
+    if (level === 0) {
+      history.push("/");
+    }
+    onDelete();
+  }
+
   // If the data has not yet been fetched, fetch
   if (!tableData) {
     fetchTableData();
@@ -338,8 +346,7 @@ function SubjectMember (props) {
                  entryPath={path}
                  entryName={title}
                  entryType={label}
-                 shouldGoBack={level === 0}
-                 onComplete={onDelete}
+                 onComplete={handleDeletion}
                  buttonClass={level === 0 ? classes.subjectHeaderButton : classes.childSubjectHeaderButton}
                  size={level === 0 ? "large" : null}
                />
@@ -443,6 +450,8 @@ function SubjectMember (props) {
     </>
   );
 };
+
+let SubjectMember = withRouter(SubjectMemberWithoutHistory);
 
 // Component that displays a preview of the saved form answers
 function FormData(props) {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -267,7 +267,7 @@ function SubjectHeader (props) {
 /**
  * Component that displays all forms related to a Subject. Do not use directly, use SubjectMember instead.
  */
-function SubjectMemberWithoutHistory (props) {
+function SubjectMemberInternal (props) {
   let { classes, data, history, id, level, maxDisplayed, onDelete, pageSize } = props;
   // Error message set when fetching the data from the server fails
   let [ error, setError ] = useState();
@@ -451,7 +451,7 @@ function SubjectMemberWithoutHistory (props) {
   );
 };
 
-let SubjectMember = withRouter(SubjectMemberWithoutHistory);
+let SubjectMember = withRouter(SubjectMemberInternal);
 
 // Component that displays a preview of the saved form answers
 function FormData(props) {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -156,10 +156,6 @@ function SubjectContainer(props) {
   // 'level' of subject component
   const currentLevel = level || 0;
 
-  if (deleted) {
-    return null;
-  }
-
   // Fetch the subject's data as JSON from the server.
   // The data will contain the subject metadata,
   // such as authorship and versioning information.
@@ -190,6 +186,10 @@ function SubjectContainer(props) {
   useEffect(() => {
     fetchData();
   }, []);
+
+  if (deleted) {
+    return null;
+  }
 
   // If the data has not yet been fetched, return an in-progress symbol
   if (!data) {


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/LFS-869)

Steps to reproduce this bug:

1. Build the latest dev branch
2. Create a new Demographics Form and an associated Subject
3. Visit the Subject's Patient Chart
4. Click the large Delete Patient trash can icon as opposed to the small Delete Form trash can icon
5. Follow through with the deletion confirmation dialogs
6. A whitescreen error should no longer occur. In addition, it will redirect you to the dashboard when deleting the top level subject.