### PR TITLE
CARDS-1164: Smaller form headers on smaller screens

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
@@ -173,8 +173,8 @@ function DeleteButton(props) {
       </Dialog>
       {variant == "icon" ?
         <Tooltip title={buttonText}>
-          <IconButton component="span" onClick={handleClick} className={buttonClass}>
-            <Delete fontSize={size ? size : "default"}/>
+          <IconButton component="span" onClick={handleClick} className={buttonClass} size={size}>
+            <Delete fontSize={size == "small" ? size : undefined}/>
           </IconButton>
         </Tooltip>
         :
@@ -193,10 +193,12 @@ function DeleteButton(props) {
 DeleteButton.propTypes = {
   variant: PropTypes.oneOf(["icon", "text", "extended"]), // "extended" means both icon and text
   label: PropTypes.string,
+  size: PropTypes.oneOf(["small", "medium"]),
 }
 
 DeleteButton.defaultProps = {
   variant: "icon",
+  size: "medium",
 }
 
 export default withStyles(QuestionnaireStyle)(withRouter(DeleteButton));

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -41,7 +41,7 @@ function Forms(props) {
   }, [entry]);
 
   if (entry) {
-    return <Form id={entry[1]} key={location.pathname}/>;
+    return <Form id={entry[1]} key={location.pathname} contentOffset={props.contentOffset}/>;
   }
 
   const columns = [

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
@@ -31,7 +31,7 @@ function Questionnaires(props) {
   const entry = /Questionnaires\/([^.]+)/.exec(location.pathname);
 
   if (entry) {
-    return <Questionnaire id={entry[1]} key={location.pathname}/>;
+    return <Questionnaire id={entry[1]} key={location.pathname} contentOffset={props.contentOffset}/>;
   }
 
   let columns = [

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -47,7 +47,7 @@ import MoreIcon from '@material-ui/icons/MoreVert';
 import QuestionnaireStyle, { FORM_ENTRY_CONTAINER_PROPS } from "./QuestionnaireStyle";
 import FormEntry, { QUESTION_TYPES, ENTRY_TYPES } from "./FormEntry";
 import moment from "moment";
-import { getHierarchy, getTextHierarchy } from "./Subject";
+import { getHierarchy, getTextHierarchy, getHierarchyAsList } from "./Subject";
 import { SelectorDialog, parseToArray } from "./SubjectSelector";
 import { FormProvider } from "./FormContext";
 import { FormUpdateProvider } from "./FormUpdateContext";
@@ -57,6 +57,7 @@ import MainActionButton from "../components/MainActionButton.jsx";
 import FormPagination from "./FormPagination";
 import { usePageNameWriterContext } from "../themePage/Page.jsx";
 import FormattedText from "../components/FormattedText.jsx";
+import ResourceHeader from "./ResourceHeader.jsx";
 
 class Page {
   constructor(visible) {
@@ -365,31 +366,23 @@ function Form (props) {
 
   pages.length = 0;
 
-  return (
-    <form action={data?.["@path"]} method="POST" onSubmit={handleSubmit} onChange={()=>setLastSaveStatus(undefined)} key={id} ref={formNode}>
-      <Grid container {...FORM_ENTRY_CONTAINER_PROPS} >
-        <Grid item className={classes.formHeader} xs={12}>
-          { parentDetails && <Typography variant="overline">
-            {parentDetails}
-          </Typography> }
-          <Typography variant="h2">
-            {title}
+  let getFormMenu = (size, className) => (
             <div className={classes.actionsMenu}>
                 {isEdit ?
                   <Tooltip title="Save and close" onClick={onClose}>
-                    <IconButton color="primary">
+                    <IconButton color="primary" size={size}>
                       <DoneIcon />
                     </IconButton>
                   </Tooltip>
                   :
                   <Tooltip title="Edit">
-                    <IconButton color="primary" onClick={onEdit}>
+                    <IconButton color="primary" onClick={onEdit} size={size}>
                       <EditIcon />
                     </IconButton>
                   </Tooltip>
                 }
                 <Tooltip title="More actions" onClick={(event) => {setActionsMenu(event.currentTarget)}}>
-                  <IconButton>
+                  <IconButton size={size}>
                     <MoreIcon fontSize="small" />
                   </IconButton>
                 </Tooltip>
@@ -424,7 +417,19 @@ function Form (props) {
                   </List>
                 </Popover>
             </div>
-          </Typography>
+  )
+
+  return (
+    <form action={data?.["@path"]} method="POST" onSubmit={handleSubmit} onChange={()=>setLastSaveStatus(undefined)} key={id} ref={formNode}>
+      <Grid container {...FORM_ENTRY_CONTAINER_PROPS} >
+        <ResourceHeader
+          title={title}
+          breadcrumbs={[<Breadcrumbs separator="/">{getHierarchyAsList(data?.subject).map(a => <Typography variant="overline" key={a}>{a}</Typography>)}</Breadcrumbs>]}
+          separator=":"
+          titleAction={getFormMenu()}
+          breadcrumbAction={getFormMenu("small")}
+          contentOffset={props.contentOffset}
+        >
           <FormattedText variant="subtitle1" color="textSecondary">
             {data?.questionnaire?.description}
           </FormattedText>
@@ -448,7 +453,7 @@ function Form (props) {
             : ""
           }
           </Breadcrumbs>
-        </Grid>
+        </ResourceHeader>
         { /* We also expose the URL of the output form and the save function to any children. This shouldn't interfere
           with any other values placed inside the context since no variable name should be able to have a '/' in it */}
         <FormProvider additionalFormData={{

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -142,11 +142,14 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onCha
   );
 }
 
-let displayInformation = (infoDefinition, key, pageActive, isEdit) => {
+let displayInformation = (infoDefinition, key, classes, pageActive, isEdit) => {
   return (
     isEdit && pageActive && infoDefinition.text &&
     <Grid item key={key}>
-      <Card>
+      <Card
+        className={classes.informationCard}
+        variant="outlined"
+        >
         <CardContent>
           <FormattedText>{infoDefinition.text}</FormattedText>
         </CardContent>
@@ -177,6 +180,6 @@ let displayInformation = (infoDefinition, key, pageActive, isEdit) => {
   } else if (SECTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
     return displaySection(entryDefinition, path, depth, existingAnswers, keyProp, onChange, visibleCallback, pageActive, isEdit, instanceId);
   } else if (INFO_TYPES.includes(entryDefinition["jcr:primaryType"])) {
-    return displayInformation(entryDefinition, keyProp, pageActive, isEdit);
+    return displayInformation(entryDefinition, keyProp, classes, pageActive, isEdit);
   }
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Question.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Question.jsx
@@ -33,6 +33,7 @@ function Question (props) {
 
   return (
     <Card
+      variant="outlined"
       className={classes.questionCard}
       >
       <CardHeader

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
@@ -18,6 +18,7 @@
 //
 
 import React, { useEffect, useState } from "react";
+import { Link } from 'react-router-dom';
 import PropTypes from "prop-types";
 
 import {
@@ -41,6 +42,7 @@ import CreationMenu from "../questionnaireEditor/CreationMenu";
 import { usePageNameWriterContext } from "../themePage/Page.jsx";
 import QuestionnaireItemCard from "../questionnaireEditor/QuestionnaireItemCard";
 import FormattedText from "../components/FormattedText.jsx";
+import ResourceHeader from "./ResourceHeader";
 
 let _stripCardsNamespace = str => str.replaceAll(/^cards:/g, "");
 
@@ -127,16 +129,18 @@ let Questionnaire = (props) => {
         classes={classes}
         onActionDone={() => reloadData()}
       >
-      <Grid container direction="column" spacing={4} wrap="nowrap">
-      <Grid item>
-        <Typography variant="h2">{questionnaireTitle} </Typography>
+      <ResourceHeader
+        title={questionnaireTitle}
+        breadcrumbs={[<Link to={/((.*)\/Questionnaires)\/([^.]+)/.exec(location.pathname)[1]}>Questionnaires</Link>]}
+        contentOffset={props.contentOffset}
+        >
         {
           data?.['jcr:createdBy'] && data?.['jcr:created'] &&
             <Typography variant="overline">
               Created by {data['jcr:createdBy']} on {moment(data['jcr:created']).format("dddd, MMMM Do YYYY")}
             </Typography>
         }
-      </Grid>
+      </ResourceHeader>
       { data?.["jcr:primaryType"] == "cards:Questionnaire" &&
         <Grid item>
           <QuestionnaireItemCard
@@ -168,7 +172,6 @@ let Questionnaire = (props) => {
             onClose={onCreate}
           />
       }
-      </Grid>
       </QuestionnaireItemSet>
     </>
   );
@@ -186,7 +189,7 @@ let QuestionnaireItemSet = (props) => {
 
   return (
     <Grid container direction="column" spacing={4} wrap="nowrap">
-      <Grid item>{children}</Grid>
+      {children}
       {
         data ?
         Object.entries(data).filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType']))

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import { green, grey } from '@material-ui/core/colors';
+import { orange, grey } from '@material-ui/core/colors';
 
 // Props used in grid containers for displaying Form entries
 export const FORM_ENTRY_CONTAINER_PROPS = {
@@ -178,17 +178,8 @@ const questionnaireStyle = theme => ({
     sectionHeader: {
         paddingBottom: "0 !important",
     },
-    subjectCard: {
-        minHeight: "200px",
-    },
-    subjectFormHeader: {
-        paddingBottom: "0 !important",
-    },
-    subjectFormHeaderButton: {
-        padding: "0 !important"
-    },
     subjectAvatar : {
-        backgroundColor: green[500],
+        backgroundColor: "orange",
     },
     subjectTitleWithAvatar: {
         marginLeft: theme.spacing(-7),
@@ -484,18 +475,16 @@ const questionnaireStyle = theme => ({
         fontFamily: "'Roboto', 'Helvetica', 'Arial', sans-serif",
     },
     subjectChip: {
-        color:'white',
         marginBottom: theme.spacing(1),
         marginRight: theme.spacing(1),
     },
     INCOMPLETEChip: {
-        backgroundColor: theme.palette.warning.main
     },
     INVALIDChip: {
-        backgroundColor: theme.palette.error.main
+        borderColor: theme.palette.error.main,
+        color: theme.palette.error.main,
     },
     DefaultChip: {
-        backgroundColor: theme.palette.warning.main
     },
     formPreviewQuestion: {
         "& .MuiChip-root" : {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -28,7 +28,7 @@ export const FORM_ENTRY_CONTAINER_PROPS = {
     wrap: "nowrap"
   };
 
-const GRID_SPACE_UNIT = FORM_ENTRY_CONTAINER_PROPS.spacing/2;
+export const GRID_SPACE_UNIT = FORM_ENTRY_CONTAINER_PROPS.spacing/2;
 
 const questionnaireStyle = theme => ({
     questionCard : {
@@ -181,13 +181,6 @@ const questionnaireStyle = theme => ({
     subjectCard: {
         minHeight: "200px",
     },
-    subjectHeader: {
-        position: "sticky",
-        top: 0,
-        paddingTop: theme.spacing(4) + 'px !important',
-        backgroundColor: theme.palette.background.paper,
-        zIndex: "1010",
-    },
     subjectFormHeader: {
         paddingBottom: "0 !important",
     },
@@ -232,6 +225,16 @@ const questionnaireStyle = theme => ({
           minWidth: "100px",
           marginTop: theme.spacing(-1.5),
         },
+      },
+    },
+    subjectTabs: {
+      marginLeft: theme.spacing(GRID_SPACE_UNIT),
+      "& .MuiTab-root" : {
+        minWidth: "auto",
+        textTransform: "initial",
+      },
+      "& .MuiTabs-indicator": {
+        background: "orange",
       },
     },
     timelineContainer: {
@@ -379,16 +382,6 @@ const questionnaireStyle = theme => ({
         display: "block",
         marginLeft: theme.spacing(0)
     },
-    formHeader: {
-        position: "sticky",
-        width: "100%",
-        top: 0,
-        paddingTop: theme.spacing(4) + 'px !important',
-        backgroundColor: theme.palette.background.paper,
-        opacity: 1,
-        zIndex: "1010",
-        margin: theme.spacing(2),
-    },
     formFooter: {
         position: "sticky",
         bottom: theme.spacing(0),
@@ -419,9 +412,6 @@ const questionnaireStyle = theme => ({
         border: "1px solid " + theme.palette.divider,
         borderRadius: theme.spacing(3),
         display: "flex",
-        float: "right",
-        marginRight : theme.spacing(2),
-        marginTop: theme.spacing(1)
     },
     actionsMenuItem: {
         padding: theme.spacing(0,1),
@@ -435,11 +425,6 @@ const questionnaireStyle = theme => ({
     },
     subjectSubHeader: {
         display: "block"
-    },
-    subjectHeaderButton: {
-        float: "right",
-        marginTop: theme.spacing(1),
-        marginRight: theme.spacing(-0.5)
     },
     childSubjectHeaderButton: {
         left: theme.spacing(1)

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -49,6 +49,9 @@ const questionnaireStyle = theme => ({
         borderRadius: theme.spacing(0.5),
       }
     },
+    informationCard: {
+      borderColor: theme.palette.info.dark,
+    },
     viewModeAnswers :{
       paddingTop: theme.spacing(0),
       "& .MuiList-root": {
@@ -177,6 +180,13 @@ const questionnaireStyle = theme => ({
     },
     sectionHeader: {
         paddingBottom: "0 !important",
+        "& > h5" : {
+          padding: theme.spacing(.5, GRID_SPACE_UNIT),
+          background: theme.palette.action.hover,
+        },
+        "& > .MuiTypography-caption" : {
+          padding: theme.spacing(0, GRID_SPACE_UNIT),
+        }
     },
     subjectAvatar : {
         backgroundColor: "orange",

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -50,7 +50,6 @@ const questionnaireStyle = theme => ({
       }
     },
     informationCard: {
-      borderColor: theme.palette.info.dark,
     },
     viewModeAnswers :{
       paddingTop: theme.spacing(0),
@@ -181,7 +180,7 @@ const questionnaireStyle = theme => ({
     sectionHeader: {
         paddingBottom: "0 !important",
         "& > h5" : {
-          padding: theme.spacing(.5, GRID_SPACE_UNIT),
+          padding: theme.spacing(1, GRID_SPACE_UNIT),
           background: theme.palette.action.hover,
         },
         "& > .MuiTypography-caption" : {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ResourceHeader.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ResourceHeader.jsx
@@ -1,0 +1,134 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React from "react";
+import PropTypes from "prop-types";
+
+import {
+  Breadcrumbs,
+  Grid,
+  Typography,
+  Zoom,
+  useScrollTrigger,
+  makeStyles,
+} from "@material-ui/core";
+
+import { grey } from '@material-ui/core/colors';
+
+import { GRID_SPACE_UNIT } from "./QuestionnaireStyle";
+
+const useStyles = makeStyles(theme => ({
+    resourceHeader: {
+      position: "sticky",
+      top: 0,
+      margin: theme.spacing(2*GRID_SPACE_UNIT, GRID_SPACE_UNIT, 0),
+      backgroundColor: grey[100],
+      zIndex: "1010",
+      "& .MuiBreadcrumbs-li" : {
+        color: theme.palette.text.primary,
+      },
+    },
+    currentItem : {
+      display: "flex",
+      alignItems: "center",
+    },
+    breadcrumbAction : {
+      marginLeft: theme.spacing(2),
+    },
+    resourceTitle: {
+      backgroundColor: grey[100],
+      margin: theme.spacing(0, GRID_SPACE_UNIT, GRID_SPACE_UNIT),
+      paddingTop: "0 !important",
+    }
+}))
+
+/**
+ * Component that displays the header of a resource (e.g. a form, a subject, a questionnaire)
+ * with breadcrumbs and title, actions. The breadcrumbs are sticky and will include the title
+ * and actions once the actual title is scrolled out of view.
+ *
+ * @example
+ * <ResourceHEader
+ *  title="..."
+ *  breadcrumb={}
+ *  titleAction={<DeleteButton .../>}
+ *  >
+ *    Subtitle or description
+ * </ResourceHeader>
+ *
+ */
+function ResourceHeader (props) {
+  let { title, breadcrumbs, separator, titleAction, breadcrumbAction, children } = props;
+
+  const classes = useStyles();
+
+  const fullBreadcrumbTrigger = useScrollTrigger({
+    target: window,
+    disableHysteresis: true,
+    threshold: 120,
+  });
+
+  return (
+    <>
+    <Grid item xs={12} className={classes.resourceHeader} style={{top: props.contentOffset}}>
+      <Breadcrumbs separator={separator}>
+        {Array.from(breadcrumbs || []).map(item => <Typography variant="overline" key={item}>{item}</Typography>)}
+        <Zoom in={fullBreadcrumbTrigger}>
+          <div className={classes.currentItem}>
+            <Typography variant="subtitle2">{title}</Typography>
+            {breadcrumbAction && <div className={classes.breadcrumbAction}>{breadcrumbAction}</div>}
+          </div>
+        </Zoom>
+      </Breadcrumbs>
+    </Grid>
+    <Grid item xs={12} className={classes.resourceTitle}>
+      <Grid container direction="row" justify="space-between" alignItems="center">
+        <Grid item>
+          <Typography component="h2" variant="h4">{title}</Typography>
+        </Grid>
+        <Grid item>{titleAction}</Grid>
+      </Grid>
+      {children}
+    </Grid>
+    </>
+  )
+};
+
+ResourceHeader.propTypes = {
+  title: PropTypes.string.isRequired,
+  breadcrumbs: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]),
+  separator: PropTypes.string,
+  titleAction: PropTypes.node,
+  breadcrumbAction: PropTypes.node,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]),
+  contentOffset: PropTypes.number,
+}
+
+ResourceHeader.defaultProps = {
+  separator: "/",
+  contentOffset: 0,
+}
+
+export default ResourceHeader;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ResourceHeader.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ResourceHeader.jsx
@@ -22,9 +22,9 @@ import PropTypes from "prop-types";
 
 import {
   Breadcrumbs,
+  Collapse,
   Grid,
   Typography,
-  Zoom,
   useScrollTrigger,
   makeStyles,
 } from "@material-ui/core";
@@ -37,6 +37,7 @@ const useStyles = makeStyles(theme => ({
     resourceHeader: {
       position: "sticky",
       top: 0,
+      paddingBottom: "0 !important",
       margin: theme.spacing(2*GRID_SPACE_UNIT, GRID_SPACE_UNIT, 0),
       backgroundColor: grey[100],
       zIndex: "1010",
@@ -50,6 +51,10 @@ const useStyles = makeStyles(theme => ({
     },
     breadcrumbAction : {
       marginLeft: theme.spacing(2),
+    },
+    headerSeparator: {
+      visibility: "hidden",
+      border: "0 none",
     },
     resourceTitle: {
       backgroundColor: grey[100],
@@ -105,7 +110,7 @@ function ResourceHeader (props) {
   const fullBreadcrumbTrigger = useScrollTrigger({
     target: window,
     disableHysteresis: true,
-    threshold: 120,
+    threshold: 60,
   });
 
   return (
@@ -113,23 +118,27 @@ function ResourceHeader (props) {
     <Grid item xs={12} className={classes.resourceHeader} style={{top: props.contentOffset}}>
       <Breadcrumbs separator={separator}>
         {Array.from(breadcrumbs || []).map(item => <Typography variant="overline" key={item}>{item}</Typography>)}
-        <Zoom in={fullBreadcrumbTrigger}>
+        <Collapse in={fullBreadcrumbTrigger}>
           <div className={classes.currentItem}>
             <Typography variant="subtitle2">{title}</Typography>
             {breadcrumbAction && <div className={classes.breadcrumbAction}>{breadcrumbAction}</div>}
           </div>
-        </Zoom>
+        </Collapse>
       </Breadcrumbs>
+      <Collapse in={fullBreadcrumbTrigger}>
+        <hr className={classes.headerSeparator} />
+      </Collapse>
     </Grid>
-    <Grid item xs={12} className={classes.resourceTitle}>
-      <Grid container direction="row" justify="space-between" alignItems="center">
-        <Grid item>
-          <Typography component="h2" variant="h4">{title}</Typography>
+    <Collapse in={!(fullBreadcrumbTrigger)}
+      component={Grid} item xs={12} className={classes.resourceTitle}>
+        <Grid container direction="row" justify="space-between" alignItems="center">
+          <Grid item>
+            <Typography component="h2" variant="h4">{title}</Typography>
+          </Grid>
+          <Grid item>{titleAction}</Grid>
         </Grid>
-        <Grid item>{titleAction}</Grid>
-      </Grid>
-      {children}
-    </Grid>
+        {children}
+    </Collapse>
     </>
   )
 };

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ResourceHeader.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ResourceHeader.jsx
@@ -66,12 +66,36 @@ const useStyles = makeStyles(theme => ({
  * @example
  * <ResourceHEader
  *  title="..."
- *  breadcrumb={}
+ *  breadcrumbs={}
  *  titleAction={<DeleteButton .../>}
  *  >
  *    Subtitle or description
  * </ResourceHeader>
  *
+ * Output when fully displayed:
+ * --------------------------------------------------------------------
+ * | Breadcrumbs / Breadcrumbs /                                      |
+ * | Title                                              titleAction   |
+ * | Other (children)                                                 |
+ * --------------------------------------------------------------------
+ * Output when scrolling up:
+ * --------------------------------------------------------------------
+ * | Breadcrumbs / Breadcrumbs / Title  breadcrumbAction              |
+ * --------------------------------------------------------------------
+ *
+ *
+ * @param {string} title  - the title of the resource, to be displayed in the header; required
+ * @param {Array.<node>} breadcrumbs - the breadcrumb items displayed above the title; this line
+ *  will be sticky when scrolling up, and will include the title once the title line is scrolled
+ *  out of view
+ * @param {string} separator - the breadcrumbs separator, defaults to /
+ * @param {node} titleAction - a React node specifying a button or menu associated with the
+ *   resource and displayed at the right side of the title
+ * @param {node} breadcrumbAction - a React node specifying a button or menu associated with the
+ *   resource and displayed at the right side of the breadcrumbs + title when the page is scrolled to
+ *   hide the main title and titleAction line; it is usually a more compact version of titleAction
+ * @param {Array.<node>} children - any other content that will be displayed in the header, under
+ *   the title and titleAction line
  */
 function ResourceHeader (props) {
   let { title, breadcrumbs, separator, titleAction, breadcrumbAction, children } = props;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -68,7 +68,7 @@ function Section(props) {
   const isRecurrent = sectionDefinition['recurrent'];
   const [ focus, setFocus ] = useState(false);
 
-  const headerVariant = (depth > MAX_HEADING_LEVEL - MIN_HEADING_LEVEL ? "body1" : ("h" + (depth+MIN_HEADING_LEVEL)));
+  const headerVariant = "h5";
   const titleEl = sectionDefinition["label"] &&
     ((idx, uuid) =>
       <Typography variant={headerVariant} className={uuid == selectedUUID ? classes.highlightedTitle: undefined}>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -506,6 +506,7 @@ function SubjectMemberInternal (props) {
                                            return <Chip
                                              key={status}
                                              label={wordToTitleCase(status)}
+                                             variant="outlined"
                                              className={`${classes.subjectChip} ${classes[status + "Chip"] || classes.DefaultChip}`}
                                              size="small"
                                            />

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -44,6 +44,7 @@ import {
 import FileIcon from "@material-ui/icons/InsertDriveFile";
 import DeleteButton from "../dataHomepage/DeleteButton.jsx";
 import EditButton from "../dataHomepage/EditButton.jsx";
+import ResourceHeader from "./ResourceHeader.jsx"
 import SubjectTimeline from "./SubjectTimeline.jsx";
 
 /***
@@ -88,6 +89,19 @@ export function getTextHierarchy (node, withType = false) {
     return `${ancestors} / ${type}${output}`;
   } else {
     return type + output;
+  }
+}
+
+// Recursive function to get the list of ancestors as an array
+export function getHierarchyAsList (node) {
+  let props = defaultCreator(node);
+  let parent = <>{node.type.label} <Link {...props}>{node.identifier}</Link></>;
+  if (node["parents"]) {
+    let ancestors = getHierarchyAsList(node["parents"]);
+    ancestors.push(parent);
+    return ancestors;
+  } else {
+    return [parent];
   }
 }
 
@@ -145,9 +159,9 @@ function Subject(props) {
         New form for this Subject
       </NewFormDialog>
       <Grid container spacing={4} direction="column" className={classes.subjectContainer}>
-        <SubjectHeader id={currentSubjectId} key={"SubjectHeader"}  classes={classes} getSubject={handleSubject} history={history}/>
+        <SubjectHeader id={currentSubjectId} key={"SubjectHeader"}  classes={classes} getSubject={handleSubject} history={history} contentOffset={props.contentOffset}/>
         {
-          <Tabs value={activeTab} onChange={(event, value) => {
+          <Tabs className={classes.subjectTabs} value={activeTab} onChange={(event, value) => {
             setTab(value);
           }}>
             {tabs.map((tab) => {
@@ -325,20 +339,29 @@ function SubjectHeader(props) {
   let label = subject?.data?.type?.label || "Subject";
   let title = `${label} ${identifier}`;
   let path = subject?.data?.["@path"] || "/Subjects/" + id;
-  let action = <DeleteButton
+  let getActionButton = size => (
+            <div>
+               <DeleteButton
                  entryPath={path}
                  entryName={title}
                  entryType={label}
                  onComplete={handleDeletion}
-                 buttonClass={classes.subjectHeaderButton}
-                 size={"large"}
+                 size={size}
                />
-  let parentDetails = subject?.data?.['parents'] && getHierarchy(subject.data['parents']);
+            </div>
+  );
+  let parentDetails = (subject?.data?.['parents'] && getHierarchyAsList(subject.data['parents']) || []);
+  parentDetails.unshift(<Link to={/((.*)\/Subjects)\/([^.]+)/.exec(location.pathname)[1]}>Subjects</Link>);
 
   return (
-    subject?.data && <Grid item className={classes.subjectHeader}>
-      {parentDetails && <Typography variant="overline">{parentDetails}</Typography>}
-      <Typography variant="h2">{title}{action}</Typography>
+    subject?.data &&
+      <ResourceHeader
+        title={title}
+        breadcrumbs={parentDetails}
+        titleAction={getActionButton("medium")}
+        breadcrumbAction={getActionButton("small")}
+        contentOffset={props.contentOffset}
+        >
       {
         subject?.data?.['jcr:created'] ?
         <Typography
@@ -348,7 +371,7 @@ function SubjectHeader(props) {
         </Typography>
         : ""
       }
-    </Grid>
+      </ResourceHeader>
   );
 }
 


### PR DESCRIPTION
In addition to reworking the headers to take up less screen space (both on big and small screens), this PR also changes:
* the look of all resource page headers (Form, Subject, Questionnaire)
* the look of subject pages: different avatar color, less prominent chips
* the look of forms: restyled question cards and section titles

To be tested with and without the `demo` run mode, on different window sizes, and with different sizes of subject ids and questionnaire titles.