### PR TITLE
CARDS-1332: jcr:lastModified for Questionnaires does not get updated sometimes

### DIFF
--- a/modules/versioning/src/main/java/io/uhndata/cards/versioning/LastModifiedEditor.java
+++ b/modules/versioning/src/main/java/io/uhndata/cards/versioning/LastModifiedEditor.java
@@ -77,7 +77,7 @@ public class LastModifiedEditor extends DefaultEditor
     public void propertyAdded(final PropertyState after)
         throws CommitFailedException
     {
-        if ("value".equals(after.getName()) || "notes".equals(after.getName())) {
+        if (!after.getName().startsWith("jcr:") && !after.getName().startsWith("sling:")) {
             handleAnswerChange();
         }
     }


### PR DESCRIPTION
This PR causes `jcr:lastModified` to be updated whenever the node or a descendant node changes a non-internal property (eg. not `jcr:...` and not `sling:...`)

To test:

- Ensure that the `jcr:lastModified` property of Questionnaire nodes updates every time that the Questionnaire is changed.
- Ensure that the `jcr:lastModified` property of Form nodes updates with the same behavior as on the `dev` branch.