### PR TITLE
CARDS-1164: Smaller form headers on smaller screens - action position

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/ResourceHeader.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ResourceHeader.jsx
@@ -115,7 +115,7 @@ function ResourceHeader (props) {
   return (
     <>
     <Grid item xs={12} className={classes.resourceHeader} style={{top: props.contentOffset}} id="cards-resource-header">
-      <Grid container direction="row" justify="space-between" alignItems="center">
+      <Grid container direction="row" justify="space-between" alignItems="center" wrap="nowrap">
         <Grid item>
           <Breadcrumbs separator={separator}>
             {Array.from(breadcrumbs || []).map(item => <Typography variant="overline" key={item}>{item}</Typography>)}
@@ -124,7 +124,7 @@ function ResourceHeader (props) {
             </Collapse>
           </Breadcrumbs>
         </Grid>
-        <Collapse in={!!action &&  fullBreadcrumbTrigger} component={Grid}>
+        <Collapse in={!!action &&  fullBreadcrumbTrigger} component={Grid} item>
           <div className={classes.breadcrumbAction}>{action}</div>
         </Collapse>
       </Grid>


### PR DESCRIPTION
Improved the action position in the sticky header on small screens

Before:
![image](https://user-images.githubusercontent.com/651980/130533610-81443184-5a7f-444a-b264-dd9f564d9f25.png)


After:
![image](https://user-images.githubusercontent.com/651980/130533461-9c35a39f-57e0-455b-bce3-a284969ca44b.png)
