### PR TITLE
LFS-1141: Create a Sling API endpoint that when accessed, with the proper authentication keys, will mark a CARDS deployment as ready for upgrade

### DIFF
--- a/distribution/src/main/provisioning/01-boot.txt
+++ b/distribution/src/main/provisioning/01-boot.txt
@@ -40,7 +40,7 @@
     # permissions_trusted requires that after self-registration, users must be manually added to the TrustedUsers group by an administrator before they can access data.
     # permissions_ownership enforces data ownership and explicit data sharing
 
-    sling.run.mode.install.options=oak_tar,oak_mongo|forms,noforms|nolfs,lfs|nokids,kids|nocardiac_rehab,cardiac_rehab|permissions_open,permissions_trusted,permissions_ownership
+    sling.run.mode.install.options=oak_tar,oak_mongo|forms,noforms|nolfs,lfs|nokids,kids|nocardiac_rehab,cardiac_rehab|permissions_open,permissions_trusted,permissions_ownership,demo
 
     repository.home=${sling.home}/repository
     localIndexDir=${sling.home}/repository/index

--- a/distribution/src/main/provisioning/01-boot.txt
+++ b/distribution/src/main/provisioning/01-boot.txt
@@ -40,7 +40,7 @@
     # permissions_trusted requires that after self-registration, users must be manually added to the TrustedUsers group by an administrator before they can access data.
     # permissions_ownership enforces data ownership and explicit data sharing
 
-    sling.run.mode.install.options=oak_tar,oak_mongo|forms,noforms|nolfs,lfs|nokids,kids|nocardiac_rehab,cardiac_rehab|permissions_open,permissions_trusted,permissions_ownership,demo
+    sling.run.mode.install.options=oak_tar,oak_mongo|forms,noforms|nolfs,lfs|nokids,kids|nocardiac_rehab,cardiac_rehab|permissions_open,permissions_trusted,permissions_ownership
 
     repository.home=${sling.home}/repository
     localIndexDir=${sling.home}/repository/index

--- a/distribution/src/main/provisioning/62-demo-banner.txt
+++ b/distribution/src/main/provisioning/62-demo-banner.txt
@@ -26,7 +26,3 @@
 [artifacts runModes=demo]
     ca.sickkids.ccm.lfs/lfs-modules-demo-banner/${lfs.version}
     ca.sickkids.ccm.lfs/lfs-modules-upgrade-marker/${lfs.version}
-
-[configurations runModes=demo]
-    org.apache.sling.jcr.repoinit.RepositoryInitializer-github_user
-        scripts=["create user github with password github"]

--- a/distribution/src/main/provisioning/62-demo-banner.txt
+++ b/distribution/src/main/provisioning/62-demo-banner.txt
@@ -25,3 +25,8 @@
 
 [artifacts runModes=demo]
     ca.sickkids.ccm.lfs/lfs-modules-demo-banner/${lfs.version}
+    ca.sickkids.ccm.lfs/lfs-modules-upgrade-marker/${lfs.version}
+
+[configurations runModes=demo]
+    org.apache.sling.jcr.repoinit.RepositoryInitializer-github_user
+        scripts=["create user github with password github"]

--- a/modules/data-entry/src/main/provisioning/model.txt
+++ b/modules/data-entry/src/main/provisioning/model.txt
@@ -63,21 +63,11 @@
     org.apache.sling.jcr.repoinit.RepositoryInitializer-forms_demo
         scripts=["\
             create user github with password github \
-            create path (lfs:QuestionnairesHomepage) /Questionnaires \
             create path (lfs:FormsHomepage) /Forms \
             create path (lfs:SubjectsHomepage) /Subjects \
-            create path (lfs:SubjectTypesHomepage) /SubjectTypes \
-\
-            set ACL on /Forms,/Subjects \
-                allow jcr:all for everyone \
-            end \
 \
             set ACL on /Forms,/Subjects \
                 deny jcr:all for github \
-            end \
-\
-            set ACL on /Questionnaires,/SubjectTypes \
-                allow jcr:read for everyone \
             end \
           "]
 

--- a/modules/data-entry/src/main/provisioning/model.txt
+++ b/modules/data-entry/src/main/provisioning/model.txt
@@ -59,6 +59,28 @@
             end \
           "]
 
+[configurations runModes=forms,demo]
+    org.apache.sling.jcr.repoinit.RepositoryInitializer-forms_demo
+        scripts=["\
+            create user github with password github \
+            create path (lfs:QuestionnairesHomepage) /Questionnaires \
+            create path (lfs:FormsHomepage) /Forms \
+            create path (lfs:SubjectsHomepage) /Subjects \
+            create path (lfs:SubjectTypesHomepage) /SubjectTypes \
+\
+            set ACL on /Forms,/Subjects \
+                allow jcr:all for everyone \
+            end \
+\
+            set ACL on /Forms,/Subjects \
+                deny jcr:all for github \
+            end \
+\
+            set ACL on /Questionnaires,/SubjectTypes \
+                allow jcr:read for everyone \
+            end \
+          "]
+
 [configurations runModes=forms,permissions_trusted]
     org.apache.sling.jcr.repoinit.RepositoryInitializer-forms_trusted
         scripts=["\

--- a/modules/upgrade-marker/pom.xml
+++ b/modules/upgrade-marker/pom.xml
@@ -7,9 +7,7 @@
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
-
   http://www.apache.org/licenses/LICENSE-2.0
-
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,35 +20,27 @@
 
   <parent>
     <groupId>ca.sickkids.ccm.lfs</groupId>
-    <artifactId>lfs-parent</artifactId>
+    <artifactId>lfs-modules</artifactId>
     <version>0.9-SNAPSHOT</version>
   </parent>
 
-  <artifactId>lfs-modules</artifactId>
-  <packaging>pom</packaging>
-  <name>LFS Modules</name>
+  <artifactId>lfs-modules-upgrade-marker</artifactId>
+  <packaging>bundle</packaging>
+  <name>CARDS Upgrade Marker</name>
 
-  <modules>
-    <module>startup-customization</module>
-    <module>form-completion-status</module>
-    <module>commons</module>
-    <module>ui-extension</module>
-    <module>login</module>
-    <module>homepage</module>
-    <module>pedigree</module>
-    <module>subjects</module>
-    <module>data-entry</module>
-    <module>ldap-support</module>
-    <module>utils</module>
-    <module>principals</module>
-    <module>permissions</module>
-    <module>permissions-ownership</module>
-    <module>vocabularies</module>
-    <module>variants</module>
-    <module>demo-banner</module>
-    <module>aggregated-frontend</module>
-    <module>versioning</module>
-    <module>favicon</module>
-    <module>upgrade-marker</module>
-  </modules>
+  <build>
+    <plugins>
+      <!-- This is an OSGi bundle -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Sling-Initial-Content>SLING-INF/content/;path:=/</Sling-Initial-Content>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/modules/upgrade-marker/src/main/resources/SLING-INF/content/UpgradeMarker.json
+++ b/modules/upgrade-marker/src/main/resources/SLING-INF/content/UpgradeMarker.json
@@ -1,0 +1,6 @@
+{
+    "value": false,
+    "security:acl": [
+        { "principal": "github", "granted": ["jcr:all"] }
+    ]
+}


### PR DESCRIPTION
This PR adds to the `demo` runMode and introduces a new Sling user (`github`) and the `/UpgradeMarker` JCR node which is assigned the permission `jcr:all` to the `github` user. The purpose of this is so that when a new release of CARDS is made, GitHub Actions can call upon this `/UpgradeMarker` node and mark the demo site as ready for upgrade. This `/UpgradeMarker` JCR node can then be periodically queried by a cron job on the server to upgrade the version of CARDS used on the demo site if a newer version is available.

Testing:

- The following properties should be true:
  - The `/UpgradeMarker` JCR node should _not_ be present when _not_ in the `demo` runMode
  - The `github` user should _not_ be enabled when _not_ in the `demo` runMode
  - The `/UpgradeMarker` JCR node should be present when in the `demo` runMode
  - The `github` user should be present when in the `demo` runMode
  - The `github` user should be able to set the `value` property of `UpgradeMarker`
    - `curl -u github:github -XPOST -d 'value=true' http://localhost:8080/UpgradeMarker`
    - `curl -u github:github -XPOST -d 'value=false' http://localhost:8080/UpgradeMarker`
  - The `github` user should be able to read the properties of `UpgradeMarker`
    - `curl -u github:github http://localhost:8080/UpgradeMarker.json`
  - CARDS users who are not `admin` and not `github` should _not_ be able to read or write to the `/UpgradeMarker` JCR node