### PR TITLE
LFS-1160: Deleting the variants file after using the variants uploader triggers an error

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -31,7 +31,7 @@ function Forms(props) {
   const questionnaireID = /questionnaire=([^&]+)/.exec(location.search)?.[1];
   const pageNameWriter = usePageNameWriterContext();
 
-  const entry = /Forms\/([^.]+)/.exec(location.pathname);
+  const entry = /Forms\/([^.\/]+)/.exec(location.pathname);
 
   // When moving from a specific form to the "Forms" page, ensure that the title properly changes
   useEffect(() => {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -113,7 +113,7 @@ function Form (props) {
   let formNode = React.useRef();
   let pageNameWriter = usePageNameWriterContext();
   const history = useHistory();
-  const formURL = `/Forms/${id}`;
+  const formURL = `/Forms/${id}`.replace(/\/$/, "");
   const urlBase = "/content.html";
   const isEdit = window.location.pathname.endsWith(".edit");
   let globalLoginDisplay = useContext(GlobalLoginContext);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -113,7 +113,7 @@ function Form (props) {
   let formNode = React.useRef();
   let pageNameWriter = usePageNameWriterContext();
   const history = useHistory();
-  const formURL = `/Forms/${id}`.replace(/\/$/, "");
+  const formURL = `/Forms/${id}`;
   const urlBase = "/content.html";
   const isEdit = window.location.pathname.endsWith(".edit");
   let globalLoginDisplay = useContext(GlobalLoginContext);

--- a/modules/variants/src/main/frontend/src/variantFilesContainer.jsx
+++ b/modules/variants/src/main/frontend/src/variantFilesContainer.jsx
@@ -647,24 +647,24 @@ export default function VariantFilesContainer() {
       let data = new FormData();
 
       // Assemble the questionnaire into our payload FormData
-      let formPath = "Forms/" + uuidv4() + "/";
-      data.append(formPath + "jcr:primaryType", "lfs:Form");
-      data.append(formPath + "questionnaire", "/Questionnaires/SomaticVariants");
-      data.append(formPath + "questionnaire@TypeHint", "Reference");
-      data.append(formPath + "subject", `/${subjectPath}/${tumorPath}` + (file?.region?.path ? `/${regionPath}` : ""));
-      data.append(formPath + "subject@TypeHint", "Reference");
+      let formPath = "Forms/" + uuidv4();
+      data.append(formPath + "/jcr:primaryType", "lfs:Form");
+      data.append(formPath + "/questionnaire", "/Questionnaires/SomaticVariants");
+      data.append(formPath + "/questionnaire@TypeHint", "Reference");
+      data.append(formPath + "/subject", `/${subjectPath}/${tumorPath}` + (file?.region?.path ? `/${regionPath}` : ""));
+      data.append(formPath + "/subject@TypeHint", "Reference");
 
       // Assemble the FileResourceAnswer
-      let answerPath = formPath + uuidv4() + "/";
-      data.append(answerPath + "jcr:primaryType", "lfs:FileResourceAnswer");
-      data.append(answerPath + "question", "/Questionnaires/SomaticVariants/file");
-      data.append(answerPath + "question@TypeHint", "Reference");
-      data.append(answerPath + "value", "/" + answerPath + file.name);
+      let answerPath = formPath + "/" + uuidv4();
+      data.append(answerPath + "/jcr:primaryType", "lfs:FileResourceAnswer");
+      data.append(answerPath + "/question", "/Questionnaires/SomaticVariants/file");
+      data.append(answerPath + "/question@TypeHint", "Reference");
+      data.append(answerPath + "/value", "/" + answerPath + "/" + file.name);
 
       // Assemble the details about the file itself
-      let filePath = answerPath + file.name;
+      let filePath = answerPath + "/" + file.name;
       data.append(filePath, file);
-      data.append(filePath + "@TypeHint", "nt:file");
+      data.append(filePath + "/@TypeHint", "nt:file");
 
       var xhr = new XMLHttpRequest();
       xhr.open('POST', '/');
@@ -841,7 +841,7 @@ export default function VariantFilesContainer() {
                     {patientSubjectLabel} <Link href={subjectPath} target="_blank"> {file.subject.id} </Link> /&nbsp;
                     {tumorSubjectLabel} <Link href={tumorPath} target="_blank"> {file.tumor.id} </Link>
                     { file?.region?.path && <> / {regionSubjectLabel} <Link href={regionPath} target="_blank"> {file.region.id} </Link> </> }
-                    { file.formPath && <> : <Link href={file.formPath.replace("/Forms", "Forms").replace(/\/$/, "")} target="_blank">{somaticVariantsTitle}</Link> </>}
+                    { file.formPath && <> : <Link href={file.formPath.replace("/Forms", "Forms")} target="_blank">{somaticVariantsTitle}</Link> </>}
                   </Typography>
                 : <div className={classes.fileFormSection}>
                   <TextField

--- a/modules/variants/src/main/frontend/src/variantFilesContainer.jsx
+++ b/modules/variants/src/main/frontend/src/variantFilesContainer.jsx
@@ -841,7 +841,7 @@ export default function VariantFilesContainer() {
                     {patientSubjectLabel} <Link href={subjectPath} target="_blank"> {file.subject.id} </Link> /&nbsp;
                     {tumorSubjectLabel} <Link href={tumorPath} target="_blank"> {file.tumor.id} </Link>
                     { file?.region?.path && <> / {regionSubjectLabel} <Link href={regionPath} target="_blank"> {file.region.id} </Link> </> }
-                    { file.formPath && <> : <Link href={file.formPath.replace("/Forms", "Forms")} target="_blank">{somaticVariantsTitle}</Link> </>}
+                    { file.formPath && <> : <Link href={file.formPath.replace("/Forms", "Forms").replace(/\/$/, "")} target="_blank">{somaticVariantsTitle}</Link> </>}
                   </Typography>
                 : <div className={classes.fileFormSection}>
                   <TextField

--- a/modules/variants/src/main/frontend/src/variantFilesContainer.jsx
+++ b/modules/variants/src/main/frontend/src/variantFilesContainer.jsx
@@ -678,7 +678,7 @@ export default function VariantFilesContainer() {
           // state: "done" change should turn all subject inputs into the link text
           uploadProgress[file.name] = { state: "done", percentage: 100 };
 
-          file.formPath = "/" + formPath;
+          file.formPath = formPath;
           file.sent = true;
           selectedFiles[selectedFiles.findIndex(el => el.name === file.name)] = file;
           setSelectedFiles(selectedFiles);
@@ -841,7 +841,7 @@ export default function VariantFilesContainer() {
                     {patientSubjectLabel} <Link href={subjectPath} target="_blank"> {file.subject.id} </Link> /&nbsp;
                     {tumorSubjectLabel} <Link href={tumorPath} target="_blank"> {file.tumor.id} </Link>
                     { file?.region?.path && <> / {regionSubjectLabel} <Link href={regionPath} target="_blank"> {file.region.id} </Link> </> }
-                    { file.formPath && <> : <Link href={file.formPath.replace("/Forms", "Forms")} target="_blank">{somaticVariantsTitle}</Link> </>}
+                    { file.formPath && <> : <Link href={file.formPath} target="_blank">{somaticVariantsTitle}</Link> </>}
                   </Typography>
                 : <div className={classes.fileFormSection}>
                   <TextField


### PR DESCRIPTION
This PR introduces the following changes:

- Trim the trailing slash from the URL that opens the new Form when within the variants uploader
- Ensure that all network access done by a Form to said Form's JCR node does not contain a trailing slash

To test:

1. Build this branch (`git checkout LFS-1160`, `mvn clean install`)
2. Start CARDS with the `lfs` runMode enabled
3. Create a fake Variants CSV file (`echo "Hello World" > AB12345_1.csv`)
4. Upload this CSV file through the _Variants_ uploader
5. Mouse over the _Somatic Variants_ link for the uploaded file. Verify that its target URL does not contain a trailing slash
6. Click the link
7. Click the _Edit_ pencil button
8. Click the trash can icon to delete the uploaded CSV file
9. Click _Save_. The Form should save properly

Test part two:

10. Repeat the above test but after getting to _step 6_, add a trailing slash to the loaded webpage (browser address bar) and reload. Ensure that the rest of the test completes properly.