### PR TITLE
LFS-1155: Wrong resource type recorded for date, time, and pedigree answers

### DIFF
--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -566,7 +566,7 @@
   - value (date)
 
   // Hardcode the resource type.
-  - sling:resourceType (STRING) = "lfs/lfs:DateAnswer" mandatory autocreated protected
+  - sling:resourceType (STRING) = "lfs/DateAnswer" mandatory autocreated protected
 
   // Hardcode the resource supertype.
   - sling:resourceSuperType (STRING) = "lfs/Answer" mandatory autocreated protected
@@ -577,7 +577,7 @@
   - value (string)
 
   // Hardcode the resource type.
-  - sling:resourceType (STRING) = "lfs/lfs:TimeAnswer" mandatory autocreated protected
+  - sling:resourceType (STRING) = "lfs/TimeAnswer" mandatory autocreated protected
 
   // Hardcode the resource supertype.
   - sling:resourceSuperType (STRING) = "lfs/Answer" mandatory autocreated protected
@@ -592,7 +592,7 @@
   - image (string)
 
   // Hardcode the resource type.
-  - sling:resourceType (STRING) = "lfs/lfs:PedigreeAnswer" mandatory autocreated protected
+  - sling:resourceType (STRING) = "lfs/PedigreeAnswer" mandatory autocreated protected
 
   // Hardcode the resource supertype.
   - sling:resourceSuperType (STRING) = "lfs/Answer" mandatory autocreated protected


### PR DESCRIPTION
To test:
* start in lfs mode
* create a new Patient Information form
* fill in a pedigree and a date field
* save
* open its deep json
* look at the sling:resourceType for these fields, they should be formatted as should be just lfs/DateAnswer (as opposed to having a double prefix, e.g. lfs/lfs:DateAnswer before this fix)