### PR TITLE
LFS-1198: "is empty" and "is not empty" comparators do not work when multiple Questionnaires have identically named answer nodes

### DIFF
--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/PaginationServlet.java
@@ -428,17 +428,26 @@ public class PaginationServlet extends SlingSafeMethodsServlet
                     )
                 );
             } else {
-                joindata.append(
-                    String.format(
-                        " and %s%d.'question'='%s' and %s%d.'value'%s",
-                        childprefix,
-                        i,
-                        sanitizedFieldName,
-                        childprefix,
-                        i,
-                        comparison
-                    )
-                );
+                final String[] possibleQuestions = fieldnames[i].split(",");
+                joindata.append(" and (");
+                for (int j = 0; j < possibleQuestions.length; j++) {
+                    joindata.append(
+                        String.format(
+                            " %s%d.'question'='%s' and %s%d.'value'%s",
+                            childprefix,
+                            i,
+                            this.sanitizeField(possibleQuestions[j]),
+                            childprefix,
+                            i,
+                            comparison
+                        )
+                    );
+                    // Add an 'or' if there are more possible conditions
+                    if (j + 1 != possibleQuestions.length) {
+                        joindata.append(" or");
+                    }
+                }
+                joindata.append(")");
             }
         }
         return joindata.toString();


### PR DESCRIPTION
This PR fixes a bug where, although multiple answer node identifiers were being sent to the back-end as a comma separated list, this list was only being iterated through for _binary_ comparators (ie. `=`, `<>`, `<`, `>`, `<=`, `>=`) and not _unary_ comparators (ie. `is empty`, `is not empty`). This caused the filtering by unary comparators functionality to break whenever the back-end received a comma separated list of answer node identifiers - something that occurs in the case where different questionnaires have identically named answer nodes. In the `lfs` runMode, this happens as both the _Patient information_ and _Tissue Metrix_ Questionnaires have a _Date of birth_ answer node.

To test:

1. Build this branch (`git checkout LFS-1198`, `mvn clean install`)
2. Start CARDS with the `lfs` runMode enabled
3. Experiment with creating both _Patient information_ and _Tissue Metrix_ Forms which have empty and non-empty _Date of birth_ fields. Ensuring that filtering by _Date of birth is empty_ and _Date of birth is not empty_ works as expected