### PR TITLE
LFS-1206 Regression Fix

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -68,6 +68,12 @@ function NewFormDialog(props) {
     setSelectedQuestionnaire(null);
     setSelectedSubject(null);
     setDisableProgress(false);
+    setError();
+  }
+
+  let closeAllDialogs = () => {
+    setDialogOpen(false);
+    setNewSubjectPopperOpen(false);
   }
 
   let createForm = (subject) => {
@@ -259,7 +265,7 @@ function NewFormDialog(props) {
         open={mode === MODE_ACTION ? dialogOpen : open}
         onClose={() => {
           resetDialogState();
-          setDialogOpen(false);
+          closeAllDialogs();
           if (onClose) {
             onClose();
           }
@@ -417,8 +423,7 @@ function NewFormDialog(props) {
         disabled={isFetching}
         onClose={() => {
           resetDialogState();
-          setNewSubjectPopperOpen(false);
-          setError();
+          closeAllDialogs();
           if (onClose) {
             onClose();
           }


### PR DESCRIPTION
This PR fixes the regression that occurred when the creation of a new Subject was cancelled from within a dialog window that was opened from the Forms (and not the Dashboard) page. The fix works by re-configuring the Cancel button to always close the dialog window regardless of how said dialog window was opened.

The original bug reporting and the steps to reproduce this bug can be found at https://github.com/ccmbioinfo/lfs/pull/667#issuecomment-868104426

This PR also modifies the `resetDialogState` function, therefore when testing, please ensure that all LFS-1206 tests still pass.