### PR TITLE
LFS-143: Releases should have production-transpiled resources

### DIFF
--- a/modules/aggregated-frontend/src/main/frontend/webpack.config-template.js
+++ b/modules/aggregated-frontend/src/main/frontend/webpack.config-template.js
@@ -51,6 +51,7 @@ ENTRY_CONTENT
     extensions: ['*', '.js', '.jsx']
   },
   optimization: {
+    usedExports: false,
     runtimeChunk: 'single',
     splitChunks: {
       chunks: 'all',

--- a/modules/aggregated-frontend/src/main/frontend/webpack.config-template.js
+++ b/modules/aggregated-frontend/src/main/frontend/webpack.config-template.js
@@ -20,6 +20,7 @@
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 
 module_name = require("./package.json").name + ".";
 
@@ -52,6 +53,16 @@ ENTRY_CONTENT
   },
   optimization: {
     usedExports: false,
+    minimize: true,
+    minimizer: [
+      new TerserPlugin({
+        terserOptions: {
+          mangle: {
+            reserved: ['$super']
+          }
+        }
+      })
+    ],
     runtimeChunk: 'single',
     splitChunks: {
       chunks: 'all',

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,7 @@
     <checkstyle.skip>false</checkstyle.skip>
     <dependencyCheck.skip>false</dependencyCheck.skip>
     <coverage.instructionRatio>1.00</coverage.instructionRatio>
+    <webpackArguments>--mode=development</webpackArguments>
   </properties>
 
   <dependencyManagement>
@@ -586,6 +587,9 @@
               <goals>
                 <goal>webpack</goal>
               </goals>
+              <configuration>
+                <arguments>${webpackArguments}</arguments>
+              </configuration>
             </execution>
           </executions>
           <configuration>
@@ -806,6 +810,9 @@
       <!-- Profile used when the release plugin executes. We want javadocs and source jars to be released
            + ensure we sign files using GPG. -->
       <id>release</id>
+      <properties>
+        <webpackArguments>--mode=production</webpackArguments>
+      </properties>
       <activation>
         <property>
           <!-- This property is automatically defined by the Maven release plugin when executing


### PR DESCRIPTION
When building CARDS with Maven, with the `release` profile enabled, Webpack is instructed to compile front-end resources in _production_ mode.

To test:

1. Checkout this branch (`git checkout LFS-143`)
2. Delete the following code block from `pom.xml`
```xml
          <plugin>
            <groupId>org.apache.maven.plugins</groupId>
            <artifactId>maven-javadoc-plugin</artifactId>
            <executions>
              <execution>
                <id>attach-javadocs</id>
                <goals>
                  <goal>jar</goal>
                </goals>
              </execution>
            </executions>
          </plugin>
          <plugin>
            <groupId>org.apache.maven.plugins</groupId>
            <artifactId>maven-gpg-plugin</artifactId>
            <executions>
              <execution>
                <id>sign-artifacts</id>
                <phase>verify</phase>
                <goals>
                  <goal>sign</goal>
                </goals>
                <configuration>
                  <useAgent>true</useAgent>
                </configuration>
              </execution>
            </executions>
          </plugin>
```
3. Build this branch with the `release` profile enabled (`mvn clean install -Prelease`)
4. Start CARDS using the `start_cards.sh` script and experiment with various runModes (eg. `lfs`, `demo`, `cardiac_rehab`, etc...). All should work as expected.

While testing, I noticed that sometimes the _Administration_ Sidebar menu item appears alongside the other menu items (_Dashboard_, _Subjects_, _Forms_, etc...) instead of at the bottom of the Sidebar menu. This seems to be a stochastic problem (race condition?) and any feedback on why this occurs would be very much appreciated. 