### PR TITLE
LFS-939: Add the ability to specify "compact" display for questions with predefined options - all options on one line

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -352,6 +352,7 @@ function MultipleChoice(props) {
           className={classes.selectionList}
           value={selection.length > 0 && selection[0][VALUE_POS]}
         >
+          <List>
           {generateDefaultOptions(options, selection, disabled, isRadio, selectNonGhostOption, removeOption)}
           {/* Ghost radio for the text input */}
           {
@@ -378,6 +379,7 @@ function MultipleChoice(props) {
             />
           </ListItem>
           }
+          </List>
         </RadioGroup>
         {ghostInput}
         {warning}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -264,7 +264,7 @@ function MultipleChoice(props) {
   // Hold the input box for either multiple choice type
   let ghostInput = (input || textbox) && (<div className={isBare ? classes.bareAnswer : classes.searchWrapper}>
       <TextField
-        helperText={maxAnswers !== 1 && "Press ENTER to add a new line"}
+        helperText={maxAnswers !== 1 && "Press ENTER to add a new option"}
         className={classes.textField + (maxAnswers === 1 && (!defaults || defaults.length == 0) ? (' ' + classes.answerField) : '')}
         onChange={(event) => {
           setGhostName(event.target.value);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -352,7 +352,7 @@ function MultipleChoice(props) {
           className={classes.selectionList}
           value={selection.length > 0 && selection[0][VALUE_POS]}
         >
-          <List>
+          <List className={classes.optionsList}>
           {generateDefaultOptions(options, selection, disabled, isRadio, selectNonGhostOption, removeOption)}
           {/* Ghost radio for the text input */}
           {
@@ -394,7 +394,7 @@ function MultipleChoice(props) {
   } else {
     return (
       <React.Fragment>
-        <List className={classes.checkboxList}>
+        <List className={classes.optionsList}>
           {generateDefaultOptions(options, selection, disabled, isRadio, selectNonGhostOption, removeOption)}
         </List>
         {ghostInput}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Question.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Question.jsx
@@ -27,7 +27,7 @@ import QuestionnaireStyle from "./QuestionnaireStyle";
 // GUI for displaying answers
 function Question (props) {
   let { classes, children, questionDefinition, existingAnswer, isEdit, preventDefaultView, defaultDisplayFormatter } = props;
-  let { text, description } = { ...questionDefinition, ...props }
+  let { text, compact, description } = { ...questionDefinition, ...props }
 
   return (
     <Card>
@@ -37,7 +37,7 @@ function Question (props) {
         subheader={description}
         className={classes.questionHeader}
         />
-      <CardContent>
+      <CardContent className={compact ? classes.compactLayout : null}>
         { !isEdit && !preventDefaultView && existingAnswer ?
           <List>
             { Array.of(existingAnswer?.[1]["displayedValue"]).flat().map( (item, idx) => {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -190,18 +190,26 @@ const questionnaireStyle = theme => ({
     },
     compactLayout : {
       "& .MuiFormGroup-root" : {
-        flexDirection: "row",
+        [theme.breakpoints.up('sm')]: {
+          flexDirection: "row",
+        }
       },
       "& .MuiListItem-root" : {
-        display: "inline-flex",
-        width: "auto",
+        [theme.breakpoints.up('sm')]: {
+          display: "inline-flex",
+          width: "auto",
+        },
       },
       "& .MuiList-root" : {
-        display: "inline-block",
+        [theme.breakpoints.up('sm')]: {
+          display: "inline-block",
+        },
       },
       "& .MuiList-root + div > .MuiFormControl-root" : {
-        minWidth: "100px",
-        marginTop: "-10px",
+        [theme.breakpoints.up('sm')]: {
+          minWidth: "100px",
+          marginTop: "-10px",
+        },
       },
     },
     collapsedSection: {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -194,12 +194,6 @@ const questionnaireStyle = theme => ({
           flexDirection: "row",
         }
       },
-      "& .MuiListItem-root" : {
-        [theme.breakpoints.up('sm')]: {
-          display: "inline-flex",
-          width: "auto",
-        },
-      },
       "& .MuiList-root" : {
         [theme.breakpoints.up('sm')]: {
           display: "inline-block",
@@ -209,6 +203,12 @@ const questionnaireStyle = theme => ({
         [theme.breakpoints.up('sm')]: {
           minWidth: "100px",
           marginTop: "-10px",
+        },
+      },
+      "& .MuiListItem-root" : {
+        [theme.breakpoints.up('sm')]: {
+          display: "inline-flex",
+          width: "auto",
         },
       },
     },

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -189,11 +189,6 @@ const questionnaireStyle = theme => ({
         }
     },
     compactLayout : {
-      "& .MuiFormGroup-root" : {
-        [theme.breakpoints.up('sm')]: {
-          flexDirection: "row",
-        }
-      },
       "& .MuiList-root" : {
         [theme.breakpoints.up('sm')]: {
           display: "inline-block",

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -69,7 +69,7 @@ const questionnaireStyle = theme => ({
             width: "100%",
         }
     },
-    checkboxList: {
+    optionsList: {
         padding: theme.spacing(0),
     },
     deleteButton: {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -188,6 +188,22 @@ const questionnaireStyle = theme => ({
           marginBottom: "0 !important",
         }
     },
+    compactLayout : {
+      "& .MuiFormGroup-root" : {
+        flexDirection: "row",
+      },
+      "& .MuiListItem-root" : {
+        display: "inline-flex",
+        width: "auto",
+      },
+      "& .MuiList-root" : {
+        display: "inline-block",
+      },
+      "& .MuiList-root + div > .MuiFormControl-root" : {
+        minWidth: "100px",
+        marginTop: "-10px",
+      },
+    },
     collapsedSection: {
         padding: "0 !important"
     },

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -7,11 +7,16 @@
       "hidden": {},
       "input": {},
       "textbox": {},
-      "list": {},
-      "list+input" : {}
+      "list": {
+        "compact" : "boolean"
+      },
+      "list+input" : {
+        "compact" : "boolean"
+      }
     },
     "dataType": {
       "boolean": {
+        "compact" : "boolean",
         "minAnswers": {"0":{}, "1":{}},
         "yesLabel": "string",
         "noLabel": "string",

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -182,6 +182,9 @@
   - minValue (double)
   - maxValue (double)
 
+  // For questions that have a list of options, whether the options are displayed on a single line (compact) or one per line (default)
+  - compact (boolean)
+
   // For numeric answers, the measurement unit used for the value (kg, cm, cGy...).
   // This will be displayed as an input end adornment.
   - unitOfMeasurement (string)

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -182,7 +182,7 @@
   - minValue (double)
   - maxValue (double)
 
-  // For questions that have a list of options, whether the options are displayed on a single line (compact) or one per line (default)
+  // For questions that have a list of options, whether all the options are displayed on a single line (compact), or one per line (default)
   - compact (boolean)
 
   // For numeric answers, the measurement unit used for the value (kg, cm, cGy...).


### PR DESCRIPTION
To test, use the questionnaire wizard to set the `compact` property to `true` for any question that has `dataType` : `boolean` or `displayType`: `list` or `list+input`, then create a form for that questionnaire to see how the options are displayed.