### PR TITLE
[Misc] Re-enable NCR Notes for vocab questions

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -32,6 +32,7 @@ export const VALUE_POS = 1;
 function Answer (props) {
   let { answers, answerMetadata, answerNodeType, existingAnswer, path, questionName, questionDefinition, valueType, isMultivalued, onChangeNote, noteComponent, noteProps, onAddedAnswerPath, onDecidedOutputPath, sectionAnswersState } = props;
   let { enableNotes } = { ...props, ...questionDefinition };
+  let { onAddSuggestion } = { ...props, ...noteProps };
   let [ answerID ] = useState((existingAnswer && existingAnswer[0]) || uuidv4());
   let answerPath = path + "/" + answerID;
 
@@ -103,6 +104,7 @@ function Answer (props) {
           existingAnswer={existingAnswer}
           answerPath={answerPath}
           onChangeNote={onChangeNote}
+          onAddSuggestion={onAddSuggestion}
           {...noteProps}
           />
       }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -204,25 +204,25 @@ function MultipleChoice(props) {
   // Add a non-default option
   // Returns whether an option was added (true) or a matching option already existed (false)
   let addOption = (id, name) => {
-    if ( !options.some((option) => {return option[VALUE_POS] === id}) &&
+    setOptions((oldOptions) => {
+      if ( !oldOptions.some((option) => {return option[VALUE_POS] === id}) &&
         !defaults.some((option) => {return option[VALUE_POS] === id})) {
-      setOptions((oldOptions) => {
         let newOptions = oldOptions.slice();
         newOptions.push([name, id, false]);
         return newOptions;
-      });
-    }
+      }
+      return oldOptions;
+    });
   }
 
   // Remove a non-default option
   let removeOption = (id, name) => {
     onChange && onChange(id); // will trigger callback in Form.jsx
     setOptions( (old) => {
-      let newOptions = old.filter(
+      return old.filter(
         (option) => {
           return !(option[VALUE_POS] === id) || option[IS_DEFAULT_POS]
         });
-      return newOptions;
     });
     unselect(id, name);
     return;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -425,6 +425,7 @@ function MultipleChoice(props) {
           answers={answers}
           existingAnswer={existingAnswer}
           questionName={questionName}
+          onAddSuggestion={acceptEnteredOption}
           {...rest}
           />
       </React.Fragment>
@@ -438,6 +439,7 @@ function MultipleChoice(props) {
           answers={answers}
           existingAnswer={existingAnswer}
           questionName={questionName}
+          onAddSuggestion={acceptEnteredOption}
           {...rest}
           />
       </React.Fragment>
@@ -487,6 +489,7 @@ function MultipleChoice(props) {
           answers={answers}
           existingAnswer={existingAnswer}
           questionName={questionName}
+          onAddSuggestion={acceptEnteredOption}
           {...rest}
           />
       </React.Fragment>
@@ -504,6 +507,7 @@ function MultipleChoice(props) {
           existingAnswer={existingAnswer}
           questionName={questionName}
           isMultivalued={true}
+          onAddSuggestion={acceptEnteredOption}
           {...rest}
           />
       </React.Fragment>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -147,17 +147,17 @@ function MultipleChoice(props) {
       return false;
     }
 
-    // Do not add anything if we are at our maximum number of selections
-    if (maxAnswers > 0 && selection.length >= maxAnswers) {
-      return;
-    }
-
-    // Do not add duplicates
-    if (selection.some(element => {return element[VALUE_POS] === id})) {
-      return;
-    }
-
     setSelection( old => {
+      // Do not add anything if we are at our maximum number of selections
+      if (maxAnswers > 0 && old.length >= maxAnswers) {
+        return old;
+      }
+
+      // Do not add duplicates
+      if (old.some(element => {return element[VALUE_POS] === id})) {
+        return old;
+      }
+
       let newSelection = old.filter((option) => {
         return (option[VALUE_POS] !== "" && option[LABEL_POS] !== "")
           // And if we've gotten here and there's an "na" option, we remove it from the selection

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -315,30 +315,37 @@ function MultipleChoice(props) {
     onUpdate && onUpdate(event.target.value);
   }
 
+  // Certain classes that implement MultipleChoice might add options of their own
+  // e.g. The vocab selector and the NCRNote component.
+  // In those cases, we want to ensure the same behaviour as if they had entered
+  // in a ghosts input normally
+  let acceptOptionFromWidget = (value, label) => {
+    // If we are bare or a radio, the selected option should become the value
+    // unless it is one of the defaults
+    let isDefault = defaults.filter((option) => {
+      return (option[VALUE_POS] === value || option[LABEL_POS] === label)
+    })[0];
+    if ((isBare || isRadio) && !isDefault) {
+      setGhostName(label);
+      setGhostValue(value);
+    } else {
+      // In all other cases, we want to clear the ghost value
+      setGhostValue(GHOST_SENTINEL);
+    }
+    updateGhost(value, label);
+    acceptEnteredOption(value, label);
+    onUpdate && onUpdate(value);
+  }
+
   // Hold the input box for either multiple choice type
   let CustomInput = customInput;
   let ghostInput = (input || textbox || customInput) && (<div className={isBare ? classes.bareAnswer : classes.searchWrapper}>
       {
         customInput ?
           <CustomInput
-            onClick={(value, label) => {
-              // If we are bare or a radio, the selected option should become the value
-              // unless it is one of the defaults
-              let isDefault = defaults.filter((option) => {
-                return (option[VALUE_POS] === value)
-              })[0];
-              if ((isBare || isRadio) && !isDefault) {
-                setGhostName(label);
-                setGhostValue(value);
-              } else {
-                // In all other cases, we want to clear the ghost value
-                setGhostValue(GHOST_SENTINEL);
-              }
-              acceptEnteredOption(value, label);
-              onUpdate && onUpdate(value);
-            }}
             initialSelection={selection.filter(option => option[VALUE_POS])}
             onRemoveOption={removeOption}
+            onClick={acceptOptionFromWidget}
             onChange = {ghostUpdateEvent}
             value={ghostSelected ? ghostName : undefined}
             disabled={disabled}
@@ -425,7 +432,7 @@ function MultipleChoice(props) {
           answers={answers}
           existingAnswer={existingAnswer}
           questionName={questionName}
-          onAddSuggestion={acceptEnteredOption}
+          onAddSuggestion={acceptOptionFromWidget}
           {...rest}
           />
       </React.Fragment>
@@ -439,7 +446,7 @@ function MultipleChoice(props) {
           answers={answers}
           existingAnswer={existingAnswer}
           questionName={questionName}
-          onAddSuggestion={acceptEnteredOption}
+          onAddSuggestion={acceptOptionFromWidget}
           {...rest}
           />
       </React.Fragment>
@@ -489,7 +496,7 @@ function MultipleChoice(props) {
           answers={answers}
           existingAnswer={existingAnswer}
           questionName={questionName}
-          onAddSuggestion={acceptEnteredOption}
+          onAddSuggestion={acceptOptionFromWidget}
           {...rest}
           />
       </React.Fragment>
@@ -507,7 +514,7 @@ function MultipleChoice(props) {
           existingAnswer={existingAnswer}
           questionName={questionName}
           isMultivalued={true}
-          onAddSuggestion={acceptEnteredOption}
+          onAddSuggestion={acceptOptionFromWidget}
           {...rest}
           />
       </React.Fragment>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/VocabularyQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/VocabularyQuestion.jsx
@@ -30,6 +30,8 @@ import AnswerComponentManager from "./AnswerComponentManager";
 import MultipleChoice from "./MultipleChoice";
 import VocabularyQuery from "../vocabQuery/VocabularyQuery.jsx";
 
+import NCRNote from "./NCRNote.jsx";
+
 // Component that renders a vocabulary question.
 //
 // Sample usage:
@@ -68,6 +70,10 @@ function VocabularyQuestion(props) {
           allowTermSelection: true
         }}
         answerNodeType = "cards:VocabularyAnswer"
+        noteComponent={NCRNote}
+        noteProps={{
+          vocabulary: questionDefinition.sourceVocabularies
+        }}
         {...props}
         />
     </Question>);

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -95,7 +95,8 @@
             "compact" : "boolean",
             "answerOptions" : "options"
           }
-        }
+        },
+        "enableNotes": "boolean"
       },
       "computed": {
         "expression": "string",


### PR DESCRIPTION
Fixup a regression by #589 that caused vocabulary notes to use the default note instead of the `NCRNote.jsx` component

**To test**: Start up LFS with NCR, install HANCESTRO, edit the Patient Information so that `Patient Information/Race` has notes enabled, and then type in some text with relevant keywords and make sure that NCR is still working and that terms can still be added by clicking on them. I couldn't get NCR running locally, so someone should test that you can still add terms by clicking on them.