### PR TITLE
CARDS-742: Sections with no visible questions get marked incomplete

### DIFF
--- a/modules/form-completion-status/src/main/java/io/uhndata/cards/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/io/uhndata/cards/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -265,6 +265,21 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     }
 
     /**
+     * Checks if a NodeBuilder represents an empty Form and returns true
+     * if that is the case. Otherwise, this method returns false.
+     *
+     */
+    private boolean isEmptyForm(NodeBuilder n)
+    {
+        if (isForm(n)) {
+            if (!(n.getChildNodeNames().iterator().hasNext())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Gather all status flags from all the (satisfied) descendants of the current node and store them as the status
      * flags of the current node.
      *
@@ -275,8 +290,8 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         // Iterate through all children of this node
         final Iterator<String> childrenNames = this.currentNodeBuilder.getChildNodeNames().iterator();
         boolean isInvalid = false;
-        // If there are no children yet, the form is brand new, thus incomplete
-        boolean isIncomplete = !childrenNames.hasNext();
+        // If this Form has no children yet, the form is brand new, thus incomplete
+        boolean isIncomplete = isEmptyForm(this.currentNodeBuilder);
         while (childrenNames.hasNext()) {
             final String selectedChildName = childrenNames.next();
             final NodeBuilder selectedChild = this.currentNodeBuilder.getChildNode(selectedChildName);

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/LabeledConditionalSections.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/LabeledConditionalSections.xml
@@ -1,0 +1,410 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>LabeledConditionalSections</name>
+	<primaryNodeType>cards:Questionnaire</primaryNodeType>
+	<property>
+		<name>title</name>
+		<value>Labeled Conditional Sections</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>description</name>
+		<value>CARDS-742</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>requiredSubjectTypes</name>
+		<values>
+			<value>/SubjectTypes/Patient</value>
+		</values>
+		<type>Reference</type>
+	</property>
+	<node>
+		<name>Label 1</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>label</name>
+			<value>Label 1</value>
+			<type>String</type>
+		</property>
+		<node>
+			<name>date001</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Date 1</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>MM-dd-yyyy</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+		</node>
+		<node>
+			<name>Conditional Data Fields 001</name>
+			<primaryNodeType>cards:Section</primaryNodeType>
+			<node>
+				<name>date002</name>
+				<primaryNodeType>cards:Question</primaryNodeType>
+				<property>
+					<name>text</name>
+					<value>Date 2</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>dataType</name>
+					<value>date</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>dateFormat</name>
+					<value>MM-dd-yyyy</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>maxAnswers</name>
+					<value>1</value>
+					<type>Long</type>
+				</property>
+				<property>
+					<name>minAnswers</name>
+					<value>1</value>
+					<type>Long</type>
+				</property>
+			</node>
+			<node>
+				<name>condition</name>
+				<primaryNodeType>cards:Conditional</primaryNodeType>
+				<property>
+					<name>comparator</name>
+					<value>=</value>
+					<type>String</type>
+				</property>
+				<node>
+					<name>operandA</name>
+					<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+					<property>
+						<name>value</name>
+						<values>
+							<value>event_type</value>
+						</values>
+						<type>String</type>
+					</property>
+					<property>
+						<name>isReference</name>
+						<value>True</value>
+						<type>Boolean</type>
+					</property>
+				</node>
+				<node>
+					<name>operandB</name>
+					<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+					<property>
+						<name>value</name>
+						<values>
+							<value>Type B</value>
+						</values>
+						<type>String</type>
+					</property>
+					<property>
+						<name>isReference</name>
+						<value>False</value>
+						<type>Boolean</type>
+					</property>
+				</node>
+			</node>
+		</node>
+		<node>
+			<name>event_type</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Type of event</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>text</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>list</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<node>
+				<name>Type A</name>
+				<primaryNodeType>cards:AnswerOption</primaryNodeType>
+				<property>
+					<name>label</name>
+					<value>Type A</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>value</name>
+					<value>Type A</value>
+					<type>String</type>
+				</property>
+			</node>
+			<node>
+				<name>Type B</name>
+				<primaryNodeType>cards:AnswerOption</primaryNodeType>
+				<property>
+					<name>label</name>
+					<value>Type B</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>value</name>
+					<value>Type B</value>
+					<type>String</type>
+				</property>
+			</node>
+		</node>
+	</node>
+	<node>
+		<name>Type A</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>label</name>
+			<value>Type A</value>
+			<type>String</type>
+		</property>
+		<node>
+			<name>TypeA_Section</name>
+			<primaryNodeType>cards:Section</primaryNodeType>
+			<node>
+				<name>condition</name>
+				<primaryNodeType>cards:Conditional</primaryNodeType>
+				<property>
+					<name>comparator</name>
+					<value>=</value>
+					<type>String</type>
+				</property>
+				<node>
+					<name>operandA</name>
+					<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+					<property>
+						<name>value</name>
+						<values>
+							<value>event_type</value>
+						</values>
+						<type>String</type>
+					</property>
+					<property>
+						<name>isReference</name>
+						<value>True</value>
+						<type>Boolean</type>
+					</property>
+				</node>
+				<node>
+					<name>operandB</name>
+					<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+					<property>
+						<name>value</name>
+						<values>
+							<value>Type A</value>
+						</values>
+						<type>String</type>
+					</property>
+					<property>
+						<name>isReference</name>
+						<value>False</value>
+						<type>Boolean</type>
+					</property>
+				</node>
+			</node>
+		</node>
+		<node>
+			<name>typeA_nameSection</name>
+			<primaryNodeType>cards:Section</primaryNodeType>
+			<node>
+				<name>typeA_name</name>
+				<primaryNodeType>cards:Question</primaryNodeType>
+				<property>
+					<name>text</name>
+					<value>Type A name</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>dataType</name>
+					<value>text</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>minAnswers</name>
+					<value>1</value>
+					<type>Long</type>
+				</property>
+			</node>
+			<node>
+				<name>condition</name>
+				<primaryNodeType>cards:Conditional</primaryNodeType>
+				<property>
+					<name>comparator</name>
+					<value>=</value>
+					<type>String</type>
+				</property>
+				<node>
+					<name>operandA</name>
+					<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+					<property>
+						<name>value</name>
+						<values>
+							<value>event_type</value>
+						</values>
+						<type>String</type>
+					</property>
+					<property>
+						<name>isReference</name>
+						<value>True</value>
+						<type>Boolean</type>
+					</property>
+				</node>
+				<node>
+					<name>operandB</name>
+					<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+					<property>
+						<name>value</name>
+						<values>
+							<value>Type A</value>
+						</values>
+						<type>String</type>
+					</property>
+					<property>
+						<name>isReference</name>
+						<value>False</value>
+						<type>Boolean</type>
+					</property>
+				</node>
+			</node>
+		</node>
+	</node>
+	<node>
+		<name>Type B</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>label</name>
+			<value>Type B</value>
+			<type>String</type>
+		</property>
+		<node>
+			<name>TypeB_Section</name>
+			<primaryNodeType>cards:Section</primaryNodeType>
+			<node>
+				<name>typeB_class</name>
+				<primaryNodeType>cards:Question</primaryNodeType>
+				<property>
+					<name>text</name>
+					<value>Type B name</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>dataType</name>
+					<value>text</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>displayMode</name>
+					<value>input</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>maxAnswers</name>
+					<value>1</value>
+					<type>Long</type>
+				</property>
+				<property>
+					<name>minAnswers</name>
+					<value>1</value>
+					<type>Long</type>
+				</property>
+			</node>
+			<node>
+				<name>condition</name>
+				<primaryNodeType>cards:Conditional</primaryNodeType>
+				<property>
+					<name>comparator</name>
+					<value>=</value>
+					<type>String</type>
+				</property>
+				<node>
+					<name>operandA</name>
+					<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+					<property>
+						<name>value</name>
+						<values>
+							<value>event_type</value>
+						</values>
+						<type>String</type>
+					</property>
+					<property>
+						<name>isReference</name>
+						<value>True</value>
+						<type>Boolean</type>
+					</property>
+				</node>
+				<node>
+					<name>operandB</name>
+					<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+					<property>
+						<name>value</name>
+						<values>
+							<value>Type B</value>
+						</values>
+						<type>String</type>
+					</property>
+					<property>
+						<name>isReference</name>
+						<value>False</value>
+						<type>Boolean</type>
+					</property>
+				</node>
+			</node>
+		</node>
+	</node>
+</node>


### PR DESCRIPTION
This PR fixes the bug described by CARDS-742 where sections with no visible questions were being incorrectly marked as `INCOMPLETE`. The PR also introduces the _Labeled Conditional Sections_ Questionnaire in the `test` runMode for testing this PR.

To test:

1. Build this branch (`mvn clean install`)
2. Start with the `proms` runMode enabled.
3. Create a _Smoking cessation_ Form. Ensure that, on the _Dashboard_, it appears in the _Draft_ tab when it is incomplete and that it appears in the _Completed_ tab when it is complete.
4. Stop CARDS, `rm -rf sling` and restart with the `test` runMode enabled.
5. Create a new _Labeled Conditional Sections_ Form.
6. Verify that for _Type A_ events and _Type B_ events, the Form is placed in the _Completed_ / _Draft_ tab as it should be - that is, _Completed_ when all mandatory questions have been answered, _Draft_ otherwise.