### PR TITLE
LFS-1183: Ignore term GEO:000000374 from HANCESTRO vocabulary

### DIFF
--- a/modules/vocabularies-ignore/src/main/resources/SLING-INF/content/HANCESTRO/GEO000000374.json
+++ b/modules/vocabularies-ignore/src/main/resources/SLING-INF/content/HANCESTRO/GEO000000374.json
@@ -1,0 +1,4 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "value": "http://purl.obolibrary.org/obo/GEO:000000374"
+}


### PR DESCRIPTION
This Pull Request implements LFS-1183 by adding the term class `http://purl.obolibrary.org/obo/GEO:000000374` to the list of term classes to ignore when installing the _HANCESTRO_ vocabulary.

To test:

1. Build the `dev` branch, set a valid BioPortal API Key, and install HANCESTRO.
2. Visit, `http://localhost:8080/Vocabularies/HANCESTRO/GEO000000374.json`. Valid JSON should be returned.
3. Stop CARDS, build the `LFS-1183` branch, start CARDS, set a valid BioPortal API Key, and install HANCESTRO.
4. Visit, `http://localhost:8080/Vocabularies/HANCESTRO/GEO000000374.json`. A 404 error page should be returned.