### PR TITLE
LFS-1098: After a vocabulary is installed, all its nodes should be checked in

### DIFF
--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/BioOntologyIndexer.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/BioOntologyIndexer.java
@@ -132,11 +132,11 @@ public class BioOntologyIndexer implements VocabularyIndexer
             parser.parse(temporaryFile, description, this::createVocabularyTermNode);
 
             /*
-             * Save the JCR session. If any errors occur before this step, all proposed changes will not be applied and
-             * the repository will remain in its original state. Lucene indexing is automatically performed by the
-             * Jackrabbit Oak repository when this is performed.
+             * Save the JCR session and check-in nodes. If any errors occur before this step, all proposed changes
+             * will not be applied and the repository will remain in its original state. Lucene indexing is
+             * automatically performed by the Jackrabbit Oak repository when this is performed.
              */
-            OntologyIndexerUtils.saveSession(homepage);
+            OntologyIndexerUtils.finalizeInstall(homepage);
 
             // Success response json
             this.utils.writeStatusJson(request, response, true, null);

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/BioOntologyIndexer.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/BioOntologyIndexer.java
@@ -21,7 +21,6 @@ package ca.sickkids.ccm.lfs.vocabularies.internal;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.jcr.Node;
@@ -81,9 +80,6 @@ public class BioOntologyIndexer implements VocabularyIndexer
     /** The vocabulary node where the indexed data must be placed. */
     private InheritableThreadLocal<Node> vocabularyNode = new InheritableThreadLocal<>();
 
-    /** The list which holds all JCR vocabulary nodes associated with a vocabulary to be checked-in. */
-    private InheritableThreadLocal<ArrayList<Node>> nodesToCheckIn = new InheritableThreadLocal<>();
-
     @Override
     public boolean canIndex(String source)
     {
@@ -129,12 +125,8 @@ public class BioOntologyIndexer implements VocabularyIndexer
             // Download the source
             temporaryFile = this.repository.downloadVocabularySource(description);
 
-            // Keep track of the JCR Nodes that are to be checked in
-            this.nodesToCheckIn.set(new ArrayList<Node>());
-
             // Create a new Vocabulary node representing this vocabulary
-            this.vocabularyNode.set(OntologyIndexerUtils.createVocabularyNode(
-                homepage, description, this.nodesToCheckIn));
+            this.vocabularyNode.set(OntologyIndexerUtils.createVocabularyNode(homepage, description));
 
             // Parse the source file and create VocabularyTerm node children
             parser.parse(temporaryFile, description, this::createVocabularyTermNode);
@@ -145,9 +137,6 @@ public class BioOntologyIndexer implements VocabularyIndexer
              * Jackrabbit Oak repository when this is performed.
              */
             OntologyIndexerUtils.saveSession(homepage);
-
-            // Check-in the nodes
-            OntologyIndexerUtils.checkInVocabulary(homepage, this.nodesToCheckIn);
 
             // Success response json
             this.utils.writeStatusJson(request, response, true, null);
@@ -164,6 +153,6 @@ public class BioOntologyIndexer implements VocabularyIndexer
 
     private void createVocabularyTermNode(VocabularyTermSource term)
     {
-        OntologyIndexerUtils.createVocabularyTermNode(term, this.vocabularyNode, this.nodesToCheckIn);
+        OntologyIndexerUtils.createVocabularyTermNode(term, this.vocabularyNode);
     }
 }

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/BioOntologyIndexer.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/BioOntologyIndexer.java
@@ -21,6 +21,7 @@ package ca.sickkids.ccm.lfs.vocabularies.internal;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.jcr.Node;
@@ -80,6 +81,9 @@ public class BioOntologyIndexer implements VocabularyIndexer
     /** The vocabulary node where the indexed data must be placed. */
     private InheritableThreadLocal<Node> vocabularyNode = new InheritableThreadLocal<>();
 
+    /** The list which holds all JCR vocabulary nodes associated with a vocabulary to be checked-in. */
+    private InheritableThreadLocal<ArrayList<Node>> nodesToCheckIn = new InheritableThreadLocal<>();
+
     @Override
     public boolean canIndex(String source)
     {
@@ -125,8 +129,12 @@ public class BioOntologyIndexer implements VocabularyIndexer
             // Download the source
             temporaryFile = this.repository.downloadVocabularySource(description);
 
+            // Keep track of the JCR Nodes that are to be checked in
+            this.nodesToCheckIn.set(new ArrayList<Node>());
+
             // Create a new Vocabulary node representing this vocabulary
-            this.vocabularyNode.set(OntologyIndexerUtils.createVocabularyNode(homepage, description));
+            this.vocabularyNode.set(OntologyIndexerUtils.createVocabularyNode(
+                homepage, description, this.nodesToCheckIn));
 
             // Parse the source file and create VocabularyTerm node children
             parser.parse(temporaryFile, description, this::createVocabularyTermNode);
@@ -137,6 +145,9 @@ public class BioOntologyIndexer implements VocabularyIndexer
              * Jackrabbit Oak repository when this is performed.
              */
             OntologyIndexerUtils.saveSession(homepage);
+
+            // Check-in the nodes
+            OntologyIndexerUtils.checkInVocabulary(homepage, this.nodesToCheckIn);
 
             // Success response json
             this.utils.writeStatusJson(request, response, true, null);
@@ -153,6 +164,6 @@ public class BioOntologyIndexer implements VocabularyIndexer
 
     private void createVocabularyTermNode(VocabularyTermSource term)
     {
-        OntologyIndexerUtils.createVocabularyTermNode(term, this.vocabularyNode);
+        OntologyIndexerUtils.createVocabularyTermNode(term, this.vocabularyNode, this.nodesToCheckIn);
     }
 }

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/FileUploadIndexer.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/FileUploadIndexer.java
@@ -148,11 +148,11 @@ public class FileUploadIndexer implements VocabularyIndexer
             parser.parse(temporaryFile, description, this::createVocabularyTermNode);
 
             /*
-             * Save the JCR session. If any errors occur before this step, all proposed changes will not be applied and
-             * the repository will remain in its original state. Lucene indexing is automatically performed by the
-             * Jackrabbit Oak repository when this is performed.
+             * Save the JCR session and check-in nodes. If any errors occur before this step, all proposed changes
+             * will not be applied and the repository will remain in its original state. Lucene indexing is
+             * automatically performed by the Jackrabbit Oak repository when this is performed.
              */
-            OntologyIndexerUtils.saveSession(homepage);
+            OntologyIndexerUtils.finalizeInstall(homepage);
 
             // Success response json
             this.utils.writeStatusJson(request, response, true, null);

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/FileUploadIndexer.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/FileUploadIndexer.java
@@ -21,7 +21,6 @@ package ca.sickkids.ccm.lfs.vocabularies.internal;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.jcr.Node;
@@ -78,9 +77,6 @@ public class FileUploadIndexer implements VocabularyIndexer
 
     /** The vocabulary node where the indexed data must be placed. */
     private InheritableThreadLocal<Node> vocabularyNode = new InheritableThreadLocal<>();
-
-    /** The list which holds all JCR vocabulary nodes associated with a vocabulary to be checked-in. */
-    private InheritableThreadLocal<ArrayList<Node>> nodesToCheckIn = new InheritableThreadLocal<>();
 
     @Override
     public boolean canIndex(String source)
@@ -145,12 +141,8 @@ public class FileUploadIndexer implements VocabularyIndexer
                 FileUtils.copyInputStreamToFile(uploadedOntology.getInputStream(), temporaryFile);
             }
 
-            // Keep track of the JCR Nodes that are to be checked in
-            this.nodesToCheckIn.set(new ArrayList<Node>());
-
             // Create a new Vocabulary node representing this vocabulary
-            this.vocabularyNode.set(OntologyIndexerUtils.createVocabularyNode(
-                homepage, description, this.nodesToCheckIn));
+            this.vocabularyNode.set(OntologyIndexerUtils.createVocabularyNode(homepage, description));
 
             // Parse the source file and create VocabularyTerm node children
             parser.parse(temporaryFile, description, this::createVocabularyTermNode);
@@ -161,9 +153,6 @@ public class FileUploadIndexer implements VocabularyIndexer
              * Jackrabbit Oak repository when this is performed.
              */
             OntologyIndexerUtils.saveSession(homepage);
-
-            // Check-in the nodes
-            OntologyIndexerUtils.checkInVocabulary(homepage, this.nodesToCheckIn);
 
             // Success response json
             this.utils.writeStatusJson(request, response, true, null);
@@ -186,6 +175,6 @@ public class FileUploadIndexer implements VocabularyIndexer
      */
     private void createVocabularyTermNode(VocabularyTermSource term)
     {
-        OntologyIndexerUtils.createVocabularyTermNode(term, this.vocabularyNode, this.nodesToCheckIn);
+        OntologyIndexerUtils.createVocabularyTermNode(term, this.vocabularyNode);
     }
 }

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/FileUploadIndexer.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/FileUploadIndexer.java
@@ -21,6 +21,7 @@ package ca.sickkids.ccm.lfs.vocabularies.internal;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.jcr.Node;
@@ -77,6 +78,9 @@ public class FileUploadIndexer implements VocabularyIndexer
 
     /** The vocabulary node where the indexed data must be placed. */
     private InheritableThreadLocal<Node> vocabularyNode = new InheritableThreadLocal<>();
+
+    /** The list which holds all JCR vocabulary nodes associated with a vocabulary to be checked-in. */
+    private InheritableThreadLocal<ArrayList<Node>> nodesToCheckIn = new InheritableThreadLocal<>();
 
     @Override
     public boolean canIndex(String source)
@@ -141,8 +145,12 @@ public class FileUploadIndexer implements VocabularyIndexer
                 FileUtils.copyInputStreamToFile(uploadedOntology.getInputStream(), temporaryFile);
             }
 
+            // Keep track of the JCR Nodes that are to be checked in
+            this.nodesToCheckIn.set(new ArrayList<Node>());
+
             // Create a new Vocabulary node representing this vocabulary
-            this.vocabularyNode.set(OntologyIndexerUtils.createVocabularyNode(homepage, description));
+            this.vocabularyNode.set(OntologyIndexerUtils.createVocabularyNode(
+                homepage, description, this.nodesToCheckIn));
 
             // Parse the source file and create VocabularyTerm node children
             parser.parse(temporaryFile, description, this::createVocabularyTermNode);
@@ -153,6 +161,9 @@ public class FileUploadIndexer implements VocabularyIndexer
              * Jackrabbit Oak repository when this is performed.
              */
             OntologyIndexerUtils.saveSession(homepage);
+
+            // Check-in the nodes
+            OntologyIndexerUtils.checkInVocabulary(homepage, this.nodesToCheckIn);
 
             // Success response json
             this.utils.writeStatusJson(request, response, true, null);
@@ -175,6 +186,6 @@ public class FileUploadIndexer implements VocabularyIndexer
      */
     private void createVocabularyTermNode(VocabularyTermSource term)
     {
-        OntologyIndexerUtils.createVocabularyTermNode(term, this.vocabularyNode);
+        OntologyIndexerUtils.createVocabularyTermNode(term, this.vocabularyNode, this.nodesToCheckIn);
     }
 }

--- a/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/OntologyIndexerUtils.java
+++ b/modules/vocabularies/src/main/java/ca/sickkids/ccm/lfs/vocabularies/internal/OntologyIndexerUtils.java
@@ -137,12 +137,11 @@ public final class OntologyIndexerUtils
      * @param vocabulariesHomepage the <code>VocabulariesHomepage</code> node obtained from the request
      * @throws VocabularyIndexException if session is not successfully saved
      */
-    public static void saveSession(Node vocabulariesHomepage)
+    private static void saveSession(Node vocabulariesHomepage)
         throws VocabularyIndexException
     {
         try {
             vocabulariesHomepage.getSession().save();
-            checkInVocabulary(vocabulariesHomepage);
         } catch (RepositoryException e) {
             String message = "Failed to save session: " + e.getMessage();
             throw new VocabularyIndexException(message, e);
@@ -155,7 +154,7 @@ public final class OntologyIndexerUtils
      * @param vocabulariesHomepage the <code>VocabulariesHomepage</code> node obtained from the request
      * @throws VocabularyIndexException if the checking-in of a Node fails
      */
-    public static void checkInVocabulary(Node vocabulariesHomepage) throws VocabularyIndexException
+    private static void checkInVocabulary(Node vocabulariesHomepage) throws VocabularyIndexException
     {
         try {
             final VersionManager vm = vocabulariesHomepage.getSession().getWorkspace().getVersionManager();
@@ -169,5 +168,18 @@ public final class OntologyIndexerUtils
             //Cleanup
             NODES_TO_CHECK_IN.remove();
         }
+    }
+
+    /**
+     * Finalizes the vocabulary install by saving the JCR session and checking in all the newly installed
+     * Vocabulary nodes.
+     *
+     * @param vocabulariesHomepage the <code>VocabulariesHomepage</code> node obtained from the request
+     * @throws VocabularyIndexException if the JCR session is not successfully saved or the checking-in of a Node fails
+     */
+    public static void finalizeInstall(Node vocabulariesHomepage) throws VocabularyIndexException
+    {
+        saveSession(vocabulariesHomepage);
+        checkInVocabulary(vocabulariesHomepage);
     }
 }


### PR DESCRIPTION
This PR implements LFS-1098 by keeping an internal list of all JCR nodes added from the installation of a vocabulary (either from BioPortal or from a local file). After committing the nodes to JCR, the internal list is used to check-in each node so that they have a version history.

To test:
1. Build this branch
2. Start CARDS in the `dev` runmode with a valid BioPortal API key
3. Install a vocabulary from BioPortal and inspect it in Composum (under `/Vocabularies/`). Ensure that both the root node of the vocabulary (eg. `HANCESTRO`) and all descendant nodes (eg. `Aruba`, `Australia`, `Austria`, etc...) have the property `jcr:isCheckedOut` set to `false`.
4. Install a vocabulary from a local file, inspect it in Composum and ensure that the above test passes.