### PR TITLE
LFS-1239: start_cards.sh should detect failure to start the java process and terminate

### DIFF
--- a/start_cards.sh
+++ b/start_cards.sh
@@ -34,6 +34,10 @@ function ctrl_c() {
   exit
 }
 
+function check_cards_running() {
+  jobs -pr | grep '^'$CARDS_PID'$' > /dev/null
+}
+
 function handle_cards_java_fail() {
   echo -e "${TERMINAL_RED}*****************************************${TERMINAL_NOCOLOR}"
   echo -e "${TERMINAL_RED}*                                       *${TERMINAL_NOCOLOR}"
@@ -142,7 +146,7 @@ then
     #Check if CARDS was able to bind
     python3 Utilities/HostConfig/check_tcp_listen.py --tcp_port $BIND_PORT --pid $CARDS_PID && break
     #If the CARDS Java process has terminated, stop this script altogether
-    kill -0 $CARDS_PID > /dev/null 2> /dev/null || handle_cards_java_fail
+    check_cards_running || handle_cards_java_fail
   done
 fi
 
@@ -158,7 +162,7 @@ while true
 do
   echo "Waiting for CARDS to start"
   #If the CARDS Java process has terminated, stop this script altogether
-  kill -0 $CARDS_PID > /dev/null 2> /dev/null || handle_cards_java_fail
+  check_cards_running || handle_cards_java_fail
   curl --fail $CARDS_URL/system/sling/info.sessionInfo.json > /dev/null 2> /dev/null && break
   sleep 5
 done


### PR DESCRIPTION
This PR causes `start_cards.sh` to exit if the CARDS `java` process terminates. This includes the possibility of the `java` process terminating because the CARDS jar file is not present.

To test:

- Complete these tests in all possible testing environments (WSL, Linux with `python3-psutil` installed, Linux without `python3-psutil` installed)
- After running `mvn clean install`, the `./start_cards.sh` script should work as expected
  - CTRL+C should kill the running CARDS instance
- After running `mvn clean`, running the `./start_cards.sh` script should result in it terminating after a brief period of time as the CARDS jar file is not available
- Rebuild with `mvn clean install`, start CARDS using the `./start_cards.sh` script and kill the CARDS java process using the `kill` command. The `start_cards.sh` script should exit with a _CARDS Java process failure_ message