### PR TITLE
LFS-1036: YAML files generated by generate_compose_yaml.py should (optionally) specify a localhost TCP port for direct access to Apache Sling

### DIFF
--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -36,6 +36,7 @@ argparser.add_argument('--enable_ncr', help='Add a Neural Concept Recognizer ser
 argparser.add_argument('--oak_filesystem', help='Use the filesystem (instead of MongoDB) as the back-end for Oak/JCR', action='store_true')
 argparser.add_argument('--external_mongo', help='Use an external MongoDB instance instead of providing our own', action='store_true')
 argparser.add_argument('--ssl_proxy', help='Protect this service with SSL/TLS (use https:// instead of http://)', action='store_true')
+argparser.add_argument('--sling_admin_port', help='The localhost TCP port which should be forwarded to lfsinitial:8080', type=int)
 args = argparser.parse_args()
 
 MONGO_SHARD_COUNT = args.shards
@@ -235,6 +236,9 @@ if args.oak_filesystem:
 
 if not (args.oak_filesystem or args.external_mongo):
     yaml_obj['services']['lfsinitial']['depends_on'] = ['router']
+
+if args.sling_admin_port:
+    yaml_obj['services']['lfsinitial']['ports'] = ["127.0.0.1:{}:8080".format(args.sling_admin_port)]
 
 #Configure the NCR container (if enabled) - only one for now
 if ENABLE_NCR:


### PR DESCRIPTION
This Pull Request implements LFS-1036 by adding the `--sling_admin_port` optional argument to `generate_compose_yaml.py` so that when specified, `localhost:PORT` will be forwarded to TCP port 8080 on the `lfsinitial` container. This is necessary for LFS-930 so that CARDS (Apache Sling) may be started so as to be configured without exposing the non-configured (default password) CARDS instance to the outside world.

To test:
1. Build this branch (`mvn clean install`)
2. `cd compose-cluster`
3. `python3 generate_compose_yaml.py --oak_filesystem`
4. `docker-compose build`
5. `docker-compose up -d`
6. **CARDS should be accessible at http://localhost:8080**
7. `docker-compose down`
8. `docker-compose rm`
9. `docker volume prune -f`
10. `./cleanup.sh`
11. `python generate_compose_yaml.py --oak_filesystem --sling_admin_port 8081`
12. `docker-compose build`
13. `docker-compose up -d`
14. **CARDS should be accessible at both http://localhost:8080 _and_ http://localhost:8081**