### PR TITLE
LFS-1223: Create a utility program for backing up and restoring the tag of a running Docker image

### DIFF
--- a/Utilities/ContainerManagement/backup_image_tag.sh
+++ b/Utilities/ContainerManagement/backup_image_tag.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+TAG_TO_BACKUP=$1
+BACKUP_FILE=$2
+
+docker image inspect $TAG_TO_BACKUP --format='{{index .RepoDigests 0}}' > $BACKUP_FILE

--- a/Utilities/ContainerManagement/backup_image_tag.sh
+++ b/Utilities/ContainerManagement/backup_image_tag.sh
@@ -20,4 +20,11 @@
 TAG_TO_BACKUP=$1
 BACKUP_FILE=$2
 
-docker image inspect $TAG_TO_BACKUP --format='{{index .RepoDigests 0}}' > $BACKUP_FILE
+REPO_DIGEST=$(docker image inspect $TAG_TO_BACKUP --format='{{index .RepoDigests 0}}' 2>/dev/null)
+if [ -z $REPO_DIGEST ]
+then
+  echo "Error: There is no RepoDigest associated with this image. Are you sure this image was pulled from Docker Hub?" 2>&1
+  exit -1
+fi
+
+echo $REPO_DIGEST > $BACKUP_FILE

--- a/Utilities/ContainerManagement/restore_image_tag.sh
+++ b/Utilities/ContainerManagement/restore_image_tag.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+TAG_TO_RESTORE=$1
+BACKUP_FILE=$2
+
+docker image tag $(cat $BACKUP_FILE) $TAG_TO_RESTORE


### PR DESCRIPTION
This PR implements LFS-1223 by providing the `backup_image_tag.sh` and `restore_image_tag.sh` utility programs. These utility programs will be used when implementing LFS-1214 so that if updating a Docker image causes something to break, we can easily roll back to the previously working version of said Docker image.

To test:
1. Pull the latest Docker httpd image (`docker pull httpd`)
2. Tag this `httpd:latest` image as `nginx:latest` (`docker image tag httpd:latest nginx:latest`)
3. Start the mock `nginx:latest` image which is in reality `httpd:latest` (`docker run --rm -p 8080:80 -d nginx:latest`). Visiting http://localhost:8080 should load an Apache Httpd page
4. Stop this container
5. Backup the `nginx:latest` image tag (`./Utilities/ContainerManagement/backup_image_tag.sh nginx:latest ~/nginx.tagbackup`)
6. Pull the real `nginx:latest` (`docker pull nginx`)
7. Start the nginx image with the same command as before (`docker run --rm -p 8080:80 -d nginx:latest`). Visiting http://localhost:8080 should load an Nginx page.
8. Stop this container
9. Restore the backed-up `nginx:latest` tag (`./Utilities/ContainerManagement/restore_image_tag.sh nginx:latest ~/nginx.tagbackup`)
10. Start a `nginx:latest` container again (`docker run --rm -p 8080:80 -d nginx:latest`). Visiting http://localhost:8080 should load an Apache Httpd page as in step 9 we have restored the `nginx:latest` tag to its backed-up value which is an Apache httpd Docker image.