### PR TITLE
LFS-877: When clicking (+) on a subject chart, don't allow the creation of new subjects that are not descendants of the current subject

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -223,8 +223,8 @@ function NewFormDialog(props) {
   }
 
   // if the current subject is the only required type for the questionnaire or if the
-  // only acceptable subjects are the subject we're looking at or children (e.g.
-  // tumors and patients), filter the acceptable subject types that can be created.
+  // only acceptable subjects are the subject we're looking at or its descendents (e.g.
+  // tumors and tumor regions for a tumor), filter the acceptable subject types that can be created.
   let allowedSubjectTypes = selectedQuestionnaire && parseToArray(selectedQuestionnaire["requiredSubjectTypes"]);
   let filteredAllowedSubjectTypes = allowedSubjectTypes;
   if (selectedQuestionnaire && currentSubject) {

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -223,7 +223,7 @@ function NewFormDialog(props) {
   }
 
   // if the current subject is the only required type for the questionnaire or if the
-  // only acceptable subjects are the subject we're looking at or non-children (e.g.
+  // only acceptable subjects are the subject we're looking at or children (e.g.
   // tumors and patients), filter the acceptable subject types that can be created.
   let allowedSubjectTypes = selectedQuestionnaire && parseToArray(selectedQuestionnaire["requiredSubjectTypes"]);
   let filteredAllowedSubjectTypes = allowedSubjectTypes;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -453,6 +453,11 @@ export function NewSubjectDialog (props) {
 
     promise.then((json) => {
       let newAllowedTypes = parseToArray(json);
+      if (currentSubject) {
+        // If we have a subject we must be a child of, only allow subject types who are children of the current type
+        let prefix = currentSubject["type"]["@path"];
+        newAllowedTypes.filter((newType) => newType["@path"].startsWith(prefix) && newType["@path"] != prefix);
+      }
       setNewSubjectAllowedTypes((old) => {
         let newTypes = old.slice();
         newTypes.push(newAllowedTypes);


### PR DESCRIPTION
This PR restricts the ability to create subjects of subject types that are not descendents of the currently viewed subject. E.g. you can no longer create a Patient or a Tumour from the tumour chart, only TumourRegions.

**To test**: Create a bunch of different forms from different patient/tumour/tumour region charts. You should no longer be able to create any subject that is not a child of the currently-selected chart.