### PR TITLE
LFS-911: Refactor lfs:Subject and lfs:SubjectType nodes to use a tree structure instead of parent references

### DIFF
--- a/cardiac-rehab-resources/clinical-data/pom.xml
+++ b/cardiac-rehab-resources/clinical-data/pom.xml
@@ -43,7 +43,7 @@
             <Sling-Initial-Content>
               SLING-INF/content/Questionnaires/;path:=/Questionnaires/;overwrite:=true;checkin:=true,
               SLING-INF/content/libs/lfs/resources/;path:=/libs/lfs/resources/;overwrite:=true,
-              SLING-INF/content/libs/lfs/conf/;path:=/libs/lfs/conf/;overwrite:=false,overwriteProperties:=true
+              SLING-INF/content/libs/lfs/conf/;path:=/libs/lfs/conf/;overwrite:=false;overwriteProperties:=true
             </Sling-Initial-Content>
           </instructions>
         </configuration>


### PR DESCRIPTION
Bugfix: cardiac_rehab mode is broken due to invalid Sling-Initial-Content syntax