### PR TITLE
LFS-1168: Clean up the look of questionnaire and subject selection dialogs

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -29,6 +29,7 @@ import {
 } from "@material-ui/core";
 import AddIcon from "@material-ui/icons/Add";
 import MaterialTable from "material-table";
+import Alert from '@material-ui/lab/Alert';
 
 import SubjectSelectorList, { NewSubjectDialog, parseToArray } from "../questionnaire/SubjectSelector.jsx";
 import NewItemButton from "../components/NewItemButton.jsx";
@@ -257,8 +258,8 @@ function NewFormDialog(props) {
           }
         }}
       >
-        <DialogContent dividers>
-          {error && (!newSubjectPopperOpen) && <Typography color='error'>{error}</Typography>}
+        <DialogContent dividers className={classes.dialogContentWithTable}>
+          {error && (!newSubjectPopperOpen) && <Alert severity="error">{error}</Alert>}
           {progress === PROGRESS_SELECT_QUESTIONNAIRE ?
           <React.Fragment>
             {relatedForms &&

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -105,7 +105,7 @@ function UserDashboard(props) {
         }
       </Grid>
       <ResponsiveDialog title="New" width="xs" open={open} onClose={onClose}>
-        <DialogContent dividers>
+        <DialogContent dividers className={classes.dialogContentWithTable}>
           <MaterialTable
             columns={[
               { field: 'lfs:extensionName' },

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -458,7 +458,7 @@ const questionnaireStyle = theme => ({
         marginRight: 'auto',
     },
     newSubjectInput: {
-        width: '100%'
+        padding: theme.spacing(3, 3, 5),
     },
     invalidSubjectText: {
         fontStyle: "italic"
@@ -477,6 +477,22 @@ const questionnaireStyle = theme => ({
     },
     dialogTitle: {
         marginRight: theme.spacing(5)
+    },
+    dialogContentWithTable: {
+        padding: 0,
+        "& .MuiPaper-root": {
+          boxShadow: "0 none",
+        },
+        "& .MuiPaper-root > .MuiToolbar-root" : {
+          paddingRight: theme.spacing(3),
+        },
+        "& .MuiTableCell-root" : {
+          padding: theme.spacing(2, 3),
+        },
+        "& .MuiTableCell-footer" : {
+          paddingRight: theme.spacing(1),
+          paddingBottom: 0,
+        },
     },
     fileInfo: {
         padding: theme.spacing(1),

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -21,9 +21,10 @@ import React, { useRef, useEffect, useState, useContext } from "react";
 import { useHistory } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 
-import { Avatar, Button, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, Input, ListItem, ListItemAvatar, Typography, withStyles } from "@material-ui/core";
+import { Avatar, Button, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, ListItem, ListItemAvatar, TextField, withStyles } from "@material-ui/core";
 import AssignmentIndIcon from "@material-ui/icons/AssignmentInd";
 import MaterialTable from "material-table";
+import Alert from '@material-ui/lab/Alert';
 
 import { escapeJQL } from "../escape.jsx";
 import { getHierarchy, getSubjectIdFromPath } from "./Subject.jsx";
@@ -85,16 +86,19 @@ function UnstyledNewSubjectDialog (props) {
   return(
     <React.Fragment>
       <ResponsiveDialog title="Create new subject" open={open} onClose={onClose}>
-        <DialogContent dividers>
-          { error && <Typography color="error">{error}</Typography>}
-          <Input
-            autoFocus
-            disabled={disabled}
-            value={value}
-            onChange={onChangeSubject}
-            className={classes.newSubjectInput}
-            placeholder={"Enter subject identifier here"}
-            />
+        <DialogContent dividers className={classes.dialogContentWithTable}>
+          { error && <Alert severity="error">{error}</Alert>}
+          <div className={classes.newSubjectInput}>
+            <TextField
+              label="Enter subject identifier"
+              variant="outlined"
+              fullWidth
+              autoFocus
+              disabled={disabled}
+              value={value}
+              onChange={onChangeSubject}
+              />
+          </div>
           <MaterialTable
             title="Select a type"
             columns={COLUMNS}
@@ -120,6 +124,7 @@ function UnstyledNewSubjectDialog (props) {
             }
             options={{
               search: true,
+              header: false,
               addRowPosition: 'first',
               pageSize: pageSize,
               rowStyle: rowData => ({
@@ -198,8 +203,8 @@ function UnstyledSelectParentDialog (props) {
 
   return(
     <ResponsiveDialog open={open} onClose={onClose} keepMounted title={`Select parent ${parentType?.['label']} for new ${childType?.['label']}`}>
-      <DialogContent dividers>
-        { error && <Typography color="error">{error}</Typography>}
+      <DialogContent dividers className={classes.dialogContentWithTable}>
+        { error && <Alert severity="error">{error}</Alert>}
         {
           initialized &&
             <MaterialTable
@@ -232,6 +237,7 @@ function UnstyledSelectParentDialog (props) {
               }
               options={{
                 search: true,
+                header: false,
                 addRowPosition: 'first',
                 pageSize: pageSize,
                 rowStyle: rowData => ({
@@ -653,9 +659,9 @@ function UnstyledSelectorDialog (props) {
       open={open && newSubjectPopperOpen}
       />
     <ResponsiveDialog title={title} open={open} onClose={onClose}>
-      <DialogContent>
+      <DialogContent dividers className={classes.dialogContentWithTable}>
         {isPosting && <CircularProgress />}
-        {error && (!newSubjectPopperOpen) && <Typography color='error'>{error}</Typography>}
+        {error && (!newSubjectPopperOpen) && <Alert severity="error">{error}</Alert>}
         <StyledSubjectSelectorList
           allowedTypes={allowedTypes}
           disabled={disabled_controls}
@@ -967,6 +973,7 @@ function SubjectSelectorList(props) {
         }}
         options={{
           search: true,
+          header: false,
           actionsColumnIndex: -1,
           addRowPosition: 'first',
           pageSize: pageSize,


### PR DESCRIPTION
Includes [LFS-1166: _Remove column headers in subject and questionnaire selection dialogs_](https://phenotips.atlassian.net/browse/LFS-1166).

![image (40)](https://user-images.githubusercontent.com/651980/118746613-8ab02600-b826-11eb-80d1-6e3a49f8a389.png)
![image](https://user-images.githubusercontent.com/651980/118746907-09a55e80-b827-11eb-900d-b8ad10eb35d0.png)
![image (42)](https://user-images.githubusercontent.com/651980/118746624-8e43ad00-b826-11eb-9714-f767c6fa981c.png)
![image (43)](https://user-images.githubusercontent.com/651980/118746629-8f74da00-b826-11eb-8cc5-185e2f08a162.png)
![image (44)](https://user-images.githubusercontent.com/651980/118746633-90a60700-b826-11eb-9ca6-644bbb3f0255.png)
