### PR TITLE
CARDS-1373 & CARDS-1229 regression fix: BooleanQuestion options no longer appear selected.

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/BooleanQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/BooleanQuestion.jsx
@@ -61,9 +61,9 @@ function BooleanQuestion(props) {
 
   // Define the defaults for yesLabel, etc. here because we want questionDefinition to be able to
   // override them, and the props to be able to override the questionDefinition
-  let options = [[yesLabel || "Yes", 1, true], [noLabel || "No", 0, true]];
+  let options = [[yesLabel || "Yes", "1", true], [noLabel || "No", "0", true]];
   if (enableUnknown) {
-    options.push([unknownLabel || "Unknown", -1, true]);
+    options.push([unknownLabel || "Unknown", "-1", true]);
   }
 
   return (


### PR DESCRIPTION
To reproduce the issue on `dev`, start CARDS in the `lfs` run mode, create a Chemo from, and try to answer the first question ("Chemotherapy").

The regression introduced by PR #761 where all option values get converted to `String` in `MultipleChoice`, except for boolean which are handled outside of `MultipleChoice`.