### PR TITLE
LFS-1059: Create a utility program for configuring LDAP settings for a running CARDS instance

### DIFF
--- a/Utilities/Administration/configure_ldap.py
+++ b/Utilities/Administration/configure_ldap.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+"""
+
+import os
+import sys
+import requests
+from requests.auth import HTTPBasicAuth
+
+CARDS_URL = "http://localhost:8080"
+if "CARDS_URL" in os.environ:
+  CARDS_URL = os.environ["CARDS_URL"].rstrip('/')
+
+ADMIN_PASSWORD = "admin"
+if "ADMIN_PASSWORD" in os.environ:
+  ADMIN_PASSWORD = os.environ["ADMIN_PASSWORD"]
+
+CARDS_LDAP_PROVIDER_NAME = "ldap"
+if "CARDS_LDAP_PROVIDER_NAME" in os.environ:
+  CARDS_LDAP_PROVIDER_NAME = os.environ["CARDS_LDAP_PROVIDER_NAME"]
+
+if "CARDS_LDAP_HOSTNAME" in os.environ:
+  CARDS_LDAP_HOSTNAME = os.environ["CARDS_LDAP_HOSTNAME"]
+else:
+  CARDS_LDAP_HOSTNAME = input("LDAP server hostname: ")
+
+if "CARDS_LDAP_PORT" in os.environ:
+  CARDS_LDAP_PORT = os.environ["CARDS_LDAP_PORT"]
+else:
+  CARDS_LDAP_PORT = input("LDAP server port: ")
+
+CARDS_LDAP_SSL = "false"
+if "CARDS_LDAP_SSL" in os.environ:
+  CARDS_LDAP_SSL = os.environ["CARDS_LDAP_SSL"]
+
+CARDS_LDAP_TLS = "false"
+if "CARDS_LDAP_TLS" in os.environ:
+  CARDS_LDAP_TLS = os.environ["CARDS_LDAP_TLS"]
+
+CARDS_LDAP_NO_CERT_CHECK = "false"
+if "CARDS_LDAP_NO_CERT_CHECK" in os.environ:
+  CARDS_LDAP_NO_CERT_CHECK = os.environ["CARDS_LDAP_NO_CERT_CHECK"]
+
+if "CARDS_LDAP_BIND_DN" in os.environ:
+  CARDS_LDAP_BIND_DN = os.environ["CARDS_LDAP_BIND_DN"]
+else:
+  CARDS_LDAP_BIND_DN = input("LDAP Bind DN: ")
+
+if "CARDS_LDAP_BIND_PASSWORD" in os.environ:
+  CARDS_LDAP_BIND_PASSWORD = os.environ["CARDS_LDAP_BIND_PASSWORD"]
+else:
+  CARDS_LDAP_BIND_PASSWORD = input("LDAP Bind Password: ")
+
+if "CARDS_LDAP_USER_BASE_DN" in os.environ:
+  CARDS_LDAP_USER_BASE_DN = os.environ["CARDS_LDAP_USER_BASE_DN"]
+else:
+  CARDS_LDAP_USER_BASE_DN = input("LDAP User Base DN: ")
+
+if "CARDS_LDAP_USER_OBJECT_CLASS" in os.environ:
+  CARDS_LDAP_USER_OBJECT_CLASS = os.environ["CARDS_LDAP_USER_OBJECT_CLASS"]
+else:
+  CARDS_LDAP_USER_OBJECT_CLASS = input("LDAP User Object Class: ")
+
+if "CARDS_LDAP_USER_ID_ATTRIBUTE" in os.environ:
+  CARDS_LDAP_USER_ID_ATTRIBUTE = os.environ["CARDS_LDAP_USER_ID_ATTRIBUTE"]
+else:
+  CARDS_LDAP_USER_ID_ATTRIBUTE = input("LDAP User ID Attribute: ")
+
+
+form_data = {}
+form_data['apply'] = 'true'
+form_data['action'] = 'ajaxConfigManager'
+form_data['$location'] = ''
+form_data['provider.name'] = CARDS_LDAP_PROVIDER_NAME
+form_data['host.name'] = CARDS_LDAP_HOSTNAME
+form_data['host.port'] = CARDS_LDAP_PORT
+form_data['host.ssl'] = CARDS_LDAP_SSL
+form_data['host.tls'] = CARDS_LDAP_TLS
+form_data['noCertCheck'] = CARDS_LDAP_NO_CERT_CHECK
+form_data['bind.dn'] = CARDS_LDAP_BIND_DN
+form_data['bind.password'] = CARDS_LDAP_BIND_PASSWORD
+form_data['searchTimeout'] = '60s'
+form_data['adminPool.maxActive'] = '8'
+form_data['adminPool.lookupOnValidate'] = 'true'
+form_data['adminPool.lookupOnValidate'] = 'false'
+form_data['userPool.maxActive'] = '8'
+form_data['userPool.lookupOnValidate'] = 'true'
+form_data['userPool.lookupOnValidate'] = 'false'
+form_data['user.baseDN'] = CARDS_LDAP_USER_BASE_DN
+form_data['user.objectclass'] = CARDS_LDAP_USER_OBJECT_CLASS
+form_data['user.idAttribute'] = CARDS_LDAP_USER_ID_ATTRIBUTE
+form_data['user.extraFilter'] = ''
+form_data['user.makeDnPath'] = 'false'
+form_data['group.baseDN'] = 'ou=groups,o=example,dc=com'
+form_data['group.objectclass'] = 'groupOfUniqueNames'
+form_data['group.nameAttribute'] = 'cn'
+form_data['group.extraFilter'] = ''
+form_data['group.makeDnPath'] = 'false'
+form_data['group.memberAttribute'] = 'uniquemember'
+form_data['useUidForExtId'] = 'false'
+form_data['customattributes'] = ''
+
+propertylist = []
+propertylist.append('provider.name')
+propertylist.append('host.name')
+propertylist.append('host.port')
+propertylist.append('host.ssl')
+propertylist.append('host.tls')
+propertylist.append('host.noCertCheck')
+propertylist.append('bind.dn')
+propertylist.append('bind.password')
+propertylist.append('searchTimeout')
+propertylist.append('adminPool.maxActive')
+propertylist.append('adminPool.lookupOnValidate')
+propertylist.append('userPool.maxActive')
+propertylist.append('userPool.lookupOnValidate')
+propertylist.append('user.baseDN')
+propertylist.append('user.objectclass')
+propertylist.append('user.idAttribute')
+propertylist.append('user.extraFilter')
+propertylist.append('user.makeDnPath')
+propertylist.append('group.baseDN')
+propertylist.append('group.objectclass')
+propertylist.append('group.nameAttribute')
+propertylist.append('group.extraFilter')
+propertylist.append('group.makeDnPath')
+propertylist.append('group.memberAttribute')
+propertylist.append('useUidForExtId')
+propertylist.append('customattributes')
+form_data['propertylist'] = ','.join(propertylist)
+
+
+config_req = requests.post(CARDS_URL + "/system/console/configMgr/org.apache.jackrabbit.oak.security.authentication.ldap.impl.LdapIdentityProvider", data=form_data, auth=HTTPBasicAuth('admin', ADMIN_PASSWORD))
+if config_req.status_code != 200:
+  print("Error while configuring LDAP")
+  sys.exit(-1)
+print("Configured LDAP")

--- a/Utilities/Administration/configure_ldap.py
+++ b/Utilities/Administration/configure_ldap.py
@@ -42,10 +42,9 @@ if "CARDS_LDAP_HOSTNAME" in os.environ:
 else:
   CARDS_LDAP_HOSTNAME = input("LDAP server hostname: ")
 
+CARDS_LDAP_PORT = "389"
 if "CARDS_LDAP_PORT" in os.environ:
   CARDS_LDAP_PORT = os.environ["CARDS_LDAP_PORT"]
-else:
-  CARDS_LDAP_PORT = input("LDAP server port: ")
 
 CARDS_LDAP_SSL = "false"
 if "CARDS_LDAP_SSL" in os.environ:

--- a/Utilities/Administration/configure_ldap.py
+++ b/Utilities/Administration/configure_ldap.py
@@ -44,7 +44,7 @@ if '--help' in sys.argv:
   print("- CARDS_LDAP_BIND_PASSWORD: Password for connecting to the LDAP server. Prompts if not specified.")
   print("- CARDS_LDAP_USER_BASE_DN: Where to begin searching through LDAP for a user. Prompts if not specified.")
   print("- CARDS_LDAP_USER_OBJECT_CLASS: The LDAP object type which will represent a CARDS user. Prompts if not specified.")
-  print("- CARDS_LDAP_USER_ID_ATTRIBUTE: The LDAP attribute that should match the login name.")
+  print("- CARDS_LDAP_USER_ID_ATTRIBUTE: The LDAP attribute that should match the login name. Prompts if not specified.")
   sys.exit()
 
 CARDS_URL = "http://localhost:8080"

--- a/Utilities/Administration/configure_ldap.py
+++ b/Utilities/Administration/configure_ldap.py
@@ -93,29 +93,12 @@ form_data['host.name'] = CARDS_LDAP_HOSTNAME
 form_data['host.port'] = CARDS_LDAP_PORT
 form_data['host.ssl'] = CARDS_LDAP_SSL
 form_data['host.tls'] = CARDS_LDAP_TLS
-form_data['noCertCheck'] = CARDS_LDAP_NO_CERT_CHECK
+form_data['host.noCertCheck'] = CARDS_LDAP_NO_CERT_CHECK
 form_data['bind.dn'] = CARDS_LDAP_BIND_DN
 form_data['bind.password'] = CARDS_LDAP_BIND_PASSWORD
-form_data['searchTimeout'] = '60s'
-form_data['adminPool.maxActive'] = '8'
-form_data['adminPool.lookupOnValidate'] = 'true'
-form_data['adminPool.lookupOnValidate'] = 'false'
-form_data['userPool.maxActive'] = '8'
-form_data['userPool.lookupOnValidate'] = 'true'
-form_data['userPool.lookupOnValidate'] = 'false'
 form_data['user.baseDN'] = CARDS_LDAP_USER_BASE_DN
 form_data['user.objectclass'] = CARDS_LDAP_USER_OBJECT_CLASS
 form_data['user.idAttribute'] = CARDS_LDAP_USER_ID_ATTRIBUTE
-form_data['user.extraFilter'] = ''
-form_data['user.makeDnPath'] = 'false'
-form_data['group.baseDN'] = 'ou=groups,o=example,dc=com'
-form_data['group.objectclass'] = 'groupOfUniqueNames'
-form_data['group.nameAttribute'] = 'cn'
-form_data['group.extraFilter'] = ''
-form_data['group.makeDnPath'] = 'false'
-form_data['group.memberAttribute'] = 'uniquemember'
-form_data['useUidForExtId'] = 'false'
-form_data['customattributes'] = ''
 
 propertylist = []
 propertylist.append('provider.name')
@@ -126,24 +109,9 @@ propertylist.append('host.tls')
 propertylist.append('host.noCertCheck')
 propertylist.append('bind.dn')
 propertylist.append('bind.password')
-propertylist.append('searchTimeout')
-propertylist.append('adminPool.maxActive')
-propertylist.append('adminPool.lookupOnValidate')
-propertylist.append('userPool.maxActive')
-propertylist.append('userPool.lookupOnValidate')
 propertylist.append('user.baseDN')
 propertylist.append('user.objectclass')
 propertylist.append('user.idAttribute')
-propertylist.append('user.extraFilter')
-propertylist.append('user.makeDnPath')
-propertylist.append('group.baseDN')
-propertylist.append('group.objectclass')
-propertylist.append('group.nameAttribute')
-propertylist.append('group.extraFilter')
-propertylist.append('group.makeDnPath')
-propertylist.append('group.memberAttribute')
-propertylist.append('useUidForExtId')
-propertylist.append('customattributes')
 form_data['propertylist'] = ','.join(propertylist)
 
 

--- a/Utilities/Administration/configure_ldap.py
+++ b/Utilities/Administration/configure_ldap.py
@@ -25,6 +25,28 @@ import sys
 import requests
 from requests.auth import HTTPBasicAuth
 
+#Display help and exit, if instructed to do so
+if '--help' in sys.argv:
+  print("Configures a running CARDS instance to authenticate users against an LDAP server")
+  print("")
+  print("Environment Variables")
+  print("---------------------")
+  print("")
+  print("- CARDS_URL: URL of the CARDS instance. Defaults to http://localhost:8080.")
+  print("- ADMIN_PASSWORD: Admin password for the CARDS instance. Defaults to 'admin'.")
+  print("- CARDS_LDAP_PROVIDER_NAME: LDAP provider name. Defaults to 'ldap'.")
+  print("- CARDS_LDAP_HOSTNAME: Hostname of the LDAP server. Prompts if not specified.")
+  print("- CARDS_LDAP_PORT: TCP port of the LDAP server. Defaults to 389.")
+  print("- CARDS_LDAP_SSL: Enable SSL when connecting to the LDAP server. Defaults to false.")
+  print("- CARDS_LDAP_TLS: Enable TLS when connecting to the LDAP server. Defaults to false.")
+  print("- CARDS_LDAP_NO_CERT_CHECK: Disable checking the SSL/TLS certificate when connecting to the LDAP server. Defaults to false.")
+  print("- CARDS_LDAP_BIND_DN: Bind DN for connecting to the LDAP server. Prompts if not specified.")
+  print("- CARDS_LDAP_BIND_PASSWORD: Password for connecting to the LDAP server. Prompts if not specified.")
+  print("- CARDS_LDAP_USER_BASE_DN: Where to begin searching through LDAP for a user. Prompts if not specified.")
+  print("- CARDS_LDAP_USER_OBJECT_CLASS: The LDAP object type which will represent a CARDS user. Prompts if not specified.")
+  print("- CARDS_LDAP_USER_ID_ATTRIBUTE: The LDAP attribute that should match the login name.")
+  sys.exit()
+
 CARDS_URL = "http://localhost:8080"
 if "CARDS_URL" in os.environ:
   CARDS_URL = os.environ["CARDS_URL"].rstrip('/')


### PR DESCRIPTION
This Pull Request implements LFS-1059 by creating the `configure_ldap.py` program which configures a running CARDS instance to use an LDAP server for user authentication.

To test:

1. Build the `LFS-1059` branch
2. Download the test LDAP server (`docker pull dwimberger/ldap-ad-it`)
3. Start the test LDAP server (`docker run --rm -p 10389:10389 -it dwimberger/ldap-ad-it`)
4. Start CARDS
5. Attempt to login to CARDS with _Username:_ `test` and _Password:_ `secret`. This should fail and display an _unable to login_ message after approximately 1 minute.
6. Enter the `Utilities/Administration` directory
7. Run `python3 configure_ldap.py` and specify the following values at the following prompts:
    - `LDAP server hostname` = `localhost`
    - `LDAP server port` = `10389`
    - `LDAP Bind DN` = `uid=admin,ou=system`
    - `LDAP Bind Password` = `secret`
    - `LDAP User Base DN` = `dc=wimpi,dc=net`
    - `LDAP User Object Class` = `inetOrgPerson`
    - `LDAP User ID Attribute` = `samaccountname`

Alternatively, these values should be able to be specified through the `CARDS_LDAP_HOSTNAME`, `CARDS_LDAP_PORT`, `CARDS_LDAP_BIND_DN`, `CARDS_LDAP_BIND_PASSWORD`, `CARDS_LDAP_USER_BASE_DN`, `CARDS_LDAP_USER_OBJECT_CLASS`, and `CARDS_LDAP_USER_ID_ATTRIBUTE` environment variables.

8. You should now be able to log into CARDS with the _Username:_ `test` and _Password:_ `secret`