### PR TITLE
LFS-1040: The .bare JSON doesn't simplify the subject if it does not have a fullIdentifier set

### DIFF
--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/BareFormProcessor.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/BareFormProcessor.java
@@ -182,7 +182,14 @@ public class BareFormProcessor implements ResourceJsonProcessor
     {
         // Replace the subject reference with the label of the actual subject (and its parents)
         if (node.isNodeType("lfs:Form") && "subject".equals(property.getName())) {
-            return Json.createValue(property.getNode().getProperty("fullIdentifier").getString());
+            final Node subject = property.getNode();
+            if (subject.hasProperty("fullIdentifier")) {
+                return Json.createValue(subject.getProperty("fullIdentifier").getString());
+            } else if (subject.hasProperty("identifier")) {
+                return Json.createValue(subject.getProperty("identifier").getString());
+            } else {
+                return Json.createValue(subject.getName());
+            }
         }
         return input;
     }


### PR DESCRIPTION
To test:
- create a patient subject (p1)
- create a demographics form for p1
- open http://localhost:8080/system/console/components
- find and stop SubjectFullIdentifierEditorProvider
- create another patient subject (p2), verify that it does not have a fullIdentifier property, either in JSON or in Composum
- create a demographics form for p2
- open p1.data.bare.json and p2.data.bare.json, check that both of the demographics forms have a simple subject identifier instead of a detailed object