### PR TITLE
LFS-1158: The test runmode should provide a non-admin user

### DIFF
--- a/distribution/src/main/provisioning/63-test-forms.txt
+++ b/distribution/src/main/provisioning/63-test-forms.txt
@@ -25,3 +25,7 @@
 
 [artifacts runModes=test]
     ca.sickkids.ccm.lfs/lfs-modules-test-forms/${lfs.version}
+
+[configurations runModes=test]
+    org.apache.sling.jcr.repoinit.RepositoryInitializer-test_user
+        scripts=["create user testuser with password testpassword"]


### PR DESCRIPTION
This PR causes a new user, `testuser`, to automatically be created when CARDS is started with the `test` runMode.

To test:
- Build this branch (`mvn clean install`)
- When CARDS is started with the `test` runMode enabled (eg. `-Dsling.run.modes=dev,test`), you should be able to login as User: `testuser` with the Password: `testpassword`. When the `test` runMode is not specified, this `testuser`:`testpassword` account should not be available.