### PR TITLE
LFS-943: Installing ORDO fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ To specify a different URL, use `-Dsling.url=https://lfs.server:8443/system/cons
 
 `java -jar distribution/target/lfs-*.jar -Dsling.run.modes=dev` to include the content browser (Composum), accessible at `http://localhost:8080/bin/browser.html`
 
+Installing larger vocabuleries may fail due to default limits imposed on XML documents by the JVM. In this case, the app should be started with an extra parameter:
+
+`java -Djdk.xml.entityExpansionLimit=0 -jar distribution/target/lfs-*.jar`
+
 By default, the app will run with username `admin` and password `admin`.
 
 In order to use "Vocabularies" section and load vocabularies from BioPortal (bioontology.org) `BIOPORTAL_APIKEY` environment variable should be set to a valid BioPortal API key. You can [request a new account](https://bioportal.bioontology.org/accounts/new) if you don't already have one, and the API key can be found [in your profile](https://bioportal.bioontology.org/account).

--- a/distribution/docker_entry.sh
+++ b/distribution/docker_entry.sh
@@ -92,4 +92,4 @@ fi
 #Execute the volume_mounted_init.sh script if it is present
 [ -e /volume_mounted_init.sh ] && /volume_mounted_init.sh
 
-java ${SLING_RUN_MODES_CUSTOM:+-Dsling.run.modes=}$SLING_RUN_MODES_LIST ${DEBUG:+ -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005} -jar ${PROJECT_ARTIFACTID}-${PROJECT_VERSION}.jar
+java -Djdk.xml.entityExpansionLimit=0 ${SLING_RUN_MODES_CUSTOM:+-Dsling.run.modes=}$SLING_RUN_MODES_LIST ${DEBUG:+ -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005} -jar ${PROJECT_ARTIFACTID}-${PROJECT_VERSION}.jar


### PR DESCRIPTION
For standalone testing, you must explicitly add a new parameter to the command line, and it must be the first parameter:
`java -Djdk.xml.entityExpansionLimit=0 -jar distribution/target/lfs-*.jar`  (optional -p PORT and runmodes can be added here).

Hm, this is suboptimal, should we instead add a run script?