### PR TITLE
CARDS-1110: Unsaved data lost when using the browser's back feature

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -141,7 +141,7 @@ function Form (props) {
       // When component unmounts:
       return (() => {
         // cleanup event handler
-        window.removeEventListener("beforeunload", saveDataWithCheckin);
+        window.removeEventListener("beforeunload", saveDataWithCheckin, true);
       });
     }
   }, [isEdit]);


### PR DESCRIPTION
Bugfix: beforeunload event listener isn't cleared when going away from the form page