### PR TITLE
 Improvement: only list the highest affected node, not all the descendants, when forms/sections/answers will be affected by a deletion

### DIFF
--- a/modules/data-entry/src/main/java/io/uhndata/cards/DeleteServlet.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/DeleteServlet.java
@@ -342,6 +342,7 @@ public class DeleteServlet extends SlingAllMethodsServlet
      *
      * @return a string in the format "2 forms, 1 subject(subjectName)" for all traversed nodes
      */
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
     private String listReferrersFromTraversal()
     {
         try {
@@ -380,12 +381,16 @@ public class DeleteServlet extends SlingAllMethodsServlet
             }
 
             List<String> results = new ArrayList<>();
-            addNodesToResult(results, "form", formCount);
+            if (formCount > 0) {
+                addNodesToResult(results, "form", formCount);
+            } else if (answerSectionCount > 0) {
+                addNodesToResult(results, "answer section", answerSectionCount);
+            } else if (answerCount > 0) {
+                addNodesToResult(results, "answer", answerCount);
+            }
             addNodesToResult(results, "subject", subjects);
             addNodesToResult(results, "subject type", subjectTypes);
             addNodesToResult(results, "questionnaire", questionnaires);
-            addNodesToResult(results, "answer section", answerSectionCount);
-            addNodesToResult(results, "answer", answerCount);
             addNodesToResult(results, "other", otherCount);
 
             return stringArrayToList(results);


### PR DESCRIPTION
This is on top of #754 , and it changes the message displayed when deleting a questionnaire or a section to omit the number of children of the affected nodes, e.g. instead of saying that a questionnaire is referenced in 3 forms, 27 answer sections, and 300 answers, only the 3 forms are mentioned.

This is also a partial implementation of CARDS-1379, but not a good enough one.