### PR TITLE
CARDS-1324: Unable to delete questions from questionnaire designer in some situations

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/QuestionnaireItemCard.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/QuestionnaireItemCard.jsx
@@ -23,7 +23,8 @@ import PropTypes from 'prop-types';
 import {
   Card,
   CardContent,
-  IconButton
+  IconButton,
+  Tooltip,
 } from "@material-ui/core";
 
 import DeleteIcon from "@material-ui/icons/Delete";
@@ -88,14 +89,18 @@ let QuestionnaireItemCard = (props) => {
           <div>
             {action}
             {!disableEdit &&
-            <IconButton onClick={() => { setEditDialogOpen(true); }}>
-              <EditIcon />
-            </IconButton>
+            <Tooltip title="Edit">
+              <IconButton onClick={() => { setEditDialogOpen(true); }}>
+                <EditIcon />
+              </IconButton>
+            </Tooltip>
             }
             {!disableDelete &&
-            <IconButton onClick={() => { setDeleteDialogOpen(true); }}>
-              <DeleteIcon />
-            </IconButton>
+            <Tooltip title="Delete">
+              <IconButton onClick={() => { setDeleteDialogOpen(true); }} disabled={data['@referenced'] == true}>
+                <DeleteIcon />
+              </IconButton>
+            </Tooltip>
             }
           </div>
         }


### PR DESCRIPTION
Disabled the delete buttons when the question/section is `@referenced`, to avoid running into a server error when attempting deletion.

To test:
* open for editing a questionnaire without any forms -> all delete buttons should be enabled
* create a form from that questionnaire, enter some answers
* open the questionnaire for editing again -> the delete buttons for questions that have answers and for sections that have answer sets should be disabled.

The PR is in draft mode because the delete buttons of some questions/sections that would not have thrown an error upon deletion (e.g. some auto-created empty answers) still get get disabled.