### PR TITLE
Pedigree editor fixes: LFS-605, LFS-1172, LFS-1173

### DIFF
--- a/modules/pedigree/src/main/frontend/src/pedigree/pedigree.js
+++ b/modules/pedigree/src/main/frontend/src/pedigree/pedigree.js
@@ -162,7 +162,7 @@ var PedigreeEditor = Class.create({
          editor.getOkCancelDialogue().showCustomized('There are unsaved changes, do you want to save the pedigree before closing the pedigree editor?',
             'Save before closing?',
             " Save and quit ", saveAndQuitFunc,
-            " Don't save and quit ", performPedigreeClose,
+            " Quit without saving ", performPedigreeClose,
             " Keep editing pedigree ", undefined, true );
       } else {
          performPedigreeClose();

--- a/modules/pedigree/src/main/frontend/src/pedigree/shims/suggestShim.js
+++ b/modules/pedigree/src/main/frontend/src/pedigree/shims/suggestShim.js
@@ -89,7 +89,7 @@ function _p_escapeHTML(str) {
     // If free text entries allowed, mark them as such. Default: false.
     markFreeText: false,
     // The id of the element that will hold the suggest element
-    //parentContainer : "body",
+    parentContainer : "pedigreeEditor",
     // Should results fragments be highlighted when matching typed input
     highlight: true,
     // Fade the suggestion container on clear
@@ -909,7 +909,7 @@ function _p_escapeHTML(str) {
       var div = PElement("div", { 'class': "suggestItems "+ this.options.className });
 
       // Get position of target textfield
-      var pos = $(this.options.parentContainer).tagName.toLowerCase() == 'body' ? this.fld._p_cumulativeOffset() : this.fld.positionedOffset();
+      var pos = this.fld._p_cumulativeOffset();
 
       // Container width is passed as an option, or field width if no width provided.
       // The 2px substracted correspond to one pixel of border on each side of the field,

--- a/modules/pedigree/src/main/frontend/src/pedigree/view/exportSelector.js
+++ b/modules/pedigree/src/main/frontend/src/pedigree/view/exportSelector.js
@@ -92,7 +92,7 @@ var ExportSelector = Class.create( {
     });
 
     var closeShortcut = ['Esc'];
-    this.dialog = new PModalPopup(mainDiv, {close: {method : this.hide.bind(this), keys : closeShortcut}}, {extraClassName: 'pedigree-import-chooser', title: 'Pedigree export', displayCloseButton: true});
+    this.dialog = new PModalPopup(mainDiv, {close: {method : this.hide.bind(this), keys : closeShortcut}}, {extraClassName: 'pedigree-import-chooser', title: 'Pedigree export', displayCloseButton: true, verticalPosition: "top"});
   },
 
   /*

--- a/modules/pedigree/src/main/frontend/src/pedigree/view/importSelector.js
+++ b/modules/pedigree/src/main/frontend/src/pedigree/view/importSelector.js
@@ -126,7 +126,7 @@ var ImportSelector = Class.create( {
     });
 
     var closeShortcut = ['Esc'];
-    this.dialog = new PModalPopup(mainDiv, {close: {method : this.hide.bind(this), keys : closeShortcut}}, {extraClassName: 'pedigree-import-chooser', title: 'Pedigree import', displayCloseButton: true});
+    this.dialog = new PModalPopup(mainDiv, {close: {method : this.hide.bind(this), keys : closeShortcut}}, {extraClassName: 'pedigree-import-chooser', title: 'Pedigree import', displayCloseButton: true, verticalPosition : "top"});
   },
 
   /*

--- a/modules/pedigree/src/main/frontend/src/pedigree/view/nodeMenu.js
+++ b/modules/pedigree/src/main/frontend/src/pedigree/view/nodeMenu.js
@@ -152,8 +152,7 @@ var NodeMenu = Class.create({
           enableHierarchy: false,
           tooltip : false,
           fadeOnClear : false,
-          timeout : 30000,
-          parentContainer : $('body')
+          timeout : 30000
         });
         if (item._p_hasClassName('multi') && typeof(PSuggestPicker) != 'undefined') {
           item._suggestPicker = new PSuggestPicker(item, item._suggest, {
@@ -195,8 +194,7 @@ var NodeMenu = Class.create({
           enableHierarchy: false,
           tooltip : false,
           fadeOnClear : false,
-          timeout : 30000,
-          parentContainer : $('body')
+          timeout : 30000
         });
         if (item._p_hasClassName('multi') && typeof(PSuggestPicker) != 'undefined') {
           item._suggestPicker = new PSuggestPicker(item, item._suggest, {
@@ -237,8 +235,7 @@ var NodeMenu = Class.create({
           enableHierarchy: false,
           resultParent : 'is_a',
           fadeOnClear : false,
-          timeout : 30000,
-          parentContainer : $('body')
+          timeout : 30000
         });
         if (item._p_hasClassName('multi') && typeof(PSuggestPicker) != 'undefined') {
           item._suggestPicker = new PSuggestPicker(item, item._suggest, {

--- a/modules/pedigree/src/main/frontend/src/pedigree/view/okCancelDialogue.js
+++ b/modules/pedigree/src/main/frontend/src/pedigree/view/okCancelDialogue.js
@@ -53,7 +53,7 @@ var OkCancelDialogue = Class.create( {
           mainDiv._p_insert(buttons);
 
           var closeShortcut = ['Esc'];
-          this.dialog = new PModalPopup(mainDiv, {close: {method : this.hide.bind(this), keys : closeShortcut}}, {extraClassName: "pedigree-okcancel", title: "?", displayCloseButton: false});
+          this.dialog = new PModalPopup(mainDiv, {close: {method : this.hide.bind(this), keys : closeShortcut}}, {extraClassName: "pedigree-okcancel", title: "?", displayCloseButton: false, verticalPosition: "top"});
       },
 
       /**
@@ -139,11 +139,7 @@ var OkCancelDialogue = Class.create( {
               this._buttons[buttonID]._p_writeAttribute("value", buttonTitle);
               this._onButtonActions[buttonID] = actionFunction;
           }
-          if (bottomRightButton) {
-              this._buttons[buttonID]._p_setStyle({"marginLeft": "-200px", "marginRight": "10px", "float": "right"});
-          } else {
-              this._buttons[buttonID]._p_setStyle({"marginLeft": (buttonID == 0 ? "0px" : "10px"), "marginRight": "0px", "float": "none"});
-          }
+          this._buttons[buttonID]._p_setStyle({"marginLeft": (buttonID == 0 ? "0px" : "10px")});
       }
 });
 


### PR DESCRIPTION
Includes:
- [x] LFS-605: Pedigree editor: Export and Import dialogs are sometimes misplaced
- [x] LFS-1172: Unable to save Disorders and Phenotypic features in Pedigree editor
- [x] LFS-1173: When attempting to leave the pedigree without saving the changes the screen gets darker but nothing else appears to happen