### PR TITLE
LFS-1146: The test runmode should provide a sample patient

### DIFF
--- a/test-resources/pom.xml
+++ b/test-resources/pom.xml
@@ -37,7 +37,10 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Sling-Initial-Content>SLING-INF/content/Questionnaires/;path:=/Questionnaires/;overwrite:=true;checkin:=true</Sling-Initial-Content>
+            <Sling-Initial-Content>
+              SLING-INF/content/Questionnaires/;path:=/Questionnaires/;overwrite:=true;checkin:=true,
+              SLING-INF/content/Subjects/;path:=/Subjects/;overwrite:=true;checkin:=true
+            </Sling-Initial-Content>
           </instructions>
         </configuration>
       </plugin>

--- a/test-resources/src/main/resources/SLING-INF/content/Subjects/SamplePatient.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Subjects/SamplePatient.xml
@@ -22,12 +22,12 @@
 	<primaryNodeType>lfs:Subject</primaryNodeType>
 	<property>
 		<name>fullIdentifier</name>
-		<value>Sample Patient</value>
+		<value>Sample</value>
 		<type>String</type>
 	</property>
 	<property>
 		<name>identifier</name>
-		<value>Sample Patient</value>
+		<value>Sample</value>
 		<type>String</type>
 	</property>
 	<property>

--- a/test-resources/src/main/resources/SLING-INF/content/Subjects/SamplePatient.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Subjects/SamplePatient.xml
@@ -1,0 +1,38 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>SamplePatient</name>
+	<primaryNodeType>lfs:Subject</primaryNodeType>
+	<property>
+		<name>fullIdentifier</name>
+		<value>Sample Patient</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>identifier</name>
+		<value>Sample Patient</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>type</name>
+		<value>/SubjectTypes/Patient</value>
+		<type>Reference</type>
+	</property>
+</node>


### PR DESCRIPTION
This PR implements LFS-1146 by providing a sample patient named `Sample Patient` when CARDS is run in the `test` runMode.

To test:
1. Build this branch
2. Start CARDS with the `test` runMode enabled
3. Ensure that a `Patient` _Subject Type_ with the name `Sample Patient` is present