### PR TITLE
CARDS-1394: The questionnaire wizard suggests invalid default values for the na/noneOfTheAbove options in long/double/decimal questions with list or list+input display

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -137,8 +137,8 @@ function MultipleChoice(props) {
       } else if (noneOfTheAboveOption == id) {
         // If the noneOfTheAboveOption is selected, other elements are deselected but user-input options remain
         // Only keep options that are user-input
-        let defaultOptions = defaults.filter(option => option[IS_DEFAULT_POS]).map((option) => option[VALUE_POS]);
-        let newSelection = old.filter((option) => !defaultOptions.includes(option[VALUE_POS]));
+        let defaultOptionValues = defaults.filter(option => option[IS_DEFAULT_POS]).map((option) => String(option[VALUE_POS]));
+        let newSelection = old.filter((option) => !defaultOptionValues.includes(String(option[VALUE_POS])));
         newSelection.push([name, id]);
         return newSelection;
       }

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/AnswerOptions.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/AnswerOptions.jsx
@@ -55,7 +55,7 @@ let extractSortedOptions = (data) => {
 }
 
 let AnswerOptions = (props) => {
-  const { objectKey, data, path, saveButtonRef, classes } = props;
+  const { objectKey, value, data, path, saveButtonRef, classes } = props;
   let [ options, setOptions ] = useState(extractSortedOptions(data));
   let [ deletedOptions, setDeletedOptions ] = useState([]);
   let [ tempValue, setTempValue ] = useState(''); // Holds new, non-committed answer options
@@ -71,11 +71,11 @@ let AnswerOptions = (props) => {
   const notApplicable  = Object.values(data).find(option => option['jcr:primaryType'] == 'cards:AnswerOption' && option.notApplicable);
   const noneOfTheAbove = Object.values(data).find(option => option['jcr:primaryType'] == 'cards:AnswerOption' && option.noneOfTheAbove);
 
-  let [ notApplicableOption, setNotApplicableOption ] = useState(notApplicable || {"value" : "notApplicable",
+  let [ notApplicableOption, setNotApplicableOption ] = useState(notApplicable || {"value" : (value == "numberOptions" ? "-1" : "notApplicable"),
                                                                                    "label" : "None",
                                                                                    "notApplicable" : false,
                                                                                    "@path" : path + "/None"});
-  let [ noneOfTheAboveOption, setNoneOfTheAboveOption ] = useState(noneOfTheAbove || {"value": "noneOfTheAbove",
+  let [ noneOfTheAboveOption, setNoneOfTheAboveOption ] = useState(noneOfTheAbove || {"value": (value == "numberOptions" ? "0" : "noneOfTheAbove"),
                                                                                       "label" : "None of the above",
                                                                                       "noneOfTheAbove" : false,
                                                                                       "@path" : path + "/NoneOfTheAbove"});
@@ -438,7 +438,7 @@ var StyledAnswerOptions = withStyles(QuestionnaireStyle)(AnswerOptions);
 export default StyledAnswerOptions;
 
 QuestionComponentManager.registerQuestionComponent((definition) => {
-  if (definition === "options") {
+  if (["numberOptions", "textOptions"].includes(definition)) {
     return [StyledAnswerOptions, 50];
   }
 });

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -76,15 +76,7 @@
         "maxAnswers": "long",
         "unitOfMeasurement" : "string",
         "displayMode": {
-          "input": {},
-          "list": {
-            "compact" : "boolean",
-            "answerOptions" : "numberOptions"
-          },
-          "list+input" : {
-            "compact" : "boolean",
-            "answerOptions" : "numberOptions"
-          }
+          "input": {}
         }
       },
       "file": {

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -13,11 +13,11 @@
           "textbox": {},
           "list": {
             "compact" : "boolean",
-            "answerOptions" : "options"
+            "answerOptions" : "textOptions"
           },
           "list+input" : {
             "compact" : "boolean",
-            "answerOptions" : "options"
+            "answerOptions" : "textOptions"
           }
         }
       },
@@ -43,11 +43,11 @@
           "input": {},
           "list": {
             "compact" : "boolean",
-            "answerOptions" : "options"
+            "answerOptions" : "numberOptions"
           },
           "list+input" : {
             "compact" : "boolean",
-            "answerOptions" : "options"
+            "answerOptions" : "numberOptions"
           }
         }
       },
@@ -61,11 +61,11 @@
           "input": {},
           "list": {
             "compact" : "boolean",
-            "answerOptions" : "options"
+            "answerOptions" : "numberOptions"
           },
           "list+input" : {
             "compact" : "boolean",
-            "answerOptions" : "options"
+            "answerOptions" : "numberOptions"
           }
         }
       },
@@ -79,11 +79,11 @@
           "input": {},
           "list": {
             "compact" : "boolean",
-            "answerOptions" : "options"
+            "answerOptions" : "numberOptions"
           },
           "list+input" : {
             "compact" : "boolean",
-            "answerOptions" : "options"
+            "answerOptions" : "numberOptions"
           }
         }
       },
@@ -107,11 +107,11 @@
           "input": {},
           "list": {
             "compact" : "boolean",
-            "answerOptions" : "options"
+            "answerOptions" : "textOptions"
           },
           "list+input" : {
             "compact" : "boolean",
-            "answerOptions" : "options"
+            "answerOptions" : "textOptions"
           }
         },
         "enableNotes": "boolean"


### PR DESCRIPTION
Known limitation: switching the data type from `text` to `long` (or other number type) _after_ the answer options generated and displayed will not update the values of the special options to be numeric, because answer options are not re-rendered, preventing any data that has already been entered from being discarded. IMO this is ok for now and could be fixed later if it becomes a real usability issue.