### PR TITLE
CARDS-882: Upgrading questionnaires fails when there are forms filled in

### DIFF
--- a/cardiac-rehab-resources/clinical-data/pom.xml
+++ b/cardiac-rehab-resources/clinical-data/pom.xml
@@ -41,7 +41,7 @@
           <instructions>
             <Include-Resource>{maven-resources},src/main/media</Include-Resource>
             <Sling-Initial-Content>
-              SLING-INF/content/Questionnaires/;path:=/Questionnaires/;overwrite:=true,
+              SLING-INF/content/Questionnaires/;path:=/Questionnaires/;merge:=true;mergeProperties:=true;overwriteProperties:=true;uninstall:=true,
               SLING-INF/content/libs/lfs/resources/;path:=/libs/lfs/resources/;overwrite:=true,
               SLING-INF/content/libs/lfs/conf/;path:=/libs/lfs/conf/;overwrite:=false
             </Sling-Initial-Content>

--- a/cardiac-resources/clinical-data/pom.xml
+++ b/cardiac-resources/clinical-data/pom.xml
@@ -41,7 +41,7 @@
           <instructions>
             <Include-Resource>{maven-resources},src/main/media</Include-Resource>
             <Sling-Initial-Content>
-              SLING-INF/content/Questionnaires/;path:=/Questionnaires/;overwrite:=true,
+              SLING-INF/content/Questionnaires/;path:=/Questionnaires/;merge:=true;mergeProperties:=true;overwriteProperties:=true;uninstall:=true,
               SLING-INF/content/libs/lfs/resources/;path:=/libs/lfs/resources/;overwrite:=true,
               SLING-INF/content/libs/lfs/conf/;path:=/libs/lfs/conf/;overwrite:=false
             </Sling-Initial-Content>

--- a/distribution/src/main/provisioning/10-sling-base.txt
+++ b/distribution/src/main/provisioning/10-sling-base.txt
@@ -43,7 +43,7 @@
     org.apache.sling/org.apache.sling.installer.console/1.0.2
     org.apache.sling/org.apache.sling.installer.provider.jcr/3.1.26
     org.apache.sling/org.apache.sling.installer.hc/2.0.0
-    org.apache.sling/org.apache.sling.jcr.contentloader/2.2.6
+    org.apache.sling/org.apache.sling.jcr.contentloader/2.4.1.0.cards
     org.apache.sling/org.apache.sling.jcr.resource/3.0.16
     org.apache.sling/org.apache.sling.models.api/1.3.8
     org.apache.sling/org.apache.sling.models.impl/1.4.10
@@ -144,7 +144,6 @@
       "org.apache.sling.extensions.webconsolesecurityprovider",\
       "org.apache.sling.i18n",\
       "org.apache.sling.jcr.base",\
-      "org.apache.sling.jcr.contentloader",\
       "org.apache.sling.jcr.jackrabbit.usermanager",\
       "org.apache.sling.jcr.oak.server",\
       "org.apache.sling.jcr.repoinit",\
@@ -199,4 +198,9 @@
   org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-jcr-resource
     user.mapping=[
       "org.apache.sling.jcr.resource:validation\=sling-readall"
+    ]
+
+  org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-jcr-contentloader
+    user.mapping=[
+      "org.apache.sling.jcr.contentloader\=sling-jcr-content-loader"
     ]

--- a/distribution/src/main/provisioning/13-repoinit.txt
+++ b/distribution/src/main/provisioning/13-repoinit.txt
@@ -43,6 +43,12 @@
         allow   jcr:read    on /
     end
 
+    create service user sling-jcr-content-loader
+
+    set ACL for sling-jcr-content-loader
+        allow   jcr:all     on /
+    end
+
     # sling-xss
     create service user sling-xss
 

--- a/lfs-resources/clinical-data/pom.xml
+++ b/lfs-resources/clinical-data/pom.xml
@@ -43,8 +43,8 @@
             <Sling-Initial-Content>
               SLING-INF/content/libs/lfs/conf/;path:=/libs/lfs/conf/;overwrite:=false,
               SLING-INF/content/libs/lfs/resources/;path:=/libs/lfs/resources/;overwrite:=true,
-              SLING-INF/content/Questionnaires/;path:=/Questionnaires/;overwrite:=true,
-              SLING-INF/content/SubjectTypes/;path:=/SubjectTypes/;overwrite:=true
+              SLING-INF/content/Questionnaires/;path:=/Questionnaires/;merge:=true;mergeProperties:=true;overwriteProperties:=true;uninstall:=true,
+              SLING-INF/content/SubjectTypes/;path:=/SubjectTypes/;merge:=true;mergeProperties:=true;overwriteProperties:=true;uninstall:=true
             </Sling-Initial-Content>
           </instructions>
         </configuration>

--- a/lfs-resources/tissue-metrix/pom.xml
+++ b/lfs-resources/tissue-metrix/pom.xml
@@ -39,7 +39,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Sling-Initial-Content>SLING-INF/content/Questionnaires/;path:=/Questionnaires/;overwrite:=true</Sling-Initial-Content>
+            <Sling-Initial-Content>SLING-INF/content/Questionnaires/;path:=/Questionnaires/;merge:=true;mergeProperties:=true;overwriteProperties:=true;uninstall:=true</Sling-Initial-Content>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/data-entry/pom.xml
+++ b/modules/data-entry/pom.xml
@@ -51,7 +51,7 @@
               SLING-INF/content/Extensions/DashboardViews/;path:=/Extensions/DashboardViews/;overwrite:=true,
               SLING-INF/content/Extensions/Sidebar/;path:=/Extensions/Sidebar/;overwrite:=true,
               SLING-INF/content/Extensions/Views/;path:=/Extensions/Views/;overwrite:=true,
-              SLING-INF/content/SubjectTypes/;path:=/SubjectTypes/;overwrite:=true
+              SLING-INF/content/SubjectTypes/;path:=/SubjectTypes/;merge:=true;mergeProperties:=true;overwriteProperties:=true;uninstall:=true
             </Sling-Initial-Content>
           </instructions>
         </configuration>


### PR DESCRIPTION
No testing branch for this.

Changes done to the sling-jcr-contentloader module are [here](https://github.com/sdumitriu/sling-org-apache-sling-jcr-contentloader/commit/35d449af0695707e02357fa4c5e8c10db371e89f).

What works:
- new questions and sections are correctly added
- properties for existing questions are correctly added/updated/deleted
- old questions are removed if they are not being referenced (there are no forms for that questionnaire, or are in a conditional section that is not used)

What doesn't work yet:
- old questionnaires are not removed
- old questions are not deleted if they are referenced by an answer