### PR TITLE
LFS-1032: Node.js authentication proxy used by compose-cluster is not passing client HTTP headers to NeuralCR

### DIFF
--- a/compose-cluster/proxy/http_proxy.js
+++ b/compose-cluster/proxy/http_proxy.js
@@ -50,11 +50,13 @@ function checkAuthentication(opts, method_allow, method_deny) {
 
 var server = new http.Server();
 server.on('request', function(s_req, s_res) {
+	let { cookie, ...filtered_headers } = s_req.headers;
 	let client_opts = {
 		hostname: CLIENT_HOSTNAME,
 		port: CLIENT_PORT,
 		path: s_req.url,
-		method: s_req.method
+		method: s_req.method,
+		headers: filtered_headers
 	};
 	
 	//Check to see if we should allow the request or not


### PR DESCRIPTION


This Pull Request implements LFS-1032 by modifying `compose-cluster/proxy/http_proxy.js` so that it passes all HTTP client headers to NeuralCR except for the `Cookie` header as NeuralCR does not need to authenticate with Sling.

To test:

1. Checkout the `LFS-1032_test` branch
2. Build the branch (`mvn clean install`)
3. Enter the `compose-cluster/netcat` directory
4. Build this container as a _mock_ NeuralCR service with `docker build -t ccmsk/neuralcr .`
5. Go back to the `compose-cluster` directory and generate a configuration with `python3 generate_compose_yaml.py --oak_filesystem --enable_ncr`
6. `docker-compose build`
7. `docker-compose up -d`
8. Visit `http://localhost:8080` and login with Username: `admin` and Password `admin`
9. Open a new browser tab and visit `http://localhost:8080/ncr/models/`. A **Proxy Error** message will be displayed - this is okay.
10. In the `compose-cluster` directory, run `docker-compose logs neuralcr`. You should see client headers such as the `User-Agent` header containing the browser's name and its version number.