### PR TITLE
LFS-1097: generate_compose_yaml.py should allow for the user to define the subnet of IP addresses used in the docker-compose environment

### DIFF
--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -37,6 +37,7 @@ argparser.add_argument('--oak_filesystem', help='Use the filesystem (instead of 
 argparser.add_argument('--external_mongo', help='Use an external MongoDB instance instead of providing our own', action='store_true')
 argparser.add_argument('--ssl_proxy', help='Protect this service with SSL/TLS (use https:// instead of http://)', action='store_true')
 argparser.add_argument('--sling_admin_port', help='The localhost TCP port which should be forwarded to lfsinitial:8080', type=int)
+argparser.add_argument('--subnet', help='Manually specify the subnet of IP addresses to be used by the containers in this docker-compose environment')
 args = argparser.parse_args()
 
 MONGO_SHARD_COUNT = args.shards
@@ -297,6 +298,11 @@ else:
 print("Configuring the internal network")
 yaml_obj['networks'] = {}
 yaml_obj['networks']['internalnetwork'] = {}
+if args.subnet:
+	yaml_obj['networks']['internalnetwork']['ipam'] = {}
+	yaml_obj['networks']['internalnetwork']['ipam']['driver'] = 'default'
+	yaml_obj['networks']['internalnetwork']['ipam']['config'] = {}
+	yaml_obj['networks']['internalnetwork']['ipam']['config'] = [{'subnet': args.subnet}]
 
 #Save it
 with open(OUTPUT_FILENAME, 'w') as f_out:

--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -37,7 +37,7 @@ argparser.add_argument('--oak_filesystem', help='Use the filesystem (instead of 
 argparser.add_argument('--external_mongo', help='Use an external MongoDB instance instead of providing our own', action='store_true')
 argparser.add_argument('--ssl_proxy', help='Protect this service with SSL/TLS (use https:// instead of http://)', action='store_true')
 argparser.add_argument('--sling_admin_port', help='The localhost TCP port which should be forwarded to lfsinitial:8080', type=int)
-argparser.add_argument('--subnet', help='Manually specify the subnet of IP addresses to be used by the containers in this docker-compose environment')
+argparser.add_argument('--subnet', help='Manually specify the subnet of IP addresses to be used by the containers in this docker-compose environment (eg. --subnet 172.99.0.0/16)')
 args = argparser.parse_args()
 
 MONGO_SHARD_COUNT = args.shards

--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -301,7 +301,6 @@ yaml_obj['networks']['internalnetwork'] = {}
 if args.subnet:
 	yaml_obj['networks']['internalnetwork']['ipam'] = {}
 	yaml_obj['networks']['internalnetwork']['ipam']['driver'] = 'default'
-	yaml_obj['networks']['internalnetwork']['ipam']['config'] = {}
 	yaml_obj['networks']['internalnetwork']['ipam']['config'] = [{'subnet': args.subnet}]
 
 #Save it


### PR DESCRIPTION
Introduces the `--subnet` flag to the `generate_compose_yaml.py` file so that the caller of `generate_compose_yaml.py` can manually specify the IP subnet of the containers within the docker-compose environment.

To test:

1. Build this branch `mvn clean install`
2. `cd compose-cluster`
3. `python3 generate_compose_yaml.py --oak_filesystem --subnet 172.99.0.0/16`
4. `docker-compose build`
5. `docker-compose up -d`
6. Visit `http://localhost:8080`. CARDS should work normally.
7. Run `docker network inspect compose-cluster_internalnetwork`.  All containers should be in the `172.99.0.0/16` subnet.