### PR TITLE
LFS-928: Use the (+) button component (NewItemButton) for creating a new question or section in the Questionnaire Wizard

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
@@ -144,6 +144,7 @@ let Questionnaire = (props) => {
       { data &&
         <Grid item>
           <CreationMenu
+            isMainAction={true}
             data={data}
             onClose={() => { reloadData(); }}
           />

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/CreationMenu.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/CreationMenu.jsx
@@ -62,7 +62,6 @@ let CreationMenu = (props) => {
           id={"simple-menu" + data['@name']}
           anchorEl={anchorEl}
           keepMounted
-          placement={isMainAction ? "top-end" : "bottom-end"}
           open={Boolean(anchorEl)}
           onClose={handleCloseMenu}
       >

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/CreationMenu.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/CreationMenu.jsx
@@ -26,11 +26,12 @@ import {
 } from "@material-ui/core";
 
 import EditDialog from "./EditDialog";
+import NewItemButton from "../components/NewItemButton";
 
 // Menu for creating questions or sections
 
 let CreationMenu = (props) => {
-  const { data, onClose } = props;
+  const { isMainAction, data, onClose } = props;
   let [ anchorEl, setAnchorEl ] = useState(null);
   let [ entityType, setEntityType ] = useState('Question');
   let [ dialogOpen, setDialogOpen ] = useState(false);
@@ -50,13 +51,18 @@ let CreationMenu = (props) => {
 
   return (
     <>
+      { isMainAction ?
+      <NewItemButton title="Add..." onClick={handleOpenMenu} />
+      :
       <Button aria-controls={"simple-menu" + data['@name']} aria-haspopup="true" onClick={handleOpenMenu}>
         Add...
       </Button>
+      }
       <Menu
           id={"simple-menu" + data['@name']}
           anchorEl={anchorEl}
           keepMounted
+          placement={isMainAction ? "top-end" : "bottom-end"}
           open={Boolean(anchorEl)}
           onClose={handleCloseMenu}
       >
@@ -77,8 +83,13 @@ let CreationMenu = (props) => {
 }
 
 CreationMenu.propTypes = {
+  isMainAction: PropTypes.bool,
   data: PropTypes.object.isRequired,
   onClose: PropTypes.func
 };
+
+CreationMenu.defaultProps = {
+  isMainAction: false,
+}
 
 export default CreationMenu;


### PR DESCRIPTION
Known issue, not introduced in this PR: the avatar "jumps" to the left when the popup menu is displayed. Should be fixed once we pin the navbar to the top of the screen in 921.

![captured (18)](https://user-images.githubusercontent.com/651980/109067463-90312080-76bc-11eb-9ad1-c4dde6a750cf.gif)

