### PR TITLE
CARDS-1222: Write a script for upgrading the image used by a singular Mongo Docker container

### DIFF
--- a/Utilities/ContainerManagement/upgrade_mongo_image.sh
+++ b/Utilities/ContainerManagement/upgrade_mongo_image.sh
@@ -27,7 +27,7 @@ PROJECT_ROOT=$(realpath ../../)
 docker top $MONGO_CONTAINER_INSTANCE 2>/dev/null >/dev/null || { echo "Invalid specified container...exiting."; exit -1; }
 
 # Check that the container has bind-mounted a local directory to /data/db
-DATA_DIRECTORY_MOUNT=$(docker inspect -f '{{json .HostConfig.Binds }}' $MONGO_CONTAINER_INSTANCE | jq -r '.[] | select(test("^.+:/data/db$"))' | cut -d  ':' -f1)
+DATA_DIRECTORY_MOUNT=$(docker inspect -f '{{json .HostConfig.Binds }}' $MONGO_CONTAINER_INSTANCE | jq -r '.[] | select(test("^.+:/data/db(:rw){0,1}$"))' | cut -d  ':' -f1)
 [ -z $DATA_DIRECTORY_MOUNT ] && { echo "/data/db is not bind-mounted...exiting."; exit -1; }
 
 # Backup the current MONGO_IMAGE

--- a/Utilities/ContainerManagement/upgrade_mongo_image.sh
+++ b/Utilities/ContainerManagement/upgrade_mongo_image.sh
@@ -21,6 +21,9 @@ MONGO_CONTAINER_INSTANCE=$1
 MONGO_IMAGE="mongo:4.2-bionic"
 TAG_BACKUP_PATH=~/.docker_tags_backup/singular_mongo_slingstore.txt
 
+# Check if jq is installed. Exit if it is not.
+echo '' | jq . >/dev/null 2>/dev/null || { echo "jq is not installed...exiting."; exit -1; }
+
 PROJECT_ROOT=$(realpath ../../)
 
 # Check that MONGO_CONTAINER_INSTANCE is a real, running container

--- a/Utilities/ContainerManagement/upgrade_mongo_image.sh
+++ b/Utilities/ContainerManagement/upgrade_mongo_image.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+MONGO_CONTAINER_INSTANCE=$1
+MONGO_IMAGE="mongo:4.2-bionic"
+TAG_BACKUP_PATH=~/.docker_tags_backup/singular_mongo_slingstore.txt
+
+PROJECT_ROOT=$(realpath ../../)
+
+# Check that MONGO_CONTAINER_INSTANCE is a real, running container
+docker top $MONGO_CONTAINER_INSTANCE 2>/dev/null >/dev/null || { echo "Invalid specified container...exiting."; exit -1; }
+
+# Check that the container has bind-mounted a local directory to /data/db
+DATA_DIRECTORY_MOUNT=$(docker inspect -f '{{json .HostConfig.Binds }}' $MONGO_CONTAINER_INSTANCE | jq -r '.[] | select(test("^.+:/data/db$"))' | cut -d  ':' -f1)
+[ -z $DATA_DIRECTORY_MOUNT ] && { echo "/data/db is not bind-mounted...exiting."; exit -1; }
+
+# Backup the current MONGO_IMAGE
+./backup_image_tag.sh $MONGO_IMAGE $TAG_BACKUP_PATH || { echo "Failed to backup image tag...exiting."; exit -1; }
+
+# Pull the latest MONGO_IMAGE
+docker pull $MONGO_IMAGE || { echo "Failed to pull latest Docker image...exiting."; exit -1; }
+
+# Stop the Docker Compose environment
+cd $PROJECT_ROOT
+cd compose-cluster
+docker-compose down
+docker-compose rm -f
+docker volume prune -f
+
+# Stop the specified running MongoDB
+docker stop $MONGO_CONTAINER_INSTANCE
+docker rm $MONGO_CONTAINER_INSTANCE
+
+# Start the specified MongoDB (using the new image) with the same volume mount as before
+docker run -p 27017:27017 -v $DATA_DIRECTORY_MOUNT:/data/db --name $MONGO_CONTAINER_INSTANCE -d $MONGO_IMAGE || { echo "Failed to start MongoDB container...exiting."; exit -1; }
+
+# Bring everything back up
+docker-compose up -d


### PR DESCRIPTION
This PR introduces the `upgrade_mongo_image.sh` script which:

- Stops a running Docker Compose environment of CARDS which uses a singular (outside of the Docker Compose environment) Docker container of MongoDB for data persistence
- Stops the (outside of Docker Compose environment) MongoDB Docker container
- Pulls the latest `mongo:4.2-bionic` image from Docker Hub
- Restarts the (outside of Docker Compose environment) MongoDB Docker container with the same `/data/db` volume mount as before but with the new `mongo:4.2-bionic` image.
- Restarts the CARDS Docker Compose environment

To test:

- Build this branch (`mvn clean install`)
- `cd compose-cluster`
- `python3 generate_compose_yaml.py --external_mongo --external_mongo_address 172.18.0.1 --external_mongo_dbname sling --subnet 172.18.0.0/16` (leave blank for no database password)
- `docker pull mongo:4.2-bionic`
- `mkdir ~/mongodata`
- `docker run --rm -p 27017:27017 --name mongocards -v $(realpath ~/mongodata):/data/db -d mongo:4.2-bionic`
- `docker-compose build`
- `docker-compose up -d`
- Visit `http://localhost:8080`. Create some data.
- `cd ../Utilities/ContainerManagement`
- `mkdir ~/.docker_tags_backup`
- `./upgrade_mongo_image.sh mongocards`
- Visit `http://localhost:8080`. All previously entered data should still be there.
- Under `~/.docker_tags_backup/` there should be the file `singular_mongo_slingstore.txt` which contains the name and hash of the version of the MongoDB image that was in use before running the `upgrade_mongo_image.sh` script.