### PR TITLE
CARDS-699 and CARDS-1302: Add support for hidden and formatted computed questions

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -24,6 +24,7 @@ import { InputAdornment, TextField, Typography, withStyles } from "@material-ui/
 import Answer from "./Answer";
 import AnswerComponentManager from "./AnswerComponentManager";
 import Question from "./Question";
+import FormattedText from "../components/FormattedText";
 import QuestionnaireStyle from './QuestionnaireStyle';
 import { useFormReaderContext } from "./FormContext";
 
@@ -47,7 +48,7 @@ import { useFormReaderContext } from "./FormContext";
 //  />
 let ComputedQuestion = (props) => {
   const { existingAnswer, classes, ...rest} = props;
-  const { text, expression, unitOfMeasurement } = {...props.questionDefinition, ...props};
+  const { text, expression, unitOfMeasurement, displayMode } = {...props.questionDefinition, ...props};
   const [error, changeError] = useState(false);
   const [errorMessage, changeErrorMessage] = useState(false);
 
@@ -153,12 +154,20 @@ let ComputedQuestion = (props) => {
     muiInputProps.endAdornment = <InputAdornment position="end">{unitOfMeasurement}</InputAdornment>;
   }
 
+  evaluateExpression();
+  let isFormatted = (displayMode == "formatted");
+
   return (
     <Question
+      defaultDisplayFormatter={isFormatted ? (label, idx) => <FormattedText>{label}</FormattedText> : undefined}
       currentAnswers={typeof(value) !== "undefined" && value !== "" ? 1 : 0}
       {...props}
       >
       {error && <Typography color='error'>{errorMessage}</Typography>}
+      { isFormatted ? <FormattedText>
+          {value + (unitOfMeasurement ? (" " + unitOfMeasurement) : '')}
+        </FormattedText>
+      :
       <TextField
         multiline
         disabled={true}
@@ -167,6 +176,7 @@ let ComputedQuestion = (props) => {
         InputProps={muiInputProps}
         onChange={evaluateExpression()}
       />
+      }
       <Answer
         answers={answer}
         questionDefinition={props.questionDefinition}
@@ -185,6 +195,7 @@ ComputedQuestion.propTypes = {
     text: PropTypes.string.isRequired,
     expression: PropTypes.string.isRequired,
     description: PropTypes.string,
+    displayMode: PropTypes.oneOf(['input', 'formatted']),
     unitOfMeasurement: PropTypes.string
   }).isRequired
 };

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -195,7 +195,7 @@ ComputedQuestion.propTypes = {
     text: PropTypes.string.isRequired,
     expression: PropTypes.string.isRequired,
     description: PropTypes.string,
-    displayMode: PropTypes.oneOf(['input', 'formatted']),
+    displayMode: PropTypes.oneOf(['input', 'formatted', 'hidden']),
     unitOfMeasurement: PropTypes.string
   }).isRequired
 };

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -84,7 +84,7 @@ let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, o
   if (doHighlight) {
     gridClasses.push(classes.focusedQuestionnaireItem);
   }
-  if (pageActive === false) {
+  if (pageActive === false || questionDefinition.displayMode == 'hidden') {
     gridClasses.push(classes.hiddenQuestion);
   }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -604,6 +604,8 @@ export function displayQuestion(entryDefinition, data, key, classes) {
 
   // question title, to be used when 'previewing' the form
   const questionTitle = entryDefinition["text"];
+  // check the display mode and don't display if "hidden"
+  const isHidden = (entryDefinition.displayMode == "hidden");
 
   if (typeof(existingQuestionAnswer?.[1]?.value) != "undefined") {
     let prettyPrintedAnswers = existingQuestionAnswer[1]["displayedValue"];
@@ -653,6 +655,7 @@ export function displayQuestion(entryDefinition, data, key, classes) {
         break;
     }
     return (
+      isHidden ? null :
       <Typography variant="body2" component="div" key={key} className={classes.formPreviewQuestion}>{questionTitle}: {content}</Typography>
     );
   }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -22,6 +22,7 @@ import { Link, useLocation, withRouter } from 'react-router-dom';
 import PropTypes from "prop-types";
 import moment from "moment";
 
+import FormattedText from "../components/FormattedText";
 import QuestionnaireStyle from "./QuestionnaireStyle.jsx";
 import NewFormDialog from "../dataHomepage/NewFormDialog";
 import { QUESTION_TYPES, SECTION_TYPES, ENTRY_TYPES } from "./FormEntry.jsx";
@@ -641,6 +642,12 @@ export function displayQuestion(entryDefinition, data, key, classes) {
           content = "Yes";
         }
         break;
+      case "computed":
+        content = <>{ prettyPrintedAnswers.join(", ") }</>;
+        // check the display mode; if formatted, display accordingly
+        if (entryDefinition.displayMode == "formatted") {
+          content = <FormattedText>{content}</FormattedText>;
+        }
       default:
         content = <>{ prettyPrintedAnswers.join(", ") }</>
         break;

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -102,7 +102,8 @@
         "expression": "string",
         "displayMode" : {
           "input" : {},
-          "formatted" : {}
+          "formatted" : {},
+          "hidden": {}
         },
         "unitOfMeasurement" : "string"
       },

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -100,6 +100,10 @@
       },
       "computed": {
         "expression": "string",
+        "displayMode" : {
+          "input" : {},
+          "formatted" : {}
+        },
         "unitOfMeasurement" : "string"
       },
       "time": {

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ComputedTest.xml
@@ -1,0 +1,159 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>ComputedTest</name>
+	<primaryNodeType>cards:Questionnaire</primaryNodeType>
+	<property>
+		<name>title</name>
+		<value>Computed Field Test</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>description</name>
+		<value>CARDS-317, CARDS-699, CARDS-1302</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>requiredSubjectTypes</name>
+		<values>
+			<value>/SubjectTypes/Patient</value>
+		</values>
+		<type>Reference</type>
+	</property>
+	<node>
+		<name>q1</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Write something:</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>text</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>q2</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Computed, plain</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>description</name>
+			<value>
+Expected output:
+
+> You wrote [text from previous question]
+
+or
+
+> You wrote nothing
+			</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>computed</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>expression</name>
+			<value>return "You wrote " + @{q1:-"nothing"}</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>q3</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Computed, hidden</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>description</name>
+			<value>This should not appear in the form</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>computed</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>hidden</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>expression</name>
+			<value>return "You wrote " + @{q1:-nothing}</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>q4</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Computed, formatted</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>description</name>
+			<value>
+Expected output:
+
+> You **wrote** *[text from question 1]*
+
+or
+
+> You **wrote** *nothing*
+
+**Note**: How the text from question 1 is displayed may be affected by formatting characters if it contains markdown formatting characters.
+			</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>computed</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>formatted</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>expression</name>
+			<value>return "You **wrote** *" + @{q1:-nothing} + "*"</value>
+			<type>String</type>
+		</property>
+	</node>
+</node>


### PR DESCRIPTION
- [x] [CARDS-699](https://phenotips.atlassian.net/browse/CARDS-699): Add support for "hidden" questions
Technically the `displayMode` of any type of question can be set to `hidden` when manually editing the questionnaire source, however with this PR the questionnaire wizard only provides this option for `computed` questions.
- [x] [CARDS-1302](https://phenotips.atlassian.net/browse/CARDS-1302): Add support for computed fields displayed as formatted text

To test, start cards in the `test` runmode and instantiate the **Computed Field Test** questionnaire.
