### PR TITLE
CARDS-1355: Review PROMs questionnaires

### DIFF
--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
@@ -75,6 +75,11 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<type>String</type>
 			</property>
 			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
 				<name>maxAnswers</name>
 				<value>1</value>
 				<type>Long</type>
@@ -173,6 +178,11 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<name>text</name>
 				<value>Not being able to stop or control worrying</value>
 				<type>String</type>
+			</property>
+			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
 			</property>
 			<property>
 				<name>maxAnswers</name>
@@ -275,6 +285,11 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<type>String</type>
 			</property>
 			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
 				<name>maxAnswers</name>
 				<value>1</value>
 				<type>Long</type>
@@ -373,6 +388,11 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<name>text</name>
 				<value>Trouble relaxing</value>
 				<type>String</type>
+			</property>
+			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
 			</property>
 			<property>
 				<name>maxAnswers</name>
@@ -475,6 +495,11 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<type>String</type>
 			</property>
 			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
 				<name>maxAnswers</name>
 				<value>1</value>
 				<type>Long</type>
@@ -573,6 +598,11 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<name>text</name>
 				<value>Becoming easily annoyed or irritable</value>
 				<type>String</type>
+			</property>
+			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
 			</property>
 			<property>
 				<name>maxAnswers</name>
@@ -675,6 +705,11 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<type>String</type>
 			</property>
 			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
 				<name>maxAnswers</name>
 				<value>1</value>
 				<type>Long</type>
@@ -772,11 +807,6 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 			<property>
 				<name>text</name>
 				<value>How difficult have these problems made it to do work, take care of things at home, or get along with other people?</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>description</name>
-				<value>Optional, not included in final score but may help assess global impairment</value>
 				<type>String</type>
 			</property>
 			<property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
@@ -77,6 +77,11 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<type>String</type>
 			</property>
 			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
 				<name>maxAnswers</name>
 				<value>1</value>
 				<type>Long</type>
@@ -175,6 +180,11 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<name>text</name>
 				<value>Feeling down, depressed, or hopeless</value>
 				<type>String</type>
+			</property>
+			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
 			</property>
 			<property>
 				<name>maxAnswers</name>
@@ -277,6 +287,11 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<type>String</type>
 			</property>
 			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
 				<name>maxAnswers</name>
 				<value>1</value>
 				<type>Long</type>
@@ -375,6 +390,11 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<name>text</name>
 				<value>Feeling tired or having little energy</value>
 				<type>String</type>
+			</property>
+			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
 			</property>
 			<property>
 				<name>maxAnswers</name>
@@ -477,6 +497,11 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<type>String</type>
 			</property>
 			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
 				<name>maxAnswers</name>
 				<value>1</value>
 				<type>Long</type>
@@ -575,6 +600,11 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<name>text</name>
 				<value>Feeling bad about yourself — or that you are a failure or have let yourself or your family down</value>
 				<type>String</type>
+			</property>
+			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
 			</property>
 			<property>
 				<name>maxAnswers</name>
@@ -677,6 +707,11 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<type>String</type>
 			</property>
 			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
 				<name>maxAnswers</name>
 				<value>1</value>
 				<type>Long</type>
@@ -775,6 +810,11 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<name>text</name>
 				<value>Moving or speaking so slowly that other people could have noticed? Or so fidgety or restless that you have been moving a lot more than usual</value>
 				<type>String</type>
+			</property>
+			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
 			</property>
 			<property>
 				<name>maxAnswers</name>
@@ -877,6 +917,11 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<type>String</type>
 			</property>
 			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
 				<name>maxAnswers</name>
 				<value>1</value>
 				<type>Long</type>
@@ -974,11 +1019,6 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			<property>
 				<name>text</name>
 				<value>How difficult have these problems made it to do work, take care of things at home, or get along with other people?</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>description</name>
-				<value>Optional, not included in final score but may help assess global impairment</value>
 				<type>String</type>
 			</property>
 			<property>


### PR DESCRIPTION
GAD and PHQ questionnaires:
* made questions used for computing the score mandatory
* removed the description from the optional question (the patient-type user doesn't need to see it)