### PR TITLE
CARDS-1319: The generate_compose_yaml.py script should configure a bind-mount from the cardsinitial container to the local SLING directory

### DIFF
--- a/compose-cluster/.gitignore
+++ b/compose-cluster/.gitignore
@@ -5,3 +5,4 @@ shard*
 NCR_MODEL
 secrets
 SSL_CONFIG
+SLING

--- a/compose-cluster/cleanup.sh
+++ b/compose-cluster/cleanup.sh
@@ -35,4 +35,9 @@ rm proxy/000-default.conf
 echo "Removing secrets"
 rm -r secrets
 
+# Due permissions issues, we have to first remove all contents of SLING with Docker
+echo "Removing SLING"
+docker run --rm -v $(realpath ./SLING):/sling -it openjdk:8-jre-alpine sh -c 'cd /sling; find . -delete'
+rm -rf SLING
+
 echo "Done"

--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -225,6 +225,8 @@ yaml_obj['services']['cardsinitial']['networks'] = {}
 yaml_obj['services']['cardsinitial']['networks']['internalnetwork'] = {}
 yaml_obj['services']['cardsinitial']['networks']['internalnetwork']['aliases'] = ['cardsinitial']
 
+yaml_obj['services']['cardsinitial']['volumes'] = ["./SLING:/opt/cards/sling"]
+
 if args.custom_env_file:
     yaml_obj['services']['cardsinitial']['env_file'] = args.custom_env_file
 

--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -225,6 +225,13 @@ yaml_obj['services']['cardsinitial']['networks'] = {}
 yaml_obj['services']['cardsinitial']['networks']['internalnetwork'] = {}
 yaml_obj['services']['cardsinitial']['networks']['internalnetwork']['aliases'] = ['cardsinitial']
 
+#Create the ./SLING directory and copy the logback.xml file into it
+try:
+    os.mkdir("SLING")
+    shutil.copyfile("../distribution/logback.xml", "SLING/logback.xml")
+except FileExistsError:
+    print("Warning: SLING directory exists - will leave unmodified.")
+
 yaml_obj['services']['cardsinitial']['volumes'] = ["./SLING:/opt/cards/sling"]
 
 if args.custom_env_file:


### PR DESCRIPTION
This PR bind-mounts `/opt/cards/sling` in the CARDS Docker container to `compose-cluster/SLING` on the host so that configuration settings (such as installed runModes or LDAP settings) survive restarts of the Docker Compose environment.

To test:

1. Build this branch including the CARDS Docker image (`mvn clean install`)
2. `cd compose-cluster`
3. `python3 generate_compose_yaml.py --oak_filesystem`
4. `docker-compose build`
5. `docker-compose up -d`
6. Visit `http://localhost:8080/` and create some Subjects.
7. `docker-compose down`
8. `docker-compose rm`
9. `docker volume prune -f`
10. `docker-compose up -d`
11. Visit `http://localhost:8080/`. The previously created Subjects should be present.
12. `docker-compose down`
13. `docker-compose rm`
14. `docker volume prune -f`
15. `./cleanup.sh`
16. `python3 generate_compose_yaml.py --oak_filesystem`
17. `docker-compose build`
18. `docker-compose up -d`
19. Visit `http://localhost:8080/`. The previously created Subjects should be gone.