### PR TITLE
CARDS-1404: As a questionnaire designer I can specify numeric questions of type "range"

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
@@ -238,7 +238,7 @@ function NumberQuestion(props) {
         }
         <div className={classes.range}>
           <TextField
-            label="Lower limit"
+            helperText="Lower limit"
             value={lowerLimit}
             placeholder={typeof minValue != "undefined" ? `${minValue}` : ""}
             onChange={event => setLowerLimit(event.target.value)}
@@ -247,7 +247,7 @@ function NumberQuestion(props) {
             />
           <span className="separator">&mdash;</span>
           <TextField
-            label="Upper limit"
+            helperText="Upper limit"
             value={upperLimit}
             placeholder={typeof maxValue != "undefined" ? `${maxValue}` : ""}
             onChange={event => setUpperLimit(event.target.value)}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
@@ -25,6 +25,7 @@ import NumberFormat from 'react-number-format';
 import PropTypes from "prop-types";
 
 import Answer from "./Answer";
+import AnswerInstructions from "./AnswerInstructions";
 import Question from "./Question";
 import QuestionnaireStyle from "./QuestionnaireStyle";
 import MultipleChoice from "./MultipleChoice";
@@ -59,7 +60,7 @@ const DATA_TO_VALUE_TYPE = {
 //  maxValue: The maximum allowed input value
 //  minValue: The minimum allowed input value
 //  type: One of "integer" or "float" (default: "float")
-//  errorText: String to display when the input is not valid (default: "invalid input")
+//  errorText: String to display when the input is not valid (default: "")
 //  isRange: Whether or not to display a range instead of a single value
 //
 // Sample usage:
@@ -74,18 +75,18 @@ const DATA_TO_VALUE_TYPE = {
 //    errorText="Please enter an age above 18, or select the <18 option"
 //    />
 function NumberQuestion(props) {
-  const { existingAnswer, errorText, isRange, classes, ...rest} = props;
-  const { dataType, displayMode, minValue, maxValue } = {...props.questionDefinition, ...props};
+  const { existingAnswer, errorText, classes, ...rest} = props;
+  const { dataType, displayMode, minAnswers, minValue, maxValue, isRange } = {...props.questionDefinition, ...props};
   const answerNodeType = props.answerNodeType || DATA_TO_NODE_TYPE[dataType];
   const valueType = props.valueType || DATA_TO_VALUE_TYPE[dataType];
   const [ minMaxError, setMinMaxError ] = useState(false);
   const [ rangeError, setRangeError ] = useState(false);
 
-  const initialValue = existingAnswer ? existingAnswer[1].value : undefined;
+  const initialValue = Array.from(existingAnswer?.[1]?.value || []);
 
-  // The following two are only used if a default is not given, as we switch to handling values here
-  const [input, setInput] = useState(initialValue);
-  const [endInput, setEndInput] = useState(undefined);
+  // The following two are only used for range answers
+  const [lowerLimit, setLowerLimit] = useState(initialValue[0]);
+  const [upperLimit, setUpperLimit] = useState(initialValue[1]);
 
   // Callback function for our min/max
   let hasError = (text) => {
@@ -126,16 +127,26 @@ function NumberQuestion(props) {
     setMinMaxError(text && hasError(text));
   }
 
-  // Callback for a range input to check for errors on our self-stated input
-  let findRangeError = (inputToCheck, endInputToCheck) => {
+  React.useEffect(() => {
+    if (!isRange) return;
+    // Check for invalid range limits
     setMinMaxError(
-      inputToCheck && hasError(inputToCheck) ||
-      isRange && endInputToCheck && hasError(endInputToCheck)
+      lowerLimit && hasError(lowerLimit) ||
+      upperLimit && hasError(upperLimit)
     );
-    setRangeError(isRange && (Number(inputToCheck) > Number(endInputToCheck)));
+    setRangeError(
+       !lowerLimit && upperLimit ||
+       (Number(lowerLimit) > Number(upperLimit))
+    );
+  }, [lowerLimit, upperLimit]);
+
+  const answers = [];
+  // Only save ranges that have both limits specified
+  if (isRange && lowerLimit && !isNaN(+lowerLimit) && upperLimit && !isNaN(+upperLimit)) {
+    answers.push(["lower", lowerLimit]);
+    answers.push(["upper", upperLimit]);
   }
 
-  const answers = isRange ? [["start", input], ["end", endInput]] : [["start", input]];
   const textFieldProps = {
     min: minValue,
     max: maxValue,
@@ -169,12 +180,23 @@ function NumberQuestion(props) {
   }
 
   // Range error message
-  let rangeErrorMessage = "The range is invalid: the first number must be lower than the second number";
+  let rangeErrorMessage = "The range is invalid: the lower limit must be less than or equal to the upper limit";
+
+  let rangeDisplayFormatter = function(label, idx) {
+    if (idx > 0 || !(initialValue?.length)) return '';
+    let limits = initialValue.slice(0, 2);
+    // In case of invalid data (only one limit of the range is available)
+    if (limits.length == 1) {
+      limits.push("");
+    }
+    return limits.join(' - ');
+  }
 
   return (
     <Question
-      disableInstructions={!isRange}
-      currentAnswers={ typeof(input) != "undefined" && input != "" ? 1 : 0 }
+      defaultDisplayFormatter={isRange? rangeDisplayFormatter : undefined}
+      compact={isRange}
+      disableInstructions
       {...props}
       >
       { (minMaxError || rangeError) && errorText &&
@@ -199,6 +221,11 @@ function NumberQuestion(props) {
       }
       { isRange ?
         <>
+        <AnswerInstructions
+          minAnswers={Math.min(1, minAnswers)}
+          maxAnswers={0}
+          currentAnswers={lowerLimit && upperLimit ? 1 : 0}
+          />
         { rangeError &&
           <Typography
             component="p"
@@ -209,34 +236,32 @@ function NumberQuestion(props) {
           { rangeErrorMessage }
           </Typography>
         }
-        <TextField
-          className={classes.textField + " " + classes.answerField}
-          onChange={(event) => {
-            findRangeError(event.target.value, endInput);
-            setInput(event.target.value);
-          }}
-          inputProps={textFieldProps}
-          value={input}
-          InputProps={muiInputProps}
-          />
-          <Answer
-            answers={answers}
-            existingAnswer={existingAnswer}
-            answerNodeType={answerNodeType}
-            valueType={valueType}
-            {...rest}
-            />
-          <span className={classes.mdash}>&mdash;</span>
+        <div className={classes.range}>
           <TextField
-            className={classes.textField}
-            onChange={(event) => {
-              findRangeError(input, event.target.value);
-              setEndInput(event.target.value);
-            }}
+            label="Lower limit"
+            value={lowerLimit}
+            placeholder={typeof minValue != "undefined" ? `${minValue}` : ""}
+            onChange={event => setLowerLimit(event.target.value)}
             inputProps={textFieldProps}
-            value={endInput}
-            InputProps={muiInputProps}
+            InputProps={Object.assign({shrink: "true"}, muiInputProps)}
             />
+          <span className="separator">&mdash;</span>
+          <TextField
+            label="Upper limit"
+            value={upperLimit}
+            placeholder={typeof maxValue != "undefined" ? `${maxValue}` : ""}
+            onChange={event => setUpperLimit(event.target.value)}
+            inputProps={textFieldProps}
+            InputProps={Object.assign({shrink: "true"}, muiInputProps)}
+            />
+        </div>
+        <Answer
+          answers={answers}
+          existingAnswer={existingAnswer}
+          answerNodeType={answerNodeType}
+          valueType={valueType}
+          {...rest}
+          />
         </>
         :
         <MultipleChoice
@@ -303,7 +328,6 @@ NumberQuestion.propTypes = {
 
 NumberQuestion.defaultProps = {
   errorText: "",
-  isRange: false
 };
 
 const StyledNumberQuestion = withStyles(QuestionnaireStyle)(NumberQuestion)

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -113,8 +113,17 @@ const questionnaireStyle = theme => ({
             marginRight: theme.spacing(2),
         },
     },
-    mdash: {
-        padding: theme.spacing(0, 1),
+    range: {
+        display: "flex",
+        alignItems: "center",
+        "& .MuiFormControl-root" : {
+            marginTop: theme.spacing(-2),
+            maxWidth: "110px",
+            overflowX: "hidden",
+        },
+        "& .separator" : {
+            padding: theme.spacing(0, 1),
+        }
     },
     cardHeaderButton: {
         // No styles here yet

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -116,9 +116,9 @@ const questionnaireStyle = theme => ({
     range: {
         display: "flex",
         alignItems: "flex-start",
-        "& .MuiFormControl-root" : {
-            maxWidth: "110px",
-            overflowX: "hidden",
+        "& .MuiInputBase-root" : {
+            minWidth: "110px !important",
+            width: "110px",
         },
         "& .separator" : {
             padding: theme.spacing(0.5, 1),

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -115,14 +115,13 @@ const questionnaireStyle = theme => ({
     },
     range: {
         display: "flex",
-        alignItems: "center",
+        alignItems: "flex-start",
         "& .MuiFormControl-root" : {
-            marginTop: theme.spacing(-2),
             maxWidth: "110px",
             overflowX: "hidden",
         },
         "& .separator" : {
-            padding: theme.spacing(0, 1),
+            padding: theme.spacing(0.5, 1),
         }
     },
     cardHeaderButton: {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -689,7 +689,14 @@ export function displayQuestion(entryDefinition, data, key, classes) {
         }
         break;
       default:
-        content = <>{ prettyPrintedAnswers.join(", ") }</>
+        if (entryDefinition.isRange) {
+          let limits = prettyPrintedAnswers.slice(0, 2);
+          // In case of invalid data (only one limit of the range is available)
+          if (limits.length == 1) limits.push("");
+          content = <>{ limits.join(" - ") }</>
+        } else {
+          content = <>{ prettyPrintedAnswers.join(", ") }</>
+        }
         break;
     }
     return (

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -40,7 +40,9 @@
         "maxAnswers": "long",
         "unitOfMeasurement" : "string",
         "displayMode": {
-          "input": {},
+          "input": {
+            "isRange" : "boolean"
+          },
           "list": {
             "compact" : "boolean",
             "answerOptions" : "numberOptions"
@@ -58,7 +60,9 @@
         "maxAnswers": "long",
         "unitOfMeasurement" : "string",
         "displayMode": {
-          "input": {},
+          "input": {
+            "isRange" : "boolean"
+          },
           "list": {
             "compact" : "boolean",
             "answerOptions" : "numberOptions"
@@ -75,9 +79,7 @@
         "minAnswers": "long",
         "maxAnswers": "long",
         "unitOfMeasurement" : "string",
-        "displayMode": {
-          "input": {}
-        }
+        "isRange" : "boolean"
       },
       "file": {
         "minAnswers": "long",

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/RangeTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/RangeTest.xml
@@ -1,0 +1,112 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>RangeTest</name>
+	<primaryNodeType>cards:Questionnaire</primaryNodeType>
+	<property>
+		<name>title</name>
+		<value>Range Field Test</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>description</name>
+		<value>CARDS-1404</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>requiredSubjectTypes</name>
+		<values>
+			<value>/SubjectTypes/Patient</value>
+		</values>
+		<type>Reference</type>
+	</property>
+	<node>
+		<name>q1</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Long range, mandatory</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>minAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>long</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>isRange</name>
+			<value>True</value>
+			<type>Boolean</type>
+		</property>
+	</node>
+	<node>
+		<name>q2</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Double range</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>double</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>isRange</name>
+			<value>True</value>
+			<type>Boolean</type>
+		</property>
+	</node>
+	<node>
+		<name>q3</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Decimal range with min/maxValue</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>minValue</name>
+			<value>-1.5</value>
+			<type>Double</type>
+		</property>
+		<property>
+			<name>maxValue</name>
+			<value>1.5</value>
+			<type>Double</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>double</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>isRange</name>
+			<value>True</value>
+			<type>Boolean</type>
+		</property>
+	</node>
+</node>


### PR DESCRIPTION
* Made `isRange` a question definition field and enabled it in the questionnaire wizard
* Fixed bug where the upper limit of the range was dropped on form re-editing
* Improved UI of range input fields (width, labels, placeholders, alignment)
* Improved how ranges are displayed in view mode, on the form and in the subject chart
* Improved error reporting
* Improved variable names
* Added a `Range Field Test` questionnaire in the `test` run mode

**NOT done**:
* [ ] Flag range answer as invalid if lower limit > upper limit
* [ ] Generate range display value in JSON