### PR TITLE
LFS-918: An API endpoint should be available that when called as admin will cause saved data to be pushed to S3

### DIFF
--- a/cardiac-rehab-resources/backend/pom.xml
+++ b/cardiac-rehab-resources/backend/pom.xml
@@ -86,6 +86,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.servlets.annotations</artifactId>
+      <version>1.2.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.commons.scheduler</artifactId>
       <version>2.7.2</version>
     </dependency>

--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/ExportEndpoint.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/ExportEndpoint.java
@@ -54,7 +54,7 @@ public class ExportEndpoint extends SlingSafeMethodsServlet
             return;
         }
 
-        final Runnable exportJob = new ExportTask(this.resolverFactory, "manual");
+        final Runnable exportJob = new ExportTask(this.resolverFactory, "manualToday");
         final Thread thread = new Thread(exportJob);
         thread.start();
         out.write("S3 export started");

--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/ExportEndpoint.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/ExportEndpoint.java
@@ -54,7 +54,7 @@ public class ExportEndpoint extends SlingSafeMethodsServlet
             return;
         }
 
-        final Runnable exportJob = new NightlyExportTask(this.resolverFactory);
+        final Runnable exportJob = new ExportTask(this.resolverFactory);
         final Thread thread = new Thread(exportJob);
         thread.start();
         out.write("S3 export started");

--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/ExportEndpoint.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/ExportEndpoint.java
@@ -54,7 +54,7 @@ public class ExportEndpoint extends SlingSafeMethodsServlet
             return;
         }
 
-        final Runnable exportJob = new ExportTask(this.resolverFactory);
+        final Runnable exportJob = new ExportTask(this.resolverFactory, "manual");
         final Thread thread = new Thread(exportJob);
         thread.start();
         out.write("S3 export started");

--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/ExportEndpoint.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/ExportEndpoint.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package ca.sickkids.ccm.lfs.cardiacrehab.internal.export;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import javax.servlet.Servlet;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(service = { Servlet.class })
+@SlingServletResourceTypes(
+    resourceTypes = { "lfs/FormsHomepage" },
+    selectors = { "export" })
+public class ExportEndpoint extends SlingSafeMethodsServlet
+{
+    @Reference
+    private ResourceResolverFactory resolverFactory;
+
+    @Override
+    public void doGet(final SlingHttpServletRequest request, final SlingHttpServletResponse response) throws IOException
+    {
+        //TODO: Ensure that this can only be run when logged in as admin
+        final Runnable exportJob = new NightlyExportTask(this.resolverFactory);
+        final Thread thread = new Thread(exportJob);
+        thread.start();
+        final Writer out = response.getWriter();
+        out.write("Sucessfully called the ExportEndpoint");
+    }
+}

--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/ExportTask.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/ExportTask.java
@@ -51,14 +51,23 @@ public class ExportTask implements Runnable
 
     /** Provides access to resources. */
     private final ResourceResolverFactory resolverFactory;
+    private final String exportRunMode;
 
-    ExportTask(final ResourceResolverFactory resolverFactory)
+    ExportTask(final ResourceResolverFactory resolverFactory, final String exportRunMode)
     {
         this.resolverFactory = resolverFactory;
+        this.exportRunMode = exportRunMode;
     }
 
     @Override
     public void run()
+    {
+        if ("nightly".equals(this.exportRunMode)) {
+            doNightlyExport();
+        }
+    }
+
+    public void doNightlyExport()
     {
         LOGGER.info("Executing NightlyExport");
         LocalDate today = LocalDate.now();

--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/ExportTask.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/ExportTask.java
@@ -52,11 +52,24 @@ public class ExportTask implements Runnable
     /** Provides access to resources. */
     private final ResourceResolverFactory resolverFactory;
     private final String exportRunMode;
+    private final LocalDate exportLowerBound;
+    private final LocalDate exportUpperBound;
 
     ExportTask(final ResourceResolverFactory resolverFactory, final String exportRunMode)
     {
         this.resolverFactory = resolverFactory;
         this.exportRunMode = exportRunMode;
+        this.exportLowerBound = null;
+        this.exportUpperBound = null;
+    }
+
+    ExportTask(final ResourceResolverFactory resolverFactory, final String exportRunMode,
+        final LocalDate exportLowerBound, final LocalDate exportUpperBound)
+    {
+        this.resolverFactory = resolverFactory;
+        this.exportRunMode = exportRunMode;
+        this.exportLowerBound = exportLowerBound;
+        this.exportUpperBound = exportUpperBound;
     }
 
     @Override
@@ -64,6 +77,37 @@ public class ExportTask implements Runnable
     {
         if ("nightly".equals(this.exportRunMode) || "manualToday".equals(this.exportRunMode)) {
             doNightlyExport();
+        } else if ("manualAfter".equals(this.exportRunMode)) {
+            doManualExport(this.exportLowerBound, null);
+        } else if ("manualBetween".equals(this.exportRunMode)) {
+            doManualExport(this.exportLowerBound, this.exportUpperBound);
+        }
+    }
+
+    public void doManualExport(LocalDate lower, LocalDate upper)
+    {
+        LOGGER.info("Executing ManualExport");
+        String fileDateString = lower.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String requestDateStringLower = lower.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        String requestDateStringUpper = (upper != null)
+            ? upper.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+            : null;
+
+        Set<SubjectIdentifier> changedSubjects = (upper != null)
+            ? this.getChangedSubjectsBounded(requestDateStringLower, requestDateStringUpper)
+            : this.getChangedSubjects(requestDateStringLower);
+
+        for (SubjectIdentifier identifier : changedSubjects) {
+            SubjectContents subjectContents = (upper != null)
+                ? getSubjectContentsBounded(identifier.getPath(), requestDateStringLower, requestDateStringUpper)
+                : getSubjectContents(identifier.getPath(), requestDateStringLower);
+            if (subjectContents != null) {
+                String filename = String.format(
+                    "%s_formData_%s.json",
+                    cleanString(identifier.getParticipantId()),
+                    fileDateString);
+                this.output(subjectContents, filename);
+            }
         }
     }
 
@@ -190,10 +234,53 @@ public class ExportTask implements Runnable
         return Collections.emptySet();
     }
 
+    private Set<SubjectIdentifier> getChangedSubjectsBounded(String requestDateStringLower,
+        String requestDateStringUpper)
+    {
+        try (ResourceResolver resolver = this.resolverFactory.getServiceResourceResolver(null)) {
+            Set<SubjectIdentifier> subjects = new HashSet<>();
+            String query = String.format(
+                "SELECT subject.* FROM [lfs:Form] AS form INNER JOIN [lfs:Subject] AS subject"
+                    + " ON form.'subject'=subject.[jcr:uuid]"
+                    + " WHERE form.[jcr:lastModified] >= '%s'"
+                    + " AND form.[jcr:lastModified] < '%s'"
+                    + " AND NOT CONTAINS(form.[statusFlags], 'INCOMPLETE')",
+                requestDateStringLower, requestDateStringUpper
+            );
+
+            Iterator<Resource> results = resolver.findResources(query, "JCR-SQL2");
+            while (results.hasNext()) {
+                Resource subject = results.next();
+                String path = subject.getPath();
+                String participantId = subject.getValueMap().get("identifier", String.class);
+                subjects.add(new SubjectIdentifier(path, participantId));
+            }
+            return subjects;
+        } catch (LoginException e) {
+            LOGGER.warn("Failed to get service session: {}", e.getMessage(), e);
+        }
+        return Collections.emptySet();
+    }
+
     private SubjectContents getSubjectContents(String path, String requestDateString)
     {
         String subjectDataUrl = String.format("%s.data.deep.bare.-labels.-identify.relativeDates"
             + ".dataFilter:modifiedAfter=%s.dataFilter:statusNot=INCOMPLETE", path, requestDateString);
+        try (ResourceResolver resolver = this.resolverFactory.getServiceResourceResolver(null)) {
+            Resource subjectData = resolver.resolve(subjectDataUrl);
+            return new SubjectContents(subjectData.adaptTo(JsonObject.class).toString(), subjectDataUrl);
+        } catch (LoginException e) {
+            LOGGER.warn("Failed to get service session: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
+    private SubjectContents getSubjectContentsBounded(String path, String requestDateStringLower,
+        String requestDateStringUpper)
+    {
+        String subjectDataUrl = String.format("%s.data.deep.bare.-labels.-identify.relativeDates"
+            + ".dataFilter:modifiedAfter=%s.dataFilter:modifiedBefore=%s.dataFilter:statusNot=INCOMPLETE",
+            path, requestDateStringLower, requestDateStringUpper);
         try (ResourceResolver resolver = this.resolverFactory.getServiceResourceResolver(null)) {
             Resource subjectData = resolver.resolve(subjectDataUrl);
             return new SubjectContents(subjectData.adaptTo(JsonObject.class).toString(), subjectDataUrl);

--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/ExportTask.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/ExportTask.java
@@ -62,7 +62,7 @@ public class ExportTask implements Runnable
     @Override
     public void run()
     {
-        if ("nightly".equals(this.exportRunMode)) {
+        if ("nightly".equals(this.exportRunMode) || "manualToday".equals(this.exportRunMode)) {
             doNightlyExport();
         }
     }

--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/ExportTask.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/ExportTask.java
@@ -44,15 +44,15 @@ import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
-public class NightlyExportTask implements Runnable
+public class ExportTask implements Runnable
 {
     /** Default log. */
-    private static final Logger LOGGER = LoggerFactory.getLogger(NightlyExportTask.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExportTask.class);
 
     /** Provides access to resources. */
     private final ResourceResolverFactory resolverFactory;
 
-    NightlyExportTask(final ResourceResolverFactory resolverFactory)
+    ExportTask(final ResourceResolverFactory resolverFactory)
     {
         this.resolverFactory = resolverFactory;
     }

--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/NightlyExport.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/NightlyExport.java
@@ -52,7 +52,7 @@ public class NightlyExport
         options.name("NightlyExport");
         options.canRunConcurrently(true);
 
-        final Runnable exportJob = new ExportTask(this.resolverFactory);
+        final Runnable exportJob = new ExportTask(this.resolverFactory, "nightly");
 
         try {
             this.scheduler.schedule(exportJob, options);

--- a/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/NightlyExport.java
+++ b/cardiac-rehab-resources/backend/src/main/java/ca/sickkids/ccm/lfs/cardiacrehab/internal/export/NightlyExport.java
@@ -52,7 +52,7 @@ public class NightlyExport
         options.name("NightlyExport");
         options.canRunConcurrently(true);
 
-        final Runnable exportJob = new NightlyExportTask(this.resolverFactory);
+        final Runnable exportJob = new ExportTask(this.resolverFactory);
 
         try {
             this.scheduler.schedule(exportJob, options);


### PR DESCRIPTION
This branch (`LFS-918`) currently cannot be automatically merged into `dev` and therefore rebasing and manually resolving merge conflicts will need to be done. In the meantime, any feedback would be greatly appreciated.

This Pull Request adds the following features:

- Calling `/Subjects.s3push` will cause all Forms that have been created anytime after 00:00:00 today to be pushed to S3
- Calling `/Subjects.s3push?dateLowerBound=yyyy-MM-dd` (eg. `/Subjects.s3push?dateLowerBound=2021-01-01`) will cause any Forms created after or on `yyyy-MM-dd` (eg. `2021-01-01`) to be pushed to S3
- Calling `/Subjects.s3push?dateLowerBound=yyyy-MM-dd&dateUpperBound=yyyy-MM-dd` will cause any Forms created after or on `dateLowerBound` but before `dateUpperBound` to be pushed to S3

**TO DO - Refactoring:**
- [x] Rename `NightlyExportTask` to `ExportTask`
- [x] Pass a `runmode` argument to the `ExportTask` constructor
- [x] Rename `run()` to `doNightlyExport()`
- [x] Create a new `doManualExport()` method that reads start and end dates and performs the S3 push accordingly
- [x] Create a new `run()` method
- [x] When `run()` is called, read this `runmode` argument and route to the appropriate export method

Testing instructions
---------------------------

 - Create a local virtual machine
 - `docker pull minio/minio`
 - `docker run -p 9000:9000 minio/minio server /data`
 - Login to `http://localhost:9000` as `minioadmin`:`minioadmin` and create a `uhn` bucket
 - Set the date of the local VM to **now - 5 days**
 - Build this `LFS-918` branch
 - Set the following environment variables:
   - `export S3_ENDPOINT_URL="http://localhost:9000"`
   - `export S3_ENDPOINT_REGION="us-west-1"`
   - `export S3_BUCKET_NAME="uhn"`
   - `export AWS_KEY="minioadmin"`
   - `export AWS_SECRET="minioadmin"`
   - `export REFERENCE_DATE="2021-01-01"`
   - `export NIGHTLY_EXPORT_SCHEDULE="30 * * * * ?"`
 - Start Cards in the  `cardiac_rehab` runmode

 - Create a new completed Form of ActiGraph data for SubjectA
 - Set the VM date to **now - 4 days**

 - Create a new completed Form of ActiGraph data for SubjectB
 - Set the VM date to **now - 3 days**

 - Create a new completed Form of ActiGraph data for SubjectC
 - Set the VM date to **now - 2 days**

 - Create a new completed Form of ActiGraph data for SubjectD

 - Set the VM date to **now - 1 day**
 - Create a new completed Form of ActiGraph data for SubjectE

 - Set the VM date to **now**
 - Create a new completed Form of ActiGraph data for SubjectF

![multi-day-actigraph](https://user-images.githubusercontent.com/5349728/109369789-d082d100-786b-11eb-82d9-07d5d4a01210.png)


- Delete everything in the `uhn` S3 minIO bucket
- Wait for at least 30 seconds
- Reload the S3 bucket
- Only `SubjectF_formData_...json` should be present

- Within a time period that does not cross the 30th second of any given minute:
    - Empty the `uhn` S3 bucket
    - Visit `http://localhost:8080/Subjects.s3push`
    - Refresh the `uhn` S3 bucket
    - Only `SubjectF_formData_...json` should be present

- Visit `http://localhost:8080/Subjects.s3push?dateLowerBound=yyyy-MM-dd` where `yyyy-MM-dd` is two days ago from today
 - Refresh the S3 bucket
 - SubjectD, SubjectE, and SubjectF should be exported

- Visit `http://localhost:8080/Subjects.s3push?dateLowerBound=aaaa-bb-cc&dateUpperBound=xxxx-yy-zz` where `aaaa-bb-cc` is the date from 5 days ago and `xxxx-yy-zz` is the date from 2 days ago
  - eg. If today is 2021-02-26 use `http://localhost:8080/Subjects.s3push?dateLowerBound=2021-02-21&dateUpperBound=2021-02-24` 
- SubjectA, SubjectB, and SubjectC should be exported to S3.