### PR TITLE
LFS-1041, LFS-1042: As a user entering answers to a multi-valued question, I am warned that using "," or ";" to separate values in the input does not automatically generate separate answer entries

### DIFF
--- a/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/6MWT.xml
+++ b/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/6MWT.xml
@@ -1405,6 +1405,11 @@
 					<value>1</value>
 					<type>Long</type>
 				</property>
+				<property>
+					<name>enableSeparatorDetection</name>
+					<value>True</value>
+					<type>Boolean</type>
+				</property>
 				<node>
 					<name>Cane (right)</name>
 					<primaryNodeType>lfs:AnswerOption</primaryNodeType>

--- a/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Baseline Health Information.xml
+++ b/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Baseline Health Information.xml
@@ -2186,6 +2186,11 @@
 				<value>text</value>
 				<type>String</type>
 			</property>
+			<property>
+				<name>enableSeparatorDetection</name>
+				<value>True</value>
+				<type>Boolean</type>
+			</property>
 		</node>
 		<node>
 			<name>allegies_seasonal</name>

--- a/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Baseline Health Information.xml
+++ b/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Baseline Health Information.xml
@@ -1405,6 +1405,11 @@
 					<value>1</value>
 					<type>Long</type>
 				</property>
+				<property>
+					<name>enableSeparatorDetection</name>
+					<value>True</value>
+					<type>Boolean</type>
+				</property>
 			</node>
 			<node>
 				<name>condition</name>
@@ -1468,6 +1473,11 @@
 					<name>minAnswers</name>
 					<value>1</value>
 					<type>Long</type>
+				</property>
+				<property>
+					<name>enableSeparatorDetection</name>
+					<value>True</value>
+					<type>Boolean</type>
 				</property>
 			</node>
 			<node>
@@ -1993,6 +2003,11 @@
 					<value>1</value>
 					<type>Long</type>
 				</property>
+				<property>
+					<name>enableSeparatorDetection</name>
+					<value>True</value>
+					<type>Boolean</type>
+				</property>
 			</node>
 			<node>
 				<name>condition</name>
@@ -2057,6 +2072,11 @@
 					<value>1</value>
 					<type>Long</type>
 				</property>
+				<property>
+					<name>enableSeparatorDetection</name>
+					<value>True</value>
+					<type>Boolean</type>
+				</property>
 			</node>
 			<node>
 				<name>condition</name>
@@ -2120,6 +2140,11 @@
 					<name>minAnswers</name>
 					<value>1</value>
 					<type>Long</type>
+				</property>
+				<property>
+					<name>enableSeparatorDetection</name>
+					<value>True</value>
+					<type>Boolean</type>
 				</property>
 			</node>
 			<node>
@@ -2264,6 +2289,11 @@
 					<name>minAnswers</name>
 					<value>1</value>
 					<type>Long</type>
+				</property>
+				<property>
+					<name>enableSeparatorDetection</name>
+					<value>True</value>
+					<type>Boolean</type>
 				</property>
 				<node>
 					<name>Cane (right)</name>
@@ -2504,6 +2534,11 @@
 				<value>1</value>
 				<type>Long</type>
 			</property>
+			<property>
+				<name>enableSeparatorDetection</name>
+				<value>True</value>
+				<type>Boolean</type>
+			</property>
 			<node>
 				<name>Chronic back pain</name>
 				<primaryNodeType>lfs:AnswerOption</primaryNodeType>
@@ -2663,6 +2698,11 @@
 				<name>minAnswers</name>
 				<value>1</value>
 				<type>Long</type>
+			</property>
+			<property>
+				<name>enableSeparatorDetection</name>
+				<value>True</value>
+				<type>Boolean</type>
 			</property>
 			<node>
 				<name>Cerebral palsy or other paralytic syndromes</name>
@@ -3279,6 +3319,11 @@
 					<value>1</value>
 					<type>Long</type>
 				</property>
+				<property>
+					<name>enableSeparatorDetection</name>
+					<value>True</value>
+					<type>Boolean</type>
+				</property>
 			</node>
 			<node>
 				<name>condition</name>
@@ -3600,6 +3645,11 @@
 					<name>minAnswers</name>
 					<value>1</value>
 					<type>Long</type>
+				</property>
+				<property>
+					<name>enableSeparatorDetection</name>
+					<value>True</value>
+					<type>Boolean</type>
 				</property>
 			</node>
 			<node>

--- a/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Event - Clinical.xml
+++ b/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Event - Clinical.xml
@@ -286,6 +286,11 @@
 				<value>1</value>
 				<type>Long</type>
 			</property>
+			<property>
+				<name>enableSeparatorDetection</name>
+				<value>True</value>
+				<type>Boolean</type>
+			</property>
 			<node>
 				<name>Exercise stress test</name>
 				<primaryNodeType>lfs:AnswerOption</primaryNodeType>
@@ -601,6 +606,11 @@
 				<name>minAnswers</name>
 				<value>1</value>
 				<type>Long</type>
+			</property>
+			<property>
+				<name>enableSeparatorDetection</name>
+				<value>True</value>
+				<type>Boolean</type>
 			</property>
 			<node>
 				<name>Cardiac catheterization (with no intervention)</name>

--- a/modules/commons/src/main/frontend/src/components/UserInputAssistant.jsx
+++ b/modules/commons/src/main/frontend/src/components/UserInputAssistant.jsx
@@ -27,6 +27,7 @@ import {
   CardActions,
   CardContent,
   CardHeader,
+  ClickAwayListener,
   Fade,
   Popper,
   withStyles
@@ -61,6 +62,7 @@ import style from "./style.jsx";
 //   no button is displayed
 // onIgnore: if present, an 'Ignore for now' button is displayed, that disables the
 //   assistant for the current interaction with anchorEl and runs the callback function
+// onClickAway: function called when the user clicks away from the assistant element
 // children: message to display
 //
 // Sample usage:
@@ -77,7 +79,7 @@ import style from "./style.jsx";
 //
 
 function UserInputAssistant (props) {
-  const { anchorEl, variant, title, children, actionLabel, onAction, onIgnore, classes } = {...props};
+  const { anchorEl, variant, title, children, actionLabel, onAction, onIgnore, onClickAway, classes } = {...props};
   let [ enabled, setEnabled ] = useState(true);
 
   let [ placement, setPlacement ] = useState("right");
@@ -94,6 +96,7 @@ function UserInputAssistant (props) {
   }, []);
 
   return (enabled ?
+  <ClickAwayListener onClickAway={onClickAway}>
     <Popper
       className={classes.userInputAssistant}
       open={!!anchorEl}
@@ -136,6 +139,7 @@ function UserInputAssistant (props) {
       </Fade>
     )}
     </Popper>
+  </ClickAwayListener>
   : null);
 }
 UserInputAssistant.propTypes = {
@@ -145,6 +149,7 @@ UserInputAssistant.propTypes = {
   actionLabel: PropTypes.string,
   onAction: PropTypes.func,
   onIgnore: PropTypes.func,
+  onClickAway: PropTypes.func,
 };
 UserInputAssistant.defaultProps = {
   variant: 'hint',

--- a/modules/commons/src/main/frontend/src/components/UserInputAssistant.jsx
+++ b/modules/commons/src/main/frontend/src/components/UserInputAssistant.jsx
@@ -1,0 +1,152 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+
+import {
+  Avatar,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  CardHeader,
+  Fade,
+  Popper,
+  withStyles
+} from "@material-ui/core";
+import EmojiObjectsIcon from "@material-ui/icons/EmojiObjects";
+import WarningIcon from "@material-ui/icons/Warning";
+
+import style from "./style.jsx";
+
+// Component that renders a hint/tooltip/suggested action to be
+// displayed to the user as they do data entry
+//
+// Example use case: Inform the user entering coma-separated values
+// in an input that they should press enter after each value instead
+//
+// Required props:
+// title: The title of the hint
+//
+// Optional props:
+// anchorEl: the element this assistant is associated with, if absent, the message will
+//   not be displayed
+// variant: dictates the accent color and icon; one of:
+//   *  hint (primary color, lightbulb icon),
+//   *  hint-secondary (secondary color, lightbulb icon),
+//   *  success (success color, lightbulb icon),
+//   *  info (info color, lightbulb icon),
+//   *  warning (warning color, warning icon),
+//   *  error (error color, warning icon),
+// actionLabel: the label of the button that will trigger the action suggested by the
+//   assistant; if absent, no button is displayed
+// onAction: the function to perform the action suggested by the assistant; if absent,
+//   no button is displayed
+// onIgnore: if present, an 'Ignore for now' button is displayed, that disables the
+//   assistant for the current interaction with anchorEl and runs the callback function
+// children: message to display
+//
+// Sample usage:
+//<UserInputAssistant
+//  anchorEl={input}
+//  variant={hint-secondary}
+//  title="Separator detected"
+//  actionLabel="Separate and add"
+//  onAction={() => separateAndAdd()}
+//  onIgnore={() => disableSeparatorDetection()}
+//  >
+//  Don't use comma, press ENTER!
+//</UserInputAssistant>
+//
+
+function UserInputAssistant (props) {
+  const { anchorEl, variant, title, children, actionLabel, onAction, onIgnore, classes } = {...props};
+  let [ enabled, setEnabled ] = useState(true);
+
+  let [ placement, setPlacement ] = useState("right");
+
+  useEffect(() => {
+    function handleResize() {
+      setPlacement(window.innerWidth > 750 ? "right" : "bottom");
+    }
+    handleResize();
+    window.addEventListener('resize', handleResize)
+    return (() => {
+      window.removeEventListener('resize', handleResize)
+    });
+  }, []);
+
+  return (enabled ?
+    <Popper
+      className={classes.userInputAssistant}
+      open={!!anchorEl}
+      anchorEl={anchorEl}
+      placement={placement}
+      transition
+      modifiers={{
+        flip: {
+          enabled: false,
+        }
+      }}
+      >
+    {({ TransitionProps }) => (
+      <Fade {...TransitionProps} timeout={350}>
+        <Card className={`Uia-${variant} Uia-placement-${placement}`}>
+          <CardHeader
+            avatar={<Avatar>
+            {
+              ['warning', 'error'].includes(variant) ?
+              <WarningIcon/> : <EmojiObjectsIcon />
+            }
+            </Avatar>}
+            title={title}
+            titleTypographyProps={{variant: "h6"}}
+            />
+          <CardContent>
+            { children }
+          </CardContent>
+          <CardActions>
+          { actionLabel && onAction &&
+            <Button color="default" onClick={onAction}>{actionLabel}</Button>
+          }
+          { onIgnore ?
+            <Button color="default" onClick={() => {setEnabled(false); onIgnore();}}>Ignore for now</Button>
+            :
+            <Button color="default" onClick={() => {setEnabled(false)}}>Got it!</Button>
+          }
+          </CardActions>
+        </Card>
+      </Fade>
+    )}
+    </Popper>
+  : null);
+}
+UserInputAssistant.propTypes = {
+  anchorEl: PropTypes.object,
+  title: PropTypes.string.isRequired,
+  variant: PropTypes.oneOf(['hint', 'hint-secondary', 'success', 'info', 'warning', 'error']),
+  actionLabel: PropTypes.string,
+  onAction: PropTypes.func,
+  onIgnore: PropTypes.func,
+};
+UserInputAssistant.defaultProps = {
+  variant: 'hint',
+}
+export default withStyles(style)(UserInputAssistant);

--- a/modules/commons/src/main/frontend/src/components/style.jsx
+++ b/modules/commons/src/main/frontend/src/components/style.jsx
@@ -39,6 +39,77 @@ const style = theme => ({
       marginRight: theme.spacing(1),
     },
   },
+  userInputAssistant: {
+    "& .MuiCard-root" : {
+      maxWidth: "375px",
+      border: "2px solid " + theme.palette.primary.main,
+      "&.Uia-placement-right": {
+        marginLeft: theme.spacing(2),
+        "&:before" : {
+          content: "''",
+          display: "block",
+          borderTop: theme.spacing(2) + "px solid transparent",
+          borderBottom: theme.spacing(2) + "px solid transparent",
+          borderRight: theme.spacing(2) + "px solid " + theme.palette.primary.main,
+          position: "absolute",
+          left: 0,
+          top: "50%",
+          marginTop: theme.spacing(-2),
+        },
+      },
+      "&.Uia-placement-bottom": {
+        margin: theme.spacing(3,4,0),
+      },
+      "& .MuiAvatar-root" : {
+        background: theme.palette.primary.main,
+      },
+      "&.Uia-hint-secondary" : {
+        borderColor: theme.palette.secondary.main,
+        "&.Uia-placement-right:before" : {
+          borderRightColor: theme.palette.secondary.main,
+        },
+        "& .MuiAvatar-root" : {
+          background: theme.palette.secondary.main,
+        },
+      },
+      "&.Uia-success" : {
+        borderColor: theme.palette.success.main,
+        "&.Uia-placement-right:before" : {
+          borderRightColor: theme.palette.success.main,
+        },
+        "& .MuiAvatar-root" : {
+          background: theme.palette.success.main,
+        },
+      },
+      "&.Uia-info" : {
+        borderColor: theme.palette.info.main,
+        "&.Uia-placement-right:before" : {
+          borderRightColor: theme.palette.info.main,
+        },
+        "& .MuiAvatar-root" : {
+          background: theme.palette.info.main,
+        },
+      },
+      "&.Uia-warning" : {
+        borderColor: theme.palette.warning.main,
+        "&.Uia-placement-right:before" : {
+          borderRightColor: theme.palette.warning.main,
+        },
+        "& .MuiAvatar-root" : {
+          background: theme.palette.warning.main,
+        },
+      },
+      "&.Uia-error" : {
+        borderColor: theme.palette.error.main,
+        "&.Uia-placement-right:before" : {
+          borderRightColor: theme.palette.error.main,
+        },
+        "& .MuiAvatar-root" : {
+          background: theme.palette.error.main,
+        },
+      },
+    },
+  },
 });
 
 export default style;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -288,7 +288,6 @@ function MultipleChoice(props) {
   let ghostInput = (input || textbox) && (<div className={isBare ? classes.bareAnswer : classes.searchWrapper}>
       <TextField
         helperText={maxAnswers !== 1 && "Press ENTER to add a new option"}
-        FormHelperTextProps={{error: separatorDetected}}
         className={classes.textField + (isRadio ? (' ' + classes.nestedInput) : '')}
         onChange={(event) => {
           setGhostName(event.target.value);
@@ -317,7 +316,6 @@ function MultipleChoice(props) {
       />
       { maxAnswers !== 1 &&
         <UserInputAssistant
-          variant="hint-secondary"
           title="Separator detected"
           anchorEl={assistantAnchor}
           actionLabel="Separate and add"

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -244,8 +244,18 @@ function MultipleChoice(props) {
   // Split the input by the separators and add each component as a different entry
   let splitInput = (input) => {
     let entries = input?.value?.split(/\s*[,;]\s*/);
-    entries?.filter((item, index) => (item != "" && entries.indexOf(item) === index))
-            .forEach((item) => {addOption(item, item); selectOption(item, item);});
+    // Remove empty strings, duplicates, and entries that are already selected
+    entries = entries?.filter((item, index) => (item != "" && entries.indexOf(item) === index && !selection.find(option => option[VALUE_POS] == item))) || [];
+    // Add and select remaining entries
+    if (entries.length > 0) {
+      let newSelection = selection.slice();
+      entries.forEach((item) => {
+        addOption(item, item)
+        newSelection.push([item, item])
+      });
+      setSelection(newSelection);
+    }
+    // Clear the input
     setGhostName("");
     checkForSeparators(null);
   }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -324,7 +324,7 @@ function MultipleChoice(props) {
         InputProps={muiInputProps}
         inputRef={ref => {inputEl = ref}}
       />
-      { maxAnswers !== 1 &&
+      { maxAnswers !== 1 && separatorDetectionEnabled &&
         <UserInputAssistant
           title="Separator detected"
           anchorEl={assistantAnchor}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -96,6 +96,7 @@ function MultipleChoice(props) {
   const [separatorDetectionEnabled, setSeparatorDetectionEnabled] = useState(enableSeparatorDetection);
   const [separatorDetected, setSeparatorDetected] = useState(false);
   const [assistantAnchor, setAssistantAnchor] = useState(null);
+  const [tmpGhostSelection, setTmpGhostSelection] = useState(null);
 
   let selectOption = (id, name, checked = false) => {
     // Selecting a radio button option will select only that option
@@ -239,6 +240,7 @@ function MultipleChoice(props) {
     let hasSeparators = separatorDetectionEnabled && !!(input?.value?.match(/[,;]/));
     setSeparatorDetected(hasSeparators);
     setAssistantAnchor(hasSeparators ? input : null);
+    setTmpGhostSelection(hasSeparators ? [input.value, input.value] : null);
   }
 
   // Split the input by the separators and add each component as a different entry
@@ -331,6 +333,10 @@ function MultipleChoice(props) {
           actionLabel="Separate and add"
           onAction={() => {splitInput(assistantAnchor)}}
           onIgnore={() => {setSeparatorDetectionEnabled(false); assistantAnchor?.focus(); checkForSeparators(null);}}
+          onClickAway={(event) => {
+            (document.activeElement != assistantAnchor) && acceptEnteredOption();
+            checkForSeparators(null);
+          }}
           >
           Using separators such as comma or semicolon will not create separate entries.
           If you wish to enter multiple values, press ENTER to add each one.
@@ -351,6 +357,10 @@ function MultipleChoice(props) {
   // When counting current answers for proper highlighting of answer instructions to the user, exclude the empty one
   let currentAnswers = answers.filter(item => item[VALUE_POS] !== '').length;
   const instructions = <AnswerInstructions currentAnswers={currentAnswers} {...props.questionDefinition} {...props} />;
+
+  // Temporarily append the input content to answers to avoid data loss while separator detection is active and preventing
+  //  the contents of the ghost input from being added as selection
+  tmpGhostSelection?.[VALUE_POS] && !answers.find(item => item[VALUE_POS] == tmpGhostSelection[VALUE_POS]) && answers.push(tmpGhostSelection);
 
   if (isSelect) {
     return (

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -50,7 +50,7 @@ const GHOST_SENTINEL = "custom-input";
   */
 function MultipleChoice(props) {
   let { classes, existingAnswer, input, textbox, onUpdate, onChange, additionalInputProps, muiInputProps, naValue, noneOfTheAboveValue, error, questionName, ...rest } = props;
-  let { maxAnswers, minAnswers, displayMode } = {...props.questionDefinition, ...props};
+  let { maxAnswers, minAnswers, displayMode, enableSeparatorDetection } = {...props.questionDefinition, ...props};
   let defaults = props.defaults || Object.values(props.questionDefinition)
     // Keep only answer options
     // FIXME Must deal with nested options, do this recursively
@@ -93,7 +93,7 @@ function MultipleChoice(props) {
   const ghostSelected = selection.some(element => {return element[VALUE_POS] === GHOST_SENTINEL;});
   const disabled = maxAnswers > 0 && selection.length >= maxAnswers && !isRadio && !ghostSelected;
   let inputEl = null;
-  const [separatorDetectionEnabled, setSeparatorDetectionEnabled] = useState(true);
+  const [separatorDetectionEnabled, setSeparatorDetectionEnabled] = useState(enableSeparatorDetection);
   const [separatorDetected, setSeparatorDetected] = useState(false);
   const [assistantAnchor, setAssistantAnchor] = useState(null);
 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -17,6 +17,7 @@
     "dataType": {
       "text" : {
         "validationRegexp": "string",
+        "enableSeparatorDetection": "boolean",
         "minAnswers": "long",
         "maxAnswers": "long"
       },

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -178,6 +178,11 @@
   // For text answers, a regular expression that can restrict/validate the allowed answers.
   - validationRegexp (string)
 
+  // For text answers that are multivalued and display an input, enable detecting separators
+  // (,;) and notifying the user that each option should be entered separately by
+  // pressing ENTER
+  - enableSeparatorDetection (boolean)
+
   // For numeric answers, the minimum and maximum allowed values
   - minValue (double)
   - maxValue (double)


### PR DESCRIPTION
Also includes[ LFS-1042: _Some cardiac_rehab questions should have separator detection enabled_](https://phenotips.atlassian.net/browse/LFS-1042).

**To test**: `cardiac_rehab` run mode > `Baseline Health Information` > `Allergies`, and enter comma or semicolon-separated values in the input, e.g. "peanuts, gluten". Only the questions listed in LFS-1042 should have this functionality enabled.

### Questions:

1. Should this functionality be **OPT-IN** (only questions with a specific flag `enableSeparatorDetection` should have it) or **OPT-OUT** (disable where commas are needed in the values)? I propose **OPT-IN**.
2. Is the secondary color (first pic) the right choice for the UI, or is primary color (second pic) more appropriate and less alarming?

![image](https://user-images.githubusercontent.com/651980/111800930-d421da80-88a2-11eb-9ba5-b720962e9d5a.png)

![image](https://user-images.githubusercontent.com/651980/111801074-f9164d80-88a2-11eb-85fb-311118d85686.png)