### PR TITLE
LFS-900: Incorrect year of birth in Cardiac Rehab's Participant status form

### DIFF
--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/labels/DateLabelProcessor.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/labels/DateLabelProcessor.java
@@ -64,6 +64,10 @@ public class DateLabelProcessor extends SimpleAnswerLabelProcessor implements Re
         try {
             if (question != null) {
                 Property property = node.getProperty(PROP_VALUE);
+                if (question.hasProperty("dateFormat")
+                    && "yyyy".equals(question.getProperty("dateFormat").getString())) {
+                    return Json.createValue(property.getValue().getLong());
+                }
                 DateFormat format = question.hasProperty("dateFormat")
                     ? new SimpleDateFormat(question.getProperty("dateFormat").getString()) : DEFAULT_FORMAT;
                 if (property.isMultiple()) {

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/labels/DateLabelProcessor.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/labels/DateLabelProcessor.java
@@ -64,10 +64,21 @@ public class DateLabelProcessor extends SimpleAnswerLabelProcessor implements Re
         try {
             if (question != null) {
                 Property property = node.getProperty(PROP_VALUE);
+                // Treating YYYY date format as a special case
+                // because it is sent to save by front-end as a long number value
                 if (question.hasProperty("dateFormat")
                     && "yyyy".equals(question.getProperty("dateFormat").getString())) {
-                    return Json.createValue(property.getValue().toString());
+                    if (property.isMultiple()) {
+                        JsonArrayBuilder result = Json.createArrayBuilder();
+                        for (Value v : property.getValues()) {
+                            result.add(Json.createValue(v.toString()));
+                        }
+                        return result.build();
+                    } else {
+                        return Json.createValue(property.getValue().toString());
+                    }
                 }
+
                 DateFormat format = question.hasProperty("dateFormat")
                     ? new SimpleDateFormat(question.getProperty("dateFormat").getString()) : DEFAULT_FORMAT;
                 if (property.isMultiple()) {

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/labels/DateLabelProcessor.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/labels/DateLabelProcessor.java
@@ -66,7 +66,7 @@ public class DateLabelProcessor extends SimpleAnswerLabelProcessor implements Re
                 Property property = node.getProperty(PROP_VALUE);
                 if (question.hasProperty("dateFormat")
                     && "yyyy".equals(question.getProperty("dateFormat").getString())) {
-                    return Json.createValue(property.getValue().getLong());
+                    return Json.createValue(property.getValue().toString());
                 }
                 DateFormat format = question.hasProperty("dateFormat")
                     ? new SimpleDateFormat(question.getProperty("dateFormat").getString()) : DEFAULT_FORMAT;


### PR DESCRIPTION
Due to [LFS-119](https://phenotips.atlassian.net/browse/LFS-119) we [process](https://github.com/ccmbioinfo/lfs/blob/dev/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx#L146-L161) the date "yyyy" format as a special case.