### PR TITLE
LFS-1099: Description of HANCESTRO terms is not shown

### DIFF
--- a/modules/data-entry/src/main/frontend/src/vocabQuery/query.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/query.jsx
@@ -521,7 +521,7 @@ class VocabularyQuery extends React.Component {
         infoID: data["identifier"],
         infoPath: data["@path"],
         infoName: data["label"],
-        infoDefinition: data["def"] || data["description"],
+        infoDefinition: data["def"] || data["description"] || data["definition"],
         infoAlsoKnownAs: synonym,
         infoTypeOf: typeOf,
         infoAnchor: this.state.buttonRefs[data["identifier"]],


### PR DESCRIPTION
Not tested.

To test:

- start in lfs mode
- install HP and HANCESTRO
- create a new Demographics form
- search for "European" in the Race question, load the information about a term, check that it has a description ("Includes individuals who either self-report or have been..."), both when pressing the (I) button directly in the search results, and in the vocabulary browser after clicking "Learn More"
- search for "Obesity" in Comorbidities, check that it has a description ("Accumulation of substantial excess body fat")

In the future, we need to make this a special case when indexing a vocabulary so that we have one standard property present in all terms, regardless of what vocabulary it comes from.