### PR TITLE
LFS-1231: Computed field display may truncate longer values

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -160,6 +160,7 @@ let ComputedQuestion = (props) => {
       >
       {error && <Typography color='error'>{errorMessage}</Typography>}
       <TextField
+        multiline
         disabled={true}
         className={classes.textField + " " + classes.answerField}
         value={value}


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/LFS-1231)

Use case: a `computed` field that generates an "interpretation" text based on a value in the form.

Example: a form with a long variable named `score`, and a computed field named `interpretation` which has the following `expression`:

```
return (( 4 >= @{score}) ? "Minimal depression which may not require treatment"  :.
        ( 9 >= @{score}) ? "Mild depression which may require only watchful waiting" :
        (14 >= @{score}) ? "Moderate depression severity; patients should have a treatment plan ranging form counseling, followup, and/or pharmacotherapy" :
        (19 >= @{score}) ? "Moderately severe depression; patients typically should have immediate initiation of pharmacotherapy and/or psychotherapy" :
                           "severe depression; patients typically should have immediate initiation of pharmacotherapy and expedited referral to mental health specialist")
```