### PR TITLE
LFS-663/LFS-973: The dialog for editing questions should only display question properties and options that are relevant for the selected data type

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/AnswerOptions.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/AnswerOptions.jsx
@@ -28,11 +28,13 @@ import {
 } from "@material-ui/core";
 
 import QuestionnaireStyle from '../questionnaire/QuestionnaireStyle';
+import EditorInput from "./EditorInput";
+import QuestionComponentManager from "./QuestionComponentManager";
 import { v4 as uuidv4 } from 'uuid';
 import CloseIcon from '@material-ui/icons/Close';
 
 let AnswerOptions = (props) => {
-  const { data, path, saveButtonRef } = props;
+  const { objectKey, data, path, saveButtonRef } = props;
   let [ options, setOptions ] = useState(Object.values(data).filter(value => value['jcr:primaryType'] == 'lfs:AnswerOption').slice());
   let [ newUUID, setNewUUID ] = useState([]);
   let [ newValue, setNewValue ] = useState([]);
@@ -111,11 +113,7 @@ let AnswerOptions = (props) => {
   }
 
   return (
-    <Grid container alignItems='baseline' spacing={2}>
-      <Grid item xs={4}>
-        <Typography variant="subtitle2">Answer options:</Typography>
-      </Grid>
-      <Grid item xs={8}>
+    <EditorInput name={objectKey}>
       { options.map((value, index) =>
         <React.Fragment key={value['@path']}>
           <input type='hidden' name={`${value['@path']}/jcr:primaryType`} value={'lfs:AnswerOption'} />
@@ -163,8 +161,7 @@ let AnswerOptions = (props) => {
         })}
         multiline
         />
-      </Grid>
-    </Grid>
+    </EditorInput>
   )
 }
 
@@ -172,4 +169,11 @@ AnswerOptions.propTypes = {
   data: PropTypes.object.isRequired
 };
 
-export default withStyles(QuestionnaireStyle)(AnswerOptions);
+var StyledAnswerOptions = withStyles(QuestionnaireStyle)(AnswerOptions);
+export default StyledAnswerOptions;
+
+QuestionComponentManager.registerQuestionComponent((definition) => {
+  if (definition === "options") {
+    return [StyledAnswerOptions, 50];
+  }
+});

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditDialog.jsx
@@ -31,7 +31,6 @@ import {
   withStyles
 } from "@material-ui/core";
 
-import AnswerOptions from './AnswerOptions';
 import Fields from './Fields'
 
 // Dialog for editing or creating questions or sections
@@ -153,7 +152,7 @@ let EditDialog = (props) => {
 
   let targetIdField = () => {
     return (
-      <Grid container alignItems='flex-end' spacing={2} direction="row">
+      <Grid container alignItems='baseline' spacing={2} direction="row">
         <Grid item xs={4}><Typography variant="subtitle2">{type === 'Question' ? 'Variable name:' : 'Section identifier:' }</Typography></Grid>
         <Grid item xs={8}>{
           targetExists ?
@@ -174,12 +173,13 @@ let EditDialog = (props) => {
           <DialogContent>
             <Grid container direction="column" spacing={2}>
               <Grid item>{targetIdField()}</Grid>
-              <Fields data={targetExists && data || {}} JSON={json[0]} edit={true} />
-              { data && type === 'Question' &&
-                <Grid item>
-                  <AnswerOptions data={data} path={data["@path"] + (targetExists ? "" : `/${targetId}`)} saveButtonRef={saveButtonRef}/>
-                </Grid>
-              }
+              <Fields
+                data={targetExists && data || {}}
+                JSON={json[0]}
+                edit={true}
+                path={data["@path"] + (targetExists ? "" : `/${targetId}`)}
+                saveButtontRef={saveButtonRef}
+               />
             </Grid>
           </DialogContent>
           <DialogActions>

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditorInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditorInput.jsx
@@ -18,6 +18,7 @@
 //
 
 import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import {
   Grid,
@@ -29,9 +30,18 @@ let EditorInput = (props) => {
   let formatString = (key) => {
     return key.charAt(0).toUpperCase() + key.slice(1).replace( /([A-Z])/g, " $1" ).toLowerCase();
   }
+  const classes = makeStyles((theme) => ({
+    labelContainer: {
+      /* Match the input padding so the text of the label would appear aligned with the text of the input */
+      /* To do: switch to a vertical layout in the future to avoid most alignment issues  */
+      paddingTop: theme.spacing(1.75) + "px !important",
+    },
+  }))();
+
   return (
-    <Grid container alignItems='flex-end' spacing={2}>
-      <Grid item xs={4}>
+  <Grid item>
+    <Grid container alignItems="flex-start" spacing={2}>
+      <Grid item xs={4} className={classes.labelContainer}>
         <Typography variant="subtitle2">
           {formatString(name?.concat(':')) || ''}
         </Typography>
@@ -40,7 +50,8 @@ let EditorInput = (props) => {
         {children}
       </Grid>
     </Grid>
-    );
+  </Grid>
+  );
 }
 
 EditorInput.propTypes = {

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Fields.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Fields.jsx
@@ -24,6 +24,7 @@ import QuestionComponentManager from "../questionnaireEditor/QuestionComponentMa
 import QuestionnaireStyle from '../questionnaire/QuestionnaireStyle';
 
 // Unused imports required for the component manager
+import AnswerOptions from "./AnswerOptions";
 import BooleanInput from "./BooleanInput";
 import ListInput from "./ListInput";
 import NumberInput from "./NumberInput";
@@ -31,7 +32,7 @@ import ObjectInput from "./ObjectInput";
 import TextInput from "./TextInput";
 
 let Fields = (props) => {
-  let { data, JSON, edit } = props;
+  let { data, JSON, edit, ...rest } = props;
 
   /**
    * Method responsible for displaying a question from the questionnaire
@@ -44,13 +45,13 @@ let Fields = (props) => {
     // This variable must start with an upper case letter so that React treats it as a component
     const FieldDisplay = QuestionComponentManager.getQuestionComponent(value);
     return (
-      <Grid item key={key}>
         <FieldDisplay
+          key={key}
           objectKey={key}
           value={value}
           data={data}
+          {...rest}
           />
-      </Grid>
     );
   };
 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/NumberInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/NumberInput.jsx
@@ -35,6 +35,7 @@ import QuestionComponentManager from "./QuestionComponentManager";
 let NumberInput = (props) => {
   let { objectKey, data } = props;
   const defaultValue = props.value === "long" ? 0 : '';
+  const isMax = props.value === "long" && objectKey.startsWith('max');
   let [ value, setValue ] = useState(data[objectKey] || defaultValue);
 
   return (
@@ -44,10 +45,11 @@ let NumberInput = (props) => {
         name={objectKey || ''}
         id={objectKey || ''}
         type='number'
-        placeholder={objectKey.includes('maxPerSubject') ? 'Unlimited' : ''}
+        placeholder={isMax ? 'Unlimited' : ''}
         value={value}
         onChange={(event) => { setValue(event.target.value); }}
         onBlur={(event) => { setValue(event.target.value || defaultValue); }}
+        helperText={isMax ? `0 means "Unlimited"` : ''}
         InputProps={{
           inputProps: { 
             min: defaultValue 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ObjectInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ObjectInput.jsx
@@ -35,7 +35,7 @@ import QuestionComponentManager from "../questionnaireEditor/QuestionComponentMa
 // Object Input field used by Edit dialog component
 
 let ObjectInput = (props) => {
-  let { objectKey, value, data } = props;
+  let { objectKey, value, data, ...rest } = props;
   const defaultValue = data[objectKey] || (Object.keys(value || {})[0] || '');
   let [ selectedValue, setSelectedValue ] = useState(defaultValue);
   
@@ -57,10 +57,7 @@ let ObjectInput = (props) => {
       </Select>
     </EditorInput>
     { typeof(value) === 'object' && selectedValue != '' && typeof (value[selectedValue]) === 'object' ?
-      <Grid container direction="column" spacing={2}>
-        <Grid item></Grid>
-        <Fields data={data} JSON={value[selectedValue]} edit={true}/>
-      </Grid>
+        <Fields data={data} JSON={value[selectedValue]} edit={true} {...rest} />
       :
       (selectedValue != '') && <Typography color="secondary" variant="subtitle2">Unsupported: {selectedValue}</Typography>
     }

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -82,7 +82,6 @@
           "orderProperty": "lfs:Vocabulary",
           "identifierProperty": "identifier"
         },
-        "vocabularyFilter": "string",
         "minAnswers": "long",
         "maxAnswers": "long",
         "displayMode": {

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -2,35 +2,34 @@
   {
     "text": "string",
     "description": "string",
-    "displayMode": {
-      "input": {},
-      "textbox": {},
-      "list": {
-        "compact" : "boolean"
-      },
-      "list+input" : {
-        "compact" : "boolean"
-      },
-      "none": {},
-      "hidden": {}
-    },
     "dataType": {
       "text" : {
         "validationRegexp": "string",
         "minAnswers": "long",
-        "maxAnswers": "long"
+        "maxAnswers": "long",
+        "displayMode": {
+          "input": {},
+          "textbox": {},
+          "list": {
+            "compact" : "boolean",
+            "answerOptions" : "options"
+          },
+          "list+input" : {
+            "compact" : "boolean",
+            "answerOptions" : "options"
+          }
+        }
       },
       "boolean": {
-        "compact" : "boolean",
         "minAnswers": {"0":{}, "1":{}},
         "yesLabel": "string",
         "noLabel": "string",
         "enableUnknown": "boolean",
-        "unknownLabel": "string"
+        "unknownLabel": "string",
+        "compact" : "boolean"
       },
       "date" : {
-        "minAnswers": "long",
-        "maxAnswers": "long",
+        "minAnswers": {"0":{}, "1":{}},
         "dateFormat": "string"
       },
       "long": {
@@ -38,14 +37,36 @@
         "maxValue": "double",
         "minAnswers": "long",
         "maxAnswers": "long",
-        "unitOfMeasurement" : "string"
+        "unitOfMeasurement" : "string",
+        "displayMode": {
+          "input": {},
+          "list": {
+            "compact" : "boolean",
+            "answerOptions" : "options"
+          },
+          "list+input" : {
+            "compact" : "boolean",
+            "answerOptions" : "options"
+          }
+        }
       },
       "decimal": {
         "minValue": "double",
         "maxValue": "double",
         "minAnswers": "long",
         "maxAnswers": "long",
-        "unitOfMeasurement" : "string"
+        "unitOfMeasurement" : "string",
+        "displayMode": {
+          "input": {},
+          "list": {
+            "compact" : "boolean",
+            "answerOptions" : "options"
+          },
+          "list+input" : {
+            "compact" : "boolean",
+            "answerOptions" : "options"
+          }
+        }
       },
       "file": {
         "minAnswers": "long",
@@ -63,7 +84,18 @@
         },
         "vocabularyFilter": "string",
         "minAnswers": "long",
-        "maxAnswers": "long"
+        "maxAnswers": "long",
+        "displayMode": {
+          "input": {},
+          "list": {
+            "compact" : "boolean",
+            "answerOptions" : "options"
+          },
+          "list+input" : {
+            "compact" : "boolean",
+            "answerOptions" : "options"
+          }
+        }
       },
       "computed": {
         "expression": "string",
@@ -72,8 +104,7 @@
       "time": {
         "lowerLimit": "string",
         "upperLimit": "string",
-        "minAnswers": "long",
-        "maxAnswers": "long",
+        "minAnswers": {"0":{}, "1":{}},
         "errorText": "string",
         "dateFormat": "string"
       },


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/LFS-973l)

- [x] Some data types have a predefined display mode (e.g. boolean - list of options; date, time, computed - input; file - file uploader) and selecting another has no effect on how the question is displayed. The `displayMode` is now shown only when it is indeed configurable.
- [x] The user can now enter Answer options  only if `displayMode` is `list` or `list+input`
- [x] Some data types (date, time, computed) currently support at most one answer. The wizard now prevents the user from selecting other restrictions for the number of answers.
- [x] The display modes `none` and `hidden` are currently not supported and have been (temporarily) removed from the wizard UI.
- [x] Also displayed helper text explaining that for `maxAnswers` and `maxPerSubject` 0 means Unlimited.