### PR TITLE
CARDS-1389: The backend code for handling filtering by DateAnswers should use the timezone offset for the given date and not the current date

### DIFF
--- a/modules/data-entry/src/main/java/io/uhndata/cards/DateUtils.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/DateUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public final class DateUtils
+{
+    /**
+     * Hide the utility class constructor.
+     */
+    private DateUtils()
+    {
+    }
+
+    /**
+     * Returns the timezone as a GMT offset string for the given date string
+     * provided in the format yyyy-MM-dd. If date string parsing fails, the
+     * GMT offset string for the current date/time is returned instead.
+     *
+     * @param dateString a date string in the form of yyyy-MM-dd
+     * @return the GMT offset string for the given date string at 00:00:00
+     *     in the server's local timezone
+     */
+    public static String getTimezoneForDateString(String dateString)
+    {
+        SimpleDateFormat inputDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        try {
+            return new SimpleDateFormat("XXX").format(inputDateFormat.parse(dateString));
+        } catch (ParseException e) {
+            return new SimpleDateFormat("XXX").format(new Date());
+        }
+    }
+}

--- a/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
@@ -20,13 +20,10 @@ package io.uhndata.cards;
 
 import java.io.IOException;
 import java.io.Writer;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -73,7 +70,6 @@ import org.slf4j.LoggerFactory;
  *
  * @version $Id$
  */
-@SuppressWarnings("checkstyle:ClassFanOutComplexity")
 @Component(service = { Servlet.class })
 @SlingServletResourceTypes(
     resourceTypes = { "cards/QuestionnairesHomepage", "cards/FormsHomepage", "cards/SubjectsHomepage",
@@ -730,25 +726,6 @@ public class PaginationServlet extends SlingSafeMethodsServlet
     }
 
     /**
-     * Returns the timezone as a GMT offset string for the given date string
-     * provided in the format yyyy-MM-dd. If date string parsing fails, the
-     * GMT offset string for the current date/time is returned instead.
-     *
-     * @param dateString a date string in the form of yyyy-MM-dd
-     * @return the GMT offset string for the given date string at 00:00:00
-     *     in the server's local timezone
-     */
-    private String getTimezoneForDateString(String dateString)
-    {
-        SimpleDateFormat inputDateFormat = new SimpleDateFormat("yyyy-MM-dd");
-        try {
-            return new SimpleDateFormat("XXX").format(inputDateFormat.parse(dateString));
-        } catch (ParseException e) {
-            return new SimpleDateFormat("XXX").format(new Date());
-        }
-    }
-
-    /**
      * Converts a single value filter into a query condition, including the starting " and ", referencing the correct
      * question, and comparing against the filter value.
      *
@@ -790,7 +767,8 @@ public class PaginationServlet extends SlingSafeMethodsServlet
             condition.append(
                 String.format(
                     " and %s.'value'%s" + (("date".equals(filter.type))
-                        ? ("cast('%sT00:00:00.000" + getTimezoneForDateString(this.sanitizeValue(filter.value))
+                        ? ("cast('%sT00:00:00.000"
+                            + DateUtils.getTimezoneForDateString(this.sanitizeValue(filter.value))
                             + "' as date)")
                         : ("boolean".equals(filter.type)) ? "%s"
                             : StringUtils.isNotBlank(filter.value) ? "'%s'" : ""),

--- a/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
@@ -20,6 +20,7 @@ package io.uhndata.cards;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -72,6 +73,7 @@ import org.slf4j.LoggerFactory;
  *
  * @version $Id$
  */
+@SuppressWarnings("checkstyle:ClassFanOutComplexity")
 @Component(service = { Servlet.class })
 @SlingServletResourceTypes(
     resourceTypes = { "cards/QuestionnairesHomepage", "cards/FormsHomepage", "cards/SubjectsHomepage",
@@ -728,6 +730,25 @@ public class PaginationServlet extends SlingSafeMethodsServlet
     }
 
     /**
+     * Returns the timezone as a GMT offset string for the given date string
+     * provided in the format yyyy-MM-dd. If date string parsing fails, the
+     * GMT offset string for the current date/time is returned instead.
+     *
+     * @param dateString a date string in the form of yyyy-MM-dd
+     * @return the GMT offset string for the given date string at 00:00:00
+     *     in the server's local timezone
+     */
+    private String getTimezoneForDateString(String dateString)
+    {
+        SimpleDateFormat inputDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        try {
+            return new SimpleDateFormat("XXX").format(inputDateFormat.parse(dateString));
+        } catch (ParseException e) {
+            return new SimpleDateFormat("XXX").format(new Date());
+        }
+    }
+
+    /**
      * Converts a single value filter into a query condition, including the starting " and ", referencing the correct
      * question, and comparing against the filter value.
      *
@@ -769,7 +790,8 @@ public class PaginationServlet extends SlingSafeMethodsServlet
             condition.append(
                 String.format(
                     " and %s.'value'%s" + (("date".equals(filter.type))
-                        ? ("cast('%sT00:00:00.000" + new SimpleDateFormat("XXX").format(new Date()) + "' as date)")
+                        ? ("cast('%sT00:00:00.000" + getTimezoneForDateString(this.sanitizeValue(filter.value))
+                            + "' as date)")
                         : ("boolean".equals(filter.type)) ? "%s"
                             : StringUtils.isNotBlank(filter.value) ? "'%s'" : ""),
                     filter.source,


### PR DESCRIPTION
This PR fixes the CARDS-1389 bug where, if CARDS is deployed to a server with a locale set to one that incorporates clock changes (eg. Daylight savings time), _DateAnswer_ filters would not work properly for _DateAnswers_ that are outside of the current clock-change timezone. For example, if the server's locale is set to Toronto, Ontario, Canada which uses the EST/EDT timezone and a _DateAnswer_ query for _2021-01-01_ (which is in the EST timezone) is performed on _2021-09-17_ (which is in the EDT timezone) this query will not obtain the proper results. The same is true if the _DateAnswer_ query was for a date in EDT while begin performed in EST.

To test:

1. Build the CARDS-1389 branch (`mvn clean install`)
2. Start CARDS with the `lfs` runMode enabled
3. Create a new _Patient information_ Form
4. Set the _Date of birth_ to something outside of the EDT timezone (eg. 2021-01-01).
5. Save the Form.
6. Return to the Dashboard and select the _Drafts_ tab for _Forms_.
7. Filter for the entered _Date of birth_ (eg. 2021-01-01) and verify that it returns the proper result.
8. Repeat the same process of a _Date of birth_ inside the current EDT timezone (eg. 2021-09-01). Verify that the filter works properly.
9. Test the above steps on a build of the latest `dev` branch and observe that _DateAnswers_ outside of the current timezone (eg. 2021-01-01) cannot be found by setting a filter for `Date of birth = 2021-01-01`