### PR TITLE
CARDS-1429: Always display PROMS Scores in the Patient chart

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -326,9 +326,11 @@ const questionnaireStyle = theme => ({
         display: "none"
     },
     headerSection : {
-      position: "sticky",
-      top: 0,
-      zIndex: 2,
+      "&.cards-edit-section" : {
+        position: "sticky",
+        top: 0,
+        zIndex: 2,
+      },
       "& > .MuiCollapse-wrapper" : {
         border: "1px solid " + theme.palette.primary.light,
       },
@@ -346,9 +348,11 @@ const questionnaireStyle = theme => ({
       },
     },
     footerSection : {
-      position: "sticky",
-      bottom: 0,
-      paddingBottom: "0 !important",
+      "&.cards-edit-section" : {
+        position: "sticky",
+        bottom: 0,
+        paddingBottom: "0 !important",
+      },
       "& > .MuiCollapse-wrapper" : {
         border: "1px solid " + theme.palette.primary.light,
       },

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -138,8 +138,9 @@ function Section(props) {
   }
 
   const collapseClasses = [];
+  collapseClasses.push(classes[displayMode + 'Section']);
   if (isEdit) {
-    collapseClasses.push(classes[displayMode + 'Section']);
+    collapseClasses.push("cards-edit-section");
   }
   if (isEdit && !displayed || !isEdit && !hasAnswers) {
     collapseClasses.push(classes.collapsedSection);

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/AUDITC.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/AUDITC.xml
@@ -52,23 +52,76 @@
 The three-item Alcohol Use Disorders Identification Test (AUDIT-C) is a brief survey
 instrument designed to identify at-risk drinking behaviors that could indicate alcohol use
 disorder. AUDIT-C has been validated in mental health and primary care clinics.
-
-### Interpretation Instructions
-
-Add up the circled numbers for each item to derive a total score. Below are guidelines for
-interpreting symptom severity based on total score. *Note*: Total scores are interpreted
-differently for men and women.
-
-**For men: A total score of 4 or greater indicates elevated risk for hazardous drinking
-or active alcohol use disorder.**
-
-**For women: A total score of 3 or greater indicates elevated risk for hazardous
-drinking or active alcohol use disorder.**
-
-Greater scores indicate greater risk posed to the patient’s health and safety.
 			</value>
 			<type>String</type>
 		</property>
+	</node>
+	<node>
+		<name>audit_results</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>displayMode</name>
+			<value>header</value>
+			<type>String</type>
+		</property>
+		<node>
+			<name>audit_score</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>expression</name>
+				<value>return (+@{audit_1:-0} + +@{audit_2:-0} + +@{audit_3:-0})</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>unitOfMeasurement</name>
+				<value>points</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>Score</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>formatted</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>audit_interpretation</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>expression</name>
+				<value>return (
+					+@{audit_score:-0} >= 3 ? "For men: A total score of 4 or greater indicates elevated risk for hazardous drinking or active alcohol use disorder.\n" +
+					                          "For women: A total score of 3 or greater indicates elevated risk for hazardous drinking or active alcohol use disorder.\n\n" +
+					                          "Greater scores indicate greater risk posed to the patient’s health and safety."
+					                        : "No alcohol use disorder detected."
+				)</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>Interpretation</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>formatted</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+		</node>
 	</node>
 	<node>
 		<name>audit_survey</name>
@@ -444,39 +497,6 @@ Greater scores indicate greater risk posed to the patient’s health and safety.
 					<type>String</type>
 				</property>
 			</node>
-		</node>
-	</node>
-	<node>
-		<name>audit_results</name>
-		<primaryNodeType>cards:Section</primaryNodeType>
-		<property>
-			<name>displayMode</name>
-			<value>footer</value>
-			<type>String</type>
-		</property>
-		<node>
-			<name>audit_score</name>
-			<primaryNodeType>cards:Question</primaryNodeType>
-			<property>
-				<name>expression</name>
-				<value>return (+@{audit_1:-0} + +@{audit_2:-0} + +@{audit_3:-0})</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>unitOfMeasurement</name>
-				<value>points</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>text</name>
-				<value>Total</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>dataType</name>
-				<value>computed</value>
-				<type>String</type>
-			</property>
 		</node>
 	</node>
 </node>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/AUDITC.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/AUDITC.xml
@@ -48,7 +48,6 @@
 		<property>
 			<name>text</name>
 			<value>
-			
 The three-item Alcohol Use Disorders Identification Test (AUDIT-C) is a brief survey
 instrument designed to identify at-risk drinking behaviors that could indicate alcohol use
 disorder. AUDIT-C has been validated in mental health and primary care clinics.
@@ -99,8 +98,8 @@ disorder. AUDIT-C has been validated in mental health and primary care clinics.
 			<property>
 				<name>expression</name>
 				<value>return (
-					+@{audit_score:-0} >= 3 ? "For men: A total score of 4 or greater indicates elevated risk for hazardous drinking or active alcohol use disorder.\n" +
-					                          "For women: A total score of 3 or greater indicates elevated risk for hazardous drinking or active alcohol use disorder.\n\n" +
+					+@{audit_score:-0} >= 3 ? "For **men**, a total score of **4 or greater** indicates elevated risk for hazardous drinking or active alcohol use disorder. " +
+					                          "For **women**, a total score of **3 or greater** indicates elevated risk for hazardous drinking or active alcohol use disorder.\n\n" +
 					                          "Greater scores indicate greater risk posed to the patient’s health and safety."
 					                        : "No alcohol use disorder detected."
 				)</value>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/EQ5D.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/EQ5D.xml
@@ -43,6 +43,44 @@
 		<type>String</type>
 	</property>
 	<node>
+		<name>eq5d_results</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>displayMode</name>
+			<value>header</value>
+			<type>String</type>
+		</property>
+		<node>
+			<name>eq5d_score</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>expression</name>
+				<value>return (10 * (+@{eq5d_1:-0} + +@{eq5d_2:-0} + +@{eq5d_3:-0} + +@{eq5d_4:-0} + +@{eq5d_5:-0}) + (100 - +@{eq5d_6:-0}))</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>unitOfMeasurement</name>
+				<value>points</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>Score</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>formatted</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
 		<name>eq5d_survey</name>
 		<primaryNodeType>cards:Section</primaryNodeType>
 		<property>
@@ -529,39 +567,6 @@ Please enter a number to indicate how your health is TODAY.
 			<property>
 				<name>dataType</name>
 				<value>long</value>
-				<type>String</type>
-			</property>
-		</node>
-	</node>
-	<node>
-		<name>eq5d_results</name>
-		<primaryNodeType>cards:Section</primaryNodeType>
-		<property>
-			<name>displayMode</name>
-			<value>footer</value>
-			<type>String</type>
-		</property>
-		<node>
-			<name>eq5d_score</name>
-			<primaryNodeType>cards:Question</primaryNodeType>
-			<property>
-				<name>expression</name>
-				<value>return (10 * (+@{eq5d_1:-0} + +@{eq5d_2:-0} + +@{eq5d_3:-0} + +@{eq5d_4:-0} + +@{eq5d_5:-0}) + (100 - +@{eq5d_6:-0}))</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>unitOfMeasurement</name>
-				<value>points</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>text</name>
-				<value>Score</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>dataType</name>
-				<value>computed</value>
 				<type>String</type>
 			</property>
 		</node>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
@@ -64,6 +64,100 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 		</property>
 	</node>
 	<node>
+		<name>gad7_results</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>displayMode</name>
+			<value>header</value>
+			<type>String</type>
+		</property>
+		<node>
+			<name>gad7_score</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>expression</name>
+				<value>return (+@{gad7_1:-0} + +@{gad7_2:-0} + +@{gad7_3:-0} + +@{gad7_4:-0} + +@{gad7_5:-0} + +@{gad7_6:-0} + +@{gad7_7:-0})</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>unitOfMeasurement</name>
+				<value>points</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>formatted</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>Score</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>gad7_interpretation</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>expression</name>
+				<value>return   @{gad7_score} > 14 ? "Severe anxiety disorder"
+				              : @{gad7_score} >  9 ? "Moderate anxiety disorder"
+				              : @{gad7_score} >  4 ? "Mild anxiety disorder"
+				              :                      "No anxiety disorder"
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>formatted</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>Interpretation</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>gad7_impairment</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>expression</name>
+				<value>return @{gad7_8} == 0 ? "Functionally, the patient does not report limitations due to their symptoms."
+				            : @{gad7_8} == 1 ? "Functionally, the patient is *somewhat* having difficulty with life tasks due to their symptoms."
+				            : @{gad7_8} == 2 ? "Functionally, the patient finds it is *very difficult* to perform life tasks due to their symptoms."
+				            : @{gad7_8} == 3 ? "Functionally, the patient finds it is *extremely difficult* to perform life tasks due to their symptoms."
+				            : ""</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>formatted</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value> </value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
 		<name>gad7_survey</name>
 		<primaryNodeType>cards:Section</primaryNodeType>
 		<property>
@@ -1001,122 +1095,5 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 
 		</node>
 	</node>
-	<node>
-		<name>gad7_results</name>
-		<primaryNodeType>cards:Section</primaryNodeType>
-		<property>
-			<name>displayMode</name>
-			<value>footer</value>
-			<type>String</type>
-		</property>
-		<node>
-			<name>gad7_result</name>
-			<primaryNodeType>cards:Question</primaryNodeType>
-			<property>
-				<name>expression</name>
-				<value>return "### " + @{gad7_score:-0} + " point" + (@{gad7_score:-0} == 1 ? "" : "s")</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>displayMode</name>
-				<value>formatted</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>text</name>
-				<value> </value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>dataType</name>
-				<value>computed</value>
-				<type>String</type>
-			</property>
-		</node>
-		<node>
-			<name>gad7_score</name>
-			<primaryNodeType>cards:Question</primaryNodeType>
-			<property>
-				<name>expression</name>
-				<value>return (+@{gad7_1:-0} + +@{gad7_2:-0} + +@{gad7_3:-0} + +@{gad7_4:-0} + +@{gad7_5:-0} + +@{gad7_6:-0} + +@{gad7_7:-0})</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>unitOfMeasurement</name>
-				<value>points</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>displayMode</name>
-				<value>hidden</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>text</name>
-				<value>Score</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>dataType</name>
-				<value>computed</value>
-				<type>String</type>
-			</property>
-		</node>
-		<node>
-			<name>gad7_interpretation</name>
-			<primaryNodeType>cards:Question</primaryNodeType>
-			<property>
-				<name>expression</name>
-				<value>return   @{gad7_score} > 14 ? "Severe anxiety disorder"
-				              : @{gad7_score} >  9 ? "Moderate anxiety disorder"
-				              : @{gad7_score} >  4 ? "Mild anxiety disorder"
-				              :                      "No anxiety disorder"
-				</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>displayMode</name>
-				<value>formatted</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>text</name>
-				<value> </value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>dataType</name>
-				<value>computed</value>
-				<type>String</type>
-			</property>
-		</node>
-		<node>
-			<name>gad7_impairment</name>
-			<primaryNodeType>cards:Question</primaryNodeType>
-			<property>
-				<name>expression</name>
-				<value>return @{gad7_8} == 0 ? "Functionally, the patient does not report limitations due to their symptoms."
-				            : @{gad7_8} == 1 ? "Functionally, the patient is *somewhat* having difficulty with life tasks due to their symptoms."
-				            : @{gad7_8} == 2 ? "Functionally, the patient finds it is *very difficult* to perform life tasks due to their symptoms."
-				            : @{gad7_8} == 3 ? "Functionally, the patient finds it is *extremely difficult* to perform life tasks due to their symptoms."
-				            : ""</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>displayMode</name>
-				<value>formatted</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>text</name>
-				<value> </value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>dataType</name>
-				<value>computed</value>
-				<type>String</type>
-			</property>
-		</node>
-	</node>
+
 </node>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
@@ -51,7 +51,7 @@
 ### When to use
 Rapid screening for the presence of a clinically significant anxiety disorder (GAD, PD, SP and PTSD), especially in outpatient settings.
 
-### Pearls/Pitfalls
+### Pitfalls
 * The GAD-7 is useful in primary care and mental health settings as a screening tool and symptom severity measure for the four most common anxiety disorders (Generalized Anxiety Disorder, Panic Disorder, Social Phobia and PostTraumatic Stress Disorder)
 * It is 70-90% sensitive and 80-90% specific across disorders / cutoffs (see Evidence section for more).
 * Higher GAD-7 scores correlate with disability and functional impairment (in measures such as work productivity and health care utilization). ([Spitzer RL 2006](http://www.ncbi.nlm.nih.gov/pubmed/16717171)) ([Ruiz MA 2011](http://www.ncbi.nlm.nih.gov/pubmed/20692043))
@@ -105,10 +105,18 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
 				<name>expression</name>
-				<value>return   @{gad7_score} > 14 ? "Severe anxiety disorder"
+				<value>return (
+				              ( @{gad7_score} > 14 ? "Severe anxiety disorder"
 				              : @{gad7_score} >  9 ? "Moderate anxiety disorder"
 				              : @{gad7_score} >  4 ? "Mild anxiety disorder"
 				              :                      "No anxiety disorder"
+				              ) + "\n\n" + (
+				                @{gad7_8:--1} == 0 ? "Functionally, the patient does not report limitations due to their symptoms."
+				              : @{gad7_8:--1} == 1 ? "Functionally, the patient is *somewhat* having difficulty with life tasks due to their symptoms."
+				              : @{gad7_8:--1} == 2 ? "Functionally, the patient finds it is *very difficult* to perform life tasks due to their symptoms."
+				              : @{gad7_8:--1} == 3 ? "Functionally, the patient finds it is *extremely difficult* to perform life tasks due to their symptoms."
+				              : "" )
+				              )
 				</value>
 				<type>String</type>
 			</property>
@@ -120,34 +128,6 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 			<property>
 				<name>text</name>
 				<value>Interpretation</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>dataType</name>
-				<value>computed</value>
-				<type>String</type>
-			</property>
-		</node>
-		<node>
-			<name>gad7_impairment</name>
-			<primaryNodeType>cards:Question</primaryNodeType>
-			<property>
-				<name>expression</name>
-				<value>return @{gad7_8} == 0 ? "Functionally, the patient does not report limitations due to their symptoms."
-				            : @{gad7_8} == 1 ? "Functionally, the patient is *somewhat* having difficulty with life tasks due to their symptoms."
-				            : @{gad7_8} == 2 ? "Functionally, the patient finds it is *very difficult* to perform life tasks due to their symptoms."
-				            : @{gad7_8} == 3 ? "Functionally, the patient finds it is *extremely difficult* to perform life tasks due to their symptoms."
-				            : ""</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>displayMode</name>
-				<value>formatted</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>text</name>
-				<value> </value>
 				<type>String</type>
 			</property>
 			<property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
@@ -52,7 +52,7 @@
 Use as a screening tool:
 * To assist the clinician in making the diagnosis of depression.
 * To quantify depression symptoms and monitor severity.
-### Pearls/Pitfalls
+### Pitfalls
 * The Patient Health Questionnaire (PHQ)-9 is the major depressive disorder (MDD) module of the full PHQ.
 * Used to provisionally diagnose depression and grade severity of symptoms in general medical and mental health settings.
 * Scores each of the 9 DSM criteria of MDD as *0* (not at all) to *3* (nearly every day), providing a 0-27 severity score.
@@ -107,14 +107,21 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
 				<name>expression</name>
-				<value>return (4 >= @{phq9_score} ? "Scores ≤4 suggest minimal depression which may not require treatment."
+				<value>return (
+				            (  4 >= @{phq9_score} ? "Scores ≤4 suggest minimal depression which may not require treatment."
 				            :  9 >= @{phq9_score} ? "Scores 5-9 suggest mild depression which may require only watchful waiting and repeated PHQ-9 at followup."
 				            : 14 >= @{phq9_score} ? "Scores 10-14 suggest moderate depression severity; patients should have a treatment plan ranging form counseling, followup, and/or pharmacotherapy."
 				            : 19 >= @{phq9_score} ? "Scores 15-19 suggest moderately severe depression; patients typically should have immediate initiation of pharmacotherapy and/or psychotherapy."
 				            :                       "Scores 20 and greater suggest severe depression; patients typically should have immediate initiation of pharmacotherapy and expedited referral to mental health specialist."
-				            ) +
-						( @{phq9_9:-0} > 0 ? "\n\n**WARNING: This patient is having thoughts concerning for suicidal ideation or self-harm, and should be probed further, referred, or transferred for emergency psychiatric evaluation as clinically appropriate and depending on clinician overall risk assessment.**"
-						  : "")
+				            ) + "\n\n" + (
+				              @{phq9_10:--1} == 0 ? "Functionally, the patient does not report limitations due to their symptoms."
+				            : @{phq9_10:--1} == 1 ? "Functionally, the patient is *somewhat* having difficulty with life tasks due to their symptoms."
+				            : @{phq9_10:--1} == 2 ? "Functionally, the patient finds it is *very difficult* to perform life tasks due to their symptoms."
+				            : @{phq9_10:--1} == 3 ? "Functionally, the patient finds it is *extremely difficult* to perform life tasks due to their symptoms."
+				            : "" ) + (
+					      @{phq9_9:-0} > 0 ? "\n\n**WARNING: This patient is having thoughts concerning for suicidal ideation or self-harm, and should be probed further, referred, or transferred for emergency psychiatric evaluation as clinically appropriate and depending on clinician overall risk assessment.**"
+					    : "" )
+					)
 				</value>
 				<type>String</type>
 			</property>
@@ -126,36 +133,6 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			<property>
 				<name>text</name>
 				<value>Interpretation</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>dataType</name>
-				<value>computed</value>
-				<type>String</type>
-			</property>
-		</node>
-		<node>
-			<name>phq9_impairment</name>
-			<primaryNodeType>cards:Question</primaryNodeType>
-			<property>
-				<name>expression</name>
-				<value>
-				  return  ( @{phq9_10} == 0 ? "Functionally, the patient does not report limitations due to their symptoms."
-				          : @{phq9_10} == 1 ? "Functionally, the patient is *somewhat* having difficulty with life tasks due to their symptoms."
-				          : @{phq9_10} == 2 ? "Functionally, the patient finds it is *very difficult* to perform life tasks due to their symptoms."
-				          : @{phq9_10} == 3 ? "Functionally, the patient finds it is *extremely difficult* to perform life tasks due to their symptoms."
-				          : "" )
-				</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>displayMode</name>
-				<value>formatted</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>text</name>
-				<value> </value>
 				<type>String</type>
 			</property>
 			<property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
@@ -66,6 +66,106 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 		</property>
 	</node>
 	<node>
+		<name>phq9_results</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>displayMode</name>
+			<value>header</value>
+			<type>String</type>
+		</property>
+		<node>
+			<name>phq9_score</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>expression</name>
+				<value>return (+@{phq9_1:-0} + +@{phq9_2:-0} + +@{phq9_3:-0} + +@{phq9_4:-0} + +@{phq9_5:-0} + +@{phq9_6:-0} + +@{phq9_7:-0} + +@{phq9_8:-0} + +@{phq9_9:-0})</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>unitOfMeasurement</name>
+				<value>points</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>formatted</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>Score</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>phq9_interpretation</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>expression</name>
+				<value>return (4 >= @{phq9_score} ? "Scores ≤4 suggest minimal depression which may not require treatment."
+				            :  9 >= @{phq9_score} ? "Scores 5-9 suggest mild depression which may require only watchful waiting and repeated PHQ-9 at followup."
+				            : 14 >= @{phq9_score} ? "Scores 10-14 suggest moderate depression severity; patients should have a treatment plan ranging form counseling, followup, and/or pharmacotherapy."
+				            : 19 >= @{phq9_score} ? "Scores 15-19 suggest moderately severe depression; patients typically should have immediate initiation of pharmacotherapy and/or psychotherapy."
+				            :                       "Scores 20 and greater suggest severe depression; patients typically should have immediate initiation of pharmacotherapy and expedited referral to mental health specialist."
+				            ) +
+						( @{phq9_9:-0} > 0 ? "\n\n**WARNING: This patient is having thoughts concerning for suicidal ideation or self-harm, and should be probed further, referred, or transferred for emergency psychiatric evaluation as clinically appropriate and depending on clinician overall risk assessment.**"
+						  : "")
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>formatted</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>Interpretation</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>phq9_impairment</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>expression</name>
+				<value>
+				  return  ( @{phq9_10} == 0 ? "Functionally, the patient does not report limitations due to their symptoms."
+				          : @{phq9_10} == 1 ? "Functionally, the patient is *somewhat* having difficulty with life tasks due to their symptoms."
+				          : @{phq9_10} == 2 ? "Functionally, the patient finds it is *very difficult* to perform life tasks due to their symptoms."
+				          : @{phq9_10} == 3 ? "Functionally, the patient finds it is *extremely difficult* to perform life tasks due to their symptoms."
+				          : "" )
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>formatted</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value> </value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
 		<name>phq9_survey</name>
 		<primaryNodeType>cards:Section</primaryNodeType>
 		<property>
@@ -1212,128 +1312,5 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 
 	</node>
 
-	</node>
-	<node>
-		<name>phq9_results</name>
-		<primaryNodeType>cards:Section</primaryNodeType>
-		<property>
-			<name>displayMode</name>
-			<value>footer</value>
-			<type>String</type>
-		</property>
-		<node>
-			<name>phq9_result</name>
-			<primaryNodeType>cards:Question</primaryNodeType>
-			<property>
-				<name>expression</name>
-				<value>return "### " + @{phq9_score:-0} + " point" + (@{phq9_score:-0} == 1 ? "" : "s")</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>displayMode</name>
-				<value>formatted</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>text</name>
-				<value> </value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>dataType</name>
-				<value>computed</value>
-				<type>String</type>
-			</property>
-		</node>
-		<node>
-			<name>phq9_score</name>
-			<primaryNodeType>cards:Question</primaryNodeType>
-			<property>
-				<name>expression</name>
-				<value>return (+@{phq9_1:-0} + +@{phq9_2:-0} + +@{phq9_3:-0} + +@{phq9_4:-0} + +@{phq9_5:-0} + +@{phq9_6:-0} + +@{phq9_7:-0} + +@{phq9_8:-0} + +@{phq9_9:-0})</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>unitOfMeasurement</name>
-				<value>points</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>displayMode</name>
-				<value>hidden</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>text</name>
-				<value>Score</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>dataType</name>
-				<value>computed</value>
-				<type>String</type>
-			</property>
-		</node>
-		<node>
-			<name>phq9_interpretation</name>
-			<primaryNodeType>cards:Question</primaryNodeType>
-			<property>
-				<name>expression</name>
-				<value>return  4 >= @{phq9_score} ? "Scores ≤4 suggest minimal depression which may not require treatment."
-				            :  9 >= @{phq9_score} ? "Scores 5-9 suggest mild depression which may require only watchful waiting and repeated PHQ-9 at followup."
-				            : 14 >= @{phq9_score} ? "Scores 10-14 suggest moderate depression severity; patients should have a treatment plan ranging form counseling, followup, and/or pharmacotherapy."
-				            : 19 >= @{phq9_score} ? "Scores 15-19 suggest moderately severe depression; patients typically should have immediate initiation of pharmacotherapy and/or psychotherapy."
-				            :                       "Scores 20 and greater suggest severe depression; patients typically should have immediate initiation of pharmacotherapy and expedited referral to mental health specialist."
-				</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>displayMode</name>
-				<value>formatted</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>text</name>
-				<value> </value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>dataType</name>
-				<value>computed</value>
-				<type>String</type>
-			</property>
-		</node>
-		<node>
-			<name>phq9_impairment</name>
-			<primaryNodeType>cards:Question</primaryNodeType>
-			<property>
-				<name>expression</name>
-				<value>
-				  return  ( @{phq9_10} == 0 ? "Functionally, the patient does not report limitations due to their symptoms."
-				          : @{phq9_10} == 1 ? "Functionally, the patient is *somewhat* having difficulty with life tasks due to their symptoms."
-				          : @{phq9_10} == 2 ? "Functionally, the patient finds it is *very difficult* to perform life tasks due to their symptoms."
-				          : @{phq9_10} == 3 ? "Functionally, the patient finds it is *extremely difficult* to perform life tasks due to their symptoms."
-				          : "" ) +
-				          ( @{phq9_9:-0} > 0 ? "\n\n**WARNING: This patient is having thoughts concerning for suicidal ideation or self-harm, and should be probed further, referred, or transferred for emergency psychiatric evaluation as clinically appropriate and depending on clinician overall risk assessment.**"
-				          : "") 
-				</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>displayMode</name>
-				<value>formatted</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>text</name>
-				<value> </value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>dataType</name>
-				<value>computed</value>
-				<type>String</type>
-			</property>
-		</node>
 	</node>
 </node>


### PR DESCRIPTION
* Moved the results section (containing the computed score and interpretation) at the top of the forms after the intro and before the actual survey questions, in a section with `displayType=header`
* Added interpretation computed variable to AUDIT and removed interpretation instructions from intro
* Merged all interpretations in each form under a single computed variable
* Re-labeled the computed variables for consistency across all forms

Includes a small UI improvement to [CARDS-1306](https://phenotips.atlassian.net/browse/CARDS-1306) _Add support for sections that stick to the top (header section) or to the bottom (footer section) of the page when scrolling_: made the appearance of header/footer sections consistent in view and edit mode (stickiness excluded).