### PR TITLE
LFS-1136: Improve the layout of the vocabulary browser - Bugfixes

### DIFF
--- a/modules/data-entry/src/main/frontend/src/vocabQuery/browseListChild.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/browseListChild.jsx
@@ -123,20 +123,25 @@ function ListChild(props) {
   }
 
   let expandAction = (icon, title, clickHandler) => {
+    let button = (
+      <IconButton
+        color={clickHandler ? "primary" : "default"}
+        size="small"
+        className={currentlyLoading ? ' ' + classes.loadingBranch : undefined}
+        onClick={clickHandler}
+        disabled={!clickHandler}
+      >
+        { icon }
+        { currentlyLoading && <CircularProgress size={12} />}
+      </IconButton>
+    );
     return (
       <div className={classes.expandAction}>
-        <Tooltip title={title}>
-          <IconButton
-            color={clickHandler ? "primary" : "default"}
-            size="small"
-            className={currentlyLoading ? ' ' + classes.loadingBranch : undefined}
-            onClick={clickHandler}
-            disabled={!clickHandler}
-          >
-            { icon }
-            { currentlyLoading && <CircularProgress size={12} />}
-          </IconButton>
-        </Tooltip>
+        { title && clickHandler ?
+          <Tooltip title={title}>{button}</Tooltip>
+          :
+          button
+        }
       </div>
     );
   }
@@ -174,7 +179,7 @@ function ListChild(props) {
         )
         :
         ( expands ?
-          expandAction(<ArrowRight/>, "No sub-categories")
+          expandAction(<ArrowRight/>)
           :
           expandAction(<More/>, "Show parent categories", () => loadTerm(id, path))
         )

--- a/modules/data-entry/src/main/frontend/src/vocabQuery/browseListChild.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/browseListChild.jsx
@@ -59,8 +59,12 @@ function ListChild(props) {
 
   let loadTerm = (id, path) => {
     if (bolded) return;
-    setCurrentlyLoading(true);
-    changeTerm && changeTerm(id, path);
+    if (changeTerm) {
+      setCurrentlyLoading(true);
+      changeTerm(id, path);
+    } else {
+      toggleShowChildren();
+    }
   }
 
   let checkForChildren = () => {
@@ -146,6 +150,17 @@ function ListChild(props) {
     );
   }
 
+  let toggleShowChildren = () => {
+    // Prevent a race condition when rapidly opening/closing
+    // by loading children here, and stopping it from loading
+    // children again
+    if (!loadedChildren) {
+      loadChildren();
+    }
+    setExpanded(!expanded);
+    setLoadedChildren(true);
+  }
+
   // Ensure we know whether or not we have children, if this is expandable
   if (expands) {
     // Ensure our child list entries are built, if this is currently expanded
@@ -166,16 +181,7 @@ function ListChild(props) {
         expandAction(
           expanded ? <ArrowDown/> : <ArrowRight/>,
           expanded ? "Collapse" : "Expand",
-          () => {
-              // Prevent a race condition when rapidly opening/closing
-              // by loading children here, and stopping it from loading
-              // children again
-              if (!loadedChildren) {
-                loadChildren();
-              }
-              setExpanded(!expanded);
-              setLoadedChildren(true);
-          }
+          toggleShowChildren
         )
         :
         ( expands ?


### PR DESCRIPTION
- [x] Fixed regression: tooltips get stuck on when trying to expand a root node without children
- [x] Don't show a loading sign when clicking on a term but there's no changeTerm function available

Testing on this branch is not straightforward because there's no "opportunity" for these bugs to actually appear. The fixes are for when the browser is displayed in the Vocabularies admin page (pr #626), and have been pulled here from that branch.