### PR TITLE
LFS-836: LFS forms clean up

### DIFF
--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Chemotherapy.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Chemotherapy.xml
@@ -355,6 +355,11 @@
 					<value>Unknown</value>
 					<type>String</type>
 				</property>
+				<property>
+					<name>noneOfTheAbove</name>
+					<value>True</value>
+					<type>Boolean</type>
+				</property>
 			</node>
 		</node>
 		<node>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Chemotherapy.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Chemotherapy.xml
@@ -159,7 +159,7 @@
 			</property>
 			<property>
 				<name>minAnswers</name>
-				<value>1</value>
+				<value>0</value>
 				<type>Long</type>
 			</property>
 			<property>
@@ -193,7 +193,7 @@
 			</property>
 			<property>
 				<name>minAnswers</name>
-				<value>1</value>
+				<value>0</value>
 				<type>Long</type>
 			</property>
 			<property>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Chemotherapy.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Chemotherapy.xml
@@ -34,30 +34,6 @@
 		<type>Reference</type>
 	</property>
 	<node>
-		<name>diagnosis</name>
-		<primaryNodeType>lfs:Question</primaryNodeType>
-		<property>
-			<name>text</name>
-			<value>Diagnosis (Morphology) as on pathology report</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
-		<property>
-			<name>displayMode</name>
-			<value>textbox</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>dataType</name>
-			<value>text</value>
-			<type>String</type>
-		</property>
-	</node>
-	<node>
 		<name>chemotherapy</name>
 		<primaryNodeType>lfs:Question</primaryNodeType>
 		<property>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Chemotherapy.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Chemotherapy.xml
@@ -124,6 +124,11 @@
 				<value>text</value>
 				<type>String</type>
 			</property>
+			<property>
+				<name>enableNotes</name>
+				<value>True</value>
+				<type>Boolean</type>
+			</property>
 		</node>
 		<node>
 			<name>weight_at_start</name>
@@ -577,30 +582,6 @@
 				<name>enableNotes</name>
 				<value>True</value>
 				<type>Boolean</type>
-			</property>
-		</node>
-		<node>
-			<name>protocol_information</name>
-			<primaryNodeType>lfs:Question</primaryNodeType>
-			<property>
-				<name>text</name>
-				<value>Protocol information</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>maxAnswers</name>
-				<value>1</value>
-				<type>Long</type>
-			</property>
-			<property>
-				<name>displayMode</name>
-				<value>textbox</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>dataType</name>
-				<value>text</value>
-				<type>String</type>
 			</property>
 		</node>
 	</node>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Chemotherapy.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Chemotherapy.xml
@@ -140,7 +140,7 @@
 			</property>
 			<property>
 				<name>maxAnswers</name>
-				<value>1</value>
+				<value>0</value>
 				<type>Long</type>
 			</property>
 			<property>
@@ -228,6 +228,11 @@
 			<property>
 				<name>minAnswers</name>
 				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>0</value>
 				<type>Long</type>
 			</property>
 			<property>
@@ -410,6 +415,11 @@
 					<type>String</type>
 				</property>
 				<property>
+					<name>minAnswers</name>
+					<value>0</value>
+					<type>Long</type>
+				</property>
+				<property>
 					<name>maxAnswers</name>
 					<value>1</value>
 					<type>Long</type>
@@ -479,6 +489,11 @@
 					<type>String</type>
 				</property>
 				<property>
+					<name>minAnswers</name>
+					<value>0</value>
+					<type>Long</type>
+				</property>
+				<property>
 					<name>maxAnswers</name>
 					<value>1</value>
 					<type>Long</type>
@@ -507,6 +522,11 @@
 				<name>text</name>
 				<value>Cumulative dose</value>
 				<type>String</type>
+			</property>
+			<property>
+				<name>minAnswers</name>
+				<value>0</value>
+				<type>Long</type>
 			</property>
 			<property>
 				<name>maxAnswers</name>
@@ -602,8 +622,13 @@
 			<type>String</type>
 		</property>
 		<property>
+			<name>minAnswers</name>
+			<value>0</value>
+			<type>Long</type>
+		</property>
+		<property>
 			<name>maxAnswers</name>
-			<value>1</value>
+			<value>0</value>
 			<type>Long</type>
 		</property>
 		<property>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Chemotherapy.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Chemotherapy.xml
@@ -194,43 +194,17 @@
 			</property>
 		</node>
 		<node>
-			<name>agent</name>
-			<primaryNodeType>lfs:Question</primaryNodeType>
-			<property>
-				<name>text</name>
-				<value>Chemotherapy Agent</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>minAnswers</name>
-				<value>1</value>
-				<type>Long</type>
-			</property>
-			<property>
-				<name>maxAnswers</name>
-				<value>0</value>
-				<type>Long</type>
-			</property>
-			<property>
-				<name>dataType</name>
-				<value>vocabulary</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>sourceVocabularies</name>
-				<values>
-					<value>CHEBI</value>
-				</values>
-				<type>String</type>
-			</property>
-		</node>
-		<node>
 			<name>start_date</name>
 			<primaryNodeType>lfs:Question</primaryNodeType>
 			<property>
 				<name>text</name>
-				<value>Start date</value>
+				<value>Chemotherapy start date</value>
 				<type>String</type>
+			</property>
+			<property>
+				<name>minAnswers</name>
+				<value>0</value>
+				<type>Long</type>
 			</property>
 			<property>
 				<name>maxAnswers</name>
@@ -258,8 +232,13 @@
 			<primaryNodeType>lfs:Question</primaryNodeType>
 			<property>
 				<name>text</name>
-				<value>End date</value>
+				<value>Chemotherapy end date</value>
 				<type>String</type>
+			</property>
+			<property>
+				<name>minAnswers</name>
+				<value>0</value>
+				<type>Long</type>
 			</property>
 			<property>
 				<name>maxAnswers</name>
@@ -274,6 +253,42 @@
 			<property>
 				<name>dateFormat</name>
 				<value>yyyy-MM-dd</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>enableNotes</name>
+				<value>True</value>
+				<type>Boolean</type>
+			</property>
+		</node>
+		<node>
+			<name>agent</name>
+			<primaryNodeType>lfs:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Chemotherapy Agent</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>0</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>vocabulary</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>sourceVocabularies</name>
+				<values>
+					<value>CHEBI</value>
+				</values>
 				<type>String</type>
 			</property>
 			<property>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Demographics.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Demographics.xml
@@ -1045,7 +1045,7 @@
 		</property>
 		<property>
 			<name>minAnswers</name>
-			<value>1</value>
+			<value>0</value>
 			<type>Long</type>
 		</property>
 		<property>
@@ -1465,7 +1465,7 @@
 			</property>
 			<property>
 				<name>minAnswers</name>
-				<value>1</value>
+				<value>0</value>
 				<type>Long</type>
 			</property>
 			<property>
@@ -1572,7 +1572,7 @@
 		</property>
 		<property>
 			<name>minAnswers</name>
-			<value>1</value>
+			<value>0</value>
 			<type>Long</type>
 		</property>
 		<property>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Demographics.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Demographics.xml
@@ -1218,27 +1218,9 @@
 		</property>
 		<property>
 			<name>dataType</name>
-			<value>vocabulary</value>
+			<value>text</value>
 			<type>String</type>
 		</property>
-		<property>
-			<name>sourceVocabularies</name>
-			<values>
-				<value>SNOMEDCT</value>
-			</values>
-			<type>String</type>
-		</property>
-		<node>
-			<name>vocabularyFilters</name>
-			<primaryNodeType>lfs:VocabularyFilterGroup</primaryNodeType>
-			<property>
-				<name>SNOMEDCT</name>
-				<values>
-					<value>children of Relative</value>
-				</values>
-				<type>String</type>
-			</property>
-		</node>
 		<node>
 			<name>Proband</name>
 			<primaryNodeType>lfs:AnswerOption</primaryNodeType>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Demographics.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Demographics.xml
@@ -642,7 +642,7 @@
 			</property>
 			<property>
 				<name>label</name>
-				<value>Frameshift (smalll insertion)</value>
+				<value>Frameshift (small insertion)</value>
 				<type>String</type>
 			</property>
 		</node>
@@ -661,20 +661,25 @@
 			</property>
 		</node>
 		<node>
-			<name>missense</name>
+			<name>fsid</name>
 			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
 				<name>value</name>
-				<value>missense</value>
+				<value>fsid</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>label</name>
+				<value>Frameshift (small indel)</value>
 				<type>String</type>
 			</property>
 		</node>
 		<node>
-			<name>nonsense</name>
+			<name>missense</name>
 			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
 				<name>value</name>
-				<value>nonsense</value>
+				<value>Missense</value>
 				<type>String</type>
 			</property>
 		</node>
@@ -683,7 +688,21 @@
 			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
 				<name>value</name>
-				<value>missense DN</value>
+				<value>Missense DN</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>label</name>
+				<value>Missense, de novo</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>nonsense</name>
+			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
+			<property>
+				<name>value</name>
+				<value>Nonsense</value>
 				<type>String</type>
 			</property>
 		</node>
@@ -692,7 +711,7 @@
 			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
 				<name>value</name>
-				<value>splice donor</value>
+				<value>Splice donor</value>
 				<type>String</type>
 			</property>
 		</node>
@@ -701,7 +720,7 @@
 			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
 				<name>value</name>
-				<value>splice acceptor</value>
+				<value>Splice acceptor</value>
 				<type>String</type>
 			</property>
 		</node>
@@ -710,7 +729,7 @@
 			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
 				<name>value</name>
-				<value>large insertion</value>
+				<value>Large insertion</value>
 				<type>String</type>
 			</property>
 		</node>
@@ -719,7 +738,7 @@
 			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
 				<name>value</name>
-				<value>large deletion</value>
+				<value>Large deletion</value>
 				<type>String</type>
 			</property>
 		</node>
@@ -728,7 +747,7 @@
 			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
 				<name>value</name>
-				<value>synonymous</value>
+				<value>Synonymous</value>
 				<type>String</type>
 			</property>
 		</node>
@@ -737,7 +756,7 @@
 			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
 				<name>value</name>
-				<value>synonymous splicing</value>
+				<value>Synonymous splicing</value>
 				<type>String</type>
 			</property>
 		</node>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Demographics.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Demographics.xml
@@ -1016,7 +1016,7 @@
 		</property>
 		<property>
 			<name>maxAnswers</name>
-			<value>0</value>
+			<value>1</value>
 			<type>Long</type>
 		</property>
 		<property>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Demographics.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Demographics.xml
@@ -158,6 +158,11 @@
 				<value>U</value>
 				<type>String</type>
 			</property>
+			<property>
+				<name>noneOfTheAbove</name>
+				<value>True</value>
+				<type>Boolean</type>
+			</property>
 		</node>
 	</node>
 	<node>
@@ -510,6 +515,11 @@
 				<value>Undetermined</value>
 				<type>String</type>
 			</property>
+			<property>
+				<name>noneOfTheAbove</name>
+				<value>True</value>
+				<type>Boolean</type>
+			</property>
 		</node>
 	</node>
 	<node>
@@ -668,6 +678,25 @@
 				<type>String</type>
 			</property>
 		</node>
+		<node>
+			<name>U</name>
+			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
+			<property>
+				<name>value</name>
+				<value>U</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>label</name>
+				<value>Undetermined</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>noneOfTheAbove</name>
+				<value>True</value>
+				<type>Boolean</type>
+			</property>
+		</node>
 	</node>
 	<node>
 		<name>test_done_code</name>
@@ -741,6 +770,11 @@
 				<value>Unknown</value>
 				<type>String</type>
 			</property>
+			<property>
+				<name>noneOfTheAbove</name>
+				<value>True</value>
+				<type>Boolean</type>
+			</property>
 		</node>
 	</node>
 	<node>
@@ -801,6 +835,20 @@
 			<type>Boolean</type>
 		</property>
 		<node>
+			<name>NA</name>
+			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
+			<property>
+				<name>value</name>
+				<value>N/A</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>notApplicable</name>
+				<value>True</value>
+				<type>Boolean</type>
+			</property>
+		</node>
+		<node>
 			<name>Incidental</name>
 			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
@@ -835,18 +883,9 @@
 				<value>Unknown</value>
 				<type>String</type>
 			</property>
-		</node>
-		<node>
-			<name>NA</name>
-			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
-				<name>value</name>
-				<value>N/A</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>notApplicable</name>
-				<value>true</value>
+				<name>noneOfTheAbove</name>
+				<value>True</value>
 				<type>Boolean</type>
 			</property>
 		</node>
@@ -1130,6 +1169,11 @@
 				<name>label</name>
 				<value>This is the proband</value>
 				<type>String</type>
+			</property>
+			<property>
+				<name>notApplicable</name>
+				<value>True</value>
+				<type>Boolean</type>
 			</property>
 		</node>
 		<node>
@@ -1627,6 +1671,11 @@
 				<name>label</name>
 				<value>Unknown</value>
 				<type>String</type>
+			</property>
+			<property>
+				<name>noneOfTheAbove</name>
+				<value>True</value>
+				<type>Boolean</type>
 			</property>
 		</node>
 	</node>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Demographics.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Demographics.xml
@@ -212,38 +212,86 @@
 			</property>
 		</node>
 		<node>
-			<name>African race</name>
+			<name>African</name>
 			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
 				<name>value</name>
-				<value>African race</value>
+				<value>/Vocabularies/HANCESTRO/HANCESTRO_0010</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>label</name>
+				<value>African</value>
 				<type>String</type>
 			</property>
 		</node>
 		<node>
-			<name>American Indian or Alaska native</name>
+			<name>Native American</name>
 			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
 				<name>value</name>
-				<value>American Indian or Alaska native</value>
+				<value>/Vocabularies/HANCESTRO/HANCESTRO_0013</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>label</name>
+				<value>Native American</value>
 				<type>String</type>
 			</property>
 		</node>
 		<node>
-			<name>Asian or Pacific islander</name>
+			<name>Eskimo</name>
 			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
 				<name>value</name>
-				<value>Asian or Pacific islander</value>
+				<value>/Vocabularies/HANCESTRO/HANCESTRO_0595</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>label</name>
+				<value>Eskimo</value>
 				<type>String</type>
 			</property>
 		</node>
 		<node>
-			<name>Australian aborigine</name>
+			<name>Asian</name>
 			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
 				<name>value</name>
-				<value>Australian aborigine</value>
+				<value>/Vocabularies/HANCESTRO/HANCESTRO_0008</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>label</name>
+				<value>Asian</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>Pacific Islander</name>
+			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
+			<property>
+				<name>value</name>
+				<value>/Vocabularies/HANCESTRO/HANCESTRO_0574</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>label</name>
+				<value>Pacific Islander</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>Aboriginal Australian</name>
+			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
+			<property>
+				<name>value</name>
+				<value>/Vocabularies/HANCESTRO/HANCESTRO_0552</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>label</name>
+				<value>Aboriginal Australian</value>
 				<type>String</type>
 			</property>
 		</node>
@@ -252,16 +300,26 @@
 			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
 				<name>value</name>
+				<value>/Vocabularies/HANCESTRO/HANCESTRO_0005</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>label</name>
 				<value>Caucasian</value>
 				<type>String</type>
 			</property>
 		</node>
 		<node>
-			<name>Hispanic</name>
+			<name>Hispanic or Latin American</name>
 			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
 				<name>value</name>
-				<value>Hispanic</value>
+				<value>/Vocabularies/HANCESTRO/HANCESTRO_0014</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>label</name>
+				<value>Hispanic or Latin American</value>
 				<type>String</type>
 			</property>
 		</node>
@@ -270,6 +328,11 @@
 			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
 				<name>value</name>
+				<value>/Vocabularies/HANCESTRO/HANCESTRO_0487</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>label</name>
 				<value>Indian</value>
 				<type>String</type>
 			</property>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Radiotherapy.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Radiotherapy.xml
@@ -711,8 +711,13 @@
 			<type>String</type>
 		</property>
 		<property>
+			<name>minAnswers</name>
+			<value>0</value>
+			<type>Long</type>
+		</property>
+		<property>
 			<name>maxAnswers</name>
-			<value>1</value>
+			<value>0</value>
 			<type>Long</type>
 		</property>
 		<property>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Radiotherapy.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Radiotherapy.xml
@@ -116,7 +116,7 @@
 			</property>
 			<property>
 				<name>minAnswers</name>
-				<value>1</value>
+				<value>0</value>
 				<type>Long</type>
 			</property>
 			<property>
@@ -155,7 +155,7 @@
 			</property>
 			<property>
 				<name>minAnswers</name>
-				<value>1</value>
+				<value>0</value>
 				<type>Long</type>
 			</property>
 			<property>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Tumors.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Tumors.xml
@@ -109,10 +109,41 @@
 			<type>Long</type>
 		</property>
 		<property>
-			<name>dataType</name>
-			<value>text</value>
+			<name>displayMode</name>
+			<value>input</value>
 			<type>String</type>
 		</property>
+		<property>
+			<name>dataType</name>
+			<value>vocabulary</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>sourceVocabularies</name>
+			<values>
+				<value>ORDO</value>
+				<value>HP</value>
+			</values>
+			<type>String</type>
+		</property>
+		<node>
+			<name>vocabularyFilters</name>
+			<primaryNodeType>lfs:VocabularyFilterGroup</primaryNodeType>
+			<property>
+				<name>ORDO</name>
+				<values>
+					<value>Orphanet_C001</value>
+				</values>
+				<type>String</type>
+			</property>
+			<property>
+				<name>HP</name>
+				<values>
+					<value>HP:0000118</value>
+				</values>
+				<type>String</type>
+			</property>
+		</node>
 	</node>
 	<node>
 		<name>diagnosis_from_pathology_report</name>
@@ -157,10 +188,41 @@
 			<type>Long</type>
 		</property>
 		<property>
-			<name>dataType</name>
-			<value>text</value>
+			<name>displayMode</name>
+			<value>input</value>
 			<type>String</type>
 		</property>
+		<property>
+			<name>dataType</name>
+			<value>vocabulary</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>sourceVocabularies</name>
+			<values>
+				<value>ORDO</value>
+				<value>HP</value>
+			</values>
+			<type>String</type>
+		</property>
+		<node>
+			<name>vocabularyFilters</name>
+			<primaryNodeType>lfs:VocabularyFilterGroup</primaryNodeType>
+			<property>
+				<name>ORDO</name>
+				<values>
+					<value>Orphanet_C001</value>
+				</values>
+				<type>String</type>
+			</property>
+			<property>
+				<name>HP</name>
+				<values>
+					<value>HP:0000118</value>
+				</values>
+				<type>String</type>
+			</property>
+		</node>
 	</node>
 	<node>
 		<name>location</name>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Tumors.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Tumors.xml
@@ -511,64 +511,6 @@
 		</node>
 	</node>
 	<node>
-		<name>detected_by_imaging</name>
-		<primaryNodeType>lfs:Question</primaryNodeType>
-		<property>
-			<name>text</name>
-			<value>Detected by surveillance imaging</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>minAnswers</name>
-			<value>0</value>
-			<type>Long</type>
-		</property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
-		<property>
-			<name>dataType</name>
-			<value>boolean</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>enableUnknown</name>
-			<value>true</value>
-			<type>String</type>
-		</property>
-	</node>
-	<node>
-		<name>comments</name>
-		<primaryNodeType>lfs:Question</primaryNodeType>
-		<property>
-			<name>text</name>
-			<value>Comments</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>minAnswers</name>
-			<value>0</value>
-			<type>Long</type>
-		</property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
-		<property>
-			<name>displayMode</name>
-			<value>textbox</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>dataType</name>
-			<value>text</value>
-			<type>String</type>
-		</property>
-	</node>
-	<node>
 		<name>CT</name>
 		<primaryNodeType>lfs:Question</primaryNodeType>
 		<property>
@@ -1383,6 +1325,35 @@
 		</property>
 	</node>
 	<node>
+		<name>detected_by_imaging</name>
+		<primaryNodeType>lfs:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Detected by surveillance imaging</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>minAnswers</name>
+			<value>0</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>boolean</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>enableUnknown</name>
+			<value>true</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
 		<name>modality_of_detection</name>
 		<primaryNodeType>lfs:Question</primaryNodeType>
 		<property>
@@ -1544,6 +1515,35 @@
 		<property>
 			<name>text</name>
 			<value>Describe treatments done at PMH, if any</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>minAnswers</name>
+			<value>0</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>textbox</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>text</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>comments</name>
+		<primaryNodeType>lfs:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Comments</value>
 			<type>String</type>
 		</property>
 		<property>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Tumors.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Tumors.xml
@@ -503,6 +503,11 @@
 				<value>NA</value>
 				<type>String</type>
 			</property>
+			<property>
+				<name>label</name>
+				<value>N/A</value>
+				<type>String</type>
+			</property>
 		</node>
 	</node>
 	<node>
@@ -993,7 +998,7 @@
 			</property>
 			<property>
 				<name>label</name>
-				<value>NA</value>
+				<value>N/A</value>
 				<type>String</type>
 			</property>
 			<property>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Tumors.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Tumors.xml
@@ -263,6 +263,25 @@
 			<type>String</type>
 		</property>
 		<node>
+			<name>NA</name>
+			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
+			<property>
+				<name>value</name>
+				<value>NA</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>label</name>
+				<value>N/A</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>notApplicable</name>
+				<value>True</value>
+				<type>Boolean</type>
+			</property>
+		</node>
+		<node>
 			<name>B</name>
 			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
@@ -317,14 +336,10 @@
 				<value>Unknown</value>
 				<type>String</type>
 			</property>
-		</node>
-		<node>
-			<name>NA</name>
-			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
-				<name>value</name>
-				<value>NA</value>
-				<type>String</type>
+				<name>noneOfTheAbove</name>
+				<value>True</value>
+				<type>Boolean</type>
 			</property>
 		</node>
 	</node>
@@ -942,6 +957,11 @@
 				<name>label</name>
 				<value>NA</value>
 				<type>String</type>
+			</property>
+			<property>
+				<name>notApplicable</name>
+				<value>True</value>
+				<type>Boolean</type>
 			</property>
 		</node>
 		<node>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Tumors.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Tumors.xml
@@ -1212,7 +1212,7 @@
 		</property>
 		<property>
 			<name>maxAnswers</name>
-			<value>1</value>
+			<value>0</value>
 			<type>Long</type>
 		</property>
 		<property>
@@ -1241,7 +1241,7 @@
 		</property>
 		<property>
 			<name>maxAnswers</name>
-			<value>1</value>
+			<value>0</value>
 			<type>Long</type>
 		</property>
 		<property>
@@ -1261,6 +1261,21 @@
 		<property>
 			<name>text</name>
 			<value>Risk Group Assignment</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>minAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>list+input</value>
 			<type>String</type>
 		</property>
 		<node>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Tumors.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Tumors.xml
@@ -1006,6 +1006,11 @@
 			<value>text</value>
 			<type>String</type>
 		</property>
+		<property>
+			<name>enableNotes</name>
+			<value>True</value>
+			<type>Boolean</type>
+		</property>
 		<node>
 			<name>Low</name>
 			<primaryNodeType>lfs:AnswerOption</primaryNodeType>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Tumors.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Tumors.xml
@@ -38,30 +38,6 @@
 		<type>Long</type>
 	</property>
 	<node>
-		<name>lesion_number</name>
-		<primaryNodeType>lfs:Question</primaryNodeType>
-		<property>
-			<name>text</name>
-			<value>Lesion Number</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>minAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
-		<property>
-			<name>dataType</name>
-			<value>long</value>
-			<type>String</type>
-		</property>
-	</node>
-	<node>
 		<name>age_at_diagnosis</name>
 		<primaryNodeType>lfs:Question</primaryNodeType>
 		<property>

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Tumors.xml
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Tumors.xml
@@ -124,7 +124,7 @@
 		</property>
 		<property>
 			<name>minAnswers</name>
-			<value>1</value>
+			<value>0</value>
 			<type>Long</type>
 		</property>
 		<property>
@@ -177,7 +177,7 @@
 		</property>
 		<property>
 			<name>maxAnswers</name>
-			<value>0</value>
+			<value>1</value>
 			<type>Long</type>
 		</property>
 		<property>

--- a/lfs-resources/tissue-metrix/src/main/resources/SLING-INF/content/Questionnaires/TissueMetrix.xml
+++ b/lfs-resources/tissue-metrix/src/main/resources/SLING-INF/content/Questionnaires/TissueMetrix.xml
@@ -33,48 +33,6 @@
 		<type>Reference</type>
 	</property>
 	<node>
-		<name>file1</name>
-		<primaryNodeType>lfs:Question</primaryNodeType>
-		<property>
-			<name>text</name>
-			<value>File1</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
-	</node>
-	<node>
-		<name>file2</name>
-		<primaryNodeType>lfs:Question</primaryNodeType>
-		<property>
-			<name>text</name>
-			<value>File2</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
-	</node>
-	<node>
-		<name>file3</name>
-		<primaryNodeType>lfs:Question</primaryNodeType>
-		<property>
-			<name>text</name>
-			<value>File3</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
-	</node>
-	<node>
 		<name>donor_number</name>
 		<primaryNodeType>lfs:Question</primaryNodeType>
 		<property>
@@ -94,41 +52,12 @@
 		</property>
 	</node>
 	<node>
-		<name>perinatal_history</name>
+		<name>species</name>
 		<primaryNodeType>lfs:Question</primaryNodeType>
 		<property>
 			<name>text</name>
-			<value>Perinatal history</value>
+			<value>Species</value>
 			<type>String</type>
-		</property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
-		<property>
-			<name>displayMode</name>
-			<value>textbox</value>
-			<type>String</type>
-		</property>
-	</node>
-	<node>
-		<name>disease</name>
-		<primaryNodeType>lfs:Question</primaryNodeType>
-		<property>
-			<name>text</name>
-			<value>Disease</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>minAnswers</name>
-			<value>0</value>
-			<type>Long</type>
-		</property>
-		<property>
-			<name>maxAnswers</name>
-			<value>0</value>
-			<type>Long</type>
 		</property>
 		<property>
 			<name>displayMode</name>
@@ -136,45 +65,69 @@
 			<type>String</type>
 		</property>
 		<property>
-			<name>dataType</name>
-			<value>vocabulary</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>sourceVocabularies</name>
-			<values>
-				<value>MONDO</value>
-			</values>
-			<type>String</type>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
 		</property>
 		<node>
-			<name>vocabularyFilters</name>
-			<primaryNodeType>lfs:VocabularyFilterGroup</primaryNodeType>
+			<name>human</name>
+			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
 			<property>
-				<name>MONDO</name>
-				<values>
-					<value>MONDO_0000001</value>
-				</values>
+				<name>label</name>
+				<value>Human</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>value</name>
+				<value>human</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>canide</name>
+			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
+			<property>
+				<name>label</name>
+				<value>Canide</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>value</name>
+				<value>canide</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>murine</name>
+			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
+			<property>
+				<name>label</name>
+				<value>Murine</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>value</name>
+				<value>murine</value>
 				<type>String</type>
 			</property>
 		</node>
 	</node>
 	<node>
-		<name>last_fup</name>
+		<name>sex</name>
 		<primaryNodeType>lfs:Question</primaryNodeType>
 		<property>
 			<name>text</name>
-			<value>Last follow-up</value>
+			<value>Sex</value>
 			<type>String</type>
 		</property>
 		<property>
-			<name>dataType</name>
-			<value>date</value>
+			<name>description</name>
+			<value>Sex must be recorded as biological sex rather than gender.</value>
 			<type>String</type>
 		</property>
 		<property>
-			<name>dateFormat</name>
-			<value>yyyy-MM-dd</value>
+			<name>displayMode</name>
+			<value>list+input</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -182,87 +135,62 @@
 			<value>1</value>
 			<type>Long</type>
 		</property>
-	</node>
-	<node>
-		<name>date_of_birth</name>
-		<primaryNodeType>lfs:Question</primaryNodeType>
-		<property>
-			<name>text</name>
-			<value>Date of birth</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>dataType</name>
-			<value>date</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>dateFormat</name>
-			<value>yyyy-MM-dd</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
-	</node>
-	<node>
-		<name>date_of_death</name>
-		<primaryNodeType>lfs:Question</primaryNodeType>
-		<property>
-			<name>text</name>
-			<value>Date of death</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>dataType</name>
-			<value>date</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>dateFormat</name>
-			<value>yyyy-MM-dd</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
-	</node>
-	<node>
-		<name>date_registered</name>
-		<primaryNodeType>lfs:Question</primaryNodeType>
-		<property>
-			<name>text</name>
-			<value>Date registered</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>dataType</name>
-			<value>date</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>dateFormat</name>
-			<value>yyyy-MM-dd</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
-	</node>
-	<node>
-		<name>tumor</name>
-		<primaryNodeType>lfs:Question</primaryNodeType>
-		<property>
-			<name>text</name>
-			<value>Tumor type</value>
-			<type>String</type>
-		</property>
+		<node>
+			<name>M</name>
+			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
+			<property>
+				<name>label</name>
+				<value>Male</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>value</name>
+				<value>M</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>F</name>
+			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
+			<property>
+				<name>label</name>
+				<value>Female</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>value</name>
+				<value>F</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>O</name>
+			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
+			<property>
+				<name>label</name>
+				<value>Other</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>value</name>
+				<value>O</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>U</name>
+			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
+			<property>
+				<name>label</name>
+				<value>Unknown</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>value</name>
+				<value>U</value>
+				<type>String</type>
+			</property>
+		</node>
 	</node>
 	<node>
 		<name>vital_status</name>
@@ -312,26 +240,51 @@
 		</node>
 	</node>
 	<node>
-		<name>comments</name>
+		<name>date_of_birth</name>
 		<primaryNodeType>lfs:Question</primaryNodeType>
 		<property>
 			<name>text</name>
-			<value>Comments</value>
+			<value>Date of birth</value>
 			<type>String</type>
 		</property>
 		<property>
-			<name>displayMode</name>
-			<value>textbox</value>
+			<name>dataType</name>
+			<value>date</value>
 			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>yyyy-MM-dd</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
 		</property>
 	</node>
 	<node>
-		<name>mutation_status</name>
+		<name>date_of_death</name>
 		<primaryNodeType>lfs:Question</primaryNodeType>
 		<property>
 			<name>text</name>
-			<value>Mutation status</value>
+			<value>Date of death</value>
 			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>date</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>yyyy-MM-dd</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
 		</property>
 	</node>
 	<node>
@@ -429,6 +382,139 @@
 		</node>
 	</node>
 	<node>
+		<name>date_registered</name>
+		<primaryNodeType>lfs:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Date registered</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>date</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>yyyy-MM-dd</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+	</node>
+	<node>
+		<name>last_fup</name>
+		<primaryNodeType>lfs:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Last follow-up</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>date</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>yyyy-MM-dd</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+	</node>
+	<node>
+		<name>perinatal_history</name>
+		<primaryNodeType>lfs:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Perinatal history</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>textbox</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>reason_for_referral</name>
+		<primaryNodeType>lfs:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Reason for referral</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>textbox</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>disease</name>
+		<primaryNodeType>lfs:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Disease</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>minAnswers</name>
+			<value>0</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>0</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>list+input</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>vocabulary</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>sourceVocabularies</name>
+			<values>
+				<value>MONDO</value>
+			</values>
+			<type>String</type>
+		</property>
+		<node>
+			<name>vocabularyFilters</name>
+			<primaryNodeType>lfs:VocabularyFilterGroup</primaryNodeType>
+			<property>
+				<name>MONDO</name>
+				<values>
+					<value>MONDO_0000001</value>
+				</values>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
 		<name>disease_site</name>
 		<primaryNodeType>lfs:Question</primaryNodeType>
 		<property>
@@ -476,40 +562,29 @@
 		</node>
 	</node>
 	<node>
-		<name>reason_for_referral</name>
+		<name>tumor</name>
 		<primaryNodeType>lfs:Question</primaryNodeType>
 		<property>
 			<name>text</name>
-			<value>Reason for referral</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
-		<property>
-			<name>displayMode</name>
-			<value>textbox</value>
+			<value>Tumor type</value>
 			<type>String</type>
 		</property>
 	</node>
 	<node>
-		<name>sex</name>
+		<name>mutation_status</name>
 		<primaryNodeType>lfs:Question</primaryNodeType>
 		<property>
 			<name>text</name>
-			<value>Sex</value>
+			<value>Mutation status</value>
 			<type>String</type>
 		</property>
+	</node>
+	<node>
+		<name>file1</name>
+		<primaryNodeType>lfs:Question</primaryNodeType>
 		<property>
-			<name>description</name>
-			<value>Sex must be recorded as biological sex rather than gender.</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>displayMode</name>
-			<value>list+input</value>
+			<name>text</name>
+			<value>File1</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -517,62 +592,34 @@
 			<value>1</value>
 			<type>Long</type>
 		</property>
-		<node>
-			<name>M</name>
-			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
-			<property>
-				<name>label</name>
-				<value>Male</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>value</name>
-				<value>M</value>
-				<type>String</type>
-			</property>
-		</node>
-		<node>
-			<name>F</name>
-			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
-			<property>
-				<name>label</name>
-				<value>Female</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>value</name>
-				<value>F</value>
-				<type>String</type>
-			</property>
-		</node>
-		<node>
-			<name>O</name>
-			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
-			<property>
-				<name>label</name>
-				<value>Other</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>value</name>
-				<value>O</value>
-				<type>String</type>
-			</property>
-		</node>
-		<node>
-			<name>U</name>
-			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
-			<property>
-				<name>label</name>
-				<value>Unknown</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>value</name>
-				<value>U</value>
-				<type>String</type>
-			</property>
-		</node>
+	</node>
+	<node>
+		<name>file2</name>
+		<primaryNodeType>lfs:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>File2</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+	</node>
+	<node>
+		<name>file3</name>
+		<primaryNodeType>lfs:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>File3</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
 	</node>
 	<node>
 		<name>source1</name>
@@ -617,64 +664,17 @@
 		</property>
 	</node>
 	<node>
-		<name>species</name>
+		<name>comments</name>
 		<primaryNodeType>lfs:Question</primaryNodeType>
 		<property>
 			<name>text</name>
-			<value>Species</value>
+			<value>Comments</value>
 			<type>String</type>
 		</property>
 		<property>
 			<name>displayMode</name>
-			<value>list+input</value>
+			<value>textbox</value>
 			<type>String</type>
 		</property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
-		<node>
-			<name>human</name>
-			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
-			<property>
-				<name>label</name>
-				<value>Human</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>value</name>
-				<value>human</value>
-				<type>String</type>
-			</property>
-		</node>
-		<node>
-			<name>canide</name>
-			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
-			<property>
-				<name>label</name>
-				<value>Canide</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>value</name>
-				<value>canide</value>
-				<type>String</type>
-			</property>
-		</node>
-		<node>
-			<name>murine</name>
-			<primaryNodeType>lfs:AnswerOption</primaryNodeType>
-			<property>
-				<name>label</name>
-				<value>Murine</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>value</name>
-				<value>murine</value>
-				<type>String</type>
-			</property>
-		</node>
 	</node>
 </node>

--- a/lfs-resources/tissue-metrix/src/main/resources/SLING-INF/content/Questionnaires/TissueMetrix.xml
+++ b/lfs-resources/tissue-metrix/src/main/resources/SLING-INF/content/Questionnaires/TissueMetrix.xml
@@ -508,7 +508,7 @@
 			<property>
 				<name>MONDO</name>
 				<values>
-					<value>MONDO_0000001</value>
+					<value>MONDO:0000001</value>
 				</values>
 				<type>String</type>
 			</property>

--- a/lfs-resources/tissue-metrix/src/main/resources/SLING-INF/content/Questionnaires/TissueMetrix.xml
+++ b/lfs-resources/tissue-metrix/src/main/resources/SLING-INF/content/Questionnaires/TissueMetrix.xml
@@ -106,6 +106,11 @@
 			<value>1</value>
 			<type>Long</type>
 		</property>
+		<property>
+			<name>displayMode</name>
+			<value>textbox</value>
+			<type>String</type>
+		</property>
 	</node>
 	<node>
 		<name>disease</name>
@@ -330,6 +335,11 @@
 			<name>maxAnswers</name>
 			<value>1</value>
 			<type>Long</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>textbox</value>
+			<type>String</type>
 		</property>
 	</node>
 	<node>

--- a/lfs-resources/tissue-metrix/src/main/resources/SLING-INF/content/Questionnaires/TissueMetrix.xml
+++ b/lfs-resources/tissue-metrix/src/main/resources/SLING-INF/content/Questionnaires/TissueMetrix.xml
@@ -120,6 +120,44 @@
 			<value>Disease</value>
 			<type>String</type>
 		</property>
+		<property>
+			<name>minAnswers</name>
+			<value>0</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>0</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>list+input</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>vocabulary</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>sourceVocabularies</name>
+			<values>
+				<value>MONDO</value>
+			</values>
+			<type>String</type>
+		</property>
+		<node>
+			<name>vocabularyFilters</name>
+			<primaryNodeType>lfs:VocabularyFilterGroup</primaryNodeType>
+			<property>
+				<name>MONDO</name>
+				<values>
+					<value>MONDO_0000001</value>
+				</values>
+				<type>String</type>
+			</property>
+		</node>
 	</node>
 	<node>
 		<name>last_fup</name>
@@ -304,6 +342,44 @@
 			<value>Maternal ethnicity</value>
 			<type>String</type>
 		</property>
+		<property>
+			<name>minAnswers</name>
+			<value>0</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>0</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>input</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>vocabulary</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>sourceVocabularies</name>
+			<values>
+				<value>HANCESTRO</value>
+			</values>
+			<type>String</type>
+		</property>
+		<node>
+			<name>vocabularyFilters</name>
+			<primaryNodeType>lfs:VocabularyFilterGroup</primaryNodeType>
+			<property>
+				<name>HANCESTRO</name>
+				<values>
+					<value>HANCESTRO_0004</value>
+				</values>
+				<type>String</type>
+			</property>
+		</node>
 	</node>
 	<node>
 		<name>paternal_ethnicity</name>
@@ -313,6 +389,44 @@
 			<value>Paternal ethnicity</value>
 			<type>String</type>
 		</property>
+		<property>
+			<name>minAnswers</name>
+			<value>0</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>0</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>input</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>vocabulary</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>sourceVocabularies</name>
+			<values>
+				<value>HANCESTRO</value>
+			</values>
+			<type>String</type>
+		</property>
+		<node>
+			<name>vocabularyFilters</name>
+			<primaryNodeType>lfs:VocabularyFilterGroup</primaryNodeType>
+			<property>
+				<name>HANCESTRO</name>
+				<values>
+					<value>HANCESTRO_0004</value>
+				</values>
+				<type>String</type>
+			</property>
+		</node>
 	</node>
 	<node>
 		<name>disease_site</name>
@@ -322,6 +436,44 @@
 			<value>Disease site</value>
 			<type>String</type>
 		</property>
+		<property>
+			<name>minAnswers</name>
+			<value>0</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>0</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>input</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>vocabulary</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>sourceVocabularies</name>
+			<values>
+				<value>UBERON</value>
+			</values>
+			<type>String</type>
+		</property>
+		<node>
+			<name>vocabularyFilters</name>
+			<primaryNodeType>lfs:VocabularyFilterGroup</primaryNodeType>
+			<property>
+				<name>UBERON</name>
+				<values>
+					<value>BFO_0000002</value>
+				</values>
+				<type>String</type>
+			</property>
+		</node>
 	</node>
 	<node>
 		<name>reason_for_referral</name>


### PR DESCRIPTION
Draft PR because it is on top of LFS-1073 to make more of the vocabulary questions work, but it should be properly tested.

What won't work: Tumors / Diagnosis Code & Morphology Code, since they are single-valued vocabulary questions, which is not yet supported in LFS-1073.

Vocabularies to install for testing:
* HANCESTRO
* HP
* ORDO
* CHEBI
* MONDO
* UBERON