### PR TITLE
CARDS-1306 / CARDS-1352 Add support for sections that stick to the top (header section) when scrolling

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -72,7 +72,7 @@ import ResourceHeader from "./ResourceHeader.jsx";
  * @param {string} id the identifier of a form; this is the JCR node name
  */
 function Form (props) {
-  let { classes, id } = props;
+  let { classes, id, contentOffset } = props;
   // This holds the full form JSON, once it is received from the server
   let [ data, setData ] = useState();
   // Error message set when fetching the data from the server fails
@@ -97,6 +97,7 @@ function Form (props) {
   let [ paginationEnabled, setPaginationEnabled ] = useState(false);
   let [ removeWindowHandlers, setRemoveWindowHandlers ] = useState();
   let [ actionsMenu, setActionsMenu ] = useState(null);
+  let [ formContentOffset, setFormContentOffset ] = useState(contentOffset);
 
   let formNode = React.useRef();
   let pageNameWriter = usePageNameWriterContext();
@@ -105,6 +106,10 @@ function Form (props) {
   const urlBase = "/content.html";
   const isEdit = window.location.pathname.endsWith(".edit");
   let globalLoginDisplay = useContext(GlobalLoginContext);
+
+  useEffect(() => {
+    setFormContentOffset(contentOffset + (document?.getElementById('cards-resource-header')?.clientHeight || 0));
+  }, [data])
 
   useEffect(() => {
     if (isEdit) {
@@ -365,7 +370,8 @@ function Form (props) {
           breadcrumbs={[<Breadcrumbs separator="/">{getHierarchyAsList(data?.subject).map(a => <Typography variant="overline" key={a}>{a}</Typography>)}</Breadcrumbs>]}
           separator=":"
           action={formMenu}
-          contentOffset={props.contentOffset}
+          contentOffset={contentOffset}
+
         >
           <FormattedText variant="subtitle1" color="textSecondary">
             {data?.questionnaire?.description}
@@ -432,6 +438,7 @@ function Form (props) {
                     visibleCallback={pageResult.callback}
                     pageActive={pageResult.page.visible}
                     isEdit={isEdit}
+                    contentOffset={formContentOffset}
                   />
                 })
             }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -110,7 +110,9 @@ function Form (props) {
 
   useEffect(() => {
     setFormContentOffsetTop(contentOffset + (document?.getElementById('cards-resource-header')?.clientHeight || 0));
-    setFormContentOffsetBottom(document?.getElementById('cards-resource-footer')?.clientHeight || 0);
+  }, [data]);
+  useEffect(() => {
+    paginationEnabled && setFormContentOffsetBottom(document?.getElementById('cards-resource-footer')?.clientHeight || 0);
   }, [pages])
 
   useEffect(() => {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -97,7 +97,8 @@ function Form (props) {
   let [ paginationEnabled, setPaginationEnabled ] = useState(false);
   let [ removeWindowHandlers, setRemoveWindowHandlers ] = useState();
   let [ actionsMenu, setActionsMenu ] = useState(null);
-  let [ formContentOffset, setFormContentOffset ] = useState(contentOffset);
+  let [ formContentOffsetTop, setFormContentOffsetTop ] = useState(contentOffset);
+  let [ formContentOffsetBottom, setFormContentOffsetBottom ] = useState(0);
 
   let formNode = React.useRef();
   let pageNameWriter = usePageNameWriterContext();
@@ -108,8 +109,9 @@ function Form (props) {
   let globalLoginDisplay = useContext(GlobalLoginContext);
 
   useEffect(() => {
-    setFormContentOffset(contentOffset + (document?.getElementById('cards-resource-header')?.clientHeight || 0));
-  }, [data])
+    setFormContentOffsetTop(contentOffset + (document?.getElementById('cards-resource-header')?.clientHeight || 0));
+    setFormContentOffsetBottom(document?.getElementById('cards-resource-footer')?.clientHeight || 0);
+  }, [pages])
 
   useEffect(() => {
     if (isEdit) {
@@ -438,13 +440,13 @@ function Form (props) {
                     visibleCallback={pageResult.callback}
                     pageActive={pageResult.page.visible}
                     isEdit={isEdit}
-                    contentOffset={formContentOffset}
+                    contentOffset={{top: formContentOffsetTop, bottom: formContentOffsetBottom}}
                   />
                 })
             }
           </FormUpdateProvider>
         </FormProvider>
-        <Grid item xs={12} className={classes.formFooter}>
+        <Grid item xs={12} className={classes.formFooter} id="cards-resource-footer">
           <FormPagination
               saveInProgress={saveInProgress}
               lastSaveStatus={lastSaveStatus}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -120,7 +120,7 @@ let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, o
  * @param {string} key the node name of the section definition JCR node
  * @returns a React component that renders the section
  */
-let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onChange, visibleCallback, pageActive, isEdit, instanceId) => {
+let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onChange, visibleCallback, pageActive, isEdit, instanceId, contentOffset) => {
   // Find the existing AnswerSection for this section, if available
   const existingQuestionAnswer = existingAnswer && Object.entries(existingAnswer)
     .filter(([key, value]) => value["sling:resourceType"] == "cards/AnswerSection"
@@ -138,6 +138,7 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onCha
       pageActive={pageActive}
       isEdit={isEdit}
       instanceId={instanceId || ''}
+      contentOffset={contentOffset}
       />
   );
 }
@@ -171,14 +172,14 @@ let displayInformation = (infoDefinition, key, classes, pageActive, isEdit) => {
  * @returns a React component that renders the section
  */
  export default function FormEntry(props) {
-  let { classes, entryDefinition, path, depth, existingAnswers, keyProp, onAddedAnswerPath, sectionAnswersState, onChange, visibleCallback, pageActive, isEdit, instanceId} = props;
+  let { classes, entryDefinition, path, depth, existingAnswers, keyProp, onAddedAnswerPath, sectionAnswersState, onChange, visibleCallback, pageActive, isEdit, instanceId, contentOffset} = props;
   // TODO: As before, I'm writing something that's basically an if statement
   // this should instead be via a componentManager
   if (QUESTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
     if (visibleCallback) visibleCallback(true);
     return displayQuestion(entryDefinition, path, existingAnswers, keyProp, classes, onAddedAnswerPath, sectionAnswersState, onChange, pageActive, isEdit, instanceId);
   } else if (SECTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
-    return displaySection(entryDefinition, path, depth, existingAnswers, keyProp, onChange, visibleCallback, pageActive, isEdit, instanceId);
+    return displaySection(entryDefinition, path, depth, existingAnswers, keyProp, onChange, visibleCallback, pageActive, isEdit, instanceId, contentOffset);
   } else if (INFO_TYPES.includes(entryDefinition["jcr:primaryType"])) {
     return displayInformation(entryDefinition, keyProp, classes, pageActive, isEdit);
   }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
@@ -182,6 +182,7 @@ let Questionnaire = (props) => {
               <QuestionnairePreview
                 data={data}
                 title={questionnaireTitle}
+                contentOffset={props.contentOffset}
               />
             </Grid>
           </Grid>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
@@ -45,12 +45,17 @@ function QuestionnairePreview (props) {
   let [ pages, setPages ] = useState(null);
   let [ removeWindowHandlers, setRemoveWindowHandlers ] = useState();
   let [ actionsMenu, setActionsMenu ] = useState(null);
+  let [ contentOffset, setContentOffset ] = useState(props.contentOffset);
   let paginationEnabled = !!data?.paginate;
 
   let pageNameWriter = usePageNameWriterContext();
   useEffect(() => {
     pageNameWriter(title);
   }, [title])
+
+  useEffect(() => {
+    setContentOffset(props.contentOffset + (document?.getElementById('cards-resource-header')?.clientHeight || 0));
+  }, [])
 
   // If the data has not yet been fetched, return an in-progress symbol
   if (!data) {
@@ -86,6 +91,7 @@ function QuestionnairePreview (props) {
                 visibleCallback={pageResult.callback}
                 pageActive={pageResult.page.visible}
                 isEdit={true}
+                contentOffset={contentOffset}
               />
             })
         }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
@@ -45,7 +45,8 @@ function QuestionnairePreview (props) {
   let [ pages, setPages ] = useState(null);
   let [ removeWindowHandlers, setRemoveWindowHandlers ] = useState();
   let [ actionsMenu, setActionsMenu ] = useState(null);
-  let [ contentOffset, setContentOffset ] = useState(props.contentOffset);
+  let [ contentOffsetTop, setContentOffsetTop ] = useState(props.contentOffset);
+  let [ contentOffsetBottom, setContentOffsetBottom ] = useState(0);
   let paginationEnabled = !!data?.paginate;
 
   let pageNameWriter = usePageNameWriterContext();
@@ -54,8 +55,9 @@ function QuestionnairePreview (props) {
   }, [title])
 
   useEffect(() => {
-    setContentOffset(props.contentOffset + (document?.getElementById('cards-resource-header')?.clientHeight || 0));
-  }, [])
+    setContentOffsetTop(props.contentOffset + (document?.getElementById('cards-resource-header')?.clientHeight || 0));
+    setContentOffsetBottom(document?.getElementById('cards-resource-footer')?.clientHeight || 0);
+  }, [pages])
 
   // If the data has not yet been fetched, return an in-progress symbol
   if (!data) {
@@ -91,13 +93,13 @@ function QuestionnairePreview (props) {
                 visibleCallback={pageResult.callback}
                 pageActive={pageResult.page.visible}
                 isEdit={true}
-                contentOffset={contentOffset}
+                contentOffset={{top: contentOffsetTop, bottom: contentOffsetBottom}}
               />
             })
         }
         </FormUpdateProvider>
       </FormProvider>
-      <Grid item xs={12} className={classes.formFooter}>
+      <Grid item xs={12} className={classes.formFooter} id="cards-resource-footer">
         <FormPagination
             paginationEnabled={paginationEnabled}
             questionnaireData={data}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
@@ -56,7 +56,7 @@ function QuestionnairePreview (props) {
 
   useEffect(() => {
     setContentOffsetTop(props.contentOffset + (document?.getElementById('cards-resource-header')?.clientHeight || 0));
-    setContentOffsetBottom(document?.getElementById('cards-resource-footer')?.clientHeight || 0);
+    paginationEnabled && setContentOffsetBottom(document?.getElementById('cards-resource-footer')?.clientHeight || 0);
   }, [pages])
 
   // If the data has not yet been fetched, return an in-progress symbol

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -314,6 +314,26 @@ const questionnaireStyle = theme => ({
     hiddenSection: {
         display: "none"
     },
+    headerSection : {
+      position: "sticky",
+      top: 0,
+      zIndex: 2,
+      "& > .MuiCollapse-wrapper" : {
+        border: "1px solid " + theme.palette.primary.light,
+      },
+      "& .MuiGrid-item:not(:first-child)": {
+        paddingTop: 0,
+      },
+      "& .MuiGrid-item:not(:last-child)": {
+        paddingBottom: 0,
+      },
+      "& .MuiGrid-item:not(.MuiCollapse-container) > *": {
+        background: grey[100],
+      },
+      "& .MuiCard-root" : {
+        borderColor: "transparent",
+      },
+    },
     footerSection : {
       position: "sticky",
       bottom: 0,

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ResourceHeader.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ResourceHeader.jsx
@@ -113,7 +113,7 @@ function ResourceHeader (props) {
 
   return (
     <>
-    <Grid item xs={12} className={classes.resourceHeader} style={{top: props.contentOffset}}>
+    <Grid item xs={12} className={classes.resourceHeader} style={{top: props.contentOffset}} id="cards-resource-header">
       <Grid container direction="row" justify="space-between" alignItems="center">
         <Grid item>
           <Breadcrumbs separator={separator}>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -64,7 +64,7 @@ function createTitle(label, idx, isRecurrent) {
  * @param {Object} sectionDefinition the section definition JSON
  */
 function Section(props) {
-  const { classes, depth, existingAnswer, path, sectionDefinition, onChange, visibleCallback, pageActive, isEdit, instanceId } = props;
+  const { classes, depth, existingAnswer, path, sectionDefinition, onChange, visibleCallback, pageActive, isEdit, instanceId, contentOffset } = props;
   const isRecurrent = sectionDefinition['recurrent'];
   const { displayMode } = sectionDefinition;
   const [ focus, setFocus ] = useState(false);
@@ -166,6 +166,7 @@ function Section(props) {
       mountOnEnter
       unmountOnExit
       className={collapseClasses.join(" ")}
+      style={displayMode == 'header' ? {top : contentOffset}: {}}
       >
       {instanceLabels.map( (uuid, idx) => {
           const sectionPath = path + "/" + uuid;
@@ -248,6 +249,7 @@ function Section(props) {
                         classes={classes}
                         onChange={onChange}
                         isEdit={isEdit}
+                        contentOffset={contentOffset}
                         pageActive={pageActive}
                         sectionAnswersState={removableAnswers}
                         onAddedAnswerPath={(newAnswers) => {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -152,6 +152,13 @@ function Section(props) {
     collapseClasses.push(classes.hiddenSection);
   }
 
+  let sectionPosition = {};
+  if (displayMode == 'header') {
+    sectionPosition.top = contentOffset.top;
+  } else if (displayMode == 'footer') {
+    sectionPosition.bottom = contentOffset.bottom;
+  }
+
   // mountOnEnter and unmountOnExit force the inputs and children to be outside of the DOM during form submission
   // if it is not currently visible
   return useCallback(
@@ -166,7 +173,7 @@ function Section(props) {
       mountOnEnter
       unmountOnExit
       className={collapseClasses.join(" ")}
-      style={displayMode == 'header' ? {top : contentOffset}: {}}
+      style={sectionPosition}
       >
       {instanceLabels.map( (uuid, idx) => {
           const sectionPath = path + "/" + uuid;

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Section.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Section.json
@@ -7,6 +7,7 @@
         "recurrent": "boolean",
         "initialNumberOfInstances" : "long"
       },
+      "header" : {},
       "footer" : {}
     }
   }

--- a/modules/homepage/src/main/frontend/src/themePage/indexStyle.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/indexStyle.jsx
@@ -33,7 +33,7 @@ const appStyle = theme => ({
   },
   content: {
     marginTop: theme.spacing(3),
-    padding: "30px 15px"
+    padding: "30px 15px 15px"
   },
   container,
   map: {

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/StickySectionTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/StickySectionTest.xml
@@ -22,7 +22,7 @@
 	<primaryNodeType>cards:Questionnaire</primaryNodeType>
 	<property>
 		<name>title</name>
-		<value>Footer Sections Test</value>
+		<value>Header / Footer Sections Test</value>
 		<type>String</type>
 	</property>
 	<property>
@@ -47,6 +47,56 @@
 		<type>String</type>
 	</property>
 
+	<node>
+		<name>header_section_with_info</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>displayMode</name>
+			<value>header</value>
+			<type>String</type>
+		</property>
+		<node>
+			<name>info</name>
+			<primaryNodeType>cards:Information</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>
+#### This is information that should stick to the top until "Group 2" appears.
+* This list makes the ...
+* ... the content longer.
+				</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
+		<name>header_section_with_question</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>displayMode</name>
+			<value>header</value>
+			<type>String</type>
+		</property>
+		<node>
+			<name>header_question_1</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>This is a question that should stick to the top</value>
+				<type>String</type>
+			</property>
+                        <property>
+                                <name>description</name>
+                                <value>until "Group 2" appears</value>
+                                <type>String</type>
+                        </property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+		</node>
+	</node>
 	<node>
 		<name>q1_1</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
@@ -208,6 +258,56 @@
 		<type>String</type>
 	</property>
 
+	<node>
+		<name>header_section_with_info</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>displayMode</name>
+			<value>header</value>
+			<type>String</type>
+		</property>
+		<node>
+			<name>info</name>
+			<primaryNodeType>cards:Information</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>
+#### This is information that should stick to the top until "Group 2" appears.
+* This list makes the ...
+* ... the content longer.
+				</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
+		<name>header_section_with_question</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>displayMode</name>
+			<value>header</value>
+			<type>String</type>
+		</property>
+		<node>
+			<name>header_question_2</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>This is another question that should stick to the top</value>
+				<type>String</type>
+			</property>
+                        <property>
+                                <name>description</name>
+                                <value>all the way to the end of the form</value>
+                                <type>String</type>
+                        </property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+		</node>
+	</node>
 	<node>
 		<name>q1_2</name>
 		<primaryNodeType>cards:Question</primaryNodeType>


### PR DESCRIPTION
In draft mode until #739 is merged.

Also includes a fix for the footer sections introduced in #739: corrected the footer section positioning on paginated forms.

To test, use the "Header/ Footer Sections Test" questionnaire available in the test run mode. The functionality should be tested both in questionnaire preview mode and in the form editing mode.