### PR TITLE
LFS-1101: Displaying information for CHEBI terms fails

### DIFF
--- a/modules/vocabularies/pom.xml
+++ b/modules/vocabularies/pom.xml
@@ -46,7 +46,7 @@
             <Sling-Nodetypes>SLING-INF/nodetypes/vocabularies.cnd</Sling-Nodetypes>
             <!-- Initial content to be loaded on bundle installation -->
             <Sling-Initial-Content>
-              SLING-INF/content/apps/lfs/oak%3Aindex/;path:=/oak:index/;overwrite:=true,
+              SLING-INF/content/oak%3Aindex/;path:=/oak:index/;overwrite:=true,
               SLING-INF/content/Extensions/Views/;path:=/Extensions/Views/;overwrite:=true,
               SLING-INF/content/Extensions/AdminDashboard/;path:=/Extensions/AdminDashboard/;overwrite:=true
             </Sling-Initial-Content>


### PR DESCRIPTION
To test:

- index CHEBI
- access `/Vocabularies/CHEBI/CHEBI86483.info.json`; it should be a blank page on dev, a proper JSON in the PR