### PR TITLE
LFS-935 & LFS-936: Publish a manifest file of available NeuralCR / BasicCR text analysis models and provide a downloader utility

### DIFF
--- a/Utilities/NCR-Downloader/download_model.py
+++ b/Utilities/NCR-Downloader/download_model.py
@@ -38,6 +38,10 @@ argparser.add_argument('--download', help='Download a model')
 argparser.add_argument('--savedir', help='Directory to save downloaded model')
 args = argparser.parse_args()
 
+if (args.list == False) and args.download is None:
+  print("Must specify either --list or --download. Run with -h to display help.")
+  sys.exit(-1)
+
 MANIFEST_FILE = DEFAULT_MANIFEST_FILE
 if args.manifest:
   MANIFEST_FILE = args.manifest

--- a/Utilities/NCR-Downloader/download_model.py
+++ b/Utilities/NCR-Downloader/download_model.py
@@ -29,7 +29,6 @@ import argparse
 import requests
 
 DEFAULT_MANIFEST_FILE = 'model_repo.json'
-TAR_GZ_TYPES = ['NeuralCR', 'BasicCR']
 
 argparser = argparse.ArgumentParser()
 argparser.add_argument('--manifest', help='Specify an alternate models manifest file', default=DEFAULT_MANIFEST_FILE)
@@ -90,7 +89,7 @@ if args.download:
     sys.exit(-1)
 
   #Extract the .tar.gz file if necessary
-  if model_type in TAR_GZ_TYPES:
+  if model_url.endswith('.tar.gz'):
     print("Uncompressing...")
     model_archive = tarfile.open(download_filename, 'r:gz')
     model_archive.extractall(path=savedir)

--- a/Utilities/NCR-Downloader/download_model.py
+++ b/Utilities/NCR-Downloader/download_model.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+"""
+
+import os
+import sys
+import json
+import tarfile
+import hashlib
+import argparse
+import requests
+
+DEFAULT_MANIFEST_FILE = 'model_repo.json'
+TAR_GZ_TYPES = ['NeuralCR', 'BasicCR']
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('--manifest', help='Specify an alternate models manifest file', default=DEFAULT_MANIFEST_FILE)
+argparser.add_argument('--list', help='List the models available for download', action='store_true')
+argparser.add_argument('--download', help='Download a model')
+argparser.add_argument('--savedir', help='Directory to save downloaded model')
+args = argparser.parse_args()
+
+MANIFEST_FILE = DEFAULT_MANIFEST_FILE
+if args.manifest:
+  MANIFEST_FILE = args.manifest
+
+with open(MANIFEST_FILE, 'r') as f_json:
+  MODEL_REPO = json.loads(f_json.read())
+
+if args.list:
+  for model_name in MODEL_REPO:
+    model = MODEL_REPO[model_name]
+    model_title = model_name + " [" + model['type'] + "]"
+    print(model_title)
+    print('-'*len(model_title))
+    print(model['description'])
+    print('')
+  sys.exit()
+
+if args.download:
+  if args.savedir is None:
+    print("Must specify a directory to save the downloaded model")
+    sys.exit(-1)
+  if args.download not in MODEL_REPO:
+    print("Unknown model")
+    sys.exit(-1)
+  model_url = MODEL_REPO[args.download]['url']
+  model_sha256 = MODEL_REPO[args.download]['sha256']
+  model_type = MODEL_REPO[args.download]['type']
+  savedir = args.savedir.rstrip('/')
+  download_filename = "{}/{}.part".format(savedir, model_sha256)
+  print("Downloading {} from {}".format(args.download, model_url))
+  h_sha256 = hashlib.sha256()
+
+  #Download
+  with requests.get(model_url, stream=True) as download_stream:
+    download_stream.raise_for_status()
+    with open(download_filename, 'wb') as save_stream:
+      for chunk in download_stream.iter_content(chunk_size=8192):
+        save_stream.write(chunk)
+        h_sha256.update(chunk)
+
+  #Verify the downloaded file
+  if model_sha256 != h_sha256.hexdigest():
+    #Cleanup
+    os.remove(download_filename)
+    print("Downloaded model integrity check failed")
+    sys.exit(-1)
+
+  #Extract the .tar.gz file if necessary
+  if model_type in TAR_GZ_TYPES:
+    print("Uncompressing...")
+    model_archive = tarfile.open(download_filename, 'r:gz')
+    model_archive.extractall(path=savedir)
+    model_archive.close()
+    #Remove the downloaded .tar.gz file
+    os.remove(download_filename)
+  else:
+    #Rename the downloaded file to its proper name
+    os.rename(download_filename, "{}/{}".format(savedir, args.download))
+
+print("Done")

--- a/Utilities/NCR-Downloader/model_repo.json
+++ b/Utilities/NCR-Downloader/model_repo.json
@@ -1,0 +1,32 @@
+{
+  "HP": {
+    "url": "https://github.com/ccmbioinfo/NeuralCR/releases/download/1.1/HP.tar.gz",
+    "sha256": "08e48710399ce8aa321367d6dafdef87a464048b85437552edc728e0e129668b",
+    "type": "NeuralCR",
+    "description":  "Human Phenotype Ontology trained at a root of HP:0000118"
+  },
+  "MONDO": {
+    "url": "https://github.com/ccmbioinfo/NeuralCR/releases/download/1.1/MONDO.tar.gz",
+    "sha256": "942b03460a87f4372498c0792eafc6a8f7a39f4555b7baf9f6db833a13caef31",
+    "type": "NeuralCR",
+    "description": "MONDO trained at a root of MONDO:0045024"
+  },
+  "ICD-O-3-M": {
+    "url": "https://github.com/ccmbioinfo/NeuralCR/releases/download/1.1/ICD-O-3-M.tar.gz",
+    "sha256": "1b57884072965ff5043f5b38ce2befc5ac5d0a1defc65b9aef2967196d9ee4c9",
+    "type": "NeuralCR",
+    "description": "ICD-O-3-M trained at a root of 'Thing'"
+  },
+  "NCTID" : {
+    "url": "https://github.com/data-team-uhn/BasicCR/releases/download/1.0/NCTID.tar.gz",
+    "sha256": "76ce4fb6990b8d68666ec4d1aae48e2c05ea90fa4e7bde1a1776c6033b83c0b8",
+    "type": "BasicCR",
+    "description": "National Clinical Trials Identifiers"
+  },
+  "pmc_model_new.bin": {
+    "url": "https://github.com/ccmbioinfo/NeuralCR/releases/download/1.1/pmc_model_new.bin",
+    "sha256": "e9947f25ef59693c3dd46eb33418b0a44d0663f2c4675adf98c99a187c0d20c5",
+    "type": "FastText Model",
+    "description": "FastText model required for various NeuralCR trained models"
+  }
+}


### PR DESCRIPTION
This pull request implements the tasks LFS-935 and LFS-936 by:

- Publishing a manifest file of available NeuralCR / BasicCR text analysis models
- Providing a utility program to download / verify / extract the published models so that they may be made available to CARDS

To test:
1. Build this branch
2. In a new directory, clone the https://github.com/IntegralProgrammer/NeuralCR repository and checkout the `LFS-935_936_test` branch
3. Build with `docker build -t ccmsk/neuralcr .`
4. Go back to the `lfs` (CARDS) repository and enter the `compose-cluster` directory
5. `python3 generate_compose_yaml.py --enable_ncr --oak_filesystem`
6. `mkdir NCR_MODEL`
7. Navigate to the `Utilities/NCR-Downloader` directory
8. `python3 download_model.py --download pmc_model_new.bin --savedir ../../compose-cluster/NCR_MODEL/`
9. `python3 download_model.py --download HP --savedir ../../compose-cluster/NCR_MODEL/`
10. Navigate back to the `compose-cluster` directory
11. Edit the `docker-compose.yml` file, adding the environment variable `ADDITIONAL_RUN_MODES=lfs`, to the configuration for the `lfsinitial` container (ie. right below `OAK_FILESYSTEM=true`)
12. `docker-compose build`
13. `docker-compose up -d`
14. Visit http://localhost:8080, login as admin, create a new _Demographics_ Form, test the notes annotation for the _Co-Morbidities_ section (you may want to have the *HP* vocabulary installed so that human-readable ontology names persist when the Form is closed).