### PR TITLE
LFS-1074: CARDS should not start if it cannot bind to a port

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To specify a different URL, use `-Dsling.url=https://lfs.server:8443/system/cons
 
 Installing larger vocabuleries may fail due to default limits imposed on XML documents by the JVM. In this case, the app should be started with an extra parameter:
 
-`java -Djdk.xml.entityExpansionLimit=0 -jar distribution/target/lfs-*.jar`
+`./start_cards.sh -Djdk.xml.entityExpansionLimit=0`
 
 By default, the app will run with username `admin` and password `admin`.
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ To specify a different URL, use `-Dsling.url=https://lfs.server:8443/system/cons
 `mvn install -PintegrationTests` to run integration tests
 
 ## Run:
-`java -jar distribution/target/lfs-*.jar` => the app will run at `http://localhost:8080` (default port)
+`./start_cards.sh` => the app will run at `http://localhost:8080` (default port)
 
-`java -jar distribution/target/lfs-*.jar -p PORT` to run at a different port
+`./start_cards.sh -p PORT` to run at a different port
 
-`java -jar distribution/target/lfs-*.jar -Dsling.run.modes=dev` to include the content browser (Composum), accessible at `http://localhost:8080/bin/browser.html`
+`./start_cards.sh -Dsling.run.modes=dev` to include the content browser (Composum), accessible at `http://localhost:8080/bin/browser.html`
 
 Installing larger vocabuleries may fail due to default limits imposed on XML documents by the JVM. In this case, the app should be started with an extra parameter:
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 * Java 1.8+
 * Maven 3.3+
 * Python 2.5+ or Python 3.0+
+* psutil Python module (recommended)
 
 ## Build:
 `mvn clean install`

--- a/Utilities/HostConfig/argparse_bash.py
+++ b/Utilities/HostConfig/argparse_bash.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+"""
+
+# This program leverages Python's argparse module to extract an argument
+# from the set of all arguments passed to a shell script
+
+import os
+import sys
+import argparse
+
+if 'ARGUMENT_KEY' not in os.environ:
+  sys.exit(-1)
+
+if 'ARGUMENT_DEFAULT' not in os.environ:
+  sys.exit(-1)
+
+ARGUMENT_KEY = os.environ['ARGUMENT_KEY']
+ARGUMENT_DEFAULT = os.environ['ARGUMENT_DEFAULT']
+
+argparser = argparse.ArgumentParser(add_help=False)
+argparser.add_argument(ARGUMENT_KEY)
+args, unknown_args = argparser.parse_known_args()
+
+res = vars(args)[ARGUMENT_KEY.lstrip('-')]
+if res is None:
+  print(ARGUMENT_DEFAULT)
+else:
+  print(res)

--- a/Utilities/HostConfig/check_tcp_available.py
+++ b/Utilities/HostConfig/check_tcp_available.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+"""
+
+import sys
+import socket
+import argparse
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('--tcp_port', help='The TCP port to check', type=int, required=True)
+args = argparser.parse_args()
+
+exit_status = 0
+try:
+  sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+  sock.bind(('0.0.0.0', args.tcp_port))
+  sock.listen()
+except:
+  exit_status = -1
+finally:
+  sock.close()
+
+sys.exit(exit_status)

--- a/Utilities/HostConfig/check_tcp_listen.py
+++ b/Utilities/HostConfig/check_tcp_listen.py
@@ -23,8 +23,9 @@
 # This program checks if a pid is listening on a tcp port
 # Exit status 0 if yes. Exit status 1 if no.
 
+import re
+import os
 import sys
-import psutil
 import argparse
 
 argparser = argparse.ArgumentParser()
@@ -32,9 +33,38 @@ argparser.add_argument('--tcp_port', help='The TCP port to check', type=int, req
 argparser.add_argument('--pid', help='The process identifier (PID) to check', type=int, required=True)
 args = argparser.parse_args()
 
-for conn in psutil.net_connections(kind='tcp'):
-  if conn.status == 'LISTEN':
-    if (conn.pid == args.pid) and (conn.laddr.port == args.tcp_port):
+def checkProcNet(tcp_version, inode, port):
+  LOCAL_ADDR_POS = 1
+  CONNECTION_STATE_POS = 3
+  INODE_POS = 9
+  CONNECTION_STATE_VAL_LISTEN = 0x0A
+  initialized = False
+  with open('/proc/net/' + tcp_version, 'r') as net_connections:
+    for connection_line in net_connections.readlines():
+      connection_line_items = connection_line.split()
+      if not initialized:
+        initialized = True
+        continue
+      line_local_addr = connection_line_items[LOCAL_ADDR_POS]
+      line_inode = connection_line_items[INODE_POS]
+      if line_inode == inode:
+        line_port = int(line_local_addr.split(':')[1], 16)
+        if line_port == port:
+          line_state = int(connection_line_items[CONNECTION_STATE_POS], 16)
+          if CONNECTION_STATE_VAL_LISTEN == line_state:
+            return True
+  return False
+
+# Obtain the set of sockets associated with --pid
+proc_fd_path = "/proc/{}/fd/".format(args.pid)
+for fd in os.listdir(proc_fd_path):
+  fd_resource = os.readlink(os.path.join(proc_fd_path, fd))
+  if fd_resource.startswith("socket:"):
+    socket_inode = re.search('socket:\[(\d+)\]', fd_resource).group(1)
+    # Now check /proc/net/tcp and /proc/net/tcp6
+    if checkProcNet('tcp', socket_inode, args.tcp_port):
+      sys.exit(0)
+    if checkProcNet('tcp6', socket_inode, args.tcp_port):
       sys.exit(0)
 
 sys.exit(1)

--- a/Utilities/HostConfig/check_tcp_listen.py
+++ b/Utilities/HostConfig/check_tcp_listen.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+"""
+
+# This program checks if a pid is listening on a tcp port
+# Exit status 0 if yes. Exit status 1 if no.
+
+import sys
+import psutil
+import argparse
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('--tcp_port', help='The TCP port to check', type=int, required=True)
+argparser.add_argument('--pid', help='The process identifier (PID) to check', type=int, required=True)
+args = argparser.parse_args()
+
+for conn in psutil.net_connections(kind='tcp'):
+  if conn.status == 'LISTEN':
+    if (conn.pid == args.pid) and (conn.laddr.port == args.tcp_port):
+      sys.exit(0)
+
+sys.exit(1)

--- a/Utilities/HostConfig/check_tcp_listen.py
+++ b/Utilities/HostConfig/check_tcp_listen.py
@@ -23,9 +23,8 @@
 # This program checks if a pid is listening on a tcp port
 # Exit status 0 if yes. Exit status 1 if no.
 
-import re
-import os
 import sys
+import psutil
 import argparse
 
 argparser = argparse.ArgumentParser()
@@ -33,38 +32,9 @@ argparser.add_argument('--tcp_port', help='The TCP port to check', type=int, req
 argparser.add_argument('--pid', help='The process identifier (PID) to check', type=int, required=True)
 args = argparser.parse_args()
 
-def checkProcNet(tcp_version, inode, port):
-  LOCAL_ADDR_POS = 1
-  CONNECTION_STATE_POS = 3
-  INODE_POS = 9
-  CONNECTION_STATE_VAL_LISTEN = 0x0A
-  initialized = False
-  with open('/proc/net/' + tcp_version, 'r') as net_connections:
-    for connection_line in net_connections.readlines():
-      connection_line_items = connection_line.split()
-      if not initialized:
-        initialized = True
-        continue
-      line_local_addr = connection_line_items[LOCAL_ADDR_POS]
-      line_inode = connection_line_items[INODE_POS]
-      if line_inode == inode:
-        line_port = int(line_local_addr.split(':')[1], 16)
-        if line_port == port:
-          line_state = int(connection_line_items[CONNECTION_STATE_POS], 16)
-          if CONNECTION_STATE_VAL_LISTEN == line_state:
-            return True
-  return False
-
-# Obtain the set of sockets associated with --pid
-proc_fd_path = "/proc/{}/fd/".format(args.pid)
-for fd in os.listdir(proc_fd_path):
-  fd_resource = os.readlink(os.path.join(proc_fd_path, fd))
-  if fd_resource.startswith("socket:"):
-    socket_inode = re.search('socket:\[(\d+)\]', fd_resource).group(1)
-    # Now check /proc/net/tcp and /proc/net/tcp6
-    if checkProcNet('tcp', socket_inode, args.tcp_port):
-      sys.exit(0)
-    if checkProcNet('tcp6', socket_inode, args.tcp_port):
+for conn in psutil.net_connections(kind='tcp'):
+  if conn.status == 'LISTEN':
+    if (conn.pid == args.pid) and (conn.laddr.port == args.tcp_port):
       sys.exit(0)
 
 sys.exit(1)

--- a/start_cards.sh
+++ b/start_cards.sh
@@ -65,6 +65,9 @@ BIND_PORT=$(ARGUMENT_KEY='-p' ARGUMENT_DEFAULT='8080' python3 Utilities/HostConf
 #Check if the psutil Python module is installed
 python3 -c 'import psutil' 2>/dev/null && PSUTIL_INSTALLED=true || PSUTIL_INSTALLED=false
 
+#If we are in WSL, psutil will not work, therefore act as if it is not installed
+python3 -c 'import os; import sys; sys.exit(1 * ("Microsoft" not in os.uname().release))' && PSUTIL_INSTALLED=false
+
 #If psutil is not installed, simply check if BIND_PORT is available now,
 # and therefore will likely be available in the very near future
 if [ $PSUTIL_INSTALLED = false ]

--- a/start_cards.sh
+++ b/start_cards.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+BIND_TESTS=2
+BIND_TEST_SPACING=30
+
+TERMINAL_NOCOLOR='\033[0m'
+TERMINAL_RED='\033[0;31m'
+TERMINAL_GREEN='\033[0;32m'
+
+#CTRL+C should stop everything started by this script
+trap ctrl_c INT
+function ctrl_c() {
+  echo "Shutting down CARDS"
+  kill $CARDS_PID
+  wait $CARDS_PID
+  exit
+}
+
+#Start CARDS in the background
+java -jar distribution/target/lfs-*jar $@ &
+CARDS_PID=$!
+
+#Check to see if CARDS was able to bind to the TCP port
+BIND_PORT=$(ARGUMENT_KEY='-p' ARGUMENT_DEFAULT='8080' python3 Utilities/HostConfig/argparse_bash.py $@)
+for bind_test in `seq 0 $BIND_TESTS`
+do
+  #Check if we have timed out
+  if [ $bind_test = $BIND_TESTS ]
+  then
+    kill $CARDS_PID
+    wait $CARDS_PID
+    echo -e "${TERMINAL_RED}Unable to bind to TCP port${TERMINAL_NOCOLOR}"
+    exit -1
+  fi
+  sleep $BIND_TEST_SPACING
+  #Check if CARDS was able to bind
+  python3 Utilities/HostConfig/check_tcp_listen.py --tcp_port $BIND_PORT --pid $CARDS_PID && break
+done
+
+echo -e "${TERMINAL_GREEN}Started CARDS${TERMINAL_NOCOLOR}"
+
+#Wait for CTRL+C to stop everything
+read -r -d '' _ < /dev/tty


### PR DESCRIPTION
This pull request introduces the `start_cards.sh` script which should be used as a replacement for calling `java -jar` directly. Upon starting the CARDS Java process, this script checks if CARDS was able to bind to the specified TCP port (default `8080`) within a timeout. If it was able to bind, the script prints a success message. Otherwise, the script terminates, stops CARDS, and prints an error message.

To test:

- Try the various starting commands for CARDS under the **Run** section of _README.md_. The startup script should display a success message once CARDS binds to the specified TCP port. CARDS should operate normally hereafter.
- Try the various starting commands in an environment where CARDS will not be able to bind to a TCP port. For example, start listening with `netcat` on port `8080` and then attempt to start CARDS on port `8080`. The startup script should terminate and display a failure message.