### PR TITLE
LFS-1165: Display questionnaire description under the name in the selection dialog

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -270,10 +270,17 @@ function NewFormDialog(props) {
             {relatedForms &&
               <MaterialTable
                 title=""
-                columns={[
-                  { title: 'Questionnaire', field: 'title' },
-                  { title: 'Description', field: 'description' },
-                ]}
+                columns={[{
+                  field: 'title',
+                  render: q => (<>
+                                <Typography component="div">{q.title}</Typography>
+                                { q.description && <Typography component="div" variant="caption" color="textSecondary">{q.description}</Typography> }
+                                </>)
+                }, {
+                  field: 'description',
+                  searchable: true,
+                  hidden: true
+                }]}
                 data={query => {
                   let url = new URL("/query", window.location.origin);
                   let sql = `select * from [lfs:Questionnaire] as n `;
@@ -328,6 +335,7 @@ function NewFormDialog(props) {
                 }}
                 options={{
                   search: true,
+                  header: false,
                   actionsColumnIndex: -1,
                   addRowPosition: 'first',
                   pageSize: pageSize,


### PR DESCRIPTION
Done, but I'm not a big fan of what this arrangement looks like because of the large chunck of unused space at the right of the table. That plus the added vertical space to the table that is already too tall because of the larger page size makes everything look unbalanced.

It's easiest to test in the `cardiac_rehab` or `test` runmodes where we already have some questionnaire descriptions.

Known issue: searching in the descriptions doesn't currently work (that is the reason why this PR is in draft mode). However, descriptions weren't searchable before either, so it's not a regression.