### PR TITLE
CARDS-1350: Adjust the PHQ and GAD forms to use Number questions instead of Text

### DIFF
--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
@@ -91,7 +91,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>long</value>
 				<type>String</type>
 			</property>
 			<node>
@@ -196,7 +196,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>long</value>
 				<type>String</type>
 			</property>
 			<node>
@@ -301,7 +301,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>long</value>
 				<type>String</type>
 			</property>
 			<node>
@@ -406,7 +406,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>long</value>
 				<type>String</type>
 			</property>
 			<node>
@@ -511,7 +511,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>long</value>
 				<type>String</type>
 			</property>
 			<node>
@@ -616,7 +616,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>long</value>
 				<type>String</type>
 			</property>
 			<node>
@@ -721,7 +721,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>long</value>
 				<type>String</type>
 			</property>
 			<node>
@@ -821,7 +821,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>long</value>
 				<type>String</type>
 			</property>
 			<node>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
@@ -100,7 +100,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>1</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -119,7 +119,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>2</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -138,7 +138,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>3</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -157,7 +157,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>4</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -205,7 +205,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>1</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -224,7 +224,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>2</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -243,7 +243,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>3</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -262,7 +262,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>4</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -310,7 +310,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>1</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -329,7 +329,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>2</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -348,7 +348,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>3</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -367,7 +367,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>4</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -415,7 +415,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>1</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -434,7 +434,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>2</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -453,7 +453,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>3</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -472,7 +472,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>4</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -520,7 +520,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>1</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -539,7 +539,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>2</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -558,7 +558,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>3</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -577,7 +577,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>4</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -625,7 +625,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>1</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -644,7 +644,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>2</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -663,7 +663,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>3</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -682,7 +682,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>4</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -730,7 +730,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>1</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -749,7 +749,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>2</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -768,7 +768,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>3</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -787,7 +787,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>4</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -830,7 +830,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>1</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -849,7 +849,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>2</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -868,7 +868,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>3</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -887,7 +887,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<property>
 					<name>defaultOrder</name>
 					<value>4</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
@@ -93,7 +93,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>long</value>
 				<type>String</type>
 			</property>
 			<node>
@@ -198,7 +198,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>long</value>
 				<type>String</type>
 			</property>
 			<node>
@@ -303,7 +303,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>long</value>
 				<type>String</type>
 			</property>
 			<node>
@@ -408,7 +408,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>long</value>
 				<type>String</type>
 			</property>
 			<node>
@@ -513,7 +513,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>long</value>
 				<type>String</type>
 			</property>
 			<node>
@@ -618,7 +618,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>long</value>
 				<type>String</type>
 			</property>
 			<node>
@@ -723,7 +723,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>long</value>
 				<type>String</type>
 			</property>
 			<node>
@@ -828,7 +828,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>long</value>
 				<type>String</type>
 			</property>
 			<node>
@@ -933,7 +933,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>long</value>
 				<type>String</type>
 			</property>
 			<node>
@@ -1033,7 +1033,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>text</value>
+				<value>long</value>
 				<type>String</type>
 			</property>
 			<node>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
@@ -102,7 +102,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>1</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -121,7 +121,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>2</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -140,7 +140,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>3</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -159,7 +159,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>4</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -207,7 +207,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>1</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -226,7 +226,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>2</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -245,7 +245,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>3</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -264,7 +264,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>4</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -312,7 +312,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>1</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -331,7 +331,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>2</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -350,7 +350,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>3</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -369,7 +369,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>4</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -417,7 +417,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>1</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -436,7 +436,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>2</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -455,7 +455,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>3</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -474,7 +474,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>4</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -522,7 +522,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>1</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -541,7 +541,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>2</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -560,7 +560,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>3</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -579,7 +579,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>4</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -627,7 +627,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>1</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -646,7 +646,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>2</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -665,7 +665,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>3</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -684,7 +684,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>4</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -732,7 +732,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>1</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -751,7 +751,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>2</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -770,7 +770,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>3</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -789,7 +789,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>4</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -837,7 +837,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>1</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -856,7 +856,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>2</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -875,7 +875,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>3</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -894,7 +894,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>4</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -942,7 +942,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>1</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -961,7 +961,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>2</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -980,7 +980,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>3</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -999,7 +999,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>4</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -1042,7 +1042,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>1</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -1061,7 +1061,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>2</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -1080,7 +1080,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>3</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>
@@ -1099,7 +1099,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<property>
 					<name>defaultOrder</name>
 					<value>4</value>
-					<type>String</type>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>label</name>


### PR DESCRIPTION
In the UI, nothing should be different. On the back end, the type for answers should be Long. Create a new GAD7 and a new PHQ9 form, fill in the answers, save, open the .deep.json and check that:
- [x] the `jcr:primaryType` for answers is `cards:LongAnswer`
- [x] the value for answers is not quoted, but a direct number, e.g. `"value":3`