### PR TITLE
LFS-1192: When starting CARDS on a non-default port with the test runMode enabled, the non-default port setting is not passed to the vocabulary installation script

### DIFF
--- a/start_cards.sh
+++ b/start_cards.sh
@@ -93,7 +93,7 @@ function message_started_cards() {
 
 #Determine the port that CARDS is to bind to
 BIND_PORT=$(ARGUMENT_KEY='-p' ARGUMENT_DEFAULT='8080' python3 Utilities/HostConfig/argparse_bash.py $@)
-CARDS_URL="http://localhost:${BIND_PORT}"
+export CARDS_URL="http://localhost:${BIND_PORT}"
 
 #Get any specified runModes
 EXPR='{"operation": "includes", "key": "sling.run.modes", "val": "test"}' python3 \


### PR DESCRIPTION


Ensure that the vocabulary installation script has access to the `CARDS_URL` environment variable by exporting it when it is defined in the `start_cards.sh` script.

To test:
1. Build this branch (`git checkout LFS-1192`, `mvn clean install`)
2. Set a valid BioPortal API Key (`export BIOPORTAL_APIKEY="SOME-VALID-BIOPORTAL-API-KEY"`)
3. Start CARDS on a non-default port with the `test` runMode enabled (`./start_cards.sh -Dsling.run.modes=test -p 1192`)
4. Once CARDS starts, open it in the browser (`http://localhost:1192`), login, and ensure that the HANCESTRO vocabulary is installed