### PR TITLE
LFS-681: When clicking (+) on a subject child chart to add a form, do not show parent subject in the subject selection dialog

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -453,6 +453,11 @@ export function NewSubjectDialog (props) {
 
     promise.then((json) => {
       let newAllowedTypes = parseToArray(json);
+      if (currentSubject) {
+        // If we have a subject we must be a child of, only allow subject types who are children of the current type
+        let prefix = currentSubject["type"]["@path"];
+        newAllowedTypes.filter((newType) => newType["@path"].startsWith(prefix) && newType["@path"] != prefix);
+      }
       setNewSubjectAllowedTypes((old) => {
         let newTypes = old.slice();
         newTypes.push(newAllowedTypes);


### PR DESCRIPTION
This is more of a bugfix that occurs when creating a Radiotherapy or Chemotherapy form from the Tumour chart. This restricts the ability to create subjects of subject types that are not descendents of the currently viewed subject. E.g. you can no longer create a Patient or a Tumour from the tumour chart, only TumourRegions.

**To test:** Create a bunch of different forms from different patient/tumour/tumour region charts. You should no longer be able to create any subject that is not a child of the currently-selected chart.