### PR TITLE
LFS-997: Replace the deprecated org.apache.sling.starter.startup with Felix HealthCheck

### DIFF
--- a/distribution/src/main/provisioning/40-startup.txt
+++ b/distribution/src/main/provisioning/40-startup.txt
@@ -20,8 +20,10 @@
 [feature name=sling-startup]
 
 # Initial content
-[artifacts startLevel=7]
-    org.apache.sling/org.apache.sling.starter.startup/1.0.6
+[artifacts startLevel=5]
+    org.apache.felix/org.apache.felix.healthcheck.api/2.0.2
+    org.apache.felix/org.apache.felix.healthcheck.core/2.0.6
+    org.apache.felix/org.apache.felix.healthcheck.generalchecks/2.0.4
 
 [configurations]
   # By default, deny self-registration
@@ -40,3 +42,26 @@
       "-/apps", \
       "-/system", \
     ]
+
+  org.apache.felix.hc.generalchecks.ServicesCheck
+    hc.tags=[ \
+      "systemalive", \
+    ]
+    services.list=[ \
+      "org.apache.sling.jcr.api.SlingRepository", \
+      "org.apache.sling.engine.auth.Authenticator", \
+      "org.apache.sling.api.resource.ResourceResolverFactory", \
+      "org.apache.sling.api.servlets.ServletResolver", \
+      "javax.script.ScriptEngineManager", \
+    ]
+
+  org.apache.felix.hc.core.impl.filter.ServiceUnavailableFilter-startupandshutdown
+    tags=[ \
+      "systemalive", \
+    ]
+    service.ranking=I"2147483647"
+    osgi.http.whiteboard.context.select="(osgi.http.whiteboard.context.name\=*)"
+    osgi.http.whiteboard.filter.regex="(?!/system/).*"
+    responseTextFor503="classpath:ca.sickkids.ccm.lfs.startup-customization:custom_index.html"
+    autoDisableFilter=B"true"
+    avoid404DuringStartup=B"true"

--- a/modules/startup-customization/pom.xml
+++ b/modules/startup-customization/pom.xml
@@ -30,27 +30,12 @@
   <packaging>bundle</packaging>
   <name>LFS - Customizations for the startup phase of the distribution package</name>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.sling</groupId>
-      <artifactId>org.apache.sling.starter.startup</artifactId>
-      <version>1.0.6</version>
-      <scope>runtime</scope>
-    </dependency>
-  </dependencies>
-
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <!-- This is a bundle fragment, customizing the upstream Sling startup bundle -->
-            <Fragment-Host>org.apache.sling.starter.startup</Fragment-Host>
-          </instructions>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Replaces the deprecated `org.apache.sling.starter.startup` with Felix HealthCheck so that the loading screen specified by the `startup-customization` module is still used.

There are still bugs however, namely HTTP 404, HTTP 403, and HTTP 503 error pages still occur, however this also occurs on the `dev` branch and therefore can be considered to be out-of-scope for LFS-997. In production deployments, a load balancer / reverse proxy can check if `/system/sling/info.sessionInfo.json` returns HTTP 200, and if not, display a _loading / unavailable_ page.