### PR TITLE
LFS-1077: Keep input radio button and label together in compact mode

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -416,7 +416,7 @@ function MultipleChoice(props) {
           {generateDefaultOptions(options, selection, disabled, isRadio, selectNonGhostOption, removeOption)}
           {/* Ghost radio for the text input */}
           {
-          (input || textbox) && <ListItem className={classes.selectionChild + " " + classes.ghostListItem}>
+          (ghostInput && <ListItem className={classes.selectionChild + " " + classes.ghostListItem}>
             <FormControlLabel
               control={
               <Radio
@@ -456,7 +456,7 @@ function MultipleChoice(props) {
         {instructions}
         <List className={classes.optionsList}>
           {generateDefaultOptions(options, selection, disabled, isRadio, selectNonGhostOption, removeOption)}
-          <ListItem>{ghostInput}</ListItem>
+          {ghostInput && <ListItem>{ghostInput}</ListItem>}
         </List>
         <Answer
           answers={answers}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -416,7 +416,7 @@ function MultipleChoice(props) {
           {generateDefaultOptions(options, selection, disabled, isRadio, selectNonGhostOption, removeOption)}
           {/* Ghost radio for the text input */}
           {
-          (ghostInput && <ListItem className={classes.selectionChild + " " + classes.ghostListItem}>
+          ghostInput && <ListItem className={classes.selectionChild + " " + classes.ghostListItem}>
             <FormControlLabel
               control={
               <Radio


### PR DESCRIPTION
Fixed regression: empty "item" displayed for checkbox-list questions

For example, in lfs / Demographics / Mutation-Pathogenecity, after all the checkboxes there's a narrow empty box that becomes gray when hovering it. I did not test the code, when testing make sure that the unwanted box goes away, and for checkboxes + input questions, the input is still there.