### PR TITLE
LFS-1119: Vocabulary question with maxAnswers=1 has broken indentation

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/VocabularyQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/VocabularyQuestion.jsx
@@ -45,7 +45,12 @@ function VocabularyQuestion(props) {
   let { questionDefinition } = props;
   let { maxAnswers } = { ...questionDefinition, ...props };
 
+  // In order to determine indentation levels, we need to see if there are any default suggestions
+  // (i.e. children of the definition that are of type lfs:AnswerOption)
+  let defaults = props.defaults || Object.values(props.questionDefinition)
+    .filter(value => value['jcr:primaryType'] == 'lfs:AnswerOption');
   let singleInput = maxAnswers === 1;
+  let isBare = singleInput && defaults.length > 0;
 
   return (
     <Question
@@ -57,7 +62,7 @@ function VocabularyQuestion(props) {
         customInputProps = {{
           questionDefinition: questionDefinition,
           focusAfterSelecting: !singleInput,
-          isNested: singleInput
+          isNested: isBare
         }}
         answerNodeType = "lfs:VocabularyAnswer"
         {...props}

--- a/modules/data-entry/src/main/frontend/src/vocabQuery/query.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/query.jsx
@@ -91,8 +91,6 @@ class VocabularyQuery extends React.Component {
       variant='outlined'
       inputProps={{
         "aria-label": "Search"
-      }, {
-        tabIndex: isNested ? -1 : undefined
       }}
       onChange={(event) => {
         this.delayLookup(event);


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/LFS-1119)

**To test:** The lfs/Tumors/Diagnosis code question should have the right tabbing now:
Before:
![image](https://user-images.githubusercontent.com/4656440/116093580-cd8e3c00-a674-11eb-8b9d-3acaaf9093b6.png)

After: 
![image](https://user-images.githubusercontent.com/4656440/116093649-da129480-a674-11eb-9b53-fed86e3b7cf1.png)

In addition, you should be able to tab through them normally now.

Setting `maxAnswers=1` in lfs/Demographics/Race Ethnicity reported should not have any adverse behaviour.