### PR TITLE
LFS-1074: CARDS should not start if it cannot bind to a port

### DIFF
--- a/Utilities/HostConfig/check_tcp_available.py
+++ b/Utilities/HostConfig/check_tcp_available.py
@@ -20,6 +20,7 @@
   under the License.
 """
 
+import os
 import sys
 import socket
 import argparse
@@ -31,7 +32,9 @@ args = argparser.parse_args()
 exit_status = 0
 try:
   sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-  sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+  #If we are in WSL, SO_REUSEADDR will not work correctly, allowing to rebind on an unavailable port
+  if "Microsoft" not in os.uname().release:
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
   sock.bind(('0.0.0.0', args.tcp_port))
   sock.listen()
 except:

--- a/Utilities/HostConfig/check_tcp_available.py
+++ b/Utilities/HostConfig/check_tcp_available.py
@@ -31,6 +31,7 @@ args = argparser.parse_args()
 exit_status = 0
 try:
   sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+  sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
   sock.bind(('0.0.0.0', args.tcp_port))
   sock.listen()
 except:


### PR DESCRIPTION
Bugfix: The script would fail to restart right after shutting down the server due to the port being still open in the TIME_WAIT state

To reproduce:
- start CARDS
- open it in the browser (I tried in Firefox, not sure if it also happens in Chrome or not)
- quickly stop and try to restart CARDS
- fails, `*   Unable to bind to TCP port   *`
- keeps on failing for 1-2 minutes, then it starts working again

@IntegralProgrammer not very familiar with Python, can you check if this is a correct fix?