### PR TITLE
LFS-1165: Display questionnaire description under the name in the selection dialog

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -270,10 +270,17 @@ function NewFormDialog(props) {
             {relatedForms &&
               <MaterialTable
                 title=""
-                columns={[
-                  { title: 'Questionnaire', field: 'title' },
-                  { title: 'Description', field: 'description' },
-                ]}
+                columns={[{
+                  field: 'title',
+                  render: q => (<>
+                                <Typography component="div">{q.title}</Typography>
+                                { q.description && <Typography component="div" variant="caption" color="textSecondary">{q.description}</Typography> }
+                                </>)
+                }, {
+                  field: 'description',
+                  searchable: true,
+                  hidden: true
+                }]}
                 data={query => {
                   let url = new URL("/query", window.location.origin);
                   let sql = `select * from [lfs:Questionnaire] as n `;
@@ -328,6 +335,7 @@ function NewFormDialog(props) {
                 }}
                 options={{
                   search: true,
+                  header: false,
                   actionsColumnIndex: -1,
                   addRowPosition: 'first',
                   pageSize: pageSize,

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -60,7 +60,7 @@ function NewFormDialog(props) {
   const [ error, setError ] = useState("");
   const [ relatedForms, setRelatedForms ] = useState();
   const [ disableProgress, setDisableProgress ] = useState(false);
-  const [ pageSize, setPageSize ] = useState(10);
+  const [ pageSize, setPageSize ] = useState(5);
   const [ wasOpen, setWasOpen ] = useState(false);
 
   const globalLoginDisplay = useContext(GlobalLoginContext);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -61,7 +61,7 @@ let createQueryURL = (query, type, order) => {
 function UnstyledNewSubjectDialog (props) {
   const { allowedTypes, classes, continueDisabled, disabled, error, open, onClose, onChangeSubject, onChangeType, onSubmit, requiresParents, theme, value } = props;
   const [ newSubjectType, setNewSubjectType ] = useState();
-  const [ pageSize, setPageSize ] = useState(10);
+  const [ pageSize, setPageSize ] = useState(5);
 
   const globalLoginDisplay = useContext(GlobalLoginContext);
 
@@ -184,7 +184,7 @@ function UnstyledSelectParentDialog (props) {
   const { classes, childName, childType, continueDisabled, currentSubject, disabled, error, isLast, open, onBack, onChangeParent, onCreateParent, onClose, onSubmit, parentType, tableRef, theme, value } = props;
 
   const globalLoginDisplay = useContext(GlobalLoginContext);
-  const [ pageSize, setPageSize ] = useState(10);
+  const [ pageSize, setPageSize ] = useState(5);
 
   const COLUMNS = [
     { title: 'Subject', field: 'hierarchy' },
@@ -835,7 +835,7 @@ function SubjectSelectorList(props) {
     { title: 'Identifier', field: 'hierarchy' },
   ];
   const [ relatedSubjects, setRelatedSubjects ] = useState();
-  const [ pageSize, setPageSize ] = useState(10);
+  const [ pageSize, setPageSize ] = useState(5);
 
   const globalLoginDisplay = useContext(GlobalLoginContext);
 


### PR DESCRIPTION
Includes reverting LFS-1161 (now show 5 items instead of 10 in the questionnaire/subject selection dialogs by default).

It's easiest to test in the `cardiac_rehab` or `test` runmodes where we already have some questionnaire descriptions.

Known issue: searching in the descriptions doesn't currently work. However, descriptions weren't searchable before either, so it's not a regression.