### PR TITLE
LFS-535: Solve concurrency issues when uploading somatic variant files as CSVs in bulk

### DIFF
--- a/modules/variants/src/main/frontend/src/variantFilesContainer.jsx
+++ b/modules/variants/src/main/frontend/src/variantFilesContainer.jsx
@@ -681,7 +681,7 @@ export default function VariantFilesContainer() {
   /**
    * Generate the JSON representation of a single subject
    *
-   * @param {string} refType The jcr:reference:type for this subject (e.g. "Patient")
+   * @param {string} refType refType The type for this subject, without the `/SubjectType/` path prefix, e.g. "Patient/Tumor"
    * @param {string} id The identifier for this subject
    * @param {string} parent If given, supplies a parent for this subject
    */

--- a/modules/variants/src/main/frontend/src/variantFilesContainer.jsx
+++ b/modules/variants/src/main/frontend/src/variantFilesContainer.jsx
@@ -771,7 +771,7 @@ export default function VariantFilesContainer() {
   }
 
   // Only show the upload all button if there is at least one file that has yet to be sent
-  let showUploadAllButton = selectedFiles.some((file) => !file.sent);
+  let showUploadAllButton = selectedFiles.length > 1 && selectedFiles.some((file) => !file.sent);
 
   return (
   <React.Fragment>

--- a/modules/variants/src/main/frontend/src/variantFilesContainer.jsx
+++ b/modules/variants/src/main/frontend/src/variantFilesContainer.jsx
@@ -20,6 +20,7 @@
 import React, { useContext, useState } from "react";
 
 import {
+  Box,
   Button,
   Card,
   CardContent,
@@ -57,41 +58,22 @@ const useStyles = makeStyles(theme => ({
     verticalAlign: 'middle',
     paddingRight: theme.spacing(1)
   },
-  fileInfo: {
-    padding: theme.spacing(1),
-    margin: theme.spacing(3, 0),
-    fontFamily: "'Roboto', 'Helvetica', 'Arial', sans-serif",
+  fileList: {
+    "& .MuiGrid-item" : {
+      paddingLeft: theme.spacing(4),
+    }
   },
   fileFormSection : {
     display: "flex",
     alignItems: "center",
     flexWrap: "wrap",
   },
-  fileName: {
-    display: 'inline'
-  },
   fileDetail: {
     marginRight: theme.spacing(1),
     marginTop: theme.spacing(1)
   },
-  progressBar: {
-    width: "40%",
-    height: theme.spacing(2),
-    borderRadius: "2px",
-    display: "inline-block",
-    marginLeft: theme.spacing(1),
-    marginRight: theme.spacing(1),
-    verticalAlign: "text-top",
-    float: "right"
-  },
-  progressText: {
-    float: "right"
-  },
-  progress: {
-    backgroundColor: theme.palette.primary.main,
-    height: "100%",
-    margin: "0",
-    borderRadius: "2px",
+  fileProgress: {
+    maxWidth: "750px",
   },
   dragAndDropContainer: {
     margin: theme.spacing(3, 0),
@@ -825,7 +807,7 @@ export default function VariantFilesContainer() {
         </Grid>
       </form>
 
-      { selectedFiles && selectedFiles.length > 0 && <>
+      { selectedFiles && selectedFiles.length > 0 && <Grid container direction="column" spacing={4} className={classes.fileList}>
         { selectedFiles.map( (file, i) => {
             const upprogress = uploadProgress ? uploadProgress[file.name] : null;
             let subjectPath = file.subject.path?.replace("/Subjects", "Subjects");
@@ -834,23 +816,21 @@ export default function VariantFilesContainer() {
             let isDataValid = subjectPath && tumorPath;
 
             return (
-              <div key={file.name} className={classes.fileInfo}>
-                <div>
-                  <Typography variant="h6" className={classes.fileName}>{file.name}:</Typography>
-                  { upprogress && upprogress.state != "error" &&
-                    <span>
-                      <div className={classes.progressBar}>
-                        <div className={classes.progress} style={{ width: upprogress.percentage + "%" }} />
-                      </div>
-                      <div className={classes.progressText}>
-                        { upprogress.percentage + "%" }
-                      </div>
-                    </span>
-                  }
-                  { upprogress && upprogress.state == "error" && <Typography color='error'>Error uploading file</Typography> }
-                </div>
+              <Grid item key={file.name}>
+                <Typography variant="h6">{file.name}</Typography>
+                { upprogress && upprogress.state != "error" &&
+                  <Box display="flex" alignItems="center" className={classes.fileProgress}>
+                    <Box width="100%" mr={1}>
+                      <LinearProgress variant="determinate" value={upprogress.percentage} />
+                    </Box>
+                    <Box minWidth={35}>
+                      <Typography variant="body2" color="textSecondary">{upprogress.percentage + "%"}</Typography>
+                    </Box>
+                  </Box>
+                }
+                { upprogress && upprogress.state == "error" && <Typography color='error'>Error uploading file</Typography> }
                 { uploadProgress && uploadProgress[file.name] && uploadProgress[file.name].state === "done" ?
-                  <Typography variant="overline" component="div" className={classes.fileDetail}>
+                  <Typography variant="overline" component="div">
                     {patientSubjectLabel} <Link href={subjectPath} target="_blank"> {file.subject.id} </Link> /&nbsp;
                     {tumorSubjectLabel} <Link href={tumorPath} target="_blank"> {file.tumor.id} </Link>
                     { file?.region?.path && <> / {regionSubjectLabel} <Link href={regionPath} target="_blank"> {file.region.id} </Link> </> }
@@ -883,7 +863,7 @@ export default function VariantFilesContainer() {
                     helperText="Optional"
                   />
                   <label htmlFor="contained-button-file">
-                    <Button variant="outlined" color="primary" disabled={!isDataValid || file.uploading || !!error && selectedFiles.length == 0} onClick={() => uploadSingleFile(file)}>
+                    <Button variant={selectedFiles?.length > 1 ? "outlined" : "contained"} color="primary" disabled={!isDataValid || file.uploading || !!error && selectedFiles.length == 0} onClick={() => uploadSingleFile(file)}>
                       <span><BackupIcon className={classes.buttonIcon}/>
                         {file.uploading ? 'Uploading' : 'Upload'}
                       </span>
@@ -907,17 +887,18 @@ export default function VariantFilesContainer() {
                         of this file
                       </Link>
                 }
-              </div>
+              </Grid>
           ) } ) }
-      </>
-      }
-    { selectedFiles?.length > 0 ?
+      { selectedFiles?.length > 1 ?
+      <Grid item>
       <Button type="submit" variant="contained" color="primary" disabled={uploadInProgress || !!error && selectedFiles.length == 0} form="variantForm">
         <span><BackupIcon className={classes.buttonIcon}/>
           {uploadInProgress ? 'Uploading' : 'Upload all'}
         </span>
       </Button>
+      </Grid>
       : <></>}
+    </Grid>}
     <Dialog open={showVersionsDialog} onClose={() => setShowVersionsDialog(false)}>
       <DialogTitle>
         <span className={classes.dialogTitle}>Versions of {fileSelected?.name}</span>

--- a/modules/variants/src/main/frontend/src/variantFilesContainer.jsx
+++ b/modules/variants/src/main/frontend/src/variantFilesContainer.jsx
@@ -77,12 +77,15 @@ const useStyles = makeStyles(theme => ({
   progressBar: {
     width: "40%",
     height: theme.spacing(2),
-    backgroundColor: theme.palette.primary.main,
     borderRadius: "2px",
     display: "inline-block",
     marginLeft: theme.spacing(1),
     marginRight: theme.spacing(1),
-    verticalAlign: "text-top"
+    verticalAlign: "text-top",
+    float: "right"
+  },
+  progressText: {
+    float: "right"
   },
   progress: {
     backgroundColor: theme.palette.primary.main,
@@ -839,7 +842,9 @@ export default function VariantFilesContainer() {
                       <div className={classes.progressBar}>
                         <div className={classes.progress} style={{ width: upprogress.percentage + "%" }} />
                       </div>
-                      { upprogress.percentage + "%" }
+                      <div className={classes.progressText}>
+                        { upprogress.percentage + "%" }
+                      </div>
                     </span>
                   }
                   { upprogress && upprogress.state == "error" && <Typography color='error'>Error uploading file</Typography> }

--- a/modules/variants/src/main/frontend/src/variantFilesContainer.jsx
+++ b/modules/variants/src/main/frontend/src/variantFilesContainer.jsx
@@ -770,6 +770,9 @@ export default function VariantFilesContainer() {
     fetchBasicData();
   }
 
+  // Only show the upload all button if there is at least one file that has yet to be sent
+  let showUploadAllButton = selectedFiles.some((file) => !file.sent);
+
   return (
   <React.Fragment>
     <Typography variant="h2">Variants Upload</Typography>
@@ -889,7 +892,7 @@ export default function VariantFilesContainer() {
                 }
               </Grid>
           ) } ) }
-      { selectedFiles?.length > 1 ?
+      { showUploadAllButton ?
       <Grid item>
       <Button type="submit" variant="contained" color="primary" disabled={uploadInProgress || !!error && selectedFiles.length == 0} form="variantForm">
         <span><BackupIcon className={classes.buttonIcon}/>

--- a/modules/variants/src/main/frontend/src/variantFilesContainer.jsx
+++ b/modules/variants/src/main/frontend/src/variantFilesContainer.jsx
@@ -553,8 +553,7 @@ export default function VariantFilesContainer() {
    * @returns {Promise} a POST request with the subject upload
    */
   let uploadSubjectsFirst = (toUpload) => {
-    // Create a JSON representation of each file that needs to be stored.
-    // First, we need the subjects
+    // Create a JSON representation of each subject that needs to be created.
     let newSubjects = {};
     toUpload.forEach((file) => {
       let [newJson, subjectPath, tumorPath, regionPath] = assembleSubjectJson(file);
@@ -580,7 +579,7 @@ export default function VariantFilesContainer() {
       file.subject.existed = true;
     })
 
-    // Upload each file's subject one after the other
+    // Upload each file's subject in one batch
     let data = new FormData();
     data.append(':contentType', 'json');
     data.append(':operation', 'import');
@@ -607,7 +606,7 @@ export default function VariantFilesContainer() {
 
   // Event handler for the form submission event, replacing the normal browser form submission with a background fetch request.
   let upload = (event) => {
-    // Stops the normal browser form submission
+    // Stop the normal browser form submission
     event.preventDefault();
 
     setUploadInProgress(true);
@@ -719,6 +718,7 @@ export default function VariantFilesContainer() {
    *
    * @param {File} file the File object from which we can derive subject information. This should be processed via the
    * functions in onDrop prior to using this function
+   * @returns {array} An array of [JSON of the subjects, subject's key in the JSON object, tumor key in the subject, region key]
    */
   let assembleSubjectJson = (file) => {
     let json = {};
@@ -885,12 +885,7 @@ export default function VariantFilesContainer() {
                   <label htmlFor="contained-button-file">
                     <Button variant="outlined" color="primary" disabled={!isDataValid || file.uploading || !!error && selectedFiles.length == 0} onClick={() => uploadSingleFile(file)}>
                       <span><BackupIcon className={classes.buttonIcon}/>
-                        {file.uploading ? 'Uploading' :
-                            // TODO - Make this a per-upload button, pending the completion of LFS-535
-                            // TODO - judge upload status button message over all upload statuses of all files ??
-                            // uploadProgress[file.name].state =="done" ? 'Uploaded' :
-                            // uploadProgress[file.name].state =="error" ? 'Upload failed, try again?' :
-                            'Upload'}
+                        {file.uploading ? 'Uploading' : 'Upload'}
                       </span>
                     </Button>
                   </label>
@@ -919,12 +914,7 @@ export default function VariantFilesContainer() {
     { selectedFiles?.length > 0 ?
       <Button type="submit" variant="contained" color="primary" disabled={uploadInProgress || !!error && selectedFiles.length == 0} form="variantForm">
         <span><BackupIcon className={classes.buttonIcon}/>
-          {uploadInProgress ? 'Uploading' :
-              // TODO - Make this a per-upload button, pending the completion of LFS-535
-              // TODO - judge upload status button message over all upload statuses of all files ??
-              // uploadProgress[file.name].state =="done" ? 'Uploaded' :
-              // uploadProgress[file.name].state =="error" ? 'Upload failed, try again?' :
-              'Upload all'}
+          {uploadInProgress ? 'Uploading' : 'Upload all'}
         </span>
       </Button>
       : <></>}

--- a/modules/variants/src/main/frontend/src/variantFilesContainer.jsx
+++ b/modules/variants/src/main/frontend/src/variantFilesContainer.jsx
@@ -770,8 +770,11 @@ export default function VariantFilesContainer() {
     fetchBasicData();
   }
 
-  // Only show the upload all button if there is at least one file that has yet to be sent
-  let showUploadAllButton = selectedFiles.length > 1 && selectedFiles.some((file) => !file.sent);
+  // Only show the upload all button if more than one file is selected
+  let showUploadAllButton = selectedFiles.length > 1;
+  // and only enable it if there is at least one file that has yet to be sent
+  let showUploadDisabled = !selectedFiles.some((file) => !file.uploading && !file.sent);
+  let uploadAllComplete = !selectedFiles.some((file) => !file.sent);
 
   return (
   <React.Fragment>
@@ -894,9 +897,10 @@ export default function VariantFilesContainer() {
           ) } ) }
       { showUploadAllButton ?
       <Grid item>
-      <Button type="submit" variant="contained" color="primary" disabled={uploadInProgress || !!error && selectedFiles.length == 0} form="variantForm">
+      <Button type="submit" variant="contained" color="primary" disabled={!!error || showUploadDisabled} form="variantForm">
         <span><BackupIcon className={classes.buttonIcon}/>
-          {uploadInProgress ? 'Uploading' : 'Upload all'}
+          {uploadAllComplete ? 'Uploaded' :
+           uploadInProgress ? 'Uploading' : 'Upload all'}
         </span>
       </Button>
       </Grid>


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/LFS-535).

Allows the upload of multiple files at once, or one at a time with multiples selected.

![image](https://user-images.githubusercontent.com/4656440/117047998-804b4380-ace0-11eb-8107-1ba004faa544.png)

![image](https://user-images.githubusercontent.com/4656440/117047975-775a7200-ace0-11eb-9671-e6b1a0e1daa4.png)

**To test:** no combination of switching subject/tumor names, uploading single files vs uploading all, or clicking things out of order should break anything.