### PR TITLE
LFS-889: bl_med_types_other section in Baseline Medications has incorrect conditional

### DIFF
--- a/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Baseline Medications.xml
+++ b/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Baseline Medications.xml
@@ -317,7 +317,7 @@
 					<property>
 						<name>value</name>
 						<values>
-							<value>bl_med_types_#</value>
+							<value>bl_med_types</value>
 						</values>
 						<type>String</type>
 					</property>


### PR DESCRIPTION
Fix `bl_med_types_#` to correct `bl_med_types`

Fixes the "Specify other medication(s)" question in cardiac_rehab Baseline Medications form so that it will show up correctly when "Other medication" is selected in "Which of the following types of medications are prescribed?"