### PR TITLE
LFS-938: Move the BioPortalApiKey serverside code into a separate API component

### DIFF
--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/BioPortalApiKeyManager.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/BioPortalApiKeyManager.java
@@ -19,12 +19,17 @@
 package ca.sickkids.ccm.lfs.vocabularies;
 
 /**
- * Interface for BioPortal API key component.
+ * Service for BioPortal API key management.
  *
  * @version $Id$
  */
 public interface BioPortalApiKeyManager
 {
+	/**
+	 * Retrieves the BioPortal API key configured in the system.
+	 *
+	 * @return the configured key, or the empty string if no key is configured.
+	 */
     String getAPIKey();
 
     /**

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/BioPortalApiKeyManager.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/BioPortalApiKeyManager.java
@@ -25,16 +25,16 @@ package ca.sickkids.ccm.lfs.vocabularies;
  */
 public interface BioPortalApiKeyManager
 {
-	/**
-	 * Retrieves the BioPortal API key configured in the system.
-	 *
-	 * @return the configured key, or the empty string if no key is configured.
-	 */
+    /**
+     * Retrieves the BioPortal API key configured in the system.
+     *
+     * @return the configured key, or the empty string if no key is configured.
+     */
     String getAPIKey();
 
     /**
-     * Retrieves BioPortal API key from the OS environment variable.
-     * If the environment variable is not specified returns an empty string.
+     * Retrieves BioPortal API key from the OS environment variable. If the environment variable is not specified
+     * returns an empty string.
      *
      * @return BioPortal API key
      */

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/BioPortalApiKeyManager.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/BioPortalApiKeyManager.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package ca.sickkids.ccm.lfs.vocabularies;
+
+/**
+ * Interface for BioPortal API key component.
+ *
+ * @version $Id$
+ */
+public interface BioPortalApiKeyManager
+{
+    String getAPIKey();
+
+    /**
+     * Retrieves BioPortal API key from the OS environment variable.
+     * If the environment variable is not specified returns an empty string.
+     *
+     * @return BioPortal API key
+     */
+    String getAPIKeyFromEnvironment();
+
+    /**
+     * Retrieves BioPortal API key from the node. If the key is not specified returns an empty string.
+     *
+     * @return BioPortal API key
+     */
+    String getAPIKeyFromNode();
+}

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/VocabularyBioPortalApiKeyServlet.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/VocabularyBioPortalApiKeyServlet.java
@@ -21,21 +21,16 @@ package ca.sickkids.ccm.lfs.vocabularies;
 import java.io.IOException;
 import java.io.Writer;
 
-import javax.jcr.Node;
 import javax.json.Json;
 import javax.json.stream.JsonGenerator;
 import javax.servlet.Servlet;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
 import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
 import org.osgi.service.component.annotations.Component;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * A servlet that returns the current BioPortal API key.
@@ -50,68 +45,21 @@ import org.slf4j.LoggerFactory;
     )
 public class VocabularyBioPortalApiKeyServlet extends SlingSafeMethodsServlet
 {
-    /** OS environment variable which has the api key for bioontology portal. */
-    private static final String APIKEY_ENVIRONMENT_VARIABLE = "BIOPORTAL_APIKEY";
-
     /** The response from this service is a JSON object with this key holding the BioPortal API key as its value. */
     private static final String RESPONSE_JSON_KEY = "apikey";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(VocabularyIndexerServlet.class);
+    @Reference
+    private BioPortalApiKeyManager apiKeyManager;
 
     @Override
     public void doGet(final SlingHttpServletRequest request, final SlingHttpServletResponse response) throws IOException
     {
-        // req is the SlingHttpServletRequest
-        ResourceResolver resourceResolver = request.getResourceResolver();
-
         response.setContentType("application/json");
         final Writer out = response.getWriter();
         JsonGenerator jsonGen = Json.createGenerator(out);
         jsonGen.writeStartObject();
-        String key = this.getAPIKeyFromNode(resourceResolver);
-        if (!"".equals(key)) {
-            // if node exists
-            jsonGen.write(RESPONSE_JSON_KEY, key);
-        } else {
-            // if node does not exist, get api key from env variable
-            jsonGen.write(RESPONSE_JSON_KEY, this.getAPIKeyFromEnvironment());
-        }
+        String key = this.apiKeyManager.getAPIKey();
+        jsonGen.write(RESPONSE_JSON_KEY, key);
         jsonGen.writeEnd().flush();
-    }
-
-    /**
-     * Retrieves BioPortal API key from the OS environment variable.
-     * If the environment variable is not specified returns an empty string.
-     *
-     * @return BioPortal API key
-     */
-    public String getAPIKeyFromEnvironment()
-    {
-        String apiKey = System.getenv(APIKEY_ENVIRONMENT_VARIABLE);
-        apiKey = StringUtils.isBlank(apiKey) ? "" : apiKey;
-        LOGGER.info("BioPortal API key as set in the OS environment: [{}]", apiKey);
-        return apiKey;
-    }
-
-    /**
-     * Retrieves BioPortal API key from the node. If the key is not specified returns an empty string.
-     *
-     * @param resourceResolver resource resolver
-     * @return BioPortal API key
-     */
-    public String getAPIKeyFromNode(ResourceResolver resourceResolver)
-    {
-        String resourcePath = "/libs/lfs/conf/BioportalApiKey";
-        String apiKey = "";
-
-        try {
-            Resource res = resourceResolver.getResource(resourcePath);
-            Node keyNode = res.adaptTo(Node.class);
-            apiKey = keyNode.getProperty("key").getString();
-            LOGGER.info("BioPortal API key as set in the BioportalApiKey node: [{}]", apiKey);
-        } catch (Exception e) {
-            LOGGER.error("Failed to load BioPortal API key from node: {}", e.getMessage(), e);
-        }
-        return apiKey;
     }
 }

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/BioOntologyIndexer.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/BioOntologyIndexer.java
@@ -67,7 +67,7 @@ public class BioOntologyIndexer implements VocabularyIndexer
     @Reference
     private VocabularyParserUtils utils;
 
-    @Reference(name = "RepositoryHandler.bioontology")
+    @Reference(target = "(component.name=RepositoryHandler.bioontology)")
     private RepositoryHandler repository;
 
     /**

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/BioOntologyRepositoryHandler.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/BioOntologyRepositoryHandler.java
@@ -35,13 +35,12 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.sling.api.resource.ResourceResolver;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import ca.sickkids.ccm.lfs.vocabularies.VocabularyBioPortalApiKeyServlet;
+import ca.sickkids.ccm.lfs.vocabularies.BioPortalApiKeyManager;
 import ca.sickkids.ccm.lfs.vocabularies.spi.RepositoryHandler;
 import ca.sickkids.ccm.lfs.vocabularies.spi.VocabularyDescription;
 import ca.sickkids.ccm.lfs.vocabularies.spi.VocabularyDescriptionBuilder;
@@ -74,10 +73,8 @@ public class BioOntologyRepositoryHandler implements RepositoryHandler
     private static final String REQUEST_DOWNLOAD_FORMAT_RDF =
         "&download_format=rdf";
 
-    private final ThreadLocal<ResourceResolver> resolver = new ThreadLocal<>();
-
     @Reference
-    private VocabularyBioPortalApiKeyServlet apiKey;
+    private BioPortalApiKeyManager apiKeyManager;
 
     @Override
     public String getRepositoryName()
@@ -224,10 +221,7 @@ public class BioOntologyRepositoryHandler implements RepositoryHandler
      */
     private String getRequestConfiguration()
     {
-        String key = this.apiKey.getAPIKeyFromNode(this.resolver.get());
-        if ("".equals(key)) {
-            key = this.apiKey.getAPIKeyFromEnvironment();
-        }
+        String key = this.apiKeyManager.getAPIKey();
         return REQUEST_CONFIGURATION + key;
     }
 }

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/DefaultBioPortalApiKeyManager.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/DefaultBioPortalApiKeyManager.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package ca.sickkids.ccm.lfs.vocabularies.internal;
+
+import javax.jcr.Node;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.FieldOption;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ca.sickkids.ccm.lfs.vocabularies.BioPortalApiKeyManager;
+
+/**
+ * A component that provide access to BioPortal API key through node or environment.
+ *
+ * @version $Id$
+ */
+@Component
+public class DefaultBioPortalApiKeyManager implements BioPortalApiKeyManager
+{
+    /** OS environment variable which has the api key for bioontology portal. */
+    private static final String APIKEY_ENVIRONMENT_VARIABLE = "BIOPORTAL_APIKEY";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultBioPortalApiKeyManager.class);
+
+    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
+            policyOption = ReferencePolicyOption.GREEDY)
+    private ResourceResolverFactory rrf;
+
+    @Override
+    public String getAPIKey()
+    {
+        String key = this.getAPIKeyFromNode();
+        if ("".equals(key)) {
+            // if node does not exist, get api key from env variable
+            key = this.getAPIKeyFromEnvironment();
+        }
+        return key;
+    }
+
+    @Override
+    public String getAPIKeyFromEnvironment()
+    {
+        String apiKey = System.getenv(APIKEY_ENVIRONMENT_VARIABLE);
+        apiKey = StringUtils.isBlank(apiKey) ? "" : apiKey;
+        LOGGER.info("BioPortal API key as set in the OS environment: [{}]", apiKey);
+        return apiKey;
+    }
+
+    @Override
+    public String getAPIKeyFromNode()
+    {
+        String resourcePath = "/libs/lfs/conf/BioportalApiKey";
+        String apiKey = "";
+
+        try {
+            Resource res = this.rrf.getThreadResourceResolver().getResource(resourcePath);
+            Node keyNode = res.adaptTo(Node.class);
+            apiKey = keyNode.getProperty("key").getString();
+            LOGGER.info("BioPortal API key as set in the BioportalApiKey node: [{}]", apiKey);
+        } catch (Exception e) {
+            LOGGER.error("Failed to load BioPortal API key from node: {}", e.getMessage(), e);
+        }
+        return apiKey;
+    }
+}

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/DefaultBioPortalApiKeyManager.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/DefaultBioPortalApiKeyManager.java
@@ -77,10 +77,12 @@ public class DefaultBioPortalApiKeyManager implements BioPortalApiKeyManager
         String apiKey = "";
 
         try {
-            Resource res = this.rrf.getThreadResourceResolver().getResource(resourcePath);
-            Node keyNode = res.adaptTo(Node.class);
-            apiKey = keyNode.getProperty("key").getString();
-            LOGGER.debug("BioPortal API key as set in the BioportalApiKey node: [{}]", apiKey);
+            Resource res = this.rrf.getThreadResourceResolver().resolve(resourcePath);
+            if (!res.isResourceType(Resource.RESOURCE_TYPE_NON_EXISTING)) {
+                Node keyNode = res.adaptTo(Node.class);
+                apiKey = keyNode.getProperty("key").getString();
+                LOGGER.debug("BioPortal API key as set in the BioportalApiKey node: [{}]", apiKey);
+            }
         } catch (Exception e) {
             LOGGER.error("Failed to load BioPortal API key from node: {}", e.getMessage(), e);
         }

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/DefaultBioPortalApiKeyManager.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/DefaultBioPortalApiKeyManager.java
@@ -66,7 +66,7 @@ public class DefaultBioPortalApiKeyManager implements BioPortalApiKeyManager
     {
         String apiKey = System.getenv(APIKEY_ENVIRONMENT_VARIABLE);
         apiKey = StringUtils.isBlank(apiKey) ? "" : apiKey;
-        LOGGER.info("BioPortal API key as set in the OS environment: [{}]", apiKey);
+        LOGGER.debug("BioPortal API key as set in the OS environment: [{}]", apiKey);
         return apiKey;
     }
 
@@ -80,7 +80,7 @@ public class DefaultBioPortalApiKeyManager implements BioPortalApiKeyManager
             Resource res = this.rrf.getThreadResourceResolver().getResource(resourcePath);
             Node keyNode = res.adaptTo(Node.class);
             apiKey = keyNode.getProperty("key").getString();
-            LOGGER.info("BioPortal API key as set in the BioportalApiKey node: [{}]", apiKey);
+            LOGGER.debug("BioPortal API key as set in the BioportalApiKey node: [{}]", apiKey);
         } catch (Exception e) {
             LOGGER.error("Failed to load BioPortal API key from node: {}", e.getMessage(), e);
         }

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/DefaultBioPortalApiKeyManager.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/DefaultBioPortalApiKeyManager.java
@@ -47,7 +47,7 @@ public class DefaultBioPortalApiKeyManager implements BioPortalApiKeyManager
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultBioPortalApiKeyManager.class);
 
     @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
-            policyOption = ReferencePolicyOption.GREEDY)
+        policyOption = ReferencePolicyOption.GREEDY)
     private ResourceResolverFactory rrf;
 
     @Override


### PR DESCRIPTION
Also fixes:
[LFS-990: ICD* vocabularies can not longer be installed either locally or via Bioportal](https://phenotips.atlassian.net/browse/LFS-990)
[LFS-396: Failed to Install Cancer Chemoprevention Ontology](https://phenotips.atlassian.net/browse/LFS-396)
[LFS-391: Failed to Install International Classification of Functioning, Disability and Health](https://phenotips.atlassian.net/browse/LFS-391)
[LFS-389: Failed to install Plant Trait Ontology](https://phenotips.atlassian.net/browse/LFS-389)