### PR TITLE
LFS-885: Baseline Medication / Beta blockers / Patient-reported not taking should not be mandatory

### DIFF
--- a/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Baseline Medications.xml
+++ b/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Baseline Medications.xml
@@ -831,11 +831,6 @@
 					<value>list</value>
 					<type>String</type>
 				</property>
-				<property>
-					<name>minAnswers</name>
-					<value>1</value>
-					<type>Long</type>
-				</property>
 				<node>
 					<name>Patient-reported not taking</name>
 					<primaryNodeType>lfs:AnswerOption</primaryNodeType>


### PR DESCRIPTION
To reproduce: start in cardiac_rehab mode, create a new `Baseline Medications` form, select `Beta blocker` for presrcibed medication. There's a new conditional section for details about the beta blocker, with a `Click this box if the patient is not taking this prescribed medication:` question that requires selecting the only option available. It should not be required.