### PR TITLE
[misc] Allow starting in remote debug mode

### DIFF
--- a/start_cards.sh
+++ b/start_cards.sh
@@ -112,8 +112,12 @@ then
   python3 Utilities/HostConfig/check_tcp_available.py --tcp_port $BIND_PORT || handle_tcp_bind_fail
 fi
 
+#Check if debug mode was requested
+EXPR='{"operation": "includes", "key": "debug", "val": "true"}' python3 \
+  Utilities/HostConfig/java_property_parser.py $@ && DEBUG=true || DEBUG=
+
 #Start CARDS in the background
-java -jar distribution/target/lfs-*jar $@ &
+java ${DEBUG:+-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005} -jar distribution/target/lfs-*jar $@ &
 CARDS_PID=$!
 
 #Check to see if CARDS was able to bind to the TCP port


### PR DESCRIPTION
Passing `-Ddebug=true` should start cards in debug mode, blocking until a remote debugger is connected to port 5005. Not passing that argument should have no effect, everything should work as before.