### PR TITLE
CARDS-1272: Wrong question listed in filters for the Radio form

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
@@ -147,7 +147,7 @@ function Filters(props) {
         continue;
       }
 
-      newFilterableFields.push([title, ...parseSectionOrQuestionnaire(thisQuestionnaire)]);
+      newFilterableFields.push([title, ...parseSectionOrQuestionnaire(thisQuestionnaire, title+"/")]);
     }
 
     newQuestionDefinitions["Subject"] = {


### PR DESCRIPTION
This fixes a regression in introduced by CARDS-360 #677 .

Before:
![image](https://user-images.githubusercontent.com/4656440/126842675-3006a65d-f6d4-45ce-9af1-f96f509b326e.png)

After:
![image](https://user-images.githubusercontent.com/4656440/126842719-f5db287f-a71a-4dc9-88ed-36b0a3690170.png)
