### PR TITLE
LFS-911 bugfix: Refactor lfs:Subject and lfs:SubjectType nodes to use a tree structure instead of parent references.

### DIFF
--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/DeleteServlet.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/DeleteServlet.java
@@ -123,7 +123,7 @@ public class DeleteServlet extends SlingAllMethodsServlet
      * Traverse through the references of the node.
      */
     private NodeConsumer traverseReferences = (node) -> {
-        iterateReferrers(node, this.traverseNode);
+        iterateReferrers(node, this.traverseNode, false);
     };
 
     private NodeConsumer markChildNodeDeleted = (node) -> {
@@ -223,7 +223,7 @@ public class DeleteServlet extends SlingAllMethodsServlet
         // Check if this node or its children are referenced by other nodes
         iterateChildren(node, this.traverseReferences, true);
 
-        if (this.nodesTraversed.get().size() == 1) {
+        if (this.nodesTraversed.get().size() == 0) {
             this.deleteNode.accept(node);
             this.resolver.get().adaptTo(Session.class).save();
         } else {

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/DeleteServlet.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/DeleteServlet.java
@@ -119,6 +119,13 @@ public class DeleteServlet extends SlingAllMethodsServlet
         this.nodesTraversed.get().add(node);
     };
 
+    /**
+     * Traverse through the references of the node.
+     */
+    private NodeConsumer traverseReferences = (node) -> {
+        iterateReferrers(node, this.traverseNode);
+    };
+
     private NodeConsumer markChildNodeDeleted = (node) -> {
         this.childNodesDeleted.get().add(node);
 
@@ -213,8 +220,8 @@ public class DeleteServlet extends SlingAllMethodsServlet
     private void handleDelete(final SlingHttpServletResponse response, final Node node)
         throws IOException, AccessDeniedException, RepositoryException
     {
-        // Check if node is referenced by other nodes
-        iterateReferrers(node, this.traverseNode);
+        // Check if this node or its children are referenced by other nodes
+        iterateChildren(node, this.traverseReferences, true);
 
         if (this.nodesTraversed.get().size() == 1) {
             this.deleteNode.accept(node);
@@ -254,6 +261,7 @@ public class DeleteServlet extends SlingAllMethodsServlet
     private void handleRecursiveDelete(Node node)
         throws AccessDeniedException, RepositoryException
     {
+        iterateChildren(node, this.deleteNode, false);
         iterateReferrers(node, this.deleteNode);
     }
 
@@ -276,9 +284,6 @@ public class DeleteServlet extends SlingAllMethodsServlet
             iterateReferrers(references.nextProperty().getParent(), consumer, true);
         }
 
-        // Also nab references through children
-        iterateChildren(node, consumer, false);
-
         if (includeRoot) {
             consumer.accept(node);
         }
@@ -298,9 +303,9 @@ public class DeleteServlet extends SlingAllMethodsServlet
         boolean includeRoot
     ) throws RepositoryException
     {
-        final NodeIterator references = node.getNodes();
-        while (references.hasNext()) {
-            iterateChildren(references.nextNode(), consumer, true);
+        final NodeIterator children = node.getNodes();
+        while (children.hasNext()) {
+            iterateChildren(children.nextNode(), consumer, true);
         }
 
         if (includeRoot) {


### PR DESCRIPTION
This patch fixes an issue with deleting vocabularies in a non-recursive delete, as well as the error message that shows up when deleting things from a referenced form. When counting references for deletion, it does so by excluding children of the current node, but including references to those children.

Previously:
![image](https://user-images.githubusercontent.com/4656440/112039409-62ec5c80-8b1a-11eb-965e-77f4ea5446dc.png)
![image](https://user-images.githubusercontent.com/4656440/112039422-65e74d00-8b1a-11eb-93ba-53f89cbc6256.png)
([LFS-1020: _Uninstalling a vocabulary fails_](https://phenotips.atlassian.net/browse/LFS-1020) ^)

Now:
![image](https://user-images.githubusercontent.com/4656440/112039432-6aac0100-8b1a-11eb-82d0-1088bb948e96.png)
