### PR TITLE
CARDS-1355: Review PROMs questionnaires: footer section layout issue

### DIFF
--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
@@ -874,6 +874,30 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 			<type>String</type>
 		</property>
 		<node>
+			<name>gad7_result</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>expression</name>
+				<value>return "### " + @{gad7_score:-0} + " point" + (@{gad7_score:-0} == 1 ? "" : "s")</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>formatted</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value> </value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
 			<name>gad7_score</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
@@ -894,30 +918,6 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 			<property>
 				<name>text</name>
 				<value>Score</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>dataType</name>
-				<value>computed</value>
-				<type>String</type>
-			</property>
-		</node>
-		<node>
-			<name>gad7_result</name>
-			<primaryNodeType>cards:Question</primaryNodeType>
-			<property>
-				<name>expression</name>
-				<value>return "### " + @{gad7_score:-0} + " point" + (@{gad7_score:-0} == 1 ? "" : "s")</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>displayMode</name>
-				<value>formatted</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>text</name>
-				<value> </value>
 				<type>String</type>
 			</property>
 			<property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
@@ -1076,6 +1076,30 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			<type>String</type>
 		</property>
 		<node>
+			<name>phq9_result</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>expression</name>
+				<value>return "### " + @{phq9_score:-0} + " point" + (@{phq9_score:-0} == 1 ? "" : "s")</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>formatted</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value> </value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
 			<name>phq9_score</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
@@ -1096,30 +1120,6 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			<property>
 				<name>text</name>
 				<value>Score</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>dataType</name>
-				<value>computed</value>
-				<type>String</type>
-			</property>
-		</node>
-		<node>
-			<name>phq9_result</name>
-			<primaryNodeType>cards:Question</primaryNodeType>
-			<property>
-				<name>expression</name>
-				<value>return "### " + @{phq9_score:-0} + " point" + (@{phq9_score:-0} == 1 ? "" : "s")</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>displayMode</name>
-				<value>formatted</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>text</name>
-				<value> </value>
 				<type>String</type>
 			</property>
 			<property>


### PR DESCRIPTION
Quick and easy fix for layout issue in footer sections when the first question of a section is hidden: moved the hidden questions lower inside their section.

Before:
![image](https://user-images.githubusercontent.com/651980/130532867-7c794cd9-5067-4a85-8955-cbf61fd888d2.png)


After:
![image](https://user-images.githubusercontent.com/651980/130532735-1695ed64-fbc6-4ff5-b3e2-1f2b26d97805.png)


