### PR TITLE
LFS-1206: Questionnaire/Subject selector does not reset internal state when closed before completion

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -64,6 +64,12 @@ function NewFormDialog(props) {
 
   const globalLoginDisplay = useContext(GlobalLoginContext);
 
+  let resetDialogState = () => {
+    setSelectedQuestionnaire(null);
+    setSelectedSubject(null);
+    setDisableProgress(false);
+  }
+
   let createForm = (subject) => {
     setError("");
 
@@ -252,6 +258,7 @@ function NewFormDialog(props) {
         title={progress === PROGRESS_SELECT_QUESTIONNAIRE ? "Select a questionnaire" : "Select a subject"}
         open={mode === MODE_ACTION ? dialogOpen : open}
         onClose={() => {
+          resetDialogState();
           setDialogOpen(false);
           if (onClose) {
             onClose();
@@ -409,8 +416,7 @@ function NewFormDialog(props) {
         allowedTypes={filteredAllowedSubjectTypes}
         disabled={isFetching}
         onClose={() => {
-          setSelectedSubject(null);
-          setSelectedQuestionnaire(null);
+          resetDialogState();
           setNewSubjectPopperOpen(false);
           setError();
           if (onClose) {

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -410,6 +410,7 @@ function NewFormDialog(props) {
         disabled={isFetching}
         onClose={() => {
           setSelectedSubject(null);
+          setSelectedQuestionnaire(null);
           setNewSubjectPopperOpen(false);
           setError();
           if (onClose) {

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -409,6 +409,7 @@ function NewFormDialog(props) {
         allowedTypes={filteredAllowedSubjectTypes}
         disabled={isFetching}
         onClose={() => {
+          setSelectedSubject(null);
           setNewSubjectPopperOpen(false);
           setError();
           if (onClose) {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -866,6 +866,10 @@ function SubjectSelectorList(props) {
     }
   }
 
+  if (!relatedSubjects) {
+    return null;
+  }
+
   return(
     <React.Fragment>
       <MaterialTable

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -849,9 +849,11 @@ function SubjectSelectorList(props) {
     )
   }
 
-  if (!relatedSubjects) {
-    filterArray();
-  }
+  useEffect(() => {
+    if (!relatedSubjects) {
+      filterArray();
+    }
+  }, [relatedSubjects]);
 
   // if the number of related forms of a certain questionnaire/subject is at the maxPerSubject, an error is set
   let handleSelection = (rowData) => {


### PR DESCRIPTION
This PR causes the selected Subject and selected Questionnaire within the _New Form_ dialog to be reset to empty if the _New Form_ dialog is closed without actually creating a new Form.

To test, follow the instructions on https://phenotips.atlassian.net/browse/LFS-1206 on the `dev` branch to reproduce the bug. After that, build and run the `LFS-1206` branch and follow the same instructions as before this time ensuring that by _step 8_ the _New Form_ dialog is reset to its initial state and there are no initially selected _Subjects_ or _Questionnaires_.