### PR TITLE
LFS-1068: Quotation marks in question or section identifiers break the questionnaire serialization

### DIFF
--- a/distribution/src/main/provisioning/50-sling-webconsole.txt
+++ b/distribution/src/main/provisioning/50-sling-webconsole.txt
@@ -31,7 +31,7 @@
     org.apache.felix/org.apache.felix.webconsole.plugins.packageadmin/1.0.4
     org.apache.felix/org.apache.felix.webconsole.plugins.event/1.1.8
     org.apache.felix/org.apache.felix.webconsole.plugins.memoryusage/1.0.8
-    org.apache.sling/org.apache.sling.commons.johnzon/1.1.2
+    org.apache.sling/org.apache.sling.commons.johnzon/1.2.6
     org.apache.felix/org.apache.felix.bundlerepository/2.0.10
     org.apache.sling/org.apache.sling.extensions.threaddump/0.2.2
     org.apache.aries.jmx/org.apache.aries.jmx.api/1.1.5


### PR DESCRIPTION
There was a bug in the previous version of the library, which the upgrade should fix.

To test:
- does the PR solve the issue?
- are there any other things that my be broken/fixed by the upgrade, especially things with special characters like 1058, 1061, 1062?