### PR TITLE
CARDS-1307: As a user, I can export the contents of a form in text format

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -406,6 +406,15 @@ function Form (props) {
                       </Button>
                     </ListItem>
                     <ListItem className={classes.actionsMenuItem}>
+                      <Button onClick={(e) => {
+                         // Save before exporting to ensure all the data is included
+                         saveData(e, false, () => {window.open(formURL + ".txt")});
+                         setActionsMenu(null);
+                        }}>
+                        Export as text
+                      </Button>
+                    </ListItem>
+                    <ListItem className={classes.actionsMenuItem}>
                       <DeleteButton
                           entryPath={data ? data["@path"] : formURL}
                           entryName={(data?.subject?.fullIdentifier ? (data.subject.fullIdentifier + ": ") : '') + (title)}


### PR DESCRIPTION
Draft PR since it depends on #723 ,

To test:
* create a form
* click on the form menu -> notice "Export as text" has been added
* click on Export as Text

This PR only introduces the menu item, and leverages the existing text export functionality (CARDS-1283).