### PR TITLE
LFS-1123: Non-latin characters are garbled

### DIFF
--- a/distribution/src/main/provisioning/10-sling-base.txt
+++ b/distribution/src/main/provisioning/10-sling-base.txt
@@ -206,3 +206,6 @@
     servlet.post.autoCheckin=B"true"
     servlet.post.autoCheckout=B"true"
     servlet.post.checkinNewVersionableNodes=B"true"
+
+  org.apache.sling.engine.parameters
+    sling.default.parameter.encoding="UTF-8"


### PR DESCRIPTION
Try to create a new Demographics form for a patient named "ășđț", and set "ășđț" as the Family. Save, reload, the patient is named "ÄÈÄÈ" instead.