### PR TITLE
LFS-1130: Files in the compose-cluster/SSL_CONFIG directory should be ignored by both git and org.apache.rat

### DIFF
--- a/compose-cluster/.gitignore
+++ b/compose-cluster/.gitignore
@@ -4,3 +4,4 @@ mongos/mongo-router.conf
 shard*
 NCR_MODEL
 secrets
+SSL_CONFIG

--- a/pom.xml
+++ b/pom.xml
@@ -383,6 +383,7 @@
             <exclude>compose-cluster/mongos/mongo-router.conf</exclude>
             <exclude>compose-cluster/shard*/**</exclude>
             <exclude>compose-cluster/secrets/**</exclude>
+            <exclude>compose-cluster/SSL_CONFIG/**</exclude>
           </excludes>
         </configuration>
         <executions>


### PR DESCRIPTION
Presently, files in `compose-cluster/SSL_CONFIG` are checked for license headers by `org.apache.rat` and therefore if SSL certificates and keys are present, `mvn clean install` will fail.

To test:

1. Checkout this branch
2. `mkdir compose-cluster/SSL_CONFIG`
3. `echo "Hello World" > compose-cluster/SSL_CONFIG/certificate.crt`
4. `mvn clean install`
5. Should build properly while attempting this same test on the `dev` branch will result in a failure to build
6. Similarly, running `git status` will not display anything about `SSL_CONFIG` while attempting this same test on the `dev` branch will show `SSL_CONFIG` as untracked