### PR TITLE
CARDS-1304: Switch from using install runModes to normal runModes

### DIFF
--- a/distribution/src/main/provisioning/01-boot.txt
+++ b/distribution/src/main/provisioning/01-boot.txt
@@ -40,7 +40,7 @@
     # permissions_trusted requires that after self-registration, users must be manually added to the TrustedUsers group by an administrator before they can access data.
     # permissions_ownership enforces data ownership and explicit data sharing
 
-    sling.run.mode.install.options=oak_tar,oak_mongo|forms,noforms|nolfs,lfs|nokids,kids|nocardiac_rehab,cardiac_rehab|permissions_open,permissions_trusted,permissions_ownership
+    sling.run.mode.options=oak_tar,oak_mongo|forms,noforms|nolfs,lfs|nokids,kids|nocardiac_rehab,cardiac_rehab|permissions_open,permissions_trusted,permissions_ownership
 
     repository.home=${sling.home}/repository
     localIndexDir=${sling.home}/repository/index


### PR DESCRIPTION
This PR implements CARDS-1304.

To test:

- On a build of the `dev` branch:
  - Start with only the `dev` runMode enabled
  - Visit `http://localhost:8080`. This should load a _plain_ CARDS instance
  - Stop the running instance and restart with the `dev` and `lfs` runModes enabled. Ensure that you do not delete the `sling` directory
  - Visit `http://localhost:8080`. This should load a _plain_ CARDS instance
- On a build of this `CARDS-1304` branch:
  - Start with only the `dev` runMode enabled
  - Visit `http://localhost:8080`. This should load a _plain_ CARDS instance
  - Stop the running instance and restart with the `dev` and `lfs` runModes enabled. Ensure that you do not delete the `sling` directory
  - Visit `http://localhost:8080`. This should load a _cards4lfs_ CARDS instance