### PR TITLE
LFS-1230: For Number Questions with predefined options, the selected value is displayed instead of the label in view mode and in the subject chart

### DIFF
--- a/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/labels/AnswerOptionsLabelProcessor.java
+++ b/modules/data-entry/src/main/java/ca/sickkids/ccm/lfs/dataentry/internal/serialize/labels/AnswerOptionsLabelProcessor.java
@@ -47,7 +47,10 @@ public class AnswerOptionsLabelProcessor extends SimpleAnswerLabelProcessor impl
     public void leave(Node node, JsonObjectBuilder json, Function<Node, JsonValue> serializeNode)
     {
         try {
-            if (node.isNodeType("lfs:TextAnswer")) {
+            if (node.isNodeType("lfs:TextAnswer")
+                || node.isNodeType("lfs:LongAnswer")
+                || node.isNodeType("lfs:DoubleAnswer")
+                || node.isNodeType("lfs:DecimalAnswer")) {
                 addProperty(node, json, serializeNode);
             }
         } catch (RepositoryException e) {


### PR DESCRIPTION
Quick fix. Q: Is there a more extensible way to do this?