### PR TITLE
CARDS-1263: As an admin, I can access a preview of what a questionnaire looks and functions like without creating a new form ("view mode" for questionnaires)

### DIFF
--- a/modules/commons/src/main/frontend/src/components/dragAndDrop.jsx
+++ b/modules/commons/src/main/frontend/src/components/dragAndDrop.jsx
@@ -56,7 +56,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 export default function DragAndDrop(props) {
-  const { accept, multifile, handleDrop, error } = props;
+  const { accept, multifile, handleDrop, error, isDemo } = props;
   const [drag, setDrag] = useState(false);
   const [dragCounter, setDragCounter] = useState(0);
 
@@ -138,6 +138,7 @@ export default function DragAndDrop(props) {
         style={{display: 'none'}}
         onChange={onChangeFile.bind(this)}
         value=""
+        disabled={isDemo}
       />
       <div className={drag ? classes.active : classes.dropzone} >
           <IconButton color="primary" component="span">

--- a/modules/commons/src/main/frontend/src/components/dragAndDrop.jsx
+++ b/modules/commons/src/main/frontend/src/components/dragAndDrop.jsx
@@ -56,7 +56,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 export default function DragAndDrop(props) {
-  const { accept, multifile, handleDrop, error, isDemo } = props;
+  const { accept, multifile, handleDrop, error, disabled } = props;
   const [drag, setDrag] = useState(false);
   const [dragCounter, setDragCounter] = useState(0);
 
@@ -91,7 +91,7 @@ export default function DragAndDrop(props) {
     e.preventDefault();
     e.stopPropagation();
     setDrag(false);
-    if (e.dataTransfer.files && e.dataTransfer.files.length > 0 && !isDemo) {
+    if (e.dataTransfer.files && e.dataTransfer.files.length > 0 && !disabled) {
       handleDrop(e.dataTransfer.files);
       e.dataTransfer.clearData();
       setDragCounter(0);
@@ -124,7 +124,7 @@ export default function DragAndDrop(props) {
   });
 
   return (
-    <div style={{display: 'inline-block', position: 'relative'}}
+    <div style={{display: 'inline-block', position: 'relative', opacity: disabled ? 0.5 : 1}}
        onClick={handleClick.bind(this)}
        ref={dropRef}
     >
@@ -138,7 +138,7 @@ export default function DragAndDrop(props) {
         style={{display: 'none'}}
         onChange={onChangeFile.bind(this)}
         value=""
-        disabled={isDemo}
+        disabled={disabled}
       />
       <div className={drag ? classes.active : classes.dropzone} >
           <IconButton color="primary" component="span">

--- a/modules/commons/src/main/frontend/src/components/dragAndDrop.jsx
+++ b/modules/commons/src/main/frontend/src/components/dragAndDrop.jsx
@@ -91,7 +91,7 @@ export default function DragAndDrop(props) {
     e.preventDefault();
     e.stopPropagation();
     setDrag(false);
-    if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+    if (e.dataTransfer.files && e.dataTransfer.files.length > 0 && !isDemo) {
       handleDrop(e.dataTransfer.files);
       e.dataTransfer.clearData();
       setDragCounter(0);

--- a/modules/commons/src/main/frontend/src/components/dragAndDrop.jsx
+++ b/modules/commons/src/main/frontend/src/components/dragAndDrop.jsx
@@ -91,7 +91,7 @@ export default function DragAndDrop(props) {
     e.preventDefault();
     e.stopPropagation();
     setDrag(false);
-    if (e.dataTransfer.files && e.dataTransfer.files.length > 0 && !disabled) {
+    if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
       handleDrop(e.dataTransfer.files);
       e.dataTransfer.clearData();
       setDragCounter(0);

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
@@ -108,6 +108,14 @@ function DeleteButton(props) {
   }
 
   let handleDelete = () => {
+    // If no path is provided, display the button but don't do any delete calls
+    // and consider deletion successful since there's nothing to do
+    if (!entryPath) {
+      closeDialog();
+      if (onComplete) {onComplete();}
+      if (shouldGoBack) {goBack();}
+      return;
+    }
     let url = new URL(entryPath, window.location.origin);
     if (deleteRecursive) {
       url.searchParams.set("recursive", true);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FileResourceQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FileResourceQuestion.jsx
@@ -86,6 +86,7 @@ function FileResourceQuestion(props) {
   let writer = useFormUpdateWriterContext();
   let reader = useFormReaderContext();
   let saveForm = reader['/Save'];
+  let disableUploads = !!reader['/DisableUploads'];
   // Since adding new entries doesn't trigger the form's onChange, we need to force
   // the form to allow saving after we finish updating
   let allowResave = reader['/AllowResave'];
@@ -99,6 +100,10 @@ function FileResourceQuestion(props) {
 
   // Event handler for selecting files
   let upload = (files) => {
+    // Don't do anything if the context provider says uploads are disabled
+    if (disableUploads) {
+      return;
+    }
     // TODO - handle possible logged out situation here - open a login popup
     setUploadInProgress(true);
     setError("");
@@ -290,9 +295,8 @@ function FileResourceQuestion(props) {
         handleDrop={addFiles}
         multifile={maxAnswers != 1}
         error={error}
-        isDemo={window.location.pathname.startsWith("/content.html/admin/Questionnaires/")}
+        disabled={disableUploads}
         />
-
       { uploadedFiles && Object.values(uploadedFiles).length > 0 && <ul className={classes.answerField + " " + classes.fileResourceAnswerList}>
         {Object.keys(uploadedFiles).map((filepath, idx) =>
           <li key={idx}>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FileResourceQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FileResourceQuestion.jsx
@@ -290,6 +290,7 @@ function FileResourceQuestion(props) {
         handleDrop={addFiles}
         multifile={maxAnswers != 1}
         error={error}
+        isDemo={window.location.pathname.startsWith("/content.html/admin/Questionnaires/")}
         />
 
       { uploadedFiles && Object.values(uploadedFiles).length > 0 && <ul className={classes.answerField + " " + classes.fileResourceAnswerList}>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -142,7 +142,7 @@ function FormPagination (props) {
       type="submit"
       variant="contained"
       color="primary"
-      disabled={saveInProgress}
+      disabled={saveInProgress || activePage === lastValidPage()}
       className={classes.paginationButton}
       onClick={handleNext}
     >

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -68,7 +68,7 @@ function FormPagination (props) {
             });
     setPages(pagesArray);
     setPagesCallback(pagesResults);
-  }, [questionnaireData, activePage]);
+  }, [questionnaireData, activePage, paginationEnabled]);
 
   let addPage = (entryDefinition) => {
     if (paginationEnabled) {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -142,7 +142,7 @@ function FormPagination (props) {
       type="submit"
       variant="contained"
       color="primary"
-      disabled={saveInProgress || activePage === lastValidPage()}
+      disabled={saveInProgress || !enableSave && activePage === lastValidPage()}
       className={classes.paginationButton}
       onClick={handleNext}
     >

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -26,7 +26,7 @@ import {
 } from "@material-ui/core";
 
 import PropTypes from "prop-types";
-import { QUESTION_TYPES, ENTRY_TYPES } from "./FormEntry";
+import { SECTION_TYPES, ENTRY_TYPES } from "./FormEntry";
 import QuestionnaireStyle, { FORM_ENTRY_CONTAINER_PROPS } from "./QuestionnaireStyle";
 
 class Page {
@@ -73,7 +73,7 @@ function FormPagination (props) {
   let addPage = (entryDefinition) => {
     if (paginationEnabled) {
       let page;
-      if (QUESTION_TYPES.includes(entryDefinition["jcr:primaryType"]) && previousEntryType && QUESTION_TYPES.includes(previousEntryType)) {
+      if (!SECTION_TYPES.includes(entryDefinition["jcr:primaryType"]) && previousEntryType && !SECTION_TYPES.includes(previousEntryType)) {
         page = pagesArray[pagesArray.length - 1];
         questionIndex++;
       } else {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 import {
   Button,
@@ -25,20 +25,87 @@ import {
   withStyles,
 } from "@material-ui/core";
 
+import PropTypes from "prop-types";
+import { QUESTION_TYPES, ENTRY_TYPES } from "./FormEntry";
 import QuestionnaireStyle, { FORM_ENTRY_CONTAINER_PROPS } from "./QuestionnaireStyle";
 
+class Page {
+  constructor(visible) {
+    this.visible = visible;
+    this.canBeVisible = true;
+  }
+  conditionalVisible = [];
+
+  addConditionalVisible(visible, index) {
+    this.conditionalVisible[index] = visible;
+    this.canBeVisible = this.conditionalVisible.length === 0 || this.conditionalVisible.includes(true);
+  }
+}
+
 /**
- * Component that displays an page of a Form.
+ * Component that displays a page of a Form.
  */
 function FormPagination (props) {
-  let { classes, lastPage, activePage, saveInProgress, lastSaveStatus, handlePageChange } = props;
+  let { classes, saveInProgress, lastSaveStatus, setPagesCallback, paginationEnabled, enableSave, questionnaireData } = props;
 
   let [ savedLastPage, setSavedLastPage ] = useState(false);
   let [ pendingSubmission, setPendingSubmission ] = useState(false);
+  let [ pages, setPages ] = useState([]);
+  let [ activePage, setActivePage ] = useState(0);
+
+  let previousEntryType;
+  let questionIndex = 0;
+  let pagesResults = {};
+  let pagesArray = [];
+
+  useEffect(() => {
+    setPagesCallback(null);
+    Object.entries(questionnaireData)
+            .filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType']))
+            .map(([key, entryDefinition]) => {
+              let pageResult = addPage(entryDefinition);
+              pagesResults[key] = pageResult;
+            });
+    setPages(pagesArray);
+    setPagesCallback(pagesResults);
+  }, [questionnaireData, activePage]);
+
+  let addPage = (entryDefinition) => {
+    if (paginationEnabled) {
+      let page;
+      if (QUESTION_TYPES.includes(entryDefinition["jcr:primaryType"]) && previousEntryType && QUESTION_TYPES.includes(previousEntryType)) {
+        page = pagesArray[pagesArray.length - 1];
+        questionIndex++;
+      } else {
+        page = new Page(!paginationEnabled || activePage == pagesArray.length);
+        pagesArray.push(page);
+        questionIndex = 0;
+      }
+      previousEntryType = entryDefinition["jcr:primaryType"];
+
+      return {
+        page: page,
+        callback: (visible) => {page.addConditionalVisible(visible, questionIndex);}
+      }
+    } else {
+      if (pagesArray.length === 0) {
+        pagesArray.push(new Page(true));
+      }
+      return {page: pagesArray[0], callback: ()=>{}}
+    }
+  }
+
+  let lastValidPage = () => {
+    let result = pages.length - 1;
+    while (result > 0 && !pages[result].canBeVisible) {
+      result--;
+    }
+    return result;
+  }
 
   let handleNext = () => {
     setPendingSubmission(true);
-    if (activePage === lastPage()) {
+    if (activePage === lastValidPage()) {
       setSavedLastPage(true);
     } else {
       setSavedLastPage(false);
@@ -57,6 +124,19 @@ function FormPagination (props) {
     setPendingSubmission(false);
   }
 
+  let handlePageChange = (direction) => {
+    let change = (direction === "next" ? 1 : -1);
+    let nextPage = activePage;
+    while ((change === 1 || nextPage > 0) && (change === -1 || nextPage < lastValidPage())) {
+      nextPage += change;
+      if (pages[nextPage].canBeVisible) break;
+    }
+    if (nextPage !== activePage) {
+      window.scrollTo(0, 0);
+    }
+    setActivePage(nextPage);
+  }
+
   let saveButton =
     <Button
       type="submit"
@@ -66,9 +146,10 @@ function FormPagination (props) {
       className={classes.paginationButton}
       onClick={handleNext}
     >
-      {((lastPage() === 0 || activePage === lastPage()) && saveInProgress) ? 'Saving' :
+      {!enableSave ? "Next" :
+      ((lastValidPage() === 0 || activePage === lastValidPage()) && saveInProgress) ? 'Saving' :
       lastSaveStatus === false ? 'Save failed, log in and try again?' :
-      activePage < lastPage() ? "Next" :
+      activePage < lastValidPage() ? "Next" :
       lastSaveStatus && savedLastPage ? 'Saved' :
       'Save'}
     </Button>
@@ -85,10 +166,10 @@ function FormPagination (props) {
       className={`${classes.formStepper} ${isBack ? classes.formStepperTop : classes.formStepperBottom}`}
       classes={isBack ? null : {progress:classes.formStepperBottomBackground}}
       // base 0 to base 1, plus 1 for the "current page" region
-      steps={lastPage() + 2}
+      steps={lastValidPage() + 2}
       nextButton={saveButton}
       backButton={
-        lastPage() > 0
+        lastValidPage() > 0
           ? <Button
               type="submit"
               // Don't disable until form submission started
@@ -106,7 +187,8 @@ function FormPagination (props) {
     />
 
   return (
-    lastPage() > 0 ?
+    paginationEnabled ?
+    lastValidPage() > 0 ?
       <React.Fragment>
         {/* Back bar to show a different colored current page section*/}
         {stepper(true)}
@@ -115,7 +197,24 @@ function FormPagination (props) {
       </React.Fragment>
     :
       saveButton
+    : null
   );
+};
+
+FormPagination.propTypes = {
+  enableSave: PropTypes.bool,
+  paginationEnabled: PropTypes.bool,
+  questionnaireData: PropTypes.object.isRequired,
+  setPagesCallback: PropTypes.func.isRequired,
+  lastSaveStatus: PropTypes.bool,
+  saveInProgress: PropTypes.bool
+};
+
+FormPagination.defaultProps = {
+  enableSave: true,
+  paginationEnabled: true,
+  saveInProgress: false,
+  lastSaveStatus: true
 };
 
 export default withStyles(QuestionnaireStyle)(FormPagination);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
@@ -138,7 +138,7 @@ function PedigreeQuestion(props) {
       {...props}
       >
       <div className={classes.answerField}>
-      { pedigreeData.image && answerPath ?
+      { pedigreeData.image ?
         <Grid container direction="row" justify="flex-start" alignItems="flex-start" spacing={0}>
           <Grid item>
             <Tooltip title="Edit Pedigree">

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
@@ -18,7 +18,7 @@
 //
 
 import React, { useEffect, useState } from "react";
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import PropTypes from "prop-types";
 
 import {
@@ -60,7 +60,10 @@ let Questionnaire = (props) => {
   let [ data, setData ] = useState();
   let [ error, setError ] = useState();
   let [ doHighlight, setDoHighlight ] = useState(false);
-  let [ isEdit, setIsEdit ] =  useState(window.location.pathname.endsWith(".edit"));
+  let baseUrl = /((.*)\/Questionnaires)\/([^.]+)/.exec(location.pathname)[1];
+  let questionnaireUrl = `${baseUrl}/${id}`;
+  let isEdit = window.location.pathname.endsWith(".edit");
+  let history = useHistory();
 
   let pageNameWriter = usePageNameWriterContext();
 
@@ -101,6 +104,7 @@ let Questionnaire = (props) => {
   }, [questionnaireTitle]);
 
   useEffect(() => {
+    if (!isEdit) return;
     //Perform a JCR check-out of the Questionnaire
     let checkoutForm = new FormData();
     checkoutForm.set(":operation", "checkout");
@@ -127,13 +131,13 @@ let Questionnaire = (props) => {
   let questionnaireMenu = (
       <div className={classes.actionsMenu}>
         { isEdit ?
-          <Tooltip title="Preview" onClick={() => setIsEdit(false)}>
+          <Tooltip title="Preview" onClick={() => history.push(questionnaireUrl)}>
             <IconButton>
               <PreviewIcon />
             </IconButton>
           </Tooltip>
           :
-          <Tooltip title="Edit" onClick={() => setIsEdit(true)}>
+          <Tooltip title="Edit" onClick={() => history.push(questionnaireUrl + ".edit")}>
             <IconButton color="primary">
               <EditIcon />
             </IconButton>
@@ -144,6 +148,7 @@ let Questionnaire = (props) => {
           entryName={questionnaireTitle}
           entryType="Questionnaire"
           variant="icon"
+          onComplete={() => history.replace(baseUrl)}
         />
       </div>
   )
@@ -151,7 +156,7 @@ let Questionnaire = (props) => {
   let questionnaireHeader = (
         <ResourceHeader
           title={questionnaireTitle}
-          breadcrumbs={[<Link to={/((.*)\/Questionnaires)\/([^.]+)/.exec(location.pathname)[1]}>Questionnaires</Link>]}
+          breadcrumbs={[<Link to={baseUrl}>Questionnaires</Link>]}
           action={questionnaireMenu}
           contentOffset={props.contentOffset}
           >

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
@@ -155,7 +155,7 @@ let Questionnaire = (props) => {
 
   let questionnaireHeader = (
         <ResourceHeader
-          title={questionnaireTitle}
+          title={questionnaireTitle || ""}
           breadcrumbs={[<Link to={baseUrl}>Questionnaires</Link>]}
           action={questionnaireMenu}
           contentOffset={props.contentOffset}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
@@ -61,7 +61,7 @@ function QuestionnairePreview (props) {
 
   return (
     <Grid container {...FORM_ENTRY_CONTAINER_PROPS} >
-      { /* Added dummy save fucntionality for mocking file and pedigree questions functionality. */ }
+      { /* Added dummy save functionality for mocking file and pedigree questions functionality. */ }
       <FormProvider additionalFormData={{
           ['/Save']: () => { return new Promise((resolve, reject) => {return;})},
           ['/URL']: data ? data["@path"] : '',

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
@@ -65,7 +65,8 @@ function QuestionnairePreview (props) {
       <FormProvider additionalFormData={{
           ['/Save']: () => { return new Promise((resolve, reject) => {return;})},
           ['/URL']: data ? data["@path"] : '',
-          ['/AllowResave']: () => {}
+          ['/AllowResave']: () => {},
+          ['/DisableUploads'] : true
           }}>
         <FormUpdateProvider>
         { pages &&

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
@@ -21,6 +21,7 @@ import React, { useEffect, useState, useContext } from "react";
 import PropTypes from "prop-types";
 
 import {
+  CircularProgress,
   Grid,
   Typography,
   withStyles
@@ -54,19 +55,18 @@ function QuestionnairePreview (props) {
   // If the data has not yet been fetched, return an in-progress symbol
   if (!data) {
     return (
-      <Grid container justify="center">
-        <Grid item>
-          <Typography variant="h2" color="error">
-            Error obtaining questionnaire data
-          </Typography>
-        </Grid>
-      </Grid>
+      <Grid container justify="center"><Grid item><CircularProgress/></Grid></Grid>
     );
   }
 
   return (
     <Grid container {...FORM_ENTRY_CONTAINER_PROPS} >
-      <FormProvider >
+      { /* Added dummy save fucntionality for mocking file and pedigree questions functionality. */ }
+      <FormProvider additionalFormData={{
+          ['/Save']: () => { return new Promise((resolve, reject) => {return;})},
+          ['/URL']: data ? data["@path"] : '',
+          ['/AllowResave']: () => {}
+          }}>
         <FormUpdateProvider>
         { pages &&
           Object.entries(data)

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
@@ -1,0 +1,105 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React, { useEffect, useState, useContext } from "react";
+import PropTypes from "prop-types";
+
+import {
+  Grid,
+  Typography,
+  withStyles
+} from "@material-ui/core";
+
+import { FormProvider } from "./FormContext";
+import { FormUpdateProvider } from "./FormUpdateContext";
+import QuestionnaireStyle, { FORM_ENTRY_CONTAINER_PROPS } from "./QuestionnaireStyle";
+import FormEntry, { QUESTION_TYPES, ENTRY_TYPES } from "./FormEntry";
+import FormPagination from "./FormPagination";
+import { usePageNameWriterContext } from "../themePage/Page.jsx";
+
+/**
+ * Component that displays Questionnaire form preview.
+ *
+ * @param {object} data full Questionnaire data object
+ */
+function QuestionnairePreview (props) {
+  let { classes, data, title } = props;
+
+  let [ pages, setPages ] = useState(null);
+  let [ removeWindowHandlers, setRemoveWindowHandlers ] = useState();
+  let [ actionsMenu, setActionsMenu ] = useState(null);
+  let paginationEnabled = !!data?.paginate;
+
+  let pageNameWriter = usePageNameWriterContext();
+  useEffect(() => {
+    pageNameWriter(title);
+  }, [title])
+
+  // If the data has not yet been fetched, return an in-progress symbol
+  if (!data) {
+    return (
+      <Grid container justify="center">
+        <Grid item>
+          <Typography variant="h2" color="error">
+            Error obtaining questionnaire data
+          </Typography>
+        </Grid>
+      </Grid>
+    );
+  }
+
+  return (
+    <Grid container {...FORM_ENTRY_CONTAINER_PROPS} >
+      <FormProvider >
+        <FormUpdateProvider>
+        { pages &&
+          Object.entries(data)
+            .filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType']))
+            .map(([key, entryDefinition]) => {
+              let pageResult = pages[key];
+              return <FormEntry
+                key={key}
+                entryDefinition={entryDefinition}
+                path={"."}
+                depth={0}
+                existingAnswers={data}
+                keyProp={key}
+                classes={classes}
+                onChange={()=>{}}
+                visibleCallback={pageResult.callback}
+                pageActive={pageResult.page.visible}
+                isEdit={true}
+              />
+            })
+        }
+        </FormUpdateProvider>
+      </FormProvider>
+      <Grid item xs={12} className={classes.formFooter}>
+        <FormPagination
+            paginationEnabled={paginationEnabled}
+            questionnaireData={data}
+            setPagesCallback={setPages}
+            enableSave={false}
+        />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default withStyles(QuestionnaireStyle)(QuestionnairePreview);

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/NewQuestionnaireDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/NewQuestionnaireDialog.jsx
@@ -64,7 +64,7 @@ function NewQuestionnaireDialog(props) {
           // Redirect the user to the new uuid
           // FIXME: Would be better to somehow obtain the router prefix from props
           // but that is not currently possible
-          props.history.push("/content.html/admin" + URL);
+          props.history.push("/content.html/admin" + URL + ".edit");
         } else {
           return(Promise.reject(response));
         }


### PR DESCRIPTION
Contains:
[CARDS-1268](https://phenotips.atlassian.net/browse/CARDS-1268) Refactor FormPagination
[CARDS-1269](https://phenotips.atlassian.net/browse/CARDS-1269) QuestionnairePreview component
[CARDS-1270](https://phenotips.atlassian.net/browse/CARDS-1270) Menu for the Questionnare page (edit mode)

To test:
* The questionnaire preview in the administration - ensure that all types of fields work as they would in a form
* The pagination on both forms and questionnaire preview