### PR TITLE
LFS-980: Answer nodes keep getting added for computed questions

### DIFF
--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -622,6 +622,9 @@
   // Hardcode the resource type.
   - sling:resourceType (STRING) = "lfs/ComputedAnswer" mandatory autocreated protected
 
+  // Hardcode the resource supertype.
+  - sling:resourceSuperType (STRING) = "lfs/Answer" mandatory autocreated protected
+
 //-----------------------------------------------------------------------------
 // File resource answers, whose children are nt:files with the answer
 [lfs:FileResourceAnswer] > lfs:Answer


### PR DESCRIPTION
Also fixes:

LFS-909: Computed questions don't show up in view mode, only in edit mode