### PR TITLE
LFS-878: Make nolfs the default runmode, to be active unless lfs runmode is specified

### DIFF
--- a/distribution/src/main/provisioning/01-boot.txt
+++ b/distribution/src/main/provisioning/01-boot.txt
@@ -40,7 +40,7 @@
     # permissions_trusted requires that after self-registration, users must be manually added to the TrustedUsers group by an administrator before they can access data.
     # permissions_ownership enforces data ownership and explicit data sharing
 
-    sling.run.mode.install.options=oak_tar,oak_mongo|forms,noforms|lfs,nolfs|nocardiac,cardiac|nocardiac_rehab,cardiac_rehab|permissions_open,permissions_trusted,permissions_ownership
+    sling.run.mode.install.options=oak_tar,oak_mongo|forms,noforms|nolfs,lfs|nocardiac,cardiac|nocardiac_rehab,cardiac_rehab|permissions_open,permissions_trusted,permissions_ownership
 
     repository.home=${sling.home}/repository
     localIndexDir=${sling.home}/repository/index


### PR DESCRIPTION
The following _runmode_ specifications should result in the following modes of operation:

- _No runmode specified_: Generic Cards
- `lfs`: Cards4lfs datacore
- `cardiac`: Cards4kids
- `cardiac_rehab`: Cards4Care