### PR TITLE
CARDS-1374_demo

### DIFF
--- a/distribution/src/main/provisioning/50-cards.txt
+++ b/distribution/src/main/provisioning/50-cards.txt
@@ -55,6 +55,9 @@
     # Ignore unwanted terms when installing vocabularies from BioPortal
     io.uhndata.cards/cards-modules-vocabularies-ignore/${cards.version}
 
+    # Allow for users to SAML login with their UHN account
+    io.uhndata.cards/cards-modules-uhn-saml/${cards.version}
+
 [artifacts runModes=permissions_ownership]
     io.uhndata.cards/cards-permissions-ownership/${cards.version}
 

--- a/distribution/src/main/provisioning/50-cards.txt
+++ b/distribution/src/main/provisioning/50-cards.txt
@@ -55,9 +55,6 @@
     # Ignore unwanted terms when installing vocabularies from BioPortal
     io.uhndata.cards/cards-modules-vocabularies-ignore/${cards.version}
 
-    # Allow for users to SAML login with their UHN account
-    io.uhndata.cards/cards-modules-uhn-saml/${cards.version}
-
 [artifacts runModes=permissions_ownership]
     io.uhndata.cards/cards-permissions-ownership/${cards.version}
 

--- a/distribution/src/main/provisioning/51-saml.txt
+++ b/distribution/src/main/provisioning/51-saml.txt
@@ -1,0 +1,25 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+
+# Enables a user to login using a third-party Identity Provider via SAML
+[feature name=saml]
+
+[artifacts runModes=saml]
+    # Allow for users to SAML login with their UHN account
+    io.uhndata.cards/cards-modules-uhn-saml/${cards.version}

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -151,18 +151,18 @@ class SignIn extends React.Component {
                     <InputLabel htmlFor="j_password">Password for {this.state.username}</InputLabel>
                     <Input name="j_password" type={this.state.passwordIsMasked ? 'text' : 'password'} id="j_password" autoComplete="current-password" autoFocus onChange={(event) => {this.setState({password: event.target.value});}}
                       endAdornment={
-                      <InputAdornment position="end">
-                        <Tooltip title={this.state.passwordIsMasked ? "Mask Password" : "Show Password"}>
-                          <IconButton
-                            aria-label="Toggle password visibility"
-                            onClick={this.togglePasswordMask}
-                          >
-                            {this.state.passwordIsMasked ? <VisibilityIcon/> : <VisibilityOffIcon/>}
-                          </IconButton>
-                        </Tooltip>
-                      </InputAdornment>
-                    }
-                  />
+                        <InputAdornment position="end">
+                          <Tooltip title={this.state.passwordIsMasked ? "Mask Password" : "Show Password"}>
+                            <IconButton
+                              aria-label="Toggle password visibility"
+                              onClick={this.togglePasswordMask}
+                            >
+                              {this.state.passwordIsMasked ? <VisibilityIcon/> : <VisibilityOffIcon/>}
+                            </IconButton>
+                          </Tooltip>
+                        </InputAdornment>
+                      }
+                    />
                   </FormControl>
                   <Button
                     type="submit"

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -126,9 +126,13 @@ class SignIn extends React.Component {
                         .then((resp) => {
                           if (resp.ok) {
                             this.setState({failedLogin: false});
+                            return resp.json();
                           } else {
                             this.setState({failedLogin: true});
                           }
+                        })
+                        .then((data) => {
+                          data && window.open(data.value + "&username=" + this.state.username, "FederatedLoginPopupWindow", "width=600,height=600");
                         })
                         .catch((err) => this.setState({failedLogin: true}))
                       } else {

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -40,7 +40,7 @@ class SignIn extends React.Component {
 
     this.state = {
       passwordIsMasked: false,
-      failedLogin: false,
+      failedLogin: undefined,
 
       username: "",
       password: "",
@@ -83,14 +83,14 @@ class SignIn extends React.Component {
         throw Error(response.statusText);
         this.props.handleLogin && this.props.handleLogin(false);
       }
-      this.setState({failedLogin: false});
+      this.setState({failedLogin: undefined});
       this.props.handleLogin && this.props.handleLogin(true);
       if (this.props.redirectOnLogin) {
         window.location = this.loginRedirectPath();
       }
     })
     .catch((error) => {
-      this.setState({failedLogin: true});
+      this.setState({failedLogin: "Invalid username or password"});
       this.props.handleLogin && this.props.handleLogin(false);
     });
   }
@@ -101,7 +101,7 @@ class SignIn extends React.Component {
 
     return (
         <div className={classes.main}>
-            {this.state.failedLogin && <Typography component="h2" className={classes.errorMessage}>Invalid username or password</Typography>}
+            {this.state.failedLogin && <Typography component="h2" className={classes.errorMessage}>{this.state.failedLogin}</Typography>}
 
             <form className={classes.form} onSubmit={(event)=>{event.preventDefault(); this.submitLogin();}} >
 
@@ -126,10 +126,10 @@ class SignIn extends React.Component {
                         fetch(window.location.origin + "/apps/cards/SAMLDomains/" + remoteDomain + ".json")
                         .then((resp) => {
                           if (resp.ok) {
-                            this.setState({failedLogin: false});
+                            this.setState({failedLogin: undefined});
                             return resp.json();
                           } else {
-                            this.setState({failedLogin: true});
+                            this.setState({failedLogin: "Unrecognized email domain"});
                           }
                         })
                         .then((data) => {
@@ -144,9 +144,9 @@ class SignIn extends React.Component {
                           let top = (screenHeight - popupHeight) / 2 / systemZoom + screenTop;
                           data && window.open(data.value + "&username=" + this.state.username, "FederatedLoginPopupWindow", "width=" + (popupWidth / systemZoom) + ",height=" + (popupHeight / systemZoom) + ",top=" + top + ",left=" + left);
                         })
-                        .catch((err) => this.setState({failedLogin: true}))
+                        .catch((err) => this.setState({failedLogin: "Error occurred while handling third-party identity provider"}))
                       } else {
-                        this.setState({failedLogin: true});
+                        this.setState({failedLogin: "Invalid email address"});
                       }
                     }}
                   >
@@ -185,6 +185,7 @@ class SignIn extends React.Component {
                         className={classes.submit}
                         onClick={() => {
                           this.setState({
+                            failedLogin: undefined,
                             username: "",
                             password: "",
                             phase: "USERNAME_ENTRY"

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -115,7 +115,26 @@ class SignIn extends React.Component {
                     variant="contained"
                     color="primary"
                     className={classes.submit}
-                    onClick={() => this.setState({phase: "PASSWORD_ENTRY"})}
+                    onClick={() => {
+                      if (this.state.username.split("@").length - 1 == 0) {
+                        this.setState({phase: "PASSWORD_ENTRY"});
+                      } else if (this.state.username.split("@").length - 1 == 1) {
+                        let remoteUser = this.state.username.split("@")[0];
+                        let remoteDomain = this.state.username.split("@")[1];
+                        // Do a fetch() to see if we have a SAML configuration for this domain
+                        fetch(window.location.origin + "/apps/cards/SAMLDomains/" + remoteDomain + ".json")
+                        .then((resp) => {
+                          if (resp.ok) {
+                            this.setState({failedLogin: false});
+                          } else {
+                            this.setState({failedLogin: true});
+                          }
+                        })
+                        .catch((err) => this.setState({failedLogin: true}))
+                      } else {
+                        this.setState({failedLogin: true});
+                      }
+                    }}
                   >
                     Next
                   </Button>

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -133,7 +133,16 @@ class SignIn extends React.Component {
                           }
                         })
                         .then((data) => {
-                          data && window.open(data.value + "&username=" + this.state.username, "FederatedLoginPopupWindow", "width=600,height=600");
+                          let popupWidth = 600;
+                          let popupHeight = 600;
+                          let screenLeft = window.screenLeft !== undefined ? window.screenLeft : window.screenX;
+                          let screenTop = window.screenTop !== undefined ? window.screenTop : window.screenY;
+                          let screenWidth = window.innerWidth;
+                          let screenHeight = window.innerHeight;
+                          let systemZoom = screenWidth / window.screen.availWidth;
+                          let left = (screenWidth - popupWidth) / 2 / systemZoom + screenLeft;
+                          let top = (screenHeight - popupHeight) / 2 / systemZoom + screenTop;
+                          data && window.open(data.value + "&username=" + this.state.username, "FederatedLoginPopupWindow", "width=" + (popupWidth / systemZoom) + ",height=" + (popupHeight / systemZoom) + ",top=" + top + ",left=" + left);
                         })
                         .catch((err) => this.setState({failedLogin: true}))
                       } else {

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -148,8 +148,8 @@ class SignIn extends React.Component {
               { (this.state.phase == "PASSWORD_ENTRY") &&
                 <React.Fragment>
                   <FormControl margin="normal" required fullWidth>
-                    <InputLabel htmlFor="j_password">Password</InputLabel>
-                    <Input name="j_password" type={this.state.passwordIsMasked ? 'text' : 'password'} id="j_password" autoComplete="current-password" onChange={(event) => {this.setState({password: event.target.value});}}
+                    <InputLabel htmlFor="j_password">Password for {this.state.username}</InputLabel>
+                    <Input name="j_password" type={this.state.passwordIsMasked ? 'text' : 'password'} id="j_password" autoComplete="current-password" autoFocus onChange={(event) => {this.setState({password: event.target.value});}}
                       endAdornment={
                       <InputAdornment position="end">
                         <Tooltip title={this.state.passwordIsMasked ? "Mask Password" : "Show Password"}>

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -42,7 +42,9 @@ class SignIn extends React.Component {
       failedLogin: false,
 
       username: "",
-      password: ""
+      password: "",
+
+      phase: "USERNAME_ENTRY"
     };
   }
 
@@ -102,37 +104,54 @@ class SignIn extends React.Component {
 
             <form className={classes.form} onSubmit={(event)=>{event.preventDefault(); this.submitLogin();}} >
 
-              <FormControl margin="normal" required fullWidth>
-                <InputLabel htmlFor="j_username">Username</InputLabel>
-                <Input id="j_username" name="j_username" autoComplete="email" autoFocus onChange={(event) => {this.setState({username: event.target.value});}}/>
-              </FormControl>
+              { (this.state.phase == "USERNAME_ENTRY") &&
+                <React.Fragment>
+                  <FormControl margin="normal" required fullWidth>
+                    <InputLabel htmlFor="j_username">Username</InputLabel>
+                    <Input id="j_username" name="j_username" autoComplete="email" autoFocus onChange={(event) => {this.setState({username: event.target.value});}}/>
+                  </FormControl>
+                  <Button
+                    fullWidth
+                    variant="contained"
+                    color="primary"
+                    className={classes.submit}
+                    onClick={() => this.setState({phase: "PASSWORD_ENTRY"})}
+                  >
+                    Next
+                  </Button>
+                </React.Fragment>
+              }
 
-              <FormControl margin="normal" required fullWidth>
-                <InputLabel htmlFor="j_password">Password</InputLabel>
-                <Input name="j_password" type={this.state.passwordIsMasked ? 'text' : 'password'} id="j_password" autoComplete="current-password" onChange={(event) => {this.setState({password: event.target.value});}}
-                  endAdornment={
-                  <InputAdornment position="end">
-                    <Tooltip title={this.state.passwordIsMasked ? "Mask Password" : "Show Password"}>
-                      <IconButton
-                        aria-label="Toggle password visibility"
-                        onClick={this.togglePasswordMask}
-                      >
-                        {this.state.passwordIsMasked ? <VisibilityIcon/> : <VisibilityOffIcon/>}
-                      </IconButton>
-                    </Tooltip>
-                  </InputAdornment>
-                }
-              />
-              </FormControl>
-              <Button
-                type="submit"
-                fullWidth
-                variant="contained"
-                color="primary"
-                className={classes.submit}
-              >
-                Sign in
-              </Button>
+              { (this.state.phase == "PASSWORD_ENTRY") &&
+                <React.Fragment>
+                  <FormControl margin="normal" required fullWidth>
+                    <InputLabel htmlFor="j_password">Password</InputLabel>
+                    <Input name="j_password" type={this.state.passwordIsMasked ? 'text' : 'password'} id="j_password" autoComplete="current-password" onChange={(event) => {this.setState({password: event.target.value});}}
+                      endAdornment={
+                      <InputAdornment position="end">
+                        <Tooltip title={this.state.passwordIsMasked ? "Mask Password" : "Show Password"}>
+                          <IconButton
+                            aria-label="Toggle password visibility"
+                            onClick={this.togglePasswordMask}
+                          >
+                            {this.state.passwordIsMasked ? <VisibilityIcon/> : <VisibilityOffIcon/>}
+                          </IconButton>
+                        </Tooltip>
+                      </InputAdornment>
+                    }
+                  />
+                  </FormControl>
+                  <Button
+                    type="submit"
+                    fullWidth
+                    variant="contained"
+                    color="primary"
+                    className={classes.submit}
+                  >
+                    Sign in
+                  </Button>
+                </React.Fragment>
+              }
             </form>
         </div>
     );

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -21,6 +21,7 @@ import PropTypes from 'prop-types';
 import {
     Button,
     FormControl,
+    Grid,
     IconButton,
     Input,
     InputAdornment,
@@ -164,15 +165,40 @@ class SignIn extends React.Component {
                       }
                     />
                   </FormControl>
-                  <Button
-                    type="submit"
-                    fullWidth
-                    variant="contained"
-                    color="primary"
-                    className={classes.submit}
-                  >
-                    Sign in
-                  </Button>
+                  <Grid container direction="row" justifyContent="center" alignItems="center">
+                    <Grid item xs={3}>
+                    </Grid>
+                    <Grid item xs={3}>
+                      <Button
+                        fullWidth
+                        variant="contained"
+                        color="primary"
+                        className={classes.submit}
+                        onClick={() => {
+                          this.setState({
+                            username: "",
+                            password: "",
+                            phase: "USERNAME_ENTRY"
+                          });
+                        }}
+                      >
+                        Back
+                      </Button>
+                    </Grid>
+                    <Grid item xs={3}>
+                      <Button
+                        type="submit"
+                        fullWidth
+                        variant="contained"
+                        color="primary"
+                        className={classes.submit}
+                      >
+                        Sign in
+                      </Button>
+                    </Grid>
+                    <Grid item xs={3}>
+                    </Grid>
+                  </Grid>
                 </React.Fragment>
               }
             </form>

--- a/modules/uhn-saml/pom.xml
+++ b/modules/uhn-saml/pom.xml
@@ -7,9 +7,7 @@
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
-
   http://www.apache.org/licenses/LICENSE-2.0
-
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,35 +20,27 @@
 
   <parent>
     <groupId>io.uhndata.cards</groupId>
-    <artifactId>cards-parent</artifactId>
+    <artifactId>cards-modules</artifactId>
     <version>0.9-SNAPSHOT</version>
   </parent>
 
-  <artifactId>cards-modules</artifactId>
-  <packaging>pom</packaging>
-  <name>CARDS Modules</name>
+  <artifactId>cards-modules-uhn-saml</artifactId>
+  <packaging>bundle</packaging>
+  <name>CARDS - UHN SAML</name>
 
-  <modules>
-    <module>startup-customization</module>
-    <module>form-completion-status</module>
-    <module>commons</module>
-    <module>ui-extension</module>
-    <module>login</module>
-    <module>homepage</module>
-    <module>pedigree</module>
-    <module>subjects</module>
-    <module>data-entry</module>
-    <module>ldap-support</module>
-    <module>utils</module>
-    <module>principals</module>
-    <module>permissions</module>
-    <module>permissions-ownership</module>
-    <module>vocabularies</module>
-    <module>demo-banner</module>
-    <module>versioning</module>
-    <module>favicon</module>
-    <module>upgrade-marker</module>
-    <module>vocabularies-ignore</module>
-    <module>uhn-saml</module>
-  </modules>
+  <build>
+    <plugins>
+      <!-- This is an OSGi bundle -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Sling-Initial-Content>SLING-INF/content/;path:=/apps/cards/SAMLDomains/</Sling-Initial-Content>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/modules/uhn-saml/src/main/resources/SLING-INF/content/uhn.ca.json
+++ b/modules/uhn-saml/src/main/resources/SLING-INF/content/uhn.ca.json
@@ -1,0 +1,4 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "value": "https://fs.uhn.ca/adfs/ls/?wa=wsignin1.0&wtrealm=urn:federation:MicrosoftOnline"
+}


### PR DESCRIPTION
This draft PR contains the work done thus far on the _CARDS-1374_ task. Right now, the following cases are handled:

- The user logs in with a username containing no `@` symbols. They are then prompted to provide their password for their local Apache Sling account.
- The user logs in with a username of `<USERNAME>@uhn.ca` and a browser-native popup window opens to a UHN Federated Services login page where they can provide their UHN password. _Please note that this login page will not actually log the user into CARDS as SAML authentication for CARDS has not yet been setup. The example URL that opens the UHN Federated Services login page was taken from the Office 365 login._
- The user attempts to login with a username containing an identity provider name other than `uhn.ca` or they specify multiple `@` symbols and a login error is displayed.

This behavior should happen both on the initial login screen as well as on any Material-UI login dialogs invoked by a call to `fetchWithReLogin`.