### PR TITLE
[misc] Fixed build on pristine instances: wrong parent for the moved aggregated-frontend module

### DIFF
--- a/aggregated-frontend/pom.xml
+++ b/aggregated-frontend/pom.xml
@@ -22,7 +22,7 @@
 
   <parent>
     <groupId>io.uhndata.cards</groupId>
-    <artifactId>cards-modules</artifactId>
+    <artifactId>cards-parent</artifactId>
     <version>0.9-SNAPSHOT</version>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -915,11 +915,11 @@
 
   <modules>
     <module>modules</module>
-    <module>distribution</module>
+    <module>aggregated-frontend</module>
     <module>lfs-resources</module>
     <module>kids-resources</module>
     <module>cardiac-rehab-resources</module>
     <module>test-resources</module>
-    <module>aggregated-frontend</module>
+    <module>distribution</module>
   </modules>
 </project>


### PR DESCRIPTION
To reproduce the problem: delete `~/.m2/repository/io/uhndata/cards` and try to build dev.

To test: on the new branch the build works.