### PR TITLE
CARDS-1252: When creating a release of CARDS, the CARDS_DOCKER_TAG constant in compose-cluster/generate_compose_yaml.py should be set to the CARDS release number

### DIFF
--- a/compose-cluster/CardsDockerTagProperty.py
+++ b/compose-cluster/CardsDockerTagProperty.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+"""
+
+CARDS_DOCKER_TAG = "latest"

--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -24,8 +24,7 @@ import yaml
 import json
 import shutil
 import argparse
-
-CARDS_DOCKER_TAG = "latest"
+from CardsDockerTagProperty import CARDS_DOCKER_TAG
 
 argparser = argparse.ArgumentParser()
 argparser.add_argument('--shards', help='Number of MongoDB shards', default=1, type=int)

--- a/pom.xml
+++ b/pom.xml
@@ -708,7 +708,7 @@
           <artifactId>maven-bundle-plugin</artifactId>
           <version>4.2.0</version>
         </plugin>
-        <!-- Update the version that generate_compose_yaml.py uses for the generated compose file. -->
+        <!-- Update the version that CardsDockerTagProperty.py uses for the generated compose file. -->
         <!-- This is explicitly invoked during release:prepare -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -720,7 +720,7 @@
               <id>docker-compose-version</id>
               <configuration>
                 <target>
-                  <replace file="compose-cluster/generate_compose_yaml.py" token="latest" value="${project.version}" />
+                  <replace file="compose-cluster/CardsDockerTagProperty.py" token="latest" value="${project.version}" />
                 </target>
               </configuration>
               <goals>
@@ -729,7 +729,7 @@
             </execution>
           </executions>
         </plugin>
-        <!-- Commit the updated generate_compose_yaml.py file. -->
+        <!-- Commit the updated CardsDockerTagProperty.py file. -->
         <!-- This is explicitly invoked during release:prepare -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -741,7 +741,7 @@
               <id>docker-compose-version</id>
               <configuration>
                 <pushChanges>false</pushChanges>
-                <includes>compose-cluster/generate_compose_yaml.py</includes>
+                <includes>compose-cluster/CardsDockerTagProperty.py</includes>
                 <excludes>pom.xml</excludes>
                 <message>[release] Set the current release version for docker compose</message>
               </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -508,13 +508,14 @@
           <version>2.5.3</version>
           <configuration>
             <arguments>-Pquick</arguments>
+            <preparationGoals>clean verify antrun:run@docker-compose-version scm:checkin@docker-compose-version</preparationGoals>
             <!-- Avoid site generation during the release:perform to speed up release process -->
             <goals>deploy</goals>
             <mavenExecutorId>forked-path</mavenExecutorId>
             <autoVersionSubmodules>true</autoVersionSubmodules>
             <localCheckout>true</localCheckout>
             <pushChanges>false</pushChanges>
-            <tagNameFormat>phenotips-@{project.version}</tagNameFormat>
+            <tagNameFormat>cards-@{project.version}</tagNameFormat>
           </configuration>
         </plugin>
         <plugin>
@@ -706,6 +707,49 @@
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
           <version>4.2.0</version>
+        </plugin>
+        <!-- Update the version that generate_compose_yaml.py uses for the generated compose file. -->
+        <!-- This is explicitly invoked during release:prepare -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>3.0.0</version>
+          <inherited>false</inherited>
+          <executions>
+            <execution>
+              <id>docker-compose-version</id>
+              <configuration>
+                <target>
+                  <replace file="compose-cluster/generate_compose_yaml.py" token="latest" value="${project.version}" />
+                </target>
+              </configuration>
+              <goals>
+                <goal>run</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <!-- Commit the updated generate_compose_yaml.py file. -->
+        <!-- This is explicitly invoked during release:prepare -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-scm-plugin</artifactId>
+          <version>1.11.2</version>
+          <inherited>false</inherited>
+          <executions>
+            <execution>
+              <id>docker-compose-version</id>
+              <configuration>
+                <pushChanges>false</pushChanges>
+                <includes>compose-cluster/generate_compose_yaml.py</includes>
+                <excludes>pom.xml</excludes>
+                <message>[release] Set the current release version for docker compose</message>
+              </configuration>
+              <goals>
+                <goal>checkin</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
To simulate a release:

```
mvn release:prepare -DreleaseVersion=0.9.fake -DdevelopmentVersion=0.9-SNAPSHOT -Dtag=cards-0.9.fake
```

After this finishes, `git checkout cards-0.9.fake` and look at the version specified in `compose-cluster/generate_compose_yaml.py`.

To clean up: `git release:rollback ; git tag -d cards-0.9.fake`