### PR TITLE
LFS-1061 & LFS-1062: Files with URL special characters in their name can be uploaded but not downloaded or deleted

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/FileResourceQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FileResourceQuestion.jsx
@@ -206,7 +206,7 @@ function FileResourceQuestion(props) {
     // Rather than waiting to delete, we'll just delete it immediately
     let data = new FormData();
     data.append(':operation', 'delete');
-    fetchWithReLogin(globalLoginDisplay, uploadedFiles[answers[index][0]], {
+    fetchWithReLogin(globalLoginDisplay, fixFileURL(uploadedFiles[answers[index][0]], answers[index][0]), {
       method: "POST",
       body: data
       });

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FileResourceQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FileResourceQuestion.jsx
@@ -223,9 +223,13 @@ function FileResourceQuestion(props) {
     allowResave();
   }
 
+  let fixFileURL = (path, name) => {
+    return path.slice(0, path.lastIndexOf(name)) + encodeURIComponent(name);
+  }
+
   let hrefs = Array.of(existingAnswer?.[1]["value"]).flat();
   let defaultDisplayFormatter = function(label, idx) {
-    return <a href={hrefs[idx]} target="_blank" rel="noopener" download>{label}</a>;
+    return <a href={fixFileURL(hrefs[idx], label)} target="_blank" rel="noopener" download>{label}</a>;
   }
 
   return (
@@ -253,7 +257,7 @@ function FileResourceQuestion(props) {
           <li key={idx}>
             <div>
               <span>File </span>
-              <Link href={uploadedFiles[filepath]} target="_blank" rel="noopener" download>
+              <Link href={fixFileURL(uploadedFiles[filepath], filepath)} target="_blank" rel="noopener" download>
                 {filepath}
               </Link>:
               <IconButton

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -545,7 +545,9 @@ function FormData(props) {
           content = <>
             {prettyPrintedAnswers.map((answerValue, idx) => {
               let prefix = idx > 0 ? ", " : ""; // Seperator space between different files
-              return <>{prefix}<a key={answerValue} href={paths[idx]} target="_blank" rel="noopener" download>{answerValue}</a></>
+              // Encode the filename to ensure special charactars don't result in a broken link
+              let path = paths[idx].slice(0, paths[idx].lastIndexOf(answerValue)) + encodeURIComponent(answerValue);
+              return <React.Fragment key={answerValue}>{prefix}<a href={path} target="_blank" rel="noopener" download={answerValue}>{answerValue}</a></React.Fragment>
             })}
             </>
           break;


### PR DESCRIPTION
[LFS-1061: Files with URL special characters in their name can be uploaded but not downloaded](https://phenotips.atlassian.net/browse/LFS-1061)

[LFS-1062: Files with URL special characters in their name can't be deleted](https://phenotips.atlassian.net/browse/LFS-1062)

### To test LFS-1061:
- create a new questionnaire with one question of type file, or use Somatic variants in lfs runmode
- create an instance of the questionnaire
- locally create files containing special URL characters, e.g.: "test#1.csv", "final_results(?).txt"
- upload the files to the file question
- navigate to the subject chart or to the view mode of the form and try to download the files

Note: `?` appears to be replaced with a different character depending on the browser in the name of the downloaded file (`_` in Chrome, space in Firefox).

### To test LFS-1062:
- create a new questionnaire with one question of type file, or use Somatic variants in lfs runmode
- create an instance of the questionnaire
- locally create files containing special URL characters, e.g.: "test#1.csv"
- upload the files to the file question, save
- check .deep.bare.json for the form and see the file node is there
- delete the answer
- check .deep.bare.json for the form and see the file node has been removed (before these changes, only the value would be erased, while the file node woud STILL be there).