### PR TITLE
LFS-1170: Create a GitHub Action Workflow that will, upon each release of CARDS, check if the release is the latest version and if so, mark a given CARDS deployment as ready for upgrade

### DIFF
--- a/.github/workflows/mark_demo_upgrade.yml
+++ b/.github/workflows/mark_demo_upgrade.yml
@@ -1,11 +1,30 @@
 name: Mark Demo Upgrade
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   markupgrade:
     runs-on: ubuntu-latest
     steps:
-      - name: Placeholder
+      - name: Code Checkout
+        uses: actions/checkout@v2
+      - name: Fetch Tags
         run: |
-          echo "Commands to be executed go here..."
+          git fetch --tags
+      - name: Get Latest Release Tag
+        run: |
+          LATEST_GIT_TAG=$(git tag  | python3 ${{ github.workspace }}/Utilities/RepositoryManagement/get_latest_tagged_version.py)
+          echo "latest_git_tag=$LATEST_GIT_TAG" >> $GITHUB_ENV
+      - name: Print Latest Release Tag
+        run: |
+          echo "The latest CARDS version is ${{ env.latest_git_tag }}"
+      - name: Conditionally Mark Deployment For Upgrade
+        env:
+          CARDS_URL: ${{ secrets.DEMO_SERVER_URL }}
+          SLING_GITHUB_PASSWORD: ${{ secrets.DEMO_SLING_GITHUB_PASSWORD }}
+          LATEST_GIT_TAG: ${{ env.latest_git_tag }}
+        run: |
+          python3 ${{ github.workspace }}/Utilities/Administration/mark_for_upgrade.py

--- a/Utilities/Administration/mark_for_upgrade.py
+++ b/Utilities/Administration/mark_for_upgrade.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+"""
+
+import os
+import re
+import requests
+from requests.auth import HTTPBasicAuth
+
+CARDS_URL = os.environ['CARDS_URL']
+SLING_GITHUB_PASSWORD = os.environ['SLING_GITHUB_PASSWORD']
+LATEST_GIT_TAG = os.environ['LATEST_GIT_TAG']
+GITHUB_REF = os.environ['GITHUB_REF']
+
+"""
+Returns True if the version specified by `a` is greater than or equal to
+the version specified by `b`.
+"""
+def isNewerOrEqualVersion(a, b):
+  return bool([int(u) for u in a.split('.')] >= [int(u) for u in b.split('.')])
+
+print("Latest tagged release in git is: {}".format(LATEST_GIT_TAG))
+print("GitHub REF for this execution is: {}".format(GITHUB_REF))
+
+# Check if GITHUB_REF >= LATEST_GIT_TAG
+matcher = re.compile('refs/tags/cards-((\\d+\\.)*\\d+)$')
+match = matcher.match(GITHUB_REF)
+if match is not None:
+  version_string = match.groups()[0]
+  if isNewerOrEqualVersion(version_string, LATEST_GIT_TAG):
+    requests.post(CARDS_URL + "/UpgradeMarker", data={'value': True, 'upgradeVersion': version_string}, auth=HTTPBasicAuth('github', SLING_GITHUB_PASSWORD))
+  else:
+    print("Not the latest release!")
+else:
+  print("Not a valid comparable release tag!")
+
+resp = requests.get(CARDS_URL + "/UpgradeMarker.json", auth=HTTPBasicAuth('github', SLING_GITHUB_PASSWORD))
+print(resp.json())

--- a/Utilities/RepositoryManagement/get_latest_tagged_version.py
+++ b/Utilities/RepositoryManagement/get_latest_tagged_version.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+"""
+
+import re
+import sys
+
+versions = []
+
+matcher = re.compile('cards-((\\d+\\.)*\\d+)$')
+for tagline in sys.stdin.readlines():
+  match = matcher.match(tagline.rstrip())
+  if match is not None:
+    versions.append(match.groups()[0])
+
+versions.sort(key=lambda s: [int(u) for u in s.split('.')])
+if len(versions) > 0:
+  print(versions[-1])


### PR DESCRIPTION
This PR implements LFS-1170 by providing a GitHub Workflow that is triggered upon each release. If this release is the latest (by comparing version numbers, and not release dates), the CARDS demo site is marked for upgrade.

To test:

**As this test manipulates the `/UpgradeMarker` JCR node on _cardsdemo.uhndata.io_, please ensure that only one person is performing the test at any given moment otherwise the tester may see unexpected results.**

1. Create a _private_ GitHub repository called `LFS-1170-test`
2. Push this branch (`LFS-1170`) to the `LFS-1170-test` private repository
2.1 `git remote add lfs-1170-test git@github.com:GITHUBUSERNAME/LFS-1170-test`
2.2 `git checkout LFS-1170`
2.3 `git push lfs-1170-test`
3. On the `LFS-1170-test` repository, navigate to _Settings_ --> _Secrets_
4. Create a new _secret_ with the _name_ `DEMO_SERVER_URL` and _value_ `https://cardsdemo.uhndata.io`
5. Create a new _secret_ with the _name_ `DEMO_SLING_GITHUB_PASSWORD` and ask me via private message for the value.
6. In the GitHub editor, edit the file `.github/workflows/mark_demo_upgrade.yml` and change the `name` from `Mark Demo Upgrade` to `Mark Demo Deployment Upgrade`. Commit the change to the `LFS-1170` branch. Now, navigate to the _Actions_ tab and the _Mark Demo Deployment Upgrade_ workflow should be present. This step is necessary as a workaround for what is likely a bug on GitHub.
7. Create a new release of the `LFS-1170-test` repository with a _Tag version_ of `cards-0.0.1` and a _Release title_ of `cards-0.0.1`.
8. Navigate to the _Actions_ tab on the `LFS-1170-test` repository
9. Examine the `cards-0.0.1` workflow run. The _Conditionally Mark Deployment For Upgrade_ step should show, on the last line, a JSON object containing `upgradeVersion`:`0.0.1` and `value`:`True`
10. Create a new release of the `LFS-1170-test` repository with a _Tag version_ of `cards-0.1.0` and a _Release title_ of `cards-0.1.0`.
11. Navigate to the _Actions_ tab on the `LFS-1170-test` repository
12. Examine the `cards-0.1.0` workflow run. The _Conditionally Mark Deployment For Upgrade_ step should show, on the last line, a JSON object containing `upgradeVersion`:`0.1.0` and `value`:`True`
13. Create a new release of the `LFS-1170-test` repository with a _Tag version_ of `cards-0.0.2` and a _Release title_ of `cards-0.0.2`.
14. Navigate to the _Actions_ tab on the `LFS-1170-test` repository
15. Examine the `cards-0.0.2` workflow run. The _Conditionally Mark Deployment For Upgrade_ step should show, on the second last line, `Not the latest release!` and on the last line, a JSON object containing `upgradeVersion`:`0.1.0` and `value`:`True`