### PR TITLE
LFS-1109: Display problems in pedigree editor

### DIFF
--- a/modules/commons/src/main/resources/SLING-INF/content/libs/lfs/Resource/json.GET.html
+++ b/modules/commons/src/main/resources/SLING-INF/content/libs/lfs/Resource/json.GET.html
@@ -1,3 +1,4 @@
+<sly data-sly-use.contentType="ca.sickkids.ccm.lfs.scripting.ContentTypeSetter">${contentType.json}</sly>
 <!--/*
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file

--- a/modules/commons/src/main/resources/SLING-INF/content/libs/lfs/Resource/null.GET.html
+++ b/modules/commons/src/main/resources/SLING-INF/content/libs/lfs/Resource/null.GET.html
@@ -1,4 +1,5 @@
-<%--
+<sly data-sly-use.contentType="ca.sickkids.ccm.lfs.scripting.ContentTypeSetter">${contentType.html}</sly>
+<!--/*
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
   distributed with this work for additional information
@@ -15,14 +16,5 @@
   KIND, either express or implied.  See the License for the
   specific language governing permissions and limitations
   under the License.
---%><%
-if (currentNode.hasNode('jcr:content') && currentNode.getNode('jcr:content').getPrimaryItem() != '') {
-  // This extension defines custom display code in its jcr:content
-  response.setContentType(currentNode.getNode('jcr:content').getProperty("jcr:mimeType").getString());
-  out.print(currentNode.getNode('jcr:content').getPrimaryItem());
-} else {
-  // No content, include the JSON displayer for this resource.
-  response.setContentType('application/json');
-  sling.include(resource + '.infinity.json');
-}
-%>
+*/-->
+<sly data-sly-resource="${'.html' @selectors='forceInclude'}"/>

--- a/modules/data-entry/src/main/resources/SLING-INF/content/libs/lfs/dataQuery/json.GET.html
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/libs/lfs/dataQuery/json.GET.html
@@ -1,3 +1,4 @@
+<sly data-sly-use.contentType="ca.sickkids.ccm.lfs.scripting.ContentTypeSetter">${contentType.json}</sly>
 <!--/*
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file

--- a/modules/data-entry/src/main/resources/SLING-INF/content/libs/lfs/dataQuery/null.GET.html
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/libs/lfs/dataQuery/null.GET.html
@@ -1,4 +1,5 @@
-<%--
+<sly data-sly-use.contentType="ca.sickkids.ccm.lfs.scripting.ContentTypeSetter">${contentType.json}</sly>
+<!--/*
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
   distributed with this work for additional information
@@ -15,17 +16,10 @@
   KIND, either express or implied.  See the License for the
   specific language governing permissions and limitations
   under the License.
---%>
-<%
-// This script is used whenever there's no explicit extension in the URL,
-// such as http://localhost:8080/ or http://localhost:8080/query (thus "null"),
-// and the HTTP method is GET (thus "null.GET").
-// For security, HTL doesn't allow calling methods with arguments,
-// so the more powerful ESP language must be used (thus "null.GET.esp").
-
-// Sling automatically adds a content type based on the extension, but since this has no extension we must explicitly add the response ContentType.
-response.setContentType('application/json');
-
-// Include the JSON displayer for this resource.
-sling.include(resource + '.json');
-%>
+*/-->
+<!--/*
+  This script is used whenever there's no explicit extension in the URL,
+  such as http://localhost:8080/ or http://localhost:8080/query (thus "null"),
+  and the HTTP method is GET (thus "null.GET").
+*/-->
+<sly data-sly-resource="${'.json' @selectors='forceInclude'}"/>

--- a/modules/homepage/src/main/resources/SLING-INF/content/libs/lfs/Homepage/html.GET.html
+++ b/modules/homepage/src/main/resources/SLING-INF/content/libs/lfs/Homepage/html.GET.html
@@ -1,3 +1,4 @@
+<sly data-sly-use.contentType="ca.sickkids.ccm.lfs.scripting.ContentTypeSetter">${contentType.html}</sly>
 <!--/*
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file

--- a/modules/login/src/main/resources/SLING-INF/content/libs/lfs/login/html.html
+++ b/modules/login/src/main/resources/SLING-INF/content/libs/lfs/login/html.html
@@ -1,3 +1,4 @@
+<sly data-sly-use.contentType="ca.sickkids.ccm.lfs.scripting.ContentTypeSetter">${contentType.html}</sly>
 <!--/*
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file

--- a/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/Extension/null.GET.html
+++ b/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/Extension/null.GET.html
@@ -1,4 +1,5 @@
-<%--
+<sly data-sly-use.contentType="ca.sickkids.ccm.lfs.scripting.ContentTypeSetter">${contentType.json}</sly>
+<!--/*
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
   distributed with this work for additional information
@@ -15,8 +16,6 @@
   KIND, either express or implied.  See the License for the
   specific language governing permissions and limitations
   under the License.
---%><%
-// No content, just include all the extensions for this point
-response.setContentType('application/json');
-sling.include(resource + '.resolved');
-%>
+*/-->
+<!--/* Include the JSON displayer for this extensions. */-->
+<sly data-sly-resource="${'.json' @selectors='deep.forceInclude'}"/>

--- a/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPoint/null.GET.html
+++ b/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPoint/null.GET.html
@@ -1,4 +1,5 @@
-<%--
+<sly data-sly-use.contentType="ca.sickkids.ccm.lfs.scripting.ContentTypeSetter">${contentType.json}</sly>
+<!--/*
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
   distributed with this work for additional information
@@ -15,17 +16,6 @@
   KIND, either express or implied.  See the License for the
   specific language governing permissions and limitations
   under the License.
---%>
-<%
-// This script is used whenever there's no explicit extension in the URL,
-// such as http://localhost:8080/ or http://localhost:8080/content (thus "null"),
-// and the HTTP method is GET (thus "null.GET").
-// For security, HTL doesn't allow calling methods with arguments,
-// so the more powerful ESP language must be used (thus "null.GET.esp").
-
-// Sling automatically adds a content type based on the extension, but since this has no extension we must explicitly add the response ContentType.
-response.setContentType('text/html');
-
-// Include the html displayer for this resource.
-sling.include(resource + '.html');
-%>
+*/-->
+<!--/* No content, just include all the extensions for this point */-->
+<sly data-sly-resource="${'.resolved' @selectors='forceInclude'}"/>

--- a/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/null.GET.html
+++ b/modules/ui-extension/src/main/resources/SLING-INF/content/libs/lfs/ExtensionPointFinder/null.GET.html
@@ -1,4 +1,5 @@
-<%--
+<sly data-sly-use.contentType="ca.sickkids.ccm.lfs.scripting.ContentTypeSetter">${contentType.json}</sly>
+<!--/*
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
   distributed with this work for additional information
@@ -15,14 +16,6 @@
   KIND, either express or implied.  See the License for the
   specific language governing permissions and limitations
   under the License.
---%><%
-if (currentNode.hasNode('jcr:content') && currentNode.getNode('jcr:content').getPrimaryItem() != '') {
-  // This extension defines custom display code in its jcr:content
-  response.setContentType(currentNode.getNode('jcr:content').getProperty("jcr:mimeType").getString());
-  out.print(currentNode.getNode('jcr:content').getPrimaryItem());
-} else {
-  // No content, just include all the extensions for this point
-  response.setContentType('application/json');
-  sling.include(resource + '.resolved');
-}
-%>
+*/-->
+<!--/* No content, just include all the extensions for this point */-->
+<sly data-sly-resource="${'.resolved' @selectors='forceInclude'}"/>


### PR DESCRIPTION
This sets the charset to UTF-8 for most of our resources. Things to check:

- as LFS-1109 says, the pedigree child menu looks OK
- the page encoding is NOT Western (not sure how to check in Chrome, but in Firefox the View / Text Encoding menu entry should be disabled)
- nothing is broken; I changed a lot of templates from `.esp` to `.html`, with a (purposeful) backwards incompatible change: we no longer support extensions that have their own "display" as an attached file, since we never used, it was partially implemented, and we already have something better for it, `extensionRenderURL`