### PR TITLE
CARDS-1164 (Smaller form headers on smaller screens) amendment: Moved the breadcrumb action to the RIGHT of the sticky header

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -366,23 +366,23 @@ function Form (props) {
 
   pages.length = 0;
 
-  let getFormMenu = (size, className) => (
+  let formMenu = (
             <div className={classes.actionsMenu}>
                 {isEdit ?
                   <Tooltip title="Save and close" onClick={onClose}>
-                    <IconButton color="primary" size={size}>
+                    <IconButton color="primary">
                       <DoneIcon />
                     </IconButton>
                   </Tooltip>
                   :
                   <Tooltip title="Edit">
-                    <IconButton color="primary" onClick={onEdit} size={size}>
+                    <IconButton color="primary" onClick={onEdit}>
                       <EditIcon />
                     </IconButton>
                   </Tooltip>
                 }
                 <Tooltip title="More actions" onClick={(event) => {setActionsMenu(event.currentTarget)}}>
-                  <IconButton size={size}>
+                  <IconButton>
                     <MoreIcon fontSize="small" />
                   </IconButton>
                 </Tooltip>
@@ -435,8 +435,7 @@ function Form (props) {
           title={title}
           breadcrumbs={[<Breadcrumbs separator="/">{getHierarchyAsList(data?.subject).map(a => <Typography variant="overline" key={a}>{a}</Typography>)}</Breadcrumbs>]}
           separator=":"
-          titleAction={getFormMenu()}
-          breadcrumbAction={getFormMenu("small")}
+          action={formMenu}
           contentOffset={props.contentOffset}
         >
           <FormattedText variant="subtitle1" color="textSecondary">

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -228,7 +228,6 @@ const questionnaireStyle = theme => ({
       },
     },
     subjectTabs: {
-      marginLeft: theme.spacing(GRID_SPACE_UNIT),
       "& .MuiTab-root" : {
         minWidth: "auto",
         textTransform: "initial",
@@ -422,9 +421,6 @@ const questionnaireStyle = theme => ({
           width: "100%",
        }
 
-    },
-    subjectSubHeader: {
-        display: "block"
     },
     childSubjectHeaderButton: {
         left: theme.spacing(1)

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ResourceHeader.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ResourceHeader.jsx
@@ -48,6 +48,9 @@ const useStyles = makeStyles(theme => ({
         color: theme.palette.text.primary,
       },
     },
+    breadcrumbAction: {
+      margin: theme.spacing(-1.25, 0),
+    },
     headerSeparator: {
       visibility: "hidden",
       border: "0 none",
@@ -68,7 +71,7 @@ const useStyles = makeStyles(theme => ({
  * <ResourceHEader
  *  title="..."
  *  breadcrumbs={}
- *  titleAction={<DeleteButton .../>}
+ *  action={<DeleteButton .../>}
  *  >
  *    Subtitle or description
  * </ResourceHeader>
@@ -76,12 +79,12 @@ const useStyles = makeStyles(theme => ({
  * Output when fully displayed:
  * --------------------------------------------------------------------
  * | Breadcrumbs / Breadcrumbs /                                      |
- * | Title                                                titleAction |
+ * | Title                                                     action |
  * | Other (children)                                                 |
  * --------------------------------------------------------------------
  * Output when scrolling up:
  * --------------------------------------------------------------------
- * | Breadcrumbs / Breadcrumbs / Title               breadcrumbAction |
+ * | Breadcrumbs / Breadcrumbs / Title                         action |
  * --------------------------------------------------------------------
  *
  *
@@ -90,16 +93,13 @@ const useStyles = makeStyles(theme => ({
  *  will be sticky when scrolling up, and will include the title once the title line is scrolled
  *  out of view
  * @param {string} separator - the breadcrumbs separator, defaults to /
- * @param {node} titleAction - a React node specifying a button or menu associated with the
+ * @param {node} action - a React node specifying a button or menu associated with the
  *   resource and displayed at the right side of the title
- * @param {node} breadcrumbAction - a React node specifying a button or menu associated with the
- *   resource and displayed at the right side of the breadcrumbs + title when the page is scrolled to
- *   hide the main title and titleAction line; it is usually a more compact version of titleAction
  * @param {Array.<node>} children - any other content that will be displayed in the header, under
  *   the title and titleAction line
  */
 function ResourceHeader (props) {
-  let { title, breadcrumbs, separator, titleAction, breadcrumbAction, children } = props;
+  let { title, breadcrumbs, separator, action, children } = props;
 
   const classes = useStyles();
 
@@ -121,8 +121,8 @@ function ResourceHeader (props) {
             </Collapse>
           </Breadcrumbs>
         </Grid>
-        <Collapse in={!!breadcrumbAction &&  fullBreadcrumbTrigger} component={Grid}>
-          <div className={classes.breadcrumbAction}>{breadcrumbAction}</div>
+        <Collapse in={!!action &&  fullBreadcrumbTrigger} component={Grid}>
+          <div className={classes.breadcrumbAction}>{action}</div>
         </Collapse>
       </Grid>
       <Collapse in={fullBreadcrumbTrigger}>
@@ -135,7 +135,7 @@ function ResourceHeader (props) {
           <Grid item>
             <Typography component="h2" variant="h4">{title}</Typography>
           </Grid>
-          <Grid item>{titleAction}</Grid>
+          {action && <Grid item>{action}</Grid>}
         </Grid>
         {children}
     </Collapse>
@@ -150,8 +150,7 @@ ResourceHeader.propTypes = {
     PropTypes.node
   ]),
   separator: PropTypes.string,
-  titleAction: PropTypes.node,
-  breadcrumbAction: PropTypes.node,
+  action: PropTypes.node,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ResourceHeader.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ResourceHeader.jsx
@@ -41,16 +41,12 @@ const useStyles = makeStyles(theme => ({
       margin: theme.spacing(2*GRID_SPACE_UNIT, GRID_SPACE_UNIT, 0),
       backgroundColor: grey[100],
       zIndex: "1010",
+      "& .MuiBreadcrumbs-root" : {
+        width: "fit-content",
+      },
       "& .MuiBreadcrumbs-li" : {
         color: theme.palette.text.primary,
       },
-    },
-    currentItem : {
-      display: "flex",
-      alignItems: "center",
-    },
-    breadcrumbAction : {
-      marginLeft: theme.spacing(2),
     },
     headerSeparator: {
       visibility: "hidden",
@@ -80,12 +76,12 @@ const useStyles = makeStyles(theme => ({
  * Output when fully displayed:
  * --------------------------------------------------------------------
  * | Breadcrumbs / Breadcrumbs /                                      |
- * | Title                                              titleAction   |
+ * | Title                                                titleAction |
  * | Other (children)                                                 |
  * --------------------------------------------------------------------
  * Output when scrolling up:
  * --------------------------------------------------------------------
- * | Breadcrumbs / Breadcrumbs / Title  breadcrumbAction              |
+ * | Breadcrumbs / Breadcrumbs / Title               breadcrumbAction |
  * --------------------------------------------------------------------
  *
  *
@@ -116,15 +112,19 @@ function ResourceHeader (props) {
   return (
     <>
     <Grid item xs={12} className={classes.resourceHeader} style={{top: props.contentOffset}}>
-      <Breadcrumbs separator={separator}>
-        {Array.from(breadcrumbs || []).map(item => <Typography variant="overline" key={item}>{item}</Typography>)}
-        <Collapse in={fullBreadcrumbTrigger}>
-          <div className={classes.currentItem}>
-            <Typography variant="subtitle2">{title}</Typography>
-            {breadcrumbAction && <div className={classes.breadcrumbAction}>{breadcrumbAction}</div>}
-          </div>
+      <Grid container direction="row" justify="space-between" alignItems="center">
+        <Grid item>
+          <Breadcrumbs separator={separator}>
+            {Array.from(breadcrumbs || []).map(item => <Typography variant="overline" key={item}>{item}</Typography>)}
+            <Collapse in={fullBreadcrumbTrigger}>
+              <Typography variant="subtitle2">{title}</Typography>
+            </Collapse>
+          </Breadcrumbs>
+        </Grid>
+        <Collapse in={!!breadcrumbAction &&  fullBreadcrumbTrigger} component={Grid}>
+          <div className={classes.breadcrumbAction}>{breadcrumbAction}</div>
         </Collapse>
-      </Breadcrumbs>
+      </Grid>
       <Collapse in={fullBreadcrumbTrigger}>
         <hr className={classes.headerSeparator} />
       </Collapse>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ResourceHeader.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ResourceHeader.jsx
@@ -54,6 +54,8 @@ const useStyles = makeStyles(theme => ({
     headerSeparator: {
       visibility: "hidden",
       border: "0 none",
+      height: theme.spacing(2),
+      margin: 0,
     },
     resourceTitle: {
       backgroundColor: grey[100],

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -33,6 +33,8 @@ import MaterialTable, { MTablePagination } from 'material-table';
 import {
   Avatar,
   CircularProgress,
+  Card,
+  CardContent,
   Chip,
   Grid,
   Tooltip,
@@ -160,7 +162,7 @@ function Subject(props) {
       </NewFormDialog>
       <Grid container spacing={4} direction="column" className={classes.subjectContainer}>
         <SubjectHeader id={currentSubjectId} key={"SubjectHeader"}  classes={classes} getSubject={handleSubject} history={history} contentOffset={props.contentOffset}/>
-        {
+        <Grid item>
           <Tabs className={classes.subjectTabs} value={activeTab} onChange={(event, value) => {
             setTab(value);
           }}>
@@ -168,9 +170,9 @@ function Subject(props) {
               return <Tab label={tab} key={tab}/>;
             })}
           </Tabs>
-        }
-        {
-          activeTab === tabs.indexOf("Chart")
+          <Card variant="outlined"><CardContent>
+          <Grid container spacing={4} direction="column" wrap="nowrap">
+          { activeTab === tabs.indexOf("Chart")
           ? <SubjectContainer
               id={currentSubjectId}
               key={currentSubjectId}
@@ -179,13 +181,17 @@ function Subject(props) {
               pageSize={pageSize}
               subject={currentSubject}
             />
-          : <SubjectTimeline
+          : <Grid item>
+            <SubjectTimeline
               id={currentSubjectId}
               classes={classes}
               pageSize={pageSize}
               subject={currentSubject}
             />
-        }
+            </Grid> }
+          </Grid>
+          </CardContent></Card>
+        </Grid>
       </Grid>
     </React.Fragment>
   );
@@ -365,7 +371,7 @@ function SubjectHeader(props) {
         subject?.data?.['jcr:created'] ?
         <Typography
           variant="overline"
-          className={classes.subjectSubHeader}>
+          color="textSecondary" >
             Entered by {subject.data['jcr:createdBy']} on {moment(subject.data['jcr:created']).format("dddd, MMMM Do YYYY")}
         </Typography>
         : ""
@@ -433,9 +439,6 @@ function SubjectMemberInternal (props) {
     );
   }
 
-  // change styling based on 'level'
-  let headerStyle = (level == 1 ? "h4" : "h5");
-
   let identifier = data && data.identifier ? data.identifier : id;
   let label = data?.type?.label || "Subject";
   let title = `${label} ${identifier}`;
@@ -457,7 +460,7 @@ function SubjectMemberInternal (props) {
           <Grid container direction="row" spacing={1} justify="flex-start">
             <Grid item xs={false}>{avatar}</Grid>
             <Grid item>
-              <Typography variant={headerStyle}>
+              <Typography variant="h5">
                  <Link to={"/content.html" + path}>{title}</Link>
                  {action}
               </Typography>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -261,7 +261,7 @@ function SubjectContainer(props) {
 
   return (
     subject && <React.Fragment>
-      <SubjectMember classes={classes} id={id} level={currentLevel} data={subject} maxDisplayed={maxDisplayed} pageSize={pageSize} onDelete={() => {setDeleted(true)}}/>
+      <SubjectMember classes={classes} id={id} level={currentLevel} data={subject} maxDisplayed={maxDisplayed} pageSize={pageSize} onDelete={() => {setDeleted(true)}} hasChildren={!!(relatedSubjects?.length)}/>
       {relatedSubjects && relatedSubjects.length > 0 ?
         (<Grid item xs={12} className={classes.subjectNestedContainer}>
           {relatedSubjects.map( (subject, i) => {
@@ -384,7 +384,7 @@ function SubjectHeader(props) {
  * Component that displays all forms related to a Subject. Do not use directly, use SubjectMember instead.
  */
 function SubjectMemberInternal (props) {
-  let { classes, data, history, id, level, maxDisplayed, onDelete, pageSize } = props;
+  let { classes, data, history, id, level, maxDisplayed, onDelete, pageSize, hasChildren } = props;
   // Error message set when fetching the data from the server fails
   let [ error, setError ] = useState();
   let [ subjectGroups, setSubjectGroups ] = useState();
@@ -451,6 +451,15 @@ function SubjectMemberInternal (props) {
                  onComplete={onDelete}
                  buttonClass={classes.childSubjectHeaderButton}
                />
+
+  // If this is the top-level subject and we have no data to display for it, inform the user:
+  if (data && level == 0 && !(Object.keys(subjectGroups || {}).length) && !hasChildren) {
+    return (
+      <Grid item>
+        <Typography color="textSecondary" variant="caption">{`No data associated with this ${label.toLowerCase()} was found.`}</Typography>
+      </Grid>
+    )
+  }
 
   return ( data &&
     <>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -339,14 +339,14 @@ function SubjectHeader(props) {
   let label = subject?.data?.type?.label || "Subject";
   let title = `${label} ${identifier}`;
   let path = subject?.data?.["@path"] || "/Subjects/" + id;
-  let getActionButton = size => (
-            <div>
+  let subjectMenu = (
+            <div className={classes.actionsMenu}>
                <DeleteButton
                  entryPath={path}
                  entryName={title}
                  entryType={label}
                  onComplete={handleDeletion}
-                 size={size}
+                 size="medium"
                />
             </div>
   );
@@ -358,8 +358,7 @@ function SubjectHeader(props) {
       <ResourceHeader
         title={title}
         breadcrumbs={parentDetails}
-        titleAction={getActionButton("medium")}
-        breadcrumbAction={getActionButton("small")}
+        action={subjectMenu}
         contentOffset={props.contentOffset}
         >
       {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
@@ -358,14 +358,18 @@ function SubjectTimeline(props) {
     return <CircularProgress/>
   }
 
-  return <div className={classes.timelineContainer}><Timeline align="alternate" className={classes.timeline}>
+  return ( dateEntries?.length ?
+    <div className={classes.timelineContainer}><Timeline align="alternate" className={classes.timeline}>
     {
-      dateEntries && dateEntries.map((dateEntry, index) => {
+      dateEntries.map((dateEntry, index) => {
         let nextEntry = (index + 1 < dateEntries.length) ? dateEntries[index + 1] : null;
         return TimelineEntry(classes, dateEntry, index, dateEntries.length, nextEntry);
       })
     }
-  </Timeline></div>;
+    </Timeline></div>
+    :
+    <Typography color="textSecondary" variant="caption">No timeline data available</Typography>
+  )
 }
 
 SubjectTimeline.propTypes = {


### PR DESCRIPTION
This positioning of the resource header actions should be compared to what is proposed in #728 and to what is already in `dev` via #723 , and one of the 3 must be chosen.