### PR TITLE
LFS-933: Create a utility program for setting the Sling admin password

### DIFF
--- a/Utilities/Administration/set_admin_password.py
+++ b/Utilities/Administration/set_admin_password.py
@@ -1,4 +1,24 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+"""
 
 import os
 import sys

--- a/Utilities/Administration/set_admin_password.py
+++ b/Utilities/Administration/set_admin_password.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python
+
+import os
+import sys
+import requests
+from requests.auth import HTTPBasicAuth
+
+CARDS_URL = "http://localhost:8080"
+if "CARDS_URL" in os.environ:
+  CARDS_URL = os.environ["CARDS_URL"].rstrip('/')
+
+ADMIN_PASSWORD = "admin"
+if "ADMIN_PASSWORD" in os.environ:
+  ADMIN_PASSWORD = os.environ["ADMIN_PASSWORD"]
+
+new_password = input("New admin password: ")
+form_data = {}
+form_data['newPwd'] = new_password
+form_data['newPwdConfirm'] = new_password
+form_data['oldPwd'] = ADMIN_PASSWORD
+
+change_req = requests.post(CARDS_URL + "/system/userManager/user/admin.changePassword.html", data=form_data, auth=HTTPBasicAuth('admin', ADMIN_PASSWORD))
+if change_req.status_code != 200:
+  print("Error while setting admin password")
+  sys.exit(-1)
+print("Set admin password")


### PR DESCRIPTION
This pull request implements LFS-933 by providing a utility program to set the password of the Sling `admin` user.

To test, start CARDS, enter the `Utilities/Administration` directory, and run `python3 set_admin_password.py`. Enter a new password at the prompt and then verify that you can login to CARDS as `admin` using that password. Logging in to CARDS with a username of `admin` and default password of `admin` should no longer work after using this program to set a new _admin_ password.