### PR TITLE
LFS-1143: Write a script that will check if a CARDS deployment needs upgrading, and if it does, perform the upgrade preserving only the admin user and github user passwords

### DIFF
--- a/compose-cluster/check_upgrade_version.py
+++ b/compose-cluster/check_upgrade_version.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+"""
+
+import os
+import sys
+import string
+import argparse
+import requests
+from requests.auth import HTTPBasicAuth
+
+VALID_VERSION_CHARS = string.digits + "."
+
+def validate_version_string(version_string):
+  for c in version_string:
+    if c not in VALID_VERSION_CHARS:
+      return False
+  return True
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('--cards_url', help='URL for the running CARDS instance')
+args = argparser.parse_args()
+
+CARDS_URL = "http://localhost:8080"
+if "CARDS_URL" in os.environ:
+  CARDS_URL = os.environ["CARDS_URL"].rstrip('/')
+if args.cards_url is not None:
+  CARDS_URL = args.cards_url.rstrip('/')
+
+SLING_GITHUB_PASSWORD = "github"
+if "SLING_GITHUB_PASSWORD" in os.environ:
+  SLING_GITHUB_PASSWORD = os.environ["SLING_GITHUB_PASSWORD"]
+
+upgrade_check_req = requests.get(CARDS_URL + "/UpgradeMarker.json", auth=HTTPBasicAuth('github', SLING_GITHUB_PASSWORD))
+upgrade_marker_value = upgrade_check_req.json()['value']
+if type(upgrade_marker_value) == bool:
+  if upgrade_marker_value == False:
+    sys.exit(1)
+  upgrade_marker_version = upgrade_check_req.json()['upgradeVersion']
+  if type(upgrade_marker_version) == str:
+    if validate_version_string(upgrade_marker_version):
+      print(upgrade_marker_version)
+      sys.exit(0)
+
+sys.exit(-1)

--- a/compose-cluster/upgrade_demo_site.sh
+++ b/compose-cluster/upgrade_demo_site.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+PROJECT_ROOT=$(realpath ../)
+
+# CARDS_URL should point to a HTTP URL that gives direct access to
+# Apache Sling which therefore can be used for configuring (eg. setting
+# passwords) before the reverse proxy is started and the service is made
+# available.
+if [ -z $CARDS_URL ]
+then
+  echo "CARDS_URL environment variable must be set"
+  exit -1
+fi
+
+# Check if an upgrade is available. Exit if an upgrade is not available.
+# If the `value` field for the JCR node `/UpgradeMarker` is set to true
+# and `upgradeVersion` field for JCR node `/UpgradeMarker` is a legal
+# version string, upgrade to that tagged version
+echo "Checking if an upgraded version is available..."
+CARDS_NEW_VERSION=$(python3 check_upgrade_version.py) || exit
+echo "...Looks like an upgraded version is available."
+
+#Checkout the appropriate version tag
+cd $PROJECT_ROOT
+git fetch --all || exit -1
+git fetch --tags || exit -1
+git checkout cards-$CARDS_NEW_VERSION || exit -1
+
+#Build the CARDS image from the most up-to-date released source code
+mvn clean install || exit -1
+
+#Stop CARDS and cleanup
+cd compose-cluster
+docker-compose down
+docker-compose rm
+docker volume prune -f
+
+#Upgrade the version of CARDS specified in the docker-compose.yml file
+python3 upgrade_cards_image.py --cards_docker_tag $CARDS_NEW_VERSION
+
+#Start the new CARDS Docker image
+docker-compose up -d lfsinitial
+
+#Wait for CARDS to start
+while true
+do
+  echo "Waiting for CARDS to start"
+  curl --fail $CARDS_URL/system/sling/info.sessionInfo.json > /dev/null 2> /dev/null && break
+  sleep 5
+done
+
+#Set the `admin` and `github` Sling user passwords
+cd $PROJECT_ROOT/Utilities/Administration
+cat ~/.cards_credentials/github_password.txt | python3 set_sling_password.py --user github || exit -1
+cat ~/.cards_credentials/admin_password.txt | python3 set_sling_password.py || exit -1
+
+#Start the reverse proxy so that the demo becomes publicly available
+cd $PROJECT_ROOT/compose-cluster
+docker-compose up -d


### PR DESCRIPTION
This PR implements LFS-1143 by providing the `upgrade_demo_site.sh` script which checks the `/UpgradeMarker` JCR node and if this node has the `value` property set to `true` and the `upgradeVersion` property set to a legal version identifier (composed exclusively of digits and dots), a new CARDS Docker image will be built based on the version tag specified by the `upgradeVersion` property. The currently running CARDS deployment will be brought down and any saved data will be deleted. The CARDS deployment will be restarted using the specified Docker version tag and the `github` user password will be set to the password specified by `~/.cards_credentials/github_password.txt` and `admin` user password will be set to the password specified by `~/.cards_credentials/admin_password.txt`

To test:

**Given that the following test involves automatic switching of git branches, automatic git tagging, and removal of files not tracked by git, it is highly recommended that this test be performed on a separate clone of this repository and not the one used for development.**

1. If the `user.name` and `user.email` git properties are not configured, configure them (`git config user.name "test"`, `git config user.email "test@test.com"`)

2. Create a fake local release of CARDS based on this branch
2.1 `git checkout LFS-1143`
2.2 `export SNAPSHOT_VERSION=1.2.3-SNAPSHOT`
2.3 `export PROJECT=cards`
2.4 `export VERSION=1.2.3`
2.5 `` export GPG_TTY=`tty` ``
2.6 `git clean -dxf`
2.7 `mvn clean`
2.8 `git checkout -b release-${VERSION}`
2.9 `mvn release:prepare -DreleaseVersion=${VERSION} -DdevelopmentVersion=${SNAPSHOT_VERSION} -Dtag=${PROJECT}-${VERSION}`

3. Create a build of `LFS-1143`
3.1 `git checkout LFS-1143`
3.2 `mvn clean install`
3.3 The `lfs/lfs:latest` Docker image should be present when listing the locally available Docker images with `docker images`

4. Create a local Docker Compose deployment based on `lfs/lfs:latest` Docker image
4.1 `cd compose-cluster`
4.2 `python3 generate_compose_yaml.py --oak_filesystem --sling_admin_port 8081`
4.3 Edit the `docker-compose.yml` file adding the line `- ADDITIONAL_RUN_MODES=dev,lfs,demo` below the line `OAK_FILESYSTEM=true`
4.4 Start the environment (`docker-compose build`, `docker-compose up -d`)
4.5 Visit `http://localhost:8080` and login as `admin`:`admin`. The displayed CARDS version should be `0.9-SNAPSHOT`. Change the `admin` password to `admin1234`. Change the `github` user password to `github1234`.

5. Record the new, non-default, passwords
5.1 `mkdir ~/.cards_credentials`
5.2 `echo "github1234" > ~/.cards_credentials/github_password.txt`
5.3 `echo "admin1234" > ~/.cards_credentials/admin_password.txt`

6. Check if a deployment needs upgrading without marking it as ready for upgrade
6.1 `CARDS_URL=http://localhost:8081 SLING_GITHUB_PASSWORD=github1234 ./upgrade_demo_site.sh`
6.2 Given that the deployment has not been marked for upgrade, no upgrade should occur

7. Mark the deployment as ready for upgrade and perform the upgrade
7.1 `curl -u github:github1234 -XPOST -F'upgradeVersion=1.2.3' http://localhost:8080/UpgradeMarker`
7.2 `curl -u github:github1234 -XPOST -F'value=true' http://localhost:8080/UpgradeMarker`
7.3 `CARDS_URL=http://localhost:8081 SLING_GITHUB_PASSWORD=github1234 ./upgrade_demo_site.sh`

8. Once the upgrade finishes, visit `http://localhost:8080`. You should be able to login as `admin` with the password `admin1234` and as `github` with the password `github1234`. The version displayed should be `1.2.3`.