### PR TITLE
CARDS-1302: Add support for computed fields displayed as formatted text - BUGFIX

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -503,6 +503,9 @@ const questionnaireStyle = theme => ({
             },
         },
     },
+    formPreviewFormattedAnswer: {
+      display: "inline-flex",
+    },
     questionnaireDisabledListItem: {
         color: theme.palette.grey["500"]
     },

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -492,6 +492,13 @@ const questionnaireStyle = theme => ({
     DefaultChip: {
     },
     formPreviewQuestion: {
+        display: "flex",
+    },
+    formPreviewSeparator: {
+        margin: theme.spacing(0, 1.5),
+    },
+    formPreviewAnswer: {
+        fontWeight: 200,
         "& .MuiChip-root" : {
             margin: "0 0.5em 0.5em 0",
             "& .MuiChip-iconSmall": {
@@ -502,9 +509,6 @@ const questionnaireStyle = theme => ({
                 textDecoration: "none",
             },
         },
-    },
-    formPreviewFormattedAnswer: {
-      display: "inline-flex",
     },
     questionnaireDisabledListItem: {
         color: theme.palette.grey["500"]

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -680,11 +680,14 @@ export function displayQuestion(entryDefinition, data, key, classes) {
         }
         break;
       case "computed":
-        content = <>{ prettyPrintedAnswers.join(", ") }</>;
+        content = prettyPrintedAnswers.join(", ");
         // check the display mode; if formatted, display accordingly
         if (entryDefinition.displayMode == "formatted") {
-          content = <FormattedText>{content}</FormattedText>;
+          content = <FormattedText variant="body2" className={classes.formPreviewFormattedAnswer}>{content}</FormattedText>;
+        } else {
+          content = <>{content}</>;
         }
+        break;
       default:
         content = <>{ prettyPrintedAnswers.join(", ") }</>
         break;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -683,7 +683,7 @@ export function displayQuestion(entryDefinition, data, key, classes) {
         content = prettyPrintedAnswers.join(", ");
         // check the display mode; if formatted, display accordingly
         if (entryDefinition.displayMode == "formatted") {
-          content = <FormattedText variant="body2" className={classes.formPreviewFormattedAnswer}>{content}</FormattedText>;
+          content = <FormattedText variant="body2">{content}</FormattedText>;
         } else {
           content = <>{content}</>;
         }
@@ -694,7 +694,11 @@ export function displayQuestion(entryDefinition, data, key, classes) {
     }
     return (
       isHidden ? null :
-      <Typography variant="body2" component="div" key={key} className={classes.formPreviewQuestion}>{questionTitle}: {content}</Typography>
+      <Typography variant="body2" className={classes.formPreviewQuestion} key={key}>
+        {questionTitle}
+        <span className={classes.formPreviewSeparator}>–</span>
+        <div className={classes.formPreviewAnswer}>{content}</div>
+      </Typography>
     );
   }
   else return null;

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ComputedTest.xml
@@ -84,7 +84,7 @@ or
 		</property>
 		<property>
 			<name>expression</name>
-			<value>return "You wrote " + @{q1:-"nothing"}</value>
+			<value>return "You wrote " + @{q1:-nothing}</value>
 			<type>String</type>
 		</property>
 	</node>
@@ -156,4 +156,46 @@ or
 			<type>String</type>
 		</property>
 	</node>
+	<node>
+		<name>q5</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Computed, formatted multiline</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>description</name>
+			<value>
+Expected output:
+
+> * You wrote *[text from question 1]*...
+> * ...and **nothing else**
+
+or
+
+> You **wrote**: *nothing*
+
+**Note**: How the text from question 1 is displayed may be affected by formatting characters if it contains markdown formatting characters.
+			</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>computed</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>formatted</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>expression</name>
+			<value>return (@{q1:-} ? ("* You wrote *" + @{q1} + "*...\n* ...and **nothing else**") : "You wrote nothing")</value>
+			<type>String</type>
+		</property>
+	</node>
+
+
 </node>


### PR DESCRIPTION
To replicate the buggy display of formatted computed question answers on the subject chart:
* start CARDS in the test run mode
* fill out a Computed Field Test form
* go tho the patient chart to see how the answers are displayed.

In this PR:
* Fixed the buggy display of formatted answers in the patient chart
* Added multiline formatted computed question to the Computed Field Test questionnaire
* [misc] Improved the display of the form summary on the subject chart