### PR TITLE
LFS-1194: As a user, I can filter forms by "Created date" in the dashboard and on the Forms page

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/DateFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/DateFilter.jsx
@@ -27,6 +27,7 @@ import DateQuestionUtilities from "../../questionnaire/DateQuestionUtilities.jsx
 import QuestionnaireStyle from "../../questionnaire/QuestionnaireStyle.jsx";
 
 const COMPARATORS = DEFAULT_COMPARATORS.slice().concat(UNARY_COMPARATORS).concat(VALUE_COMPARATORS);
+const COMPARATORS_CREATED_DATE = DEFAULT_COMPARATORS.slice().concat(VALUE_COMPARATORS);
 
 /**
  * Display a filter on a date answer of a form. This is not meant to be instantiated directly, but is returned from FilterComponentManager's
@@ -84,5 +85,7 @@ export default StyledDateFilter;
 FilterComponentManager.registerFilterComponent((questionDefinition) => {
   if (questionDefinition.dataType === "date") {
     return [COMPARATORS, StyledDateFilter, 50];
+  } else if (questionDefinition.dataType === "createddate") {
+    return [COMPARATORS_CREATED_DATE, StyledDateFilter, 50];
   }
 });

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
@@ -108,6 +108,9 @@ function Filters(props) {
       uuids["Questionnaire"] = "lfs:Questionnaire";
       titles["Questionnaire"] = "Questionnaire";
     }
+    fields.push("CreatedDate");
+    uuids["CreatedDate"] = "lfs:CreatedDate"
+    titles["CreatedDate"] = "Created Date"
     for (let [questionName, question] of Object.entries(filterJson)) {
       // For each question, save the name, data type, and answers (if necessary)
       fields.push(questionName);
@@ -122,6 +125,9 @@ function Filters(props) {
         dataType: "questionnaire"
       };
     }
+    filterJson["CreatedDate"] = {
+      dataType: "createddate"
+    };
     setFilterableFields(fields);
     setQuestionDefinitions(filterJson);
     setFilterableTitles(titles);

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
@@ -134,11 +134,49 @@ function Filters(props) {
     setFilterableUUIDs(uuids);
   }
 
+  let removeCreatedDateTimezone = (filters) => {
+    let newFilters = [];
+    filters.forEach( (filter) => {
+      if (filter.type === "createddate") {
+        newFilters.push({ ...filter, value: filter.value.split('T')[0]});
+      } else {
+        newFilters.push({ ...filter });
+      }
+    });
+    return newFilters;
+  };
+
+  let addCreatedDateTimezone = (filters) => {
+    const getClientTimezoneOffset = () => {
+      const padTwo = (s) => {
+        if (s.length < 2) {
+          return '0' + s;
+        }
+        return s;
+      };
+      let totalOffsetMinutes = new Date().getTimezoneOffset();
+      let offsetSign = (totalOffsetMinutes < 0) ? '+' : '-';
+      let offsetMinute = Math.abs(totalOffsetMinutes) % 60;
+      let offsetHour = Math.floor(Math.abs(totalOffsetMinutes) / 60);
+      return offsetSign + padTwo(offsetHour.toString()) + ":" + padTwo(offsetMinute.toString());
+    };
+    let newFilters = [];
+    filters.forEach( (filter) => {
+      if (filter.type === "createddate") {
+        newFilters.push({ ...filter, value: filter.value + "T00:00:00" + getClientTimezoneOffset() });
+      } else {
+        newFilters.push({ ...filter });
+      }
+    });
+    return newFilters;
+  };
+
   // Open the filter selection dialog
   let openDialogAndAdd = () => {
     setDialogOpen(true);
     // Replace our defaults with a deep copy of what's actually active, plus an empty one
     let newFilters = deepCopyFilters(activeFilters);
+    newFilters = removeCreatedDateTimezone(newFilters);
     setEditingFilters(newFilters);
 
     // Bugfix: also reload every active outputChoice, in order to refresh its copy of the state variables
@@ -239,6 +277,7 @@ function Filters(props) {
         toCheck
         :
         {...toCheck, comparator: (toCheck.comparator == "=" ? "is empty" : "is not empty")}));
+    newFilters = addCreatedDateTimezone(newFilters);
     setActiveFilters(newFilters);
     onChangeFilters && onChangeFilters(newFilters);
     setDialogOpen(false);

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
@@ -328,6 +328,7 @@ function Filters(props) {
           // Include the label (if available) or value for this filter iff the comparator is not unary
           (UNARY_COMPARATORS.includes(activeFilter.comparator) ? ""
             : (" " + (activeFilter.label != undefined ? activeFilter.label : activeFilter.value)));
+        label = (activeFilter.type === "createddate") ? label.split('T')[0] : label;
         return(
           <React.Fragment key={label}>
             <Chip

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
@@ -21,7 +21,7 @@ package ca.sickkids.ccm.lfs;
 import java.io.IOException;
 import java.io.Writer;
 import java.text.SimpleDateFormat;
-import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Iterator;
@@ -293,7 +293,8 @@ public class PaginationServlet extends SlingSafeMethodsServlet
          * IF (<=) THEN CHECK (< nextDay)
          * IF (>=) THEN CHECK (>= day)
          */
-        final LocalDate nextDay = LocalDate.parse(thisDayStr).plusDays(1);
+        final ZonedDateTime thisDay = ZonedDateTime.parse(thisDayStr);
+        final ZonedDateTime nextDay = thisDay.plusDays(1);
         final String nextDayStr = nextDay.toString();
         String compareQuery;
         switch (operator) {

--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
@@ -21,6 +21,7 @@ package ca.sickkids.ccm.lfs;
 import java.io.IOException;
 import java.io.Writer;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Iterator;
@@ -65,6 +66,7 @@ import org.slf4j.LoggerFactory;
  *
  * @version $Id$
  */
+@SuppressWarnings({"checkstyle:MultipleStringLiterals"})
 @Component(service = { Servlet.class })
 @SlingServletResourceTypes(
     resourceTypes = { "lfs/QuestionnairesHomepage", "lfs/FormsHomepage", "lfs/SubjectsHomepage",
@@ -84,6 +86,7 @@ public class PaginationServlet extends SlingSafeMethodsServlet
 
     private static final String SUBJECT_IDENTIFIER = "lfs:Subject";
     private static final String QUESTIONNAIRE_IDENTIFIER = "lfs:Questionnaire";
+    private static final String CREATED_DATE_IDENTIFIER = "lfs:CreatedDate";
 
     @Override
     public void doGet(final SlingHttpServletRequest request, final SlingHttpServletResponse response)
@@ -259,7 +262,9 @@ public class PaginationServlet extends SlingSafeMethodsServlet
         StringBuilder joindata = new StringBuilder();
         for (int i = 0; i < joins.length; i++) {
             // Skip this join if it is on lfs:Subject, which does not require a child inner join
-            if (SUBJECT_IDENTIFIER.equals(joins[i]) || QUESTIONNAIRE_IDENTIFIER.equals(joins[i])) {
+            if (SUBJECT_IDENTIFIER.equals(joins[i])
+                || QUESTIONNAIRE_IDENTIFIER.equals(joins[i])
+                || CREATED_DATE_IDENTIFIER.equals(joins[i])) {
                 continue;
             }
 
@@ -276,6 +281,67 @@ public class PaginationServlet extends SlingSafeMethodsServlet
         }
 
         return joindata.toString();
+    }
+
+    private String generateDateCompareQuery(String jcrVariable, String thisDayStr, String operator)
+    {
+        /*
+         * IF (=) THEN CHECK (>= day AND < nextDay)
+         * IF (<>) THEN CHECK (< day OR >= nextDay)
+         * IF (<) THEN CHECK (< day)
+         * IF (>) THEN CHECK (>= nextDay)
+         * IF (<=) THEN CHECK (< nextDay)
+         * IF (>=) THEN CHECK (>= day)
+         */
+        final LocalDate nextDay = LocalDate.parse(thisDayStr).plusDays(1);
+        final String nextDayStr = nextDay.toString();
+        String compareQuery;
+        switch (operator) {
+            case "=":
+                compareQuery = String.format("(%s>='%s' and %s<'%s')",
+                    jcrVariable,
+                    thisDayStr,
+                    jcrVariable,
+                    nextDayStr
+                );
+                break;
+            case "<>":
+                compareQuery = String.format("(%s<'%s' or %s>='%s')",
+                    jcrVariable,
+                    thisDayStr,
+                    jcrVariable,
+                    nextDayStr
+                );
+                break;
+            case "<":
+                compareQuery = String.format("(%s<'%s')",
+                    jcrVariable,
+                    thisDayStr
+                );
+                break;
+            case ">":
+                compareQuery = String.format("(%s>='%s')",
+                    jcrVariable,
+                    nextDayStr
+                );
+                break;
+            case "<=":
+                compareQuery = String.format("(%s<'%s')",
+                    jcrVariable,
+                    nextDayStr
+                );
+                break;
+            case ">=":
+                compareQuery = String.format("(%s>='%s')",
+                    jcrVariable,
+                    thisDayStr
+                );
+                break;
+            default:
+                compareQuery = null;
+                break;
+        }
+        return compareQuery;
     }
 
     /**
@@ -332,6 +398,15 @@ public class PaginationServlet extends SlingSafeMethodsServlet
                     String.format(" and n.'questionnaire'%s'%s'",
                         this.sanitizeComparator(comparators[i]),
                         this.sanitizeField(values[i])
+                    )
+                );
+            } else if (CREATED_DATE_IDENTIFIER.equals(fields[i])) {
+                filterdata.append(" and ");
+                filterdata.append(
+                    generateDateCompareQuery(
+                        "n.'jcr:created'",
+                        this.sanitizeField(values[i]),
+                        this.sanitizeComparator(comparators[i])
                     )
                 );
             } else {


### PR DESCRIPTION
This PR introduces a _Created Date_ filter for selecting Forms that are `=`, `<>`, `<`, `>`, `<=`, or `>=` a given date.

To test:

1. Build this branch (`git checkout LFS-1194`, `mvn clean install`)
2. Start CARDS with the `lfs` runMode enabled
3. Create a new Form (and associated Subject). Fill in all mandatory questions so that the Form is marked as _complete_
4. Go to the Dashboard
5. Filter the completed Forms by _Created Date_. Experiment with various filters (eg. Filtering for `Created Date` `=` _date of Form creation_ should list the Form, while filtering for `Created Date` `<>` _date of Form creation_ should _not_ list the Form)
6. Go to the _Forms_ page and perform the same tests as done in step 5