### PR TITLE
LFS-1128: When generate_compose_yaml.py is called with the --ssl_proxy flag, add the secure flag to cookies

### DIFF
--- a/compose-cluster/proxy/https_000-default.conf
+++ b/compose-cluster/proxy/https_000-default.conf
@@ -27,6 +27,7 @@
 	Header unset WWW-Authenticate
 	Header always set Strict-Transport-Security "max-age=31536000"
 	Header edit location ^http://(.*)$ https://$1
+	Header edit Set-Cookie ^(.*)$ $1;Secure
 	ProxyPreserveHost On
 	
 	ProxyPass /ncr/ http://127.0.0.1:8600/


### PR DESCRIPTION
When `generate_compose_yaml.py` is called with the `--ssl_proxy` flag, any cookies sent from CARDS (Apache Sling) to the client (browser) should be assigned the `secure` flag as an extra security measure to prevent these cookies from being sent over plaintext HTTP.

To test:

1. Checkout this branch and build with `mvn clean install`
2. `cd compose-cluster`
3. `mkdir SSL_CONFIG`
4. `cd SSL_CONFIG`
5. `openssl req -x509 -newkey rsa:4096 -keyout certificatekey.key -out certificate.crt -days 365 -nodes`
6. `cp certificate.crt certificatechain.crt`
7. `cd ..`
8. `python3 generate_compose_yaml.py --oak_filesystem --ssl_proxy`
9. `docker-compose build`
10. `docker-compose up -d`
11. Visit `https://localhost` and ignore the SSL warning since we are connected to _localhost_
12. Login as `admin`:`admin`
13. Interact with CARDS and inspect any network request (using the developer tools). Ensure that the associated cookies have the `secure` flag set to `true`.