### PR TITLE
LFS-1147: The test runmode should have HANCESTRO already installed

### DIFF
--- a/Utilities/HostConfig/java_property_parser.py
+++ b/Utilities/HostConfig/java_property_parser.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+"""
+
+# This program leverages Python's argparse module to process the values
+# of properties passed on the Java command line as `-Dproperty=value`
+# arguments.
+
+import os
+import sys
+import json
+import argparse
+
+if 'EXPR' not in os.environ:
+  sys.exit(-1)
+
+try:
+  EXPR = json.loads(os.environ['EXPR'])
+except:
+  sys.exit(-1)
+
+argparser = argparse.ArgumentParser(add_help=False)
+argparser.add_argument('-D', action='append', nargs='*')
+args, unknown_args = argparser.parse_known_args()
+
+if EXPR['operation'] == 'includes':
+  if args.D is not None:
+    for javaProp in args.D:
+      propKey = javaProp[0].split('=')[0]
+      propVals = javaProp[0].split('=')[1].split(',')
+      if (propKey == EXPR['key']) and (EXPR['val'] in propVals):
+        sys.exit(0)
+
+sys.exit(-1)

--- a/start_cards.sh
+++ b/start_cards.sh
@@ -142,19 +142,20 @@ else
   handle_tcp_bind_ok_suboptimal
 fi
 
+#Wait for CARDS to be ready
+while true
+do
+  echo "Waiting for CARDS to start"
+  curl --fail $CARDS_URL/system/sling/info.sessionInfo.json > /dev/null 2> /dev/null && break
+  sleep 5
+done
+
 #Check if we are in the test runMode
 if [ $RUNMODE_TEST = true ]
 then
   #If a BIOPORTAL_APIKEY is present, attempt to install HANCESTRO
   if [ ! -z $BIOPORTAL_APIKEY ]
   then
-    #Wait for CARDS to be ready
-    while true
-    do
-      echo "Waiting for CARDS to start"
-      curl --fail $CARDS_URL/system/sling/info.sessionInfo.json > /dev/null 2> /dev/null && break
-      sleep 5
-    done
     #Check if HANCESTRO is already installed
     if [ -z $ADMIN_PASSWORD ]
     then

--- a/start_cards.sh
+++ b/start_cards.sh
@@ -148,8 +148,20 @@ then
       sleep 5
     done
     echo ""
-    python3 Utilities/Administration/install_vocabulary.py --bioportal_id HANCESTRO \
-      && message_hancestro_install_ok || message_hancestro_install_fail
+    #Check if HANCESTRO is already installed
+    if [ -z $ADMIN_PASSWORD ]
+    then
+      ADMIN_PASSWORD="admin"
+    fi
+    curl -u admin:$ADMIN_PASSWORD --fail $CARDS_URL/Vocabularies/HANCESTRO.json > /dev/null 2> /dev/null \
+      && HANCESTRO_INSTALLED=true || HANCESTRO_INSTALLED=false
+    if [ $HANCESTRO_INSTALLED = false ]
+    then
+      python3 Utilities/Administration/install_vocabulary.py --bioportal_id HANCESTRO \
+        && message_hancestro_install_ok || message_hancestro_install_fail
+    else
+      echo "HANCESTRO already installed"
+    fi
   else
     message_bioportal_apikey_missing
   fi

--- a/start_cards.sh
+++ b/start_cards.sh
@@ -44,19 +44,19 @@ function handle_tcp_bind_fail() {
 }
 
 function handle_tcp_bind_ok_optimal() {
-  echo -e "${TERMINAL_GREEN}*********************${TERMINAL_NOCOLOR}"
-  echo -e "${TERMINAL_GREEN}*                   *${TERMINAL_NOCOLOR}"
-  echo -e "${TERMINAL_GREEN}*   Started CARDS   *${TERMINAL_NOCOLOR}"
-  echo -e "${TERMINAL_GREEN}*                   *${TERMINAL_NOCOLOR}"
-  echo -e "${TERMINAL_GREEN}*********************${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_GREEN}*****************************${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_GREEN}*                           *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_GREEN}*   CARDS Socket BIND: OK   *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_GREEN}*                           *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_GREEN}*****************************${TERMINAL_NOCOLOR}"
 }
 
 function handle_tcp_bind_ok_suboptimal() {
-  echo -e "${TERMINAL_YELLOW}*************************************************${TERMINAL_NOCOLOR}"
-  echo -e "${TERMINAL_YELLOW}*                                               *${TERMINAL_NOCOLOR}"
-  echo -e "${TERMINAL_YELLOW}*   Started CARDS - used suboptimal bind test   *${TERMINAL_NOCOLOR}"
-  echo -e "${TERMINAL_YELLOW}*                                               *${TERMINAL_NOCOLOR}"
-  echo -e "${TERMINAL_YELLOW}*************************************************${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*********************************************************${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*                                                       *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*   CARDS Socket BIND: OK - used suboptimal bind test   *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*                                                       *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*********************************************************${TERMINAL_NOCOLOR}"
 }
 
 function message_bioportal_apikey_missing() {
@@ -81,6 +81,14 @@ function message_hancestro_install_fail() {
   echo -e "${TERMINAL_RED}* HANCESTRO install failed *${TERMINAL_NOCOLOR}"
   echo -e "${TERMINAL_RED}*                          *${TERMINAL_NOCOLOR}"
   echo -e "${TERMINAL_RED}****************************${TERMINAL_NOCOLOR}"
+}
+
+function message_started_cards() {
+  echo -e "${TERMINAL_GREEN}*********************${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_GREEN}*                   *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_GREEN}*   Started CARDS   *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_GREEN}*                   *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_GREEN}*********************${TERMINAL_NOCOLOR}"
 }
 
 #Determine the port that CARDS is to bind to
@@ -147,7 +155,6 @@ then
       curl --fail $CARDS_URL/system/sling/info.sessionInfo.json > /dev/null 2> /dev/null && break
       sleep 5
     done
-    echo ""
     #Check if HANCESTRO is already installed
     if [ -z $ADMIN_PASSWORD ]
     then
@@ -166,6 +173,8 @@ then
     message_bioportal_apikey_missing
   fi
 fi
+
+message_started_cards
 
 #Wait for CTRL+C to stop everything
 read -r -d '' _ < /dev/tty

--- a/start_cards.sh
+++ b/start_cards.sh
@@ -144,7 +144,7 @@ then
     while true
     do
       echo "Waiting for CARDS to start"
-      curl --fail $CARDS_URL/system/sling/info.sessionInfo.json && break
+      curl --fail $CARDS_URL/system/sling/info.sessionInfo.json > /dev/null 2> /dev/null && break
       sleep 5
     done
     echo ""


### PR DESCRIPTION
This PR adds the automatic installation of the HANCESTRO vocabulary into CARDS from BioPortal when `./start_cards.sh` is called with the `test` Sling runMode.

To test:
- Build this branch (`mvn clean install`)
- Start CARDS without specifying the `test` runMode (`./start_cards.sh` or `./start_cards.sh -Dsling.run.modes=dev,lfs`). CARDS should start and operate normally.
- Stop CARDS and cleanup (CTRL+C, `rm -rf sling`)
- Start CARDS with the `test` runMode but with no BioPortal API Key specified. (`./start_cards.sh -Dsling.run.modes=dev,test`). CARDS should start but the HANCESTRO vocabulary will not be installed. A `BIOPORTAL_APIKEY not specified` message should be printed to the console
- Stop CARDS and cleanup (CTRL+C, `rm -rf sling`)
- Start CARDS with the `test` runMode and an invalid BioPortal API Key (`export BIOPORTAL_APIKEY=1234` then `./start_cards.sh -Dsling.run.modes=dev,test`). CARDS should start but the HANCESTRO vocabulary will not be installed. A `HANCESTRO install failed` message should be printed to the console
- Stop CARDS and cleanup (CTRL+C, `rm -rf sling`)
- Start CARDS with the `test` runMode and with a _valid_ BioPortal API Key (`export BIOPORTAL_APIKEY=some-valid-api-key` then `./start_cards.sh -Dsling.run.modes=dev,test`). CARDS should start and operate normally in _test_ mode with the _HANCESTRO_ vocabulary installed.