### PR TITLE
CARDS-1276: Switching filters causes the input box to be treated as empty.

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
@@ -271,6 +271,15 @@ function Filters(props) {
         comparator: loadedComparators[0],
         title: filterableTitles[event.target.value]
       }
+
+      // Keep any old data, if possible
+      let newDataType = questionDefinitions[event.target.value]?.dataType || "text";
+      if (index in oldfilters && newDataType == oldfilters[index].type) {
+        newfilter.value = oldfilters[index].value;
+        newfilter.comparator = oldfilters[index].comparator;
+        newfilter.type = newDataType;
+      }
+
       newfilters[index] = newfilter;
       return(newfilters);
     });

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
@@ -269,15 +269,14 @@ function Filters(props) {
         name: event.target.value,
         uuid: filterableUUIDs[event.target.value],
         comparator: loadedComparators[0],
-        title: filterableTitles[event.target.value]
+        title: filterableTitles[event.target.value],
+        type: questionDefinitions[event.target.value]?.dataType || "text"
       }
 
       // Keep any old data, if possible
-      let newDataType = questionDefinitions[event.target.value]?.dataType || "text";
-      if (index in oldfilters && newDataType == oldfilters[index].type) {
+      if (index in oldfilters && newfilter.type == oldfilters[index].type) {
         newfilter.value = oldfilters[index].value;
         newfilter.comparator = oldfilters[index].comparator;
-        newfilter.type = newDataType;
       }
 
       newfilters[index] = newfilter;


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/CARDS-1276)

**to test**:
- lfs mode, dashboard, filters
- add filter: radiation start date = some date, apply
- modify filter, change radiation start date to radiation end date, keep the previous date, Apply
- Filter should have the same date selected as before after you save.
- The same should be true for other data types as well.