### PR TITLE
LFS-193: As a user, I can visualize the events recorded for a patient in a timeline

### DIFF
--- a/modules/data-entry/src/main/frontend/package.json
+++ b/modules/data-entry/src/main/frontend/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@material-ui/core": "4.11.2",
     "@material-ui/icons": "4.11.2",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "classnames": "2.2.6",
     "react": "16.14.0",
     "react-dom": "16.14.0",

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
@@ -164,12 +164,13 @@ export default class DateQuestionUtilities {
       let nextDate = this.amendMoment(secondDate, "yyyy-MM-dd");
 
       let diff = [];
+      let longDiff = [];
       for (const division of ["years", "months", "days"]) {
         let value = nextDate.diff(currentDate, division);
         diff.push(value);
         if (value > 0) {
           nextDate = nextDate.subtract(value, division);
-          result.long += value + division.charAt(0);
+          longDiff.push(value + division.charAt(0));
         }
       }
 
@@ -180,6 +181,7 @@ export default class DateQuestionUtilities {
       } else if (diff[2] > 0) {
         result.short = `${diff[2]}d`;
       }
+      result.long = longDiff.join(" ");
     }
     return result;
   }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
@@ -160,8 +160,8 @@ export default class DateQuestionUtilities {
     // Compute the displayed difference
     let difference = null;
     if (firstDate && secondDate) {
-      let currentDate = moment(firstDate);
-      let nextDate = moment(secondDate);
+      let currentDate = this.amendMoment(firstDate, "yyyy-MM-dd");
+      let nextDate = this.amendMoment(secondDate, "yyyy-MM-dd");
       let divisions = ["years", "months", "days"];
       for(const division of divisions) {
         let diff = nextDate.diff(currentDate, division);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
@@ -156,20 +156,20 @@ export default class DateQuestionUtilities {
     return type == this.INTERVAL_TYPE && answers.length == 2 || answers.length == 1;
   }
 
-  static dateDifference = (firstDate, secondDate) => {
+  static dateDifference = (startDateInput, endDateInput) => {
     // Compute the displayed difference
     let result = {long:""}
-    if (firstDate && secondDate) {
-      let currentDate = this.amendMoment(firstDate, "yyyy-MM-dd");
-      let nextDate = this.amendMoment(secondDate, "yyyy-MM-dd");
+    if (startDateInput && endDateInput) {
+      let startDate = this.amendMoment(startDateInput, "yyyy-MM-dd");
+      let endDate = this.amendMoment(endDateInput, "yyyy-MM-dd");
 
       let diff = [];
       let longDiff = [];
       for (const division of ["years", "months", "days"]) {
-        let value = nextDate.diff(currentDate, division);
+        let value = endDate.diff(startDate, division);
         diff.push(value);
         if (value > 0) {
-          nextDate = nextDate.subtract(value, division);
+          endDate = endDate.subtract(value, division);
           longDiff.push(value + division.charAt(0));
         }
       }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
@@ -155,4 +155,22 @@ export default class DateQuestionUtilities {
   static isAnswerComplete(answers, type) {
     return type == this.INTERVAL_TYPE && answers.length == 2 || answers.length == 1;
   }
+
+  static dateDifference = (firstDate, secondDate) => {
+    // Compute the displayed difference
+    let difference = null;
+    if (firstDate && secondDate) {
+      let currentDate = moment(firstDate);
+      let nextDate = moment(secondDate);
+      let divisions = ["years", "months", "days"];
+      for(const division of divisions) {
+        let diff = nextDate.diff(currentDate, division);
+        if (diff > 0) {
+          difference = diff + division.charAt(0);
+          break;
+        }
+      }
+    }
+    return difference;
+}
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
@@ -158,19 +158,29 @@ export default class DateQuestionUtilities {
 
   static dateDifference = (firstDate, secondDate) => {
     // Compute the displayed difference
-    let difference = null;
+    let result = {long:""}
     if (firstDate && secondDate) {
       let currentDate = this.amendMoment(firstDate, "yyyy-MM-dd");
       let nextDate = this.amendMoment(secondDate, "yyyy-MM-dd");
-      let divisions = ["years", "months", "days"];
-      for(const division of divisions) {
-        let diff = nextDate.diff(currentDate, division);
-        if (diff > 0) {
-          difference = diff + division.charAt(0);
-          break;
+
+      let diff = [];
+      for (const division of ["years", "months", "days"]) {
+        let value = nextDate.diff(currentDate, division);
+        diff.push(value);
+        if (value > 0) {
+          nextDate = nextDate.subtract(value, division);
+          result.long += value + division.charAt(0);
         }
       }
+
+      if (diff[0] > 0) {
+        result.short = `${diff[0] + (diff[1] > 6 ? 1 : 0)}y`;
+      } else if (diff[1] > 0) {
+        result.short = `${diff[1] + (diff[2] > 15 ? 1 : 0)}m`;
+      } else if (diff[2] > 0) {
+        result.short = `${diff[2]}d`;
+      }
     }
-    return difference;
-}
+    return result;
+  }
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PatientTimeline.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PatientTimeline.jsx
@@ -1,0 +1,223 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React, { useState, useContext } from "react";
+import PropTypes from "prop-types";
+import { Link, Paper } from '@material-ui/core'
+import Timeline from '@material-ui/lab/Timeline';
+import TimelineItem from '@material-ui/lab/TimelineItem';
+import TimelineSeparator from '@material-ui/lab/TimelineSeparator';
+import TimelineConnector from '@material-ui/lab/TimelineConnector';
+import TimelineContent from '@material-ui/lab/TimelineContent';
+import TimelineDot from '@material-ui/lab/TimelineDot';
+import TimelineOppositeContent from '@material-ui/lab/TimelineOppositeContent';
+
+import { formatDateAnswer } from "./DateQuestion.jsx";
+import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
+import QuestionnaireStyle from "./QuestionnaireStyle.jsx";
+import { displayQuestion, handleDisplay, ENTRY_TYPES } from "./Subject.jsx";
+
+import {
+  Typography,
+  withStyles,
+} from "@material-ui/core";
+
+const NUM_QUESTIONS = 2;
+const STRIPPED_STRINGS = ["date of", "date"]
+
+/**
+ * Component that displays a Subject's Patient Chart.
+ *
+ * @example
+ * <Subject id="9399ca39-ab9a-4db4-bf95-7760045945fe"/>
+ *
+ * @param {string} id the identifier of a subject; this is the JCR node name
+ */
+
+function PatientTimeline(props) {
+  let { id, classes, pageSize, subject } = props;
+  let [dateAnswers, setDateAnswers] = useState(null);
+  // Error message set when fetching the data from the server fails
+  let [ error, setError ] = useState();
+
+  let globalLoginDisplay = useContext(GlobalLoginContext);
+
+  let fetchFormData = (path) => {
+    return fetchWithReLogin(globalLoginDisplay, `${path}.deep.json`)
+      .then((response) => response.ok ? response.json() : Promise.reject(response))
+      // .catch(handleFormError)
+  }
+
+  let getFormData = async (baseForms) => {
+    let formDataPromises = [];
+    for (const form of baseForms) {
+      formDataPromises.push(fetchFormData(form["@path"]));
+    }
+    let results = await Promise.all(formDataPromises);
+    console.log("getFormData");
+    console.log(results);
+    return results;
+  }
+
+  let fetchForms = (customUrl) => {
+    return fetchWithReLogin(globalLoginDisplay, customUrl)
+    .then((response) => response.ok ? response.json() : Promise.reject(response));
+    // .catch(handleTableError);
+  };
+
+  let getSubjects = (parent) => {
+    let subjects = [];
+    console.log("Getting subjects");
+    console.log(parent);
+    console.log(parent["@progeny"]);
+    if (parent) {
+      if (parent["jcr:uuid"]) {
+        subjects.push(parent["jcr:uuid"]);
+      }
+      for (const child of parent["@progeny"] || []) {
+        subjects = subjects.concat(getSubjects(child));
+      }
+    }
+    return subjects;
+  }
+
+  let getForms = async () => {
+    let rootSubject = subject;
+    // TODO: convert rootSubject to top level parent
+    // TODO: add subject hierarchy to questionnaire title
+    // Will be made easy by LFS-911
+
+    let subjects = getSubjects(rootSubject);
+    console.log("getSubjects");
+    console.log(subjects);
+    let formPromises = [];
+
+    for (const subjectId of subjects) {
+      const formUrl = `/Forms.paginate?fieldname=subject&fieldvalue=${encodeURIComponent(subjectId)}&includeallstatus=true&limit=1000`;
+      formPromises.push(fetchForms(formUrl));
+    }
+    let results = await Promise.all(formPromises);
+    results = [].concat.apply([], results.map(formData => formData.rows))
+    console.log("getForms");
+    console.log(results);
+    return results;
+  }
+
+  let dateAnswerData = [];
+  let currentFormTitle;
+  let handleDisplayQuestion = (entryDefinition, data, key) => {
+    const existingQuestionAnswer = data && Object.entries(data)
+      .find(([key, value]) => value["sling:resourceSuperType"] == "lfs/Answer"
+        && value["question"]["jcr:uuid"] === entryDefinition["jcr:uuid"]);
+    if (typeof(existingQuestionAnswer?.[1]?.value) != "undefined") {
+      if (existingQuestionAnswer[1]["jcr:primaryType"] === "lfs:DateAnswer") {
+        dateAnswerData.push({"date": existingQuestionAnswer[1], followup:[], formTitle: currentFormTitle});
+      } else if (dateAnswerData.length > 0 && dateAnswerData[dateAnswerData.length - 1].followup.length < NUM_QUESTIONS) {
+        dateAnswerData[dateAnswerData.length - 1].followup.push(displayQuestion(entryDefinition, data, key));
+      }
+    }
+  }
+
+  let getDateQuestions = (formDetails) => {
+    formDetails.map(form => {
+      currentFormTitle = form.questionnaire["@name"];
+      Object.entries(form.questionnaire)
+      .filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType']))
+      .map(([key, entryDefinition]) => {
+        handleDisplay(entryDefinition, form, key, handleDisplayQuestion);
+      })
+    });
+    setDateAnswers(dateAnswerData.sort((a, b) => {
+      return a.date.value > b.date.value ? 1 : (a.date.value === b.date.value ? 0 : -1)
+    }));
+  }
+
+  if (dateAnswers === null) {
+    setDateAnswers(false);
+    getForms().then(baseForms => getFormData(baseForms))
+    .then(formDetails => getDateQuestions(formDetails));
+  }
+
+  // Callback method for the `fetchData` method, invoked when the request failed.
+  let handleError = (response) => {
+    setError(response);
+  };
+
+  return <Timeline align="alternate">
+    { dateAnswers && dateAnswers.map((dateAnswer, index) => DateTimelineEntry(classes, dateAnswer, index, dateAnswers.length)) }
+  </Timeline>;
+}
+
+function DateTimelineEntry(classes, data, index, length) {
+  let dateAnswer = data.date;
+  let date = formatDateAnswer(dateAnswer.question?.dateFormat, dateAnswer.value);
+  let questionTitle = dateAnswer.question?.text;
+
+  // Strip unwanted strings from the question title
+  for (const str of STRIPPED_STRINGS) {
+    let dateIndex = questionTitle.toLowerCase().indexOf(str);
+    if (dateIndex > -1) {
+      questionTitle = questionTitle.substring(0,dateIndex).concat(questionTitle.substring(dateIndex + str.length));
+    }
+  }
+  questionTitle = questionTitle.trim();
+  // Make sure the title starts with a capital
+  if (questionTitle.length > 0) {
+    questionTitle = questionTitle[0].toUpperCase().concat(questionTitle.substring(1));
+  }
+
+  let questionPath = dateAnswer && dateAnswer.question && dateAnswer.question["@path"];
+  let formIndex = dateAnswer && dateAnswer["@path"].indexOf("/", "/Forms/".length+1);
+  let formPath = dateAnswer && dateAnswer["@path"].substring(0, formIndex)
+
+  // TODO: Implement level. Will be made easier when 911 is complete
+  let level = 0;
+  let formTitle = data.formTitle;
+
+  return <TimelineItem key={index}>
+      <TimelineOppositeContent>
+        <Typography color="textSecondary">{date}</Typography>
+      </TimelineOppositeContent>
+      <TimelineSeparator>
+        <TimelineDot color={level == 0 ? "primary" : (level == 1 ? "secondary" : "default")}/>
+        {index !== (length - 1) && <TimelineConnector />}
+      </TimelineSeparator>
+        <TimelineContent>
+          <Paper elevation={3} className={classes.timelinePaper}>
+            <Typography variant="h6" component="h1">
+              {questionTitle} (<Link href={`/content.html${formPath}#${questionPath}`}>{formTitle}</Link>)
+            </Typography>
+            {/* TODO: fix entered on displaying wrong date */}
+            <Typography variant="caption">Entered on {formatDateAnswer("yyyy-mm-DD", dateAnswer["jcr:created"])} by {dateAnswer["jcr:createdBy"]}</Typography>
+            {data.followup}
+          </Paper>
+        </TimelineContent>
+    </TimelineItem>;
+}
+
+PatientTimeline.propTypes = {
+  id: PropTypes.string
+}
+
+PatientTimeline.defaultProps = {
+  maxDisplayed: 4,
+  pageSize: 10,
+}
+
+export default withStyles(QuestionnaireStyle)(PatientTimeline);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -237,6 +237,15 @@ const questionnaireStyle = theme => ({
         padding: "8px 16px",
         marginBottom: "40px"
     },
+    timelineAncestor: {
+        opacity: 0.3
+    },
+    timelineDateEntry: {
+        paddingBottom: theme.spacing(2),
+    },
+    timelineDateEntryFinal: {
+        paddingBottom: 0,
+    },
     mainPageAction: {
         position: 'fixed',
         bottom: theme.spacing(2),

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -232,6 +232,21 @@ const questionnaireStyle = theme => ({
           width: "auto",
         },
       },
+    timelinePaper: {
+        padding: "8px 16px",
+        marginBottom: "40px"
+    },
+    mainPageAction: {
+        position: 'fixed',
+        bottom: theme.spacing(2),
+        right: theme.spacing(4),
+        height: theme.spacing(8),
+        zIndex: 100,
+        "& > div" : {
+             position: "absolute !important",
+             top: 0,
+             right: 0,
+        },
     },
     collapsedSection: {
         padding: "0 !important"

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -233,12 +233,23 @@ const questionnaireStyle = theme => ({
         },
       },
     },
+    timelineContent: {
+        padding: theme.spacing(1,3),
+    },
     timelinePaper: {
-        padding: "8px 16px",
-        marginBottom: "40px"
+        padding: theme.spacing(1,2),
     },
     timelineAncestor: {
-        opacity: 0.3
+        opacity: 0.3,
+        "&:hover": {
+          opacity: 1,
+        },
+    },
+    timelineDate: {
+        marginTop: "-5px",
+        marginLeft: theme.spacing(-2),
+        marginRight: theme.spacing(-2),
+        color: theme.palette.primary.main
     },
     timelineDateEntry: {
         paddingBottom: theme.spacing(2),
@@ -246,17 +257,49 @@ const questionnaireStyle = theme => ({
     timelineDateEntryFinal: {
         paddingBottom: 0,
     },
-    mainPageAction: {
-        position: 'fixed',
-        bottom: theme.spacing(2),
-        right: theme.spacing(4),
-        height: theme.spacing(8),
-        zIndex: 100,
-        "& > div" : {
-             position: "absolute !important",
-             top: 0,
-             right: 0,
+    timelineConnectorGroup: {
+        display: "flex",
+        alignItems: "center",
+        flexDirection: "column",
+        flexGrow: 1
+    },
+    timelineConnectorLine: {
+        backgroundColor: theme.palette.grey["200"]
+    },
+    timelineCircle: {
+        background: theme.palette.grey["200"],
+        position: "absolute",
+        top: "50%",
+        transform: "translateY(calc(-50% + 14px))",
+        width: "35px",
+        height: "35px",
+        borderRadius: "50%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        "&:before": {
+            content: "''",
+            display: "block",
+            borderBottom: "12px solid",
+            borderBottomColor: theme.palette.grey["200"],
+            borderLeft: "12px solid transparent",
+            borderRight: "12px solid transparent",
+            position: "absolute",
+            top: "-7px"
         },
+        "&:after": {
+            content: "''",
+            display: "block",
+            borderTop: "12px solid",
+            borderTopColor: theme.palette.grey["200"],
+            borderLeft: "12px solid transparent",
+            borderRight: "12px solid transparent",
+            position: "absolute",
+            bottom: "-7px"
+        }
+    },
+    timelineSeparator: {
+        minHeight: theme.spacing(12)
     },
     collapsedSection: {
         padding: "0 !important"
@@ -514,20 +557,6 @@ const questionnaireStyle = theme => ({
     answerOptionDeleteButton: {
       right: theme.spacing(-3),
     },
-    circle: {
-        background: theme.palette.background.paper,
-        border: "2px solid",
-        borderColor: theme.palette.grey["400"],
-        position: "absolute",
-        top: "50%",
-        transform: "translateY(calc(-50% + 14px))",
-        width: "35px",
-        height: "35px",
-        borderRadius: "50%",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center"
-    }
 });
 
 export default questionnaireStyle;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -504,6 +504,20 @@ const questionnaireStyle = theme => ({
     answerOptionDeleteButton: {
       right: theme.spacing(-3),
     },
+    circle: {
+        background: theme.palette.background.paper,
+        border: "2px solid",
+        borderColor: theme.palette.grey["400"],
+        position: "absolute",
+        top: "50%",
+        transform: "translateY(calc(-50% + 14px))",
+        width: "35px",
+        height: "35px",
+        borderRadius: "50%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center"
+    }
 });
 
 export default questionnaireStyle;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -232,6 +232,7 @@ const questionnaireStyle = theme => ({
           width: "auto",
         },
       },
+    },
     timelinePaper: {
         padding: "8px 16px",
         marginBottom: "40px"

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -233,8 +233,15 @@ const questionnaireStyle = theme => ({
         },
       },
     },
+    timelineContainer: {
+        alignItems: "center",
+    },
+    timeline: {
+        maxWidth: "1000px",
+        margin: "auto"
+    },
     timelineContent: {
-        padding: theme.spacing(1,3),
+        padding: theme.spacing(1,3,3),
     },
     timelinePaper: {
         padding: theme.spacing(1,2),
@@ -246,7 +253,7 @@ const questionnaireStyle = theme => ({
         },
     },
     timelineDate: {
-        marginTop: "-5px",
+        lineHeight: "1em",
         marginLeft: theme.spacing(-2),
         marginRight: theme.spacing(-2),
         color: theme.palette.primary.main

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -214,9 +214,9 @@ function SubjectContainer(props) {
   };
 
   // Fetch this Subject's data
-  useEffect(() => {
-    fetchData();
-  }, []);
+  // useEffect(() => {
+  //   fetchData();
+  // }, []);
 
   if (deleted) {
     return null;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -24,6 +24,7 @@ import moment from "moment";
 
 import QuestionnaireStyle from "./QuestionnaireStyle.jsx";
 import NewFormDialog from "../dataHomepage/NewFormDialog";
+import { QUESTION_TYPES, SECTION_TYPES, ENTRY_TYPES } from "./FormEntry.jsx";
 import { usePageNameWriterContext } from "../themePage/Page.jsx";
 import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
 import MaterialTable, { MTablePagination } from 'material-table';
@@ -43,10 +44,6 @@ import FileIcon from "@material-ui/icons/InsertDriveFile";
 import DeleteButton from "../dataHomepage/DeleteButton.jsx";
 import EditButton from "../dataHomepage/EditButton.jsx";
 import SubjectTimeline from "./SubjectTimeline.jsx";
-
-export const QUESTION_TYPES = ["lfs:Question"];
-export const SECTION_TYPES = ["lfs:Section"];
-export const ENTRY_TYPES = QUESTION_TYPES.concat(SECTION_TYPES);
 
 /***
  * Create a URL that checks for the existence of a subject
@@ -109,6 +106,9 @@ function Subject(props) {
   const [ currentSubjectId, setCurrentSubjectId ] = useState(id);
   const [ activeTab, setActiveTab ] = useState(0);
 
+  // TODO: These tabs should be extensible.
+  // This will involve moving SubjectContainer to it's own file and moving
+  // handleDisplay() to a utility file for SubjectContainer and SubjectTimeline.
   const tabs = ["Chart", "Timeline"]
   const location = useLocation();
 
@@ -176,6 +176,9 @@ function Subject(props) {
   );
 }
 
+/**
+ * Component that recursively gets and displays the selected subject and its related SubjectTypes
+ */
 function SubjectContainer(props) {
   let { id, classes, level, maxDisplayed, pageSize, subject } = props;
   // Error message set when fetching the data from the server fails
@@ -267,10 +270,6 @@ function SubjectHeader(props) {
 
   let globalLoginDisplay = useContext(GlobalLoginContext);
 
-  if (deleted) {
-    return null;
-  }
-
   // Fetch the subject's data as JSON from the server.
   // The data will contain the subject metadata,
   // such as authorship and versioning information.
@@ -296,8 +295,14 @@ function SubjectHeader(props) {
 
   // Fetch this Subject's data
   useEffect(() => {
-    fetchSubjectData();
+    if (!deleted) {
+      fetchSubjectData();
+    }
   }, [id]);
+
+  if (deleted) {
+    return null;
+  }
 
   if (!subject?.data) {
     return (
@@ -398,7 +403,7 @@ function SubjectMemberInternal (props) {
   // Fetch table data for all forms related to a Subject
   useEffect(() => {
     fetchTableData();
-  }, [data]);
+  }, [data['jcr:uuid']]);
 
   // If an error was returned, do not display a subject at all, but report the error
   if (error) {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -104,7 +104,7 @@ export function getTextHierarchy (node, withType = false) {
  */
 
 function Subject(props) {
-  let { id, classes, maxDisplayed, pageSize } = props;
+  let { id, classes, maxDisplayed, pageSize, history } = props;
   const [ currentSubject, setCurrentSubject ] = useState();
   const [ currentSubjectId, setCurrentSubjectId ] = useState(id);
   const [ activeTab, setActiveTab ] = useState(0);
@@ -115,6 +115,9 @@ function Subject(props) {
   useEffect(() => {
     let newId = getSubjectIdFromPath(location.pathname);
     newId && setCurrentSubjectId(newId);
+    if (location.hash.length > 0 && tabs.includes(location.hash.substring(1))) {
+      setActiveTab(tabs.indexOf(location.hash.substring(1)));
+    }
   }, [location]);
 
   let pageTitle = currentSubject && getTextHierarchy(currentSubject, true);
@@ -130,18 +133,21 @@ function Subject(props) {
     setCurrentSubject(e);
   }
 
+  function setTab(index) {
+    history.replace(location.pathname+location.search+"#"+tabs[index], location.state)
+    setActiveTab(index);
+  }
+
   return (
     <React.Fragment>
-      <div className={classes.mainPageAction}>
-        <NewFormDialog currentSubject={currentSubject}>
-          New form for this Subject
-        </NewFormDialog>
-      </div>
+      <NewFormDialog currentSubject={currentSubject}>
+        New form for this Subject
+      </NewFormDialog>
       <Grid container spacing={4} direction="column" className={classes.subjectContainer}>
         <SubjectHeader id={currentSubjectId} key={"SubjectHeader"}  classes={classes} getSubject={handleSubject}/>
         {
           <Tabs value={activeTab} onChange={(event, value) => {
-            setActiveTab(value);
+            setTab(value);
           }}>
             {tabs.map((tab) => {
               return <Tab label={tab} key={tab}/>;
@@ -684,4 +690,4 @@ Subject.defaultProps = {
   pageSize: 10,
 }
 
-export default withStyles(QuestionnaireStyle)(Subject);
+export default withStyles(QuestionnaireStyle)(withRouter(Subject));

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -276,7 +276,7 @@ function SubjectHeader(props) {
   // such as authorship and versioning information.
   // Once the data arrives from the server, it will be stored in the `data` state variable.
   let fetchSubjectData = () => {
-    fetchWithReLogin(globalLoginDisplay, `/Subjects/${id}.progeny.deep.json`)
+    fetchWithReLogin(globalLoginDisplay, `/Subjects/${id}.deep.json`)
       .then((response) => response.ok ? response.json() : Promise.reject(response))
       .then(handleSubjectResponse)
       .catch(handleError);
@@ -315,10 +315,10 @@ function SubjectHeader(props) {
     );
   }
 
-  let identifier = subject?.data?.identifier ? subject.data.identifier : id;
+  let identifier = subject?.data?.identifier || id;
   let label = subject?.data?.type?.label || "Subject";
   let title = `${label} ${identifier}`;
-  let path = subject?.data ? subject.data["@path"] : "/Subjects/" + id;
+  let path = subject?.data?.["@path"] || "/Subjects/" + id;
   let action = <DeleteButton
                  entryPath={path}
                  entryName={title}
@@ -328,14 +328,14 @@ function SubjectHeader(props) {
                  buttonClass={classes.subjectHeaderButton}
                  size={"large"}
                />
-  let parentDetails = subject?.data && subject.data['parents'] && getHierarchy(subject.data['parents']);
+  let parentDetails = subject?.data?.['parents'] && getHierarchy(subject.data['parents']);
 
   return (
     subject?.data && <Grid item className={classes.subjectHeader}>
       {parentDetails && <Typography variant="overline">{parentDetails}</Typography>}
       <Typography variant="h2">{title}{action}</Typography>
       {
-        subject?.data && subject.data['jcr:createdBy'] && subject.data['jcr:created'] ?
+        subject?.data?.['jcr:created'] ?
         <Typography
           variant="overline"
           className={classes.subjectSubHeader}>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -113,8 +113,6 @@ function Subject(props) {
   const location = useLocation();
 
   useEffect(() => {
-    console.log("Subject useEffect");
-    console.log(location);
     let newId = getSubjectIdFromPath(location.pathname);
     newId && setCurrentSubjectId(newId);
   }, [location]);
@@ -205,8 +203,6 @@ function SubjectContainer(props) {
 
   // Fetch this Subject's data
   useEffect(() => {
-    console.log("SubjectContainer useEffect");
-    console.log(subject);
     if (subject) {
       fetchRelated();
     } else {
@@ -292,22 +288,8 @@ function SubjectHeader(props) {
     setSubject({});  // Prevent an infinite loop if data was not set
   };
 
-  // // Fetch children
-  // let fetchRelated = () => {
-  //   let checkRelated_url = createQueryURL(` WHERE n.'parents'='${subject.data.['jcr:uuid']}' order by n.'jcr:created'`, "lfs:Subject");
-  //   fetchWithReLogin(globalLoginDisplay, checkRelated_url)
-  //   .then((response) => response.ok ? response.json() : Promise.reject(response))
-  //   .then((json) => {
-  //     subject.data.formGroups = json.rows;
-  //     setSubject(subject)
-  //   })
-  //   .catch(handleError);
-  // }
-
   // Fetch this Subject's data
   useEffect(() => {
-    console.log("SubjectHeader useEffect");
-    console.log(id);
     fetchSubjectData();
   }, [id]);
 
@@ -413,8 +395,6 @@ function SubjectMemberInternal (props) {
 
   // Fetch table data for all forms related to a Subject
   useEffect(() => {
-    console.log("SubjectMemberInternal useEffect");
-    console.log(data);
     fetchTableData();
   }, [data]);
 
@@ -576,8 +556,6 @@ function FormData(props) {
 
   // Fetch this Form's data
   useEffect(() => {
-    console.log("FormData useEffect");
-    console.log(formID);
     getFormData(formID);
   }, [formID]);
 
@@ -601,7 +579,7 @@ function FormData(props) {
     if (result && displayed < maxDisplayed) {
       displayed++;
     } else {
-      result = <></>;
+      result = null;
     }
     return result;
   }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -582,7 +582,7 @@ function FormData(props) {
   }
   // Handle questions and sections differently
   let handleDisplayQuestion = (entryDefinition, data, key) => {
-    let result = displayQuestion(entryDefinition, data, key);
+    let result = displayQuestion(entryDefinition, data, key, classes);
     if (result && displayed < maxDisplayed) {
       displayed++;
     } else {
@@ -606,7 +606,7 @@ function FormData(props) {
 }
 
 // Display the questions/question found within sections
-export function displayQuestion(entryDefinition, data, key) {
+export function displayQuestion(entryDefinition, data, key, classes) {
   const existingQuestionAnswer = data && Object.entries(data)
     .find(([key, value]) => value["sling:resourceSuperType"] == "lfs/Answer"
       && value["question"]["jcr:uuid"] === entryDefinition["jcr:uuid"]);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -294,21 +294,17 @@ function SubjectHeader(props) {
   }, [id]);
 
   if (!subject?.data) {
-    // TODO: Remove grid container and move center into parent grid when required
     return (
-      <Grid container justify="center"><Grid item><CircularProgress/></Grid></Grid>
+      <Grid item><CircularProgress/></Grid>
     );
   }
 
   if (error) {
     return (
-    // TODO: Remove grid container and move center into parent grid when required
-      <Grid container justify="center">
-        <Grid item>
-          <Typography variant="h2" color="error">
-            Error obtaining subject data: {error.status} {error.statusText ? error.statusText : error.toString()}
-          </Typography>
-        </Grid>
+      <Grid item>
+        <Typography variant="h2" color="error">
+          Error obtaining subject data: {error.status} {error.statusText ? error.statusText : error.toString()}
+        </Typography>
       </Grid>
     );
   }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
@@ -80,13 +80,17 @@ function DateAnswerDisplay(classes, questionData, index, length, rootLevel) {
 }
 
 function CustomTimelineConnector(props) {
-  let { classes, text } = props;
-  return <React.Fragment>
-      <div className={classes.circle}>
+  let { classes, text, className} = props;
+  let divClasses = [classes.timelineConnectorGroup];
+  if (className) {
+    divClasses.push(className);
+  }
+  return <div className={divClasses.join(",")}>
+      <div className={classes.timelineCircle}>
         <Typography variant="body2">{text}</Typography>
       </div>
-      <TimelineConnector />
-    </React.Fragment>
+      <TimelineConnector className={classes.timelineConnectorLine}/>
+    </div>
 }
 
 function TimelineEntry(classes, dateEntry, index, length, nextEntry) {
@@ -98,18 +102,34 @@ function TimelineEntry(classes, dateEntry, index, length, nextEntry) {
     paperClasses.push(classes.timelineAncestor);
   }
 
+  let separatorClasses = [classes.timelineSeparator];
+  let connectorIsAncestor = false;
+  if (dateEntry.level < 0) {
+    // Grey out connector + dot
+    separatorClasses.push(classes.timelineAncestor);
+  } else if (nextEntry && nextEntry.level < 0) {
+    // Only grey out connector
+    connectorIsAncestor = true;
+  }
+
   return <TimelineItem key={index}>
-      <TimelineOppositeContent>
-        <Typography color="textSecondary">{dateText}</Typography>
+      <TimelineOppositeContent className={classes.timelineContent}>
+        <Typography color="textSecondary" className={classes.timelineDate}>{dateText}</Typography>
       </TimelineOppositeContent>
-      <TimelineSeparator className={dateEntry.level < 0 ? classes.timelineAncestor : null}>
+      <TimelineSeparator className={separatorClasses.join(",")}>
         <TimelineDot color={dateEntry.level == 0 ? "primary" : (dateEntry.level == 1 ? "secondary" : "grey")}/>
         {index !== (length - 1)
-          ? (diff ? <CustomTimelineConnector classes={classes} text={diff}/> : <TimelineConnector />)
+          ? (
+            diff
+            ? <CustomTimelineConnector
+              classes={classes}
+              text={diff}
+              className={connectorIsAncestor ? classes.timelineAncestor : null}/>
+            : <TimelineConnector className={classes.timelineConnectorLine}/>)
           : null
         }
       </TimelineSeparator>
-      <TimelineContent>
+      <TimelineContent className={classes.timelineContent}>
         <Paper elevation={3} className={paperClasses.join(",")}>
           {dateEntry.questions.map((question, index) => {
             return DateAnswerDisplay(classes, question, index, dateEntry.questions.length, dateEntry.level)
@@ -289,9 +309,11 @@ function SubjectTimeline(props) {
   }
 
   useEffect(() => {
-    getForms().then(baseForms => getFormData(baseForms))
-    .then(formDetails => getDateAnswers(formDetails))
-    .then(dateAnswers => getDateEntries(dateAnswers));
+    if (subject) {
+      getForms().then(baseForms => getFormData(baseForms))
+      .then(formDetails => getDateAnswers(formDetails))
+      .then(dateAnswers => getDateEntries(dateAnswers));
+    }
   }, [subject]);
 
   // Callback method for the `fetchData` method, invoked when the request failed.

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
@@ -29,7 +29,7 @@ import TimelineContent from '@material-ui/lab/TimelineContent';
 import TimelineDot from '@material-ui/lab/TimelineDot';
 import TimelineOppositeContent from '@material-ui/lab/TimelineOppositeContent';
 
-import { formatDateAnswer } from "./DateQuestion.jsx";
+import { formatDateAnswer } from "./DateQuestionUtilities.jsx";
 import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
 import QuestionnaireStyle from "./QuestionnaireStyle.jsx";
 import { displayQuestion, handleDisplay, ENTRY_TYPES } from "./Subject.jsx";
@@ -190,7 +190,8 @@ function SubjectTimeline(props) {
 
 function DateTimelineEntry(classes, data, index, length, nextDateAnswer) {
   let dateAnswer = data.date;
-  let dateText = formatDateAnswer(dateAnswer.question?.dateFormat, dateAnswer.value);
+  // let dateText = formatDateAnswer(dateAnswer.question?.dateFormat, dateAnswer.value);
+  let dateText = dateAnswer.value;
   let questionTitle = dateAnswer.question?.text;
 
   // Strip unwanted strings from the question title

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
@@ -348,14 +348,14 @@ function SubjectTimeline(props) {
     return <CircularProgress/>
   }
 
-  return <Timeline align="alternate">
+  return <div className={classes.timelineContainer}><Timeline align="alternate" className={classes.timeline}>
     {
       dateEntries && dateEntries.map((dateEntry, index) => {
         let nextEntry = (index + 1 < dateEntries.length) ? dateEntries[index + 1] : null;
         return TimelineEntry(classes, dateEntry, index, dateEntries.length, nextEntry);
       })
     }
-  </Timeline>;
+  </Timeline></div>;
 }
 
 SubjectTimeline.propTypes = {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
@@ -22,7 +22,8 @@ import PropTypes from "prop-types";
 import {
   CircularProgress,
   Link,
-  Paper
+  Paper,
+  Tooltip
 } from '@material-ui/core'
 import Timeline from '@material-ui/lab/Timeline';
 import TimelineItem from '@material-ui/lab/TimelineItem';
@@ -80,7 +81,7 @@ function DateAnswerDisplay(classes, questionData, index, length, rootLevel) {
 }
 
 function CustomTimelineConnector(props) {
-  let { classes, text, className} = props;
+  let { classes, shortText, longText, className} = props;
 
   let divClasses = [classes.timelineConnectorGroup];
   if (className) {
@@ -88,9 +89,11 @@ function CustomTimelineConnector(props) {
   }
 
   return <div className={divClasses.join(",")}>
-      <div className={classes.timelineCircle}>
-        <Typography variant="body2">{text}</Typography>
-      </div>
+      <Tooltip title={longText}>
+        <div className={classes.timelineCircle}>
+          <Typography variant="body2">{shortText}</Typography>
+        </div>
+      </Tooltip>
       <TimelineConnector className={classes.timelineConnectorLine}/>
     </div>
 }
@@ -122,10 +125,11 @@ function TimelineEntry(classes, dateEntry, index, length, nextEntry) {
         <TimelineDot color={dateEntry.level == 0 ? "primary" : (dateEntry.level == 1 ? "secondary" : "grey")}/>
         {index !== (length - 1)
           ? (
-            diff
+            diff.short
             ? <CustomTimelineConnector
               classes={classes}
-              text={diff}
+              shortText={diff.short}
+              longText={diff.long}
               className={connectorIsAncestor ? classes.timelineAncestor : null}/>
             : <TimelineConnector className={classes.timelineConnectorLine}/>)
           : null
@@ -310,7 +314,7 @@ function SubjectTimeline(props) {
 
     for (const dateAnswer of dateAnswers) {
       let diff = DateQuestionUtilities.dateDifference(previousDate, dateAnswer.date.value);
-      if (newDateEntries.length === 0 || diff) {
+      if (newDateEntries.length === 0 || diff.short) {
         // Create a new paper
         newDateEntries.push({
           date: dateAnswer.date.value,

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
@@ -253,7 +253,7 @@ function SubjectTimeline(props) {
       ) {
         // Append the non-date answer to the previous date answer,
         // if a previous date answer exists and hasn't met the followup question limit.
-        output[output.length - 1].followup.push(displayQuestion(questionDefinition, formData, key));
+        output[output.length - 1].followup.push(displayQuestion(questionDefinition, formData, key, classes));
       }
     }
   }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
@@ -150,7 +150,7 @@ function TimelineEntry(classes, dateEntry, index, length, nextEntry) {
  * @param {string} id the identifier of a subject; this is the JCR node name
  */
 function SubjectTimeline(props) {
-  let { id, classes, pageSize, subject } = props;
+  let { id, classes, subject } = props;
   let [dateEntries, setDateEntries] = useState(null);
   // Error message set when fetching the data from the server fails
   let [ error, setError ] = useState();
@@ -364,7 +364,6 @@ SubjectTimeline.propTypes = {
 
 SubjectTimeline.defaultProps = {
   maxDisplayed: 4,
-  pageSize: 10,
 }
 
 export default withStyles(QuestionnaireStyle)(SubjectTimeline);


### PR DESCRIPTION
- [x] Finish code commenting and clean up
- [x] Leveled timeline cards (greyed out for parents, colored dots for children) (LFS-911)
- [x] Move date difference calculation into DateQuestionUtilities, or another utility
- [x] Subject path being prepended to questionniare titles
- [x] "Entered on" dates should be removed
- [x] Bug/regression: the parent link at the top of a child subject chart or timeline is not working (the URL changes correctly, but the page content isn't rerendered)
- [x] The labels of the 2 tabs should be "Chart" (not "PatientChart") and "Timeline"
- [x] Refactoring: the timeline component should be renamed to SubjectTimeline, since it can be applied to any subject, not just to patients
- [x] Time span
- [x] All events occurring on the same date should be in the same bubble