### PR TITLE
LFS-1114: Create a utility program for listing all required vocabularies for a CARDS deployment

### DIFF
--- a/Utilities/Administration/install_required_vocabularies.sh
+++ b/Utilities/Administration/install_required_vocabularies.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+FAILURE_HANDLER=$1
+
+python3 list_required_vocabularies.py | while read -r vocab
+do
+  #Check if vocab.owl exists
+  if [ -n $VOCABULARY_FILES_PATH ] && [ -f $VOCABULARY_FILES_PATH/$vocab.owl ]
+  then
+    python3 install_vocabulary.py \
+      --vocabulary_file $VOCABULARY_FILES_PATH/$vocab.owl \
+      --vocabulary_id $vocab \
+      --vocabulary_name $vocab \
+      --vocabulary_version 1.0 || exit -1
+
+  #Check if vocab.obo exists
+  elif [ -n $VOCABULARY_FILES_PATH ] && [ -f $VOCABULARY_FILES_PATH/$vocab.obo ]
+  then
+    python3 install_vocabulary.py \
+      --vocabulary_file $VOCABULARY_FILES_PATH/$vocab.obo \
+      --vocabulary_id $vocab \
+      --vocabulary_name $vocab \
+      --vocabulary_version 1.0 || exit -1
+  else
+    #Try to install from BioPortal
+    python3 install_vocabulary.py --bioportal_id $vocab
+    #If BioPortal installation fails, either exit or just log an error
+    if [ $? -ne 0 ]
+    then
+      echo "*ERROR* Could not install $vocab"
+      [ $FAILURE_HANDLER = "exit_on_failure" ] && exit -1
+    fi
+done

--- a/Utilities/Administration/install_required_vocabularies.sh
+++ b/Utilities/Administration/install_required_vocabularies.sh
@@ -45,6 +45,7 @@ do
     if [ $? -ne 0 ]
     then
       echo "*ERROR* Could not install $vocab"
-      [ $FAILURE_HANDLER = "exit_on_failure" ] && exit -1
+      [ "$FAILURE_HANDLER" = "exit_on_failure" ] && exit -1
     fi
+  fi
 done

--- a/Utilities/Administration/install_required_vocabularies.sh
+++ b/Utilities/Administration/install_required_vocabularies.sh
@@ -1,5 +1,22 @@
 #!/bin/bash
 
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 FAILURE_HANDLER=$1
 
 python3 list_required_vocabularies.py | while read -r vocab

--- a/Utilities/Administration/list_required_vocabularies.py
+++ b/Utilities/Administration/list_required_vocabularies.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+"""
+
+import os
+import sys
+import requests
+from requests.auth import HTTPBasicAuth
+
+CARDS_URL = "http://localhost:8080"
+if "CARDS_URL" in os.environ:
+  CARDS_URL = os.environ["CARDS_URL"].rstrip('/')
+
+ADMIN_PASSWORD = "admin"
+if "ADMIN_PASSWORD" in os.environ:
+  ADMIN_PASSWORD = os.environ["ADMIN_PASSWORD"]
+
+query_req = requests.get(CARDS_URL + "/query?query=select * from [lfs:Question] as q WHERE q.'dataType'='vocabulary'&limit=1000000000", auth=HTTPBasicAuth('admin', ADMIN_PASSWORD))
+if query_req.status_code != 200:
+  print("Vocabularies query failed")
+  sys.exit(-1)
+
+required_vocabularies = set()
+for row in query_req.json()['rows']:
+  for vocab in row['sourceVocabularies']:
+    required_vocabularies.add(vocab)
+
+for vocab in required_vocabularies:
+  print(vocab)

--- a/Utilities/Administration/list_required_vocabularies.py
+++ b/Utilities/Administration/list_required_vocabularies.py
@@ -35,7 +35,8 @@ def sanitizeVocabularyIdentifier(vocab):
       output += c
   return output
 
-argparser.add_argument('--unsafe', help='Skip character filtering of the vocabulary identifiers obtained from CARDS')
+argparser = argparse.ArgumentParser()
+argparser.add_argument('--unsafe', help='Skip character filtering of the vocabulary identifiers obtained from CARDS', action='store_true')
 args = argparser.parse_args()
 
 CARDS_URL = "http://localhost:8080"


### PR DESCRIPTION
This Pull Request provides:

- The `list_required_vocabularies.py` program which queries CARDS for all _Question_ nodes with a _vocabulary_ answer and builds a compete set of all required vocabularies for a CARDS deployment.
- The `install_required_vocabularies.sh` script which reads the list of required vocabularies from `list_required_vocabularies.py` and first attempts to install them from local files and then attempts to install them from BioPortal.

To test:
1. Build this branch (`mvn clean install`)
2. Start CARDS on port `8080` with the `dev` and `lfs` runmodes and with a valid `BIOPORTAL_APIKEY`
3. Download the `chebi.obo` file from https://ftp.ebi.ac.uk/pub/databases/chebi/ontology/ (first load https://www.ebi.ac.uk/chebi/ to avoid SSL error) and save it as `CHEBI.obo` under the path `~/vocabs` (eg. `~/vocabs/CHEBI.obo`)
4. Download the _Human Ancestry Ontology_ from https://www.ebi.ac.uk/ols/ontologies/hancestro and save it as `HANCESTRO.owl` under the path `~/vocabs` (eg. `~/vocabs/HANCESTRO.owl`)
5. `cd Utilities/Administration`
6. `VOCABULARY_FILES_PATH=$(realpath ~/vocabs/) ./install_required_vocabularies.sh`
7. _HP_ should install from _BioPortal_. _CHEBI_ should install from the local file. _HANCESTRO_ should install from the local file. _SNOMEDCT_ is expected to fail.
8. Visit _http://localhost:8080/bin/browser.html_. The _HP_, _CHEBI_, and _HANCESTRO_ vocabularies should be present under the `/Vocabularies/` JCR node.