### PR TITLE
CARDS-1320: Each form should keep track of its related subjects

### DIFF
--- a/modules/data-entry/pom.xml
+++ b/modules/data-entry/pom.xml
@@ -104,6 +104,16 @@
       <version>2.18.4</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.jackrabbit</groupId>
+      <artifactId>oak-api</artifactId>
+      <version>${oak.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jackrabbit</groupId>
+      <artifactId>oak-store-spi</artifactId>
+      <version>${oak.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.scripting.sightly.runtime</artifactId>
       <version>1.1.0-1.4.0</version>

--- a/modules/data-entry/src/main/java/io/uhndata/cards/internal/FormRelatedSubjectsEditor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/internal/FormRelatedSubjectsEditor.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Value;
+
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.spi.commit.DefaultEditor;
+import org.apache.jackrabbit.oak.spi.commit.Editor;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An {@link Editor} that computes and sets the {@code relatedSubjects} property for every changed Form. The related
+ * subjects are the subject that the form belongs to, along with that subject's ancestors.
+ *
+ * @version $Id$
+ */
+public class FormRelatedSubjectsEditor extends DefaultEditor
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(FormRelatedSubjectsEditor.class);
+
+    private static final String PROP_RELATED_SUBJECTS = "relatedSubjects";
+
+    private static final String PROP_SUBJECT = "subject";
+
+    private static final String PROP_PARENTS = "parents";
+
+    private final Session session;
+
+    // This holds the builder for the current node. The methods called for editing specific properties don't receive the
+    // actual parent node of those properties, so we must manually keep track of the current node.
+    private final NodeBuilder currentNodeBuilder;
+
+    /**
+     * Simple constructor.
+     *
+     * @param nodeBuilder the current node
+     * @param session the session used to retrieve subjects by UUID
+     */
+    public FormRelatedSubjectsEditor(final NodeBuilder nodeBuilder, final Session session)
+    {
+        this.currentNodeBuilder = nodeBuilder;
+        this.session = session;
+    }
+
+    // When something changes in a node deep in the content tree, the editor is invoked starting with the root node,
+    // descending to the actually changed node through subsequent calls to childNodeChanged. The default behavior of
+    // DefaultEditor is to stop at the root, so we must override the following two methods in order for the editor to be
+    // invoked on non-root nodes.
+    @Override
+    public Editor childNodeAdded(final String name, final NodeState after)
+        throws CommitFailedException
+    {
+        return new FormRelatedSubjectsEditor(this.currentNodeBuilder.getChildNode(name), this.session);
+    }
+
+    @Override
+    public Editor childNodeChanged(String name, NodeState before, NodeState after) throws CommitFailedException
+    {
+        return new FormRelatedSubjectsEditor(this.currentNodeBuilder.getChildNode(name), this.session);
+    }
+
+    @Override
+    public void leave(NodeState before, NodeState after) throws CommitFailedException
+    {
+        if (isForm(this.currentNodeBuilder)) {
+            try {
+                setRelatedSubjects();
+            } catch (RepositoryException e) {
+                // This is not a fatal error, the related subjects is not required for a functional application
+                LOGGER.warn("Unexpected exception while computing the related subjects of form {}",
+                    this.currentNodeBuilder.getString("jcr:uuid"));
+            }
+        }
+    }
+
+    /**
+     * Gather all ancestors-and-self Subjects, starting with the target form's subject, and store them as a multi-valued
+     * {@code relatedSubjects} property of the form.
+     *
+     * @throws RepositoryException if accessing the repository fails
+     */
+    private void setRelatedSubjects() throws RepositoryException
+    {
+        final List<String> identifiers = new ArrayList<>();
+        Node subjectNode = this.session
+            .getNodeByIdentifier(this.currentNodeBuilder.getProperty(PROP_SUBJECT).getValue(Type.REFERENCE));
+
+        // Iterate through all parents of the subject
+        while (subjectNode != null) {
+            identifiers.add(subjectNode.getProperty("jcr:uuid").getString());
+            if (!subjectNode.hasProperty(PROP_PARENTS)) {
+                break;
+            }
+            Value parent;
+            if (subjectNode.getProperty(PROP_PARENTS).isMultiple()) {
+                parent = subjectNode.getProperty(PROP_PARENTS).getValues()[0];
+            } else {
+                parent = subjectNode.getProperty(PROP_PARENTS).getValue();
+            }
+            subjectNode = this.session.getNodeByIdentifier(parent.getString());
+        }
+
+        // Write relatedSubjects to the form node
+        this.currentNodeBuilder.setProperty(PROP_RELATED_SUBJECTS, identifiers, Type.WEAKREFERENCES);
+    }
+
+    /**
+     * Checks if the given node is a Form node.
+     *
+     * @param node the JCR Node to check
+     * @return {@code true} if the node is a Form node, {@code false} otherwise
+     */
+    private boolean isForm(NodeBuilder node)
+    {
+        return "cards:Form".equals(getNodeType(node));
+    }
+
+    /**
+     * Retrieves the primary node type of a node, as a String.
+     *
+     * @param node the node whose type to retrieve
+     * @return a string
+     */
+    private String getNodeType(NodeBuilder node)
+    {
+        return node.getProperty("jcr:primaryType").getValue(Type.STRING);
+    }
+}

--- a/modules/data-entry/src/main/java/io/uhndata/cards/internal/FormRelatedSubjectsEditorProvider.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/internal/FormRelatedSubjectsEditorProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.internal;
+
+import javax.jcr.Session;
+
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
+import org.apache.jackrabbit.oak.spi.commit.Editor;
+import org.apache.jackrabbit.oak.spi.commit.EditorProvider;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.FieldOption;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * A {@link EditorProvider} returning {@link FormRelatedSubjectsEditor}.
+ *
+ * @version $Id$
+ */
+@Component(service = EditorProvider.class, scope = ServiceScope.SINGLETON, immediate = true)
+public class FormRelatedSubjectsEditorProvider implements EditorProvider
+{
+    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
+        policyOption = ReferencePolicyOption.GREEDY)
+    private ResourceResolverFactory rrf;
+
+    @Override
+    public Editor getRootEditor(final NodeState before, final NodeState after, final NodeBuilder builder,
+        final CommitInfo info)
+        throws CommitFailedException
+    {
+        if (this.rrf != null && this.rrf.getThreadResourceResolver() != null) {
+            Session session = this.rrf.getThreadResourceResolver().adaptTo(Session.class);
+            // Each FormRelatedSubjectsEditor maintains a state, so a new instance must be returned each time
+            return new FormRelatedSubjectsEditor(builder, session);
+        }
+        return null;
+    }
+}

--- a/modules/data-entry/src/main/resources/SLING-INF/content/oak%3Aindex/formRelatedSubjects.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/oak%3Aindex/formRelatedSubjects.json
@@ -1,0 +1,7 @@
+{
+  "jcr:primaryType": "oak:QueryIndexDefinition",
+  "jcr:name:propertyNames": [
+    "relatedSubjects"
+  ],
+  "type": "property"
+}

--- a/modules/data-entry/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
@@ -43,6 +43,14 @@
                     "ordered": true,
                     "propertyIndex": true
                 },
+                "relatedSubjects": {
+                    "analyzed": false,
+                    "boost": 1,
+                    "nodeScopeIndex": false,
+                    "useInExcerpt": true,
+                    "ordered": true,
+                    "propertyIndex": true
+                },
                 "created": {
                     "name": "jcr:created",
                     "ordered": true,

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -725,6 +725,9 @@
   // Although recommended to have a subject, this is optional for now.
   - subject (reference) nofulltext
 
+  // A list of references to the subject that this form is about, and all its ancestor subjects, if any.
+  - relatedSubjects (weakreference) nofulltext
+
   // Children
 
   // The answers and answer sections recorded in this form.


### PR DESCRIPTION
To test:
- upload a Somatic Variants file (p_t_r.csv), open its deep.json, make sure it has `relatedSubjects` as an array of 3 subjects, the tumor region, the tumor, and the patient
- create a new Chemotherapy form for a tumor, open its deep.json, make sure it has `relatedSubjects` as an array of 2 subjects, the tumor and the patient
- create a new Patient Information form, open its deep.json, make sure it has `relatedSubjects` as an array with only one value, the patient.