### PR TITLE
Proof of concept: TreeView display for the Subject Chart

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -422,9 +422,6 @@ const questionnaireStyle = theme => ({
        }
 
     },
-    childSubjectHeaderButton: {
-        left: theme.spacing(1)
-    },
     addNewSubjectButton: {
         width: "250px"
     },

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -28,10 +28,8 @@ import NewFormDialog from "../dataHomepage/NewFormDialog";
 import { QUESTION_TYPES, SECTION_TYPES, ENTRY_TYPES } from "./FormEntry.jsx";
 import { usePageNameWriterContext } from "../themePage/Page.jsx";
 import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
-import MaterialTable, { MTablePagination } from 'material-table';
 
 import {
-  Avatar,
   CircularProgress,
   Card,
   CardContent,
@@ -47,16 +45,8 @@ import FileIcon from "@material-ui/icons/InsertDriveFile";
 import DeleteButton from "../dataHomepage/DeleteButton.jsx";
 import EditButton from "../dataHomepage/EditButton.jsx";
 import ResourceHeader from "./ResourceHeader.jsx"
+import SubjectTreeView from "./SubjectTreeView.jsx";
 import SubjectTimeline from "./SubjectTimeline.jsx";
-
-/***
- * Create a URL that checks for the existence of a subject
- */
-let createQueryURL = (query, type) => {
-  let url = new URL("/query", window.location.origin);
-  url.searchParams.set("query", `SELECT * FROM [${type}] as n` + query);
-  return url;
-}
 
 let defaultCreator = (node) => {
   return {to: "/content.html" + node["@path"]}
@@ -118,7 +108,7 @@ export function getHierarchyAsList (node) {
  */
 
 function Subject(props) {
-  let { id, classes, maxDisplayed, pageSize, history } = props;
+  let { id, classes, history } = props;
   const [ currentSubject, setCurrentSubject ] = useState();
   const [ currentSubjectId, setCurrentSubjectId ] = useState(id);
   const [ activeTab, setActiveTab ] = useState(0);
@@ -145,11 +135,6 @@ function Subject(props) {
     pageTitle && pageNameWriter(pageTitle);
   }, [pageTitle]);
 
-  // the subject data, fetched in the SubjectContainer component, will be stored in the `type` state
-  function handleSubject(e) {
-    setCurrentSubject(e);
-  }
-
   function setTab(index) {
     history.replace(location.pathname+location.search+"#"+tabs[index], location.state)
     setActiveTab(index);
@@ -161,7 +146,7 @@ function Subject(props) {
         New form for this Subject
       </NewFormDialog>
       <Grid container spacing={4} direction="column" className={classes.subjectContainer}>
-        <SubjectHeader id={currentSubjectId} key={"SubjectHeader"}  classes={classes} getSubject={handleSubject} history={history} contentOffset={props.contentOffset}/>
+        <SubjectHeader id={currentSubjectId} key={"SubjectHeader"} classes={classes} onSubjectDataFetched={setCurrentSubject} history={history} contentOffset={props.contentOffset}/>
         <Grid item>
           <Tabs className={classes.subjectTabs} value={activeTab} onChange={(event, value) => {
             setTab(value);
@@ -171,25 +156,16 @@ function Subject(props) {
             })}
           </Tabs>
           <Card variant="outlined"><CardContent>
-          <Grid container spacing={4} direction="column" wrap="nowrap">
           { activeTab === tabs.indexOf("Chart")
-          ? <SubjectContainer
-              id={currentSubjectId}
-              key={currentSubjectId}
+          ? <SubjectTreeView
               classes={classes}
-              maxDisplayed={maxDisplayed}
-              pageSize={pageSize}
               subject={currentSubject}
             />
-          : <Grid item>
-            <SubjectTimeline
-              id={currentSubjectId}
+          : <SubjectTimeline
               classes={classes}
-              pageSize={pageSize}
               subject={currentSubject}
             />
-            </Grid> }
-          </Grid>
+          }
           </CardContent></Card>
         </Grid>
       </Grid>
@@ -198,90 +174,10 @@ function Subject(props) {
 }
 
 /**
- * Component that recursively gets and displays the selected subject and its related SubjectTypes
- */
-function SubjectContainer(props) {
-  let { id, classes, level, maxDisplayed, pageSize, subject } = props;
-  // Error message set when fetching the data from the server fails
-  let [ error, setError ] = useState();
-  // hold related subjects
-  let [relatedSubjects, setRelatedSubjects] = useState();
-  // whether the subject has been deleted
-  let [ deleted, setDeleted ] = useState();
-
-  let globalLoginDisplay = useContext(GlobalLoginContext);
-
-  // 'level' of subject component
-  const currentLevel = level || 0;
-
-  // Callback method for the `fetchData` method, invoked when the request failed.
-  let handleError = (response) => {
-    setError(response);
-  };
-
-  let check_url = createQueryURL(` WHERE n.'parents'='${subject?.['jcr:uuid']}' order by n.'jcr:created'`, "cards:Subject");
-  let fetchRelated = () => {
-    fetchWithReLogin(globalLoginDisplay, check_url)
-    .then((response) => response.ok ? response.json() : Promise.reject(response))
-    .then((json) => {setRelatedSubjects(json.rows);})
-    .catch(handleError);
-  }
-
-  // Fetch this Subject's data
-  useEffect(() => {
-    if (subject) {
-      fetchRelated();
-    } else {
-      setRelatedSubjects(null);
-    }
-  }, [subject]);
-
-  if (deleted) {
-    return null;
-  }
-
-  // If the data has not yet been fetched, return an in-progress symbol
-  if (!subject) {
-    return (
-      <Grid container justify="center"><Grid item><CircularProgress/></Grid></Grid>
-    );
-  }
-
-  if (error) {
-    return (
-      <Grid container justify="center">
-        <Grid item>
-          <Typography variant="h2" color="error">
-            Error obtaining subject data: {error.status} {error.statusText ? error.statusText : error.toString()}
-          </Typography>
-        </Grid>
-      </Grid>
-    );
-  }
-
-  return (
-    subject && <React.Fragment>
-      <SubjectMember classes={classes} id={id} level={currentLevel} data={subject} maxDisplayed={maxDisplayed} pageSize={pageSize} onDelete={() => {setDeleted(true)}} hasChildren={!!(relatedSubjects?.length)}/>
-      {relatedSubjects && relatedSubjects.length > 0 ?
-        (<Grid item xs={12} className={classes.subjectNestedContainer}>
-          {relatedSubjects.map( (subject, i) => {
-            // Render component again for each related subject
-            return(
-              <SubjectContainer key={i} classes={classes} path={subject["@path"]} level={currentLevel+1} maxDisplayed={maxDisplayed} pageSize={pageSize} subject={subject}/>
-            )
-          })}
-        </Grid>
-        ) : ""
-      }
-    </React.Fragment>
-  );
-}
-
-/**
  * Component that displays the header for the selected subject and its SubjectType
  */
 function SubjectHeader(props) {
-  let { id, classes, getSubject, history } = props;
+  let { id, classes, onSubjectDataFetched, history } = props;
   // This holds the full form JSON, once it is received from the server
   let [ subject, setSubject ] = useState(null);
   // Error message set when fetching the data from the server fails
@@ -302,7 +198,7 @@ function SubjectHeader(props) {
 
   // Callback method for the `fetchData` method, invoked when the data successfully arrived from the server.
   let handleSubjectResponse = (json) => {
-    getSubject(json);
+    onSubjectDataFetched(json);
     setSubject({data: json});
   };
 
@@ -310,6 +206,7 @@ function SubjectHeader(props) {
   let handleError = (response) => {
     setError(response);
     setSubject({});  // Prevent an infinite loop if data was not set
+    onSubjectDataFetched(null);
   };
 
   // When the top-level subject is deleted, redirect to its parent if it has one, otherwise to the Subjects page
@@ -327,7 +224,7 @@ function SubjectHeader(props) {
 
   if (!subject?.data) {
     return (
-      <Grid item><CircularProgress/></Grid>
+      <Grid item><Grid container justify="center"><Grid item><CircularProgress/></Grid></Grid></Grid>
     );
   }
 
@@ -380,257 +277,6 @@ function SubjectHeader(props) {
   );
 }
 
-/**
- * Component that displays all forms related to a Subject. Do not use directly, use SubjectMember instead.
- */
-function SubjectMemberInternal (props) {
-  let { classes, data, history, id, level, maxDisplayed, onDelete, pageSize, hasChildren } = props;
-  // Error message set when fetching the data from the server fails
-  let [ error, setError ] = useState();
-  let [ subjectGroups, setSubjectGroups ] = useState();
-
-  let globalLoginDisplay = useContext(GlobalLoginContext);
-
-  const customUrl=`/Forms.paginate?fieldname=subject&fieldvalue=${encodeURIComponent(data['jcr:uuid'])}&includeallstatus=true&limit=1000`;
-
-  // Fetch the forms associated with the subject as JSON from the server
-  // It will be stored in the `tableData` state variable
-  let fetchTableData = () => {
-    fetchWithReLogin(globalLoginDisplay, customUrl)
-    .then((response) => response.ok ? response.json() : Promise.reject(response))
-    .then(handleTableResponse)
-    .catch(handleTableError);
-  };
-
-  let handleTableResponse = (json) => {
-    let groups = {};
-    json.rows.map( (entry, i) => {
-      let title = entry.questionnaire.title || entry.questionnaire["@name"];
-      groups[title]?.push(entry) || (groups[title] = [entry]);
-    })
-    setSubjectGroups(groups);
-  };
-
-  let handleTableError = (response) => {
-    setError(response);
-    setSubjectGroups({});
-  };
-
-  let wordToTitleCase = (word) => {
-    return word[0].toUpperCase() + word.slice(1).toLowerCase();
-  }
-
-
-  // Fetch table data for all forms related to a Subject
-  useEffect(() => {
-    fetchTableData();
-  }, [data['jcr:uuid']]);
-
-  // If an error was returned, do not display a subject at all, but report the error
-  if (error) {
-    return (
-      <Grid container justify="center">
-        <Grid item>
-          <Typography variant="h2" color="error">
-            Error obtaining subject data: {error.status} {error.statusText ? error.statusText : error.toString()}
-          </Typography>
-        </Grid>
-      </Grid>
-    );
-  }
-
-  let identifier = data && data.identifier ? data.identifier : id;
-  let label = data?.type?.label || "Subject";
-  let title = `${label} ${identifier}`;
-  let path = data ? data["@path"] : "/Subjects/" + id;
-  let avatar = <Avatar className={classes.subjectAvatar}>{label.split(' ').map(s => s?.charAt(0)).join('').toUpperCase()}</Avatar>;
-  let action = <DeleteButton
-                 entryPath={path}
-                 entryName={title}
-                 entryType={label}
-                 onComplete={onDelete}
-                 buttonClass={classes.childSubjectHeaderButton}
-               />
-
-  // If this is the top-level subject and we have no data to display for it, inform the user:
-  if (data && level == 0 && !(Object.keys(subjectGroups || {}).length) && !hasChildren) {
-    return (
-      <Grid item>
-        <Typography color="textSecondary" variant="caption">{`No data associated with this ${label.toLowerCase()} was found.`}</Typography>
-      </Grid>
-    )
-  }
-
-  return ( data &&
-    <>
-    {
-      level > 0 &&
-        <Grid item className={classes.subjectTitleWithAvatar}>
-          <Grid container direction="row" spacing={1} justify="flex-start">
-            <Grid item xs={false}>{avatar}</Grid>
-            <Grid item>
-              <Typography variant="h5">
-                 <Link to={"/content.html" + path}>{title}</Link>
-                 {action}
-              </Typography>
-            </Grid>
-          </Grid>
-        </Grid>
-      }
-      { subjectGroups && Object.keys(subjectGroups).length > 0 && <>
-        {
-          Object.keys(subjectGroups).map( (questionnaireTitle, j) => {
-            return(<Grid item key={questionnaireTitle}>
-              <Typography variant="h6">{questionnaireTitle}</Typography>
-              <MaterialTable
-                data={subjectGroups[questionnaireTitle]}
-                style={{ boxShadow : 'none' }}
-                options={{
-                  actionsColumnIndex: -1,
-                  emptyRowsWhenPaging: false,
-                  toolbar: false,
-                  pageSize: pageSize,
-                  header: false,
-                  rowStyle: {
-                    verticalAlign: 'top',
-                  }
-                }}
-                columns={[
-                  { title: 'Created',
-                    cellStyle: {
-                      paddingLeft: 0,
-                      fontWeight: "bold",
-                      width: '1%',
-                      whiteSpace: 'nowrap',
-                    },
-                    render: rowData => <Link to={"/content.html" + rowData["@path"]}>
-                                         {moment(rowData['jcr:created']).format("YYYY-MM-DD")}
-                                       </Link> },
-                  { title: 'Status',
-                    cellStyle: {
-                      width: '1%',
-                      whiteSpace: 'pre-wrap',
-                      paddingBottom: "8px",
-                    },
-                    render: rowData => <React.Fragment>
-                                         {rowData["statusFlags"].map((status) => {
-                                           return <Chip
-                                             key={status}
-                                             label={wordToTitleCase(status)}
-                                             variant="outlined"
-                                             className={`${classes.subjectChip} ${classes[status + "Chip"] || classes.DefaultChip}`}
-                                             size="small"
-                                           />
-                                         })}
-                                       </React.Fragment> },
-                  { title: 'Summary',
-                    render: rowData => <FormData className={classes.formData} formID={rowData["@name"]} maxDisplayed={maxDisplayed} classes={classes}/> },
-                  { title: 'Actions',
-                    cellStyle: {
-                      padding: '0',
-                      width: '20px',
-                      textAlign: 'end'
-                    },
-                    render: rowData => <React.Fragment>
-                                         <EditButton
-                                           entryPath={rowData["@path"]}
-                                           entryType="Form"
-                                         />
-                                         <DeleteButton
-                                           entryPath={rowData["@path"]}
-                                           entryName={`${identifier}: ${rowData.questionnaire["@name"]}`}
-                                           entryType="Form"
-                                           warning={rowData ? rowData["@referenced"] : false}
-                                           onComplete={fetchTableData}
-                                         />
-                                       </React.Fragment> },
-                ]}
-                components={{
-                    Pagination: props => { const { classes, ...other } = props;
-                                           return (subjectGroups[questionnaireTitle].length > pageSize && <MTablePagination {...other} />)}
-                }}
-               />
-            </Grid>)
-          })
-        }
-        </>
-      }
-    </>
-  );
-};
-
-let SubjectMember = withRouter(SubjectMemberInternal);
-
-// Component that displays a preview of the saved form answers
-function FormData(props) {
-  let { formID, maxDisplayed, classes } = props;
-  // This holds the full form JSON, once it is received from the server
-  let [ data, setData ] = useState();
-  // Error message set when fetching the data from the server fails
-  let [ error, setError ] = useState();
-  // number of form question/answers listed, will increase
-  let displayed = 0;
-
-  let globalLoginDisplay = useContext(GlobalLoginContext);
-
-  // Fetch the form's data from the server
-  // It will be stored in the `data` state variable
-  let getFormData = (formID) => {
-    fetchWithReLogin(globalLoginDisplay, `/Forms/${formID}.deep.json`)
-        .then((response) => response.ok ? response.json() : Promise.reject(response))
-        .then((json) => setData(json))
-        .catch(handleFormError)
-  }
-
-  let handleFormError = (response) => {
-    setError(response);
-    setData([]);  // Prevent an infinite loop if data was not set
-  };
-
-  // Fetch this Form's data
-  useEffect(() => {
-    getFormData(formID);
-  }, [formID]);
-
-  // If the data has not yet been fetched, return an in-progress symbol
-  if (!data) {
-    return (
-      <Grid container justify="center"><Grid item><CircularProgress/></Grid></Grid>
-    );
-  }
-
-  if (error) {
-    return (
-      <Typography variant="h2" color="error">
-        Error obtaining form data: {error.status} {error.statusText}
-      </Typography>
-    );
-  }
-  // Handle questions and sections differently
-  let handleDisplayQuestion = (entryDefinition, data, key) => {
-    let result = displayQuestion(entryDefinition, data, key, classes);
-    if (result && displayed < maxDisplayed) {
-      displayed++;
-    } else {
-      result = null;
-    }
-    return result;
-  }
-
-  if (data && data.questionnaire) {
-    return (
-      <React.Fragment>
-        {
-          Object.entries(data.questionnaire)
-          .filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType']))
-          .map(([key, entryDefinition]) => handleDisplay(entryDefinition, data, key, handleDisplayQuestion))
-        }
-      </React.Fragment>
-    );
-  }
-  else return;
-}
-
 // Display the questions/question found within sections
 export function displayQuestion(entryDefinition, data, key, classes) {
   const existingQuestionAnswer = data && Object.entries(data)
@@ -680,11 +326,14 @@ export function displayQuestion(entryDefinition, data, key, classes) {
         }
         break;
       case "computed":
-        content = <>{ prettyPrintedAnswers.join(", ") }</>;
+        content = prettyPrintedAnswers.join(", ");
         // check the display mode; if formatted, display accordingly
         if (entryDefinition.displayMode == "formatted") {
           content = <FormattedText>{content}</FormattedText>;
+        } else {
+          content = <>{content}</>;
         }
+        break;
       default:
         content = <>{ prettyPrintedAnswers.join(", ") }</>
         break;
@@ -723,11 +372,6 @@ export function handleDisplay(entryDefinition, data, key, handleDisplayQuestion)
 
 Subject.propTypes = {
   id: PropTypes.string
-}
-
-Subject.defaultProps = {
-  maxDisplayed: 4,
-  pageSize: 10,
 }
 
 export default withStyles(QuestionnaireStyle)(withRouter(Subject));

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
@@ -152,7 +152,7 @@ function TimelineEntry(classes, dateEntry, index, length, nextEntry) {
  * @param {string} id the identifier of a subject; this is the JCR node name
  */
 function SubjectTimeline(props) {
-  let { id, classes, subject } = props;
+  let { classes, subject } = props;
   let [dateEntries, setDateEntries] = useState(null);
   // Error message set when fetching the data from the server fails
   let [ error, setError ] = useState();
@@ -370,14 +370,6 @@ function SubjectTimeline(props) {
     :
     <Typography color="textSecondary" variant="caption">No timeline data available</Typography>
   )
-}
-
-SubjectTimeline.propTypes = {
-  id: PropTypes.string
-}
-
-SubjectTimeline.defaultProps = {
-  maxDisplayed: 4,
 }
 
 export default withStyles(QuestionnaireStyle)(SubjectTimeline);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTreeView.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTreeView.jsx
@@ -1,0 +1,431 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React, { useState, useContext, useEffect } from "react";
+import { Link, withRouter } from 'react-router-dom';
+
+import PropTypes from "prop-types";
+import moment from "moment";
+
+import TreeView from '@material-ui/lab/TreeView';
+import TreeItem from '@material-ui/lab/TreeItem';
+
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ChevronRightIcon from '@material-ui/icons/ChevronRight';
+import MoreIcon from '@material-ui/icons/MoreHoriz';
+
+import FormattedText from "../components/FormattedText";
+import QuestionnaireStyle from "./QuestionnaireStyle.jsx";
+import { QUESTION_TYPES, SECTION_TYPES, ENTRY_TYPES } from "./FormEntry.jsx";
+import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
+import { displayQuestion, handleDisplay } from "./Subject.jsx";
+
+import {
+  CircularProgress,
+  Chip,
+  Grid,
+  IconButton,
+  Tooltip,
+  Typography,
+  makeStyles,
+  withStyles,
+} from "@material-ui/core";
+import FileIcon from "@material-ui/icons/InsertDriveFile";
+import DeleteButton from "../dataHomepage/DeleteButton.jsx";
+import EditButton from "../dataHomepage/EditButton.jsx";
+import ResourceHeader from "./ResourceHeader.jsx"
+import SubjectTimeline from "./SubjectTimeline.jsx";
+
+
+/**
+ * Component displays the forms associated with this subject, and all its child subjects with their forms,
+ * in a browsable tree structure
+ */
+function SubjectTreeView (props) {
+  let { subject } = props;
+
+  return ( subject ?
+    <TreeView
+      defaultCollapseIcon={<ExpandMoreIcon />}
+      defaultExpandIcon={<ChevronRightIcon />}
+      disableSelection
+    >
+      <SubjectItem {...props} />
+    </TreeView>
+    : null
+  );
+}
+
+SubjectTreeView.propTypes = {
+  subject: PropTypes.object,
+}
+
+/**
+ * Component that recursively gets and displays the selected subject and its related SubjectTypes
+ */
+function SubjectItem(props) {
+  let { subject, withTitle, ...rest } = props;
+  let { classes, history } = rest;
+  // Error status set when fetching the data from the server fails
+  let [ error, setError ] = useState();
+  // Error message set when fetching the data from the server fails
+  let [ errorMessage, setErrorMessage ] = useState(null);
+  // hold related subjects
+  let [relatedSubjects, setRelatedSubjects] = useState();
+  // whether the subject has been deleted
+  let [ deleted, setDeleted ] = useState();
+
+  let globalLoginDisplay = useContext(GlobalLoginContext);
+
+  // Callback method for the `fetchData` method, invoked when the request failed.
+  let handleError = (response) => {
+    setError(response);
+  };
+  
+  // Create a URL that checks for the existence of a subject
+  let createQueryURL = (query, type) => {
+    let url = new URL("/query", window.location.origin);
+    url.searchParams.set("query", `SELECT * FROM [${type}] as n` + query);
+    return url;
+  } 
+
+  let check_url = createQueryURL(` WHERE n.'parents'='${subject?.['jcr:uuid']}' order by n.'jcr:created'`, "cards:Subject");
+
+  let fetchRelated = () => {
+    fetchWithReLogin(globalLoginDisplay, check_url)
+    .then((response) => response.ok ? response.json() : Promise.reject(response))
+    .then((json) => { setRelatedSubjects(json.rows); })
+    .catch(handleError);
+  }
+
+  // Fetch this Subject's data
+  useEffect(() => {
+    if (subject) {
+      fetchRelated();
+    } else {
+      setRelatedSubjects(null);
+    }
+  }, [subject]);
+
+  useEffect(() => {
+    setErrorMessage(error ?
+    ( <Tree item id={subject.identifier + "-error"}
+        label= {
+          <Typography color="error">
+            Error obtaining subject data: {error.status} {error.statusText ? error.statusText : error.toString()}
+          </Typography>
+        }
+      />)
+    : null);
+  }, [error]);
+
+  if (!subject || deleted) {
+    return null;
+  }
+
+  let hasParent = withTitle;
+  let hasChildren = !!(relatedSubjects?.length);
+  let noDataMessage = hasParent || hasChildren ? null : <Typography key="error" color="textSecondary" variant="caption">{`No data associated with this ${subject?.type?.label?.toLowerCase()} was found.`}</Typography>;
+
+  let forms = <SubjectForms key="forms" {...props} placeholder={noDataMessage}/>;
+  let childSubjects = relatedSubjects?.map( (s, i) => <SubjectItem key={i} subject={s} withTitle {...rest} /> ) || [];
+  let childItems = [forms];
+  if (errorMessage) {
+     childItems.push(errorMessage);
+  } else {
+     childItems.push(...childSubjects);
+  }
+
+  let identifier = subject?.identifier;
+  let label = subject?.type?.label || "Subject";
+  let title = `${label} ${identifier}`;
+  let path = subject?.["@path"];
+
+  return ( withTitle ?
+    <TreeItem
+      nodeId={identifier}
+      label={
+        <TreeItemLabel
+           variant="h6"
+           label={<>{label} <Link to={"/content.html" + path}>{identifier}</Link></>}
+           action={
+             <DeleteButton
+               entryPath={path}
+               entryName={title}
+               entryType={label}
+               onComplete={() => {setDeleted(true)}}
+            />
+          }
+        />
+      }
+    >
+     {childItems}
+    </TreeItem>
+    : <>
+      {childItems}
+    </>
+  );
+};
+
+/**
+ * Component that displays all forms related to a Subject
+ */
+function SubjectForms (props) {
+  let { subject, classes, placeholder, history } = props;
+  // Error message set when fetching the data from the server fails
+  let [ error, setError ] = useState();
+  let [ subjectGroups, setSubjectGroups ] = useState();
+
+  let globalLoginDisplay = useContext(GlobalLoginContext);
+
+  const customUrl=`/Forms.paginate?fieldname=subject&fieldvalue=${encodeURIComponent(subject['jcr:uuid'])}&includeallstatus=true&limit=1000`;
+
+  // Fetch the forms associated with the subject as JSON from the server
+  // It will be stored in the `tableData` state variable
+  let fetchTableData = () => {
+    fetchWithReLogin(globalLoginDisplay, customUrl)
+    .then((response) => response.ok ? response.json() : Promise.reject(response))
+    .then(handleTableResponse)
+    .catch(handleTableError);
+  };
+
+  let handleTableResponse = (json) => {
+    let groups = {};
+    json.rows.map( (entry, i) => {
+      let title = entry.questionnaire.title || entry.questionnaire["@name"];
+      groups[title]?.push(entry) || (groups[title] = [entry]);
+    })
+    setSubjectGroups(groups);
+  };
+
+  let handleTableError = (response) => {
+    setError(response);
+    setSubjectGroups({});
+  };
+
+  let wordToTitleCase = (word) => {
+    return word[0].toUpperCase() + word.slice(1).toLowerCase();
+  }
+
+
+  // Fetch table data for all forms related to a Subject
+  useEffect(() => {
+    fetchTableData();
+  }, [subject['jcr:uuid']]);
+
+
+  // If an error was returned, report it
+  if (error) {
+    return (
+      <TreeItem
+        nodeId={subject.identifier + "data-error"}
+        label={
+          <Typography color="error">
+            Error obtaining subject data: {error.status} {error.statusText ? error.statusText : error.toString()}
+          </Typography>
+        }
+      />
+    );
+  }
+
+  // If we have no data to display for this subject, return the specified placeholder
+  if (!subject || !(Object.keys(subjectGroups || {}).length)) {
+    return placeholder;
+  }
+
+  return (
+    <>
+        { Object.keys(subjectGroups).map( (questionnaireTitle, j) => {
+          return (
+            <TreeItem
+              key={questionnaireTitle}
+              nodeId={`${subject.identifier}-${questionnaireTitle}`}
+              label={<Typography variant="h6">{questionnaireTitle}</Typography>}
+            >
+              { subjectGroups[questionnaireTitle].map((rowData, i) => (
+                <TreeItem
+                  key={i}
+                  nodeId={`${subject.identifier}-${questionnaireTitle}-${i}`}
+                  label={
+                    <TreeItemLabel
+                      variant="subtitle1"
+                      label={<>
+                        <Link to={"/content.html" + rowData["@path"]}>
+                           {moment(rowData['jcr:created']).format("YYYY-MM-DD")}
+                        </Link>
+                        { rowData["statusFlags"].map((status) => (
+                          <Chip
+                             key={status}
+                             label="Draft"
+                             variant="outlined"
+                             className={`${classes.subjectChip} ${classes[status + "Chip"] || classes.DefaultChip}`}
+                             size="small"
+                           />
+                        ))}
+                      </>}
+                      action={<>
+                        <EditButton
+                          entryPath={rowData["@path"]}
+                          entryType="Form"
+                        />
+                        <DeleteButton
+                          entryPath={rowData["@path"]}
+                          entryName={`${subject.identifier}: ${rowData.questionnaire["@name"]}`}
+                          entryType="Form"
+                          warning={rowData ? rowData["@referenced"] : false}
+                          onComplete={fetchTableData}
+                        />
+                      </>}
+                    />
+                  }
+                 >
+                   <TreeItem
+                     nodeId={`${subject.identifier}-${questionnaireTitle}-${i}-data`}
+                     label={
+                       <TreeItemLabel
+                         label={<FormExcerpt className={classes.formData} formId={rowData["@name"]} classes={classes}/>}
+                         action={
+                           <Tooltip title="View form">
+                             <IconButton onClick={() => {history.push("/content.html" + rowData["@path"])}}>
+                               <MoreIcon />
+                             </IconButton>
+                           </Tooltip>
+                         }
+                       />
+                     }
+                   />
+                 </TreeItem>
+              ))}
+            </TreeItem>)
+          })
+        }
+    </>
+  );
+};
+
+const useTreeItemStyles = makeStyles((theme) => ({
+  treeItemLabel : {
+    display: "flex",
+    alignItems: 'center',
+    justifyContent: "space-between",
+    "& .MuiChip-root" : {
+      marginLeft: theme.spacing(1.5),
+      marginTop: theme.spacing(0.5),
+    }
+  },
+  treeItemAction: {
+  }
+}));
+// Component that displays a structured tree item label
+function TreeItemLabel(props) {
+  let {label, variant, action} = props;
+  
+  let classes = useTreeItemStyles();
+  
+  return (
+    <div className={classes.treeItemLabel}>
+      <Typography variant={variant} component="div">{label}</Typography>
+      {action && <div className={classes.treeItemAction}>{action}</div>}
+    </div>
+  )
+}
+
+// Component that displays a preview of the saved form answers
+function FormExcerpt(props) {
+  let { formId, size, classes } = props;
+  // This holds the full form JSON, once it is received from the server
+  let [ data, setData ] = useState();
+  // Error message set when fetching the data from the server fails
+  let [ error, setError ] = useState();
+  // number of form question/answers listed, will increase
+  let displayed = 0;
+
+  let globalLoginDisplay = useContext(GlobalLoginContext);
+
+  // Fetch the form's data from the server
+  // It will be stored in the `data` state variable
+  let getFormData = (formId) => {
+    fetchWithReLogin(globalLoginDisplay, `/Forms/${formId}.deep.json`)
+        .then((response) => response.ok ? response.json() : Promise.reject(response))
+        .then((json) => setData(json))
+        .catch(handleFormError)
+  }
+
+  let handleFormError = (response) => {
+    setError(response);
+    setData([]);  // Prevent an infinite loop if data was not set
+  };
+
+  // Fetch this Form's data
+  useEffect(() => {
+    getFormData(formId);
+  }, [formId]);
+
+  // If the data has not yet been fetched, return an in-progress symbol
+  if (!data) {
+    return (
+      <Grid container justify="center"><Grid item><CircularProgress/></Grid></Grid>
+    );
+  }
+
+  if (error) {
+    return (
+      <Typography color="error">
+        Error obtaining form data: {error.status} {error.statusText}
+      </Typography>
+    );
+  }
+  // Handle questions and sections differently
+  let handleDisplayQuestion = (entryDefinition, data, key) => {
+    let result = displayQuestion(entryDefinition, data, key, classes);
+    if (result && displayed < size) {
+      displayed++;
+    } else {
+      result = null;
+    }
+    return result;
+  }
+  
+  let excerpt = (
+      Object.entries(data.questionnaire)
+          .filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType']))
+          .map(([key, entryDefinition]) => handleDisplay(entryDefinition, data, key, handleDisplayQuestion))
+  );
+
+  if (data && data.questionnaire) {
+    return (
+      <React.Fragment>
+        { excerpt?.length ? excerpt : <Typography variant="caption">This form is empty.</Typography> }
+      </React.Fragment>
+    );
+  }
+  else return;
+}
+
+FormExcerpt.propTypes = {
+  formId: PropTypes.string.isRequired,
+  size: PropTypes.number,
+}
+
+FormExcerpt.defaultProps = {
+  size: 4,
+}
+
+
+export default withStyles(QuestionnaireStyle)(withRouter(SubjectTreeView));


### PR DESCRIPTION
This PR is an experiment with using the material ui lab `TreeView` component for displaying the subject chart.

To test:
* start CARDS in the lfs run mode (where there is more than one subject type)
* add multiple forms for a patient ans well as its tumors/tumor regions
* visualize the Patient chart displayed using the TreeView.