### PR TITLE
CARDS-1415: User dashboard and side bar terminology improvements

### DIFF
--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/SubjectTypes/Patient/Tumor.json
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/SubjectTypes/Patient/Tumor.json
@@ -1,5 +1,6 @@
 {
   "jcr:primaryType": "cards:SubjectType",
   "label": "Tumor",
+  "subjectListLabel" : "Tumors",
   "cards:defaultOrder": 1
 }

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/SubjectTypes/Patient/Tumor/TumorRegion.json
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/SubjectTypes/Patient/Tumor/TumorRegion.json
@@ -1,5 +1,6 @@
 {
   "jcr:primaryType": "cards:SubjectType",
   "label": "Tumor region",
+  "subjectListLabel": "Tumor Regions",
   "cards:defaultOrder": 2
 }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -75,7 +75,12 @@ function FormView(props) {
     EditButton
   ]
 
-  const tabs = ["Completed Forms", "Drafts"];
+  const tabFilter = {
+    "Completed Forms" : '',
+    "Drafts" : '&fieldname=statusFlags&fieldvalue=INCOMPLETE',
+  };
+  const tabs = Object.keys(tabFilter);
+
   const activeTabParam = new URLSearchParams(window.location.hash.substring(1)).get("forms:activeTab");
   let activeTabIndex = Math.max(tabs.indexOf(activeTabParam), 0);
   const [ activeTab, setActiveTab ] = useState(activeTabIndex);
@@ -141,7 +146,7 @@ function FormView(props) {
       <CardContent>
         <LiveTable
           columns={props.columns || columns}
-          customUrl={`/Forms.paginate?descending=true${qFilter}${activeTab == tabs.indexOf("Draft") ? '&fieldname=statusFlags&fieldvalue=INCOMPLETE' : ''}`}
+          customUrl={`/Forms.paginate?descending=true${qFilter}${tabFilter[tabs[activeTab]]}`}
           defaultLimit={10}
           joinChildren="cards:Answer"
           filters

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -75,7 +75,7 @@ function FormView(props) {
     EditButton
   ]
 
-  const tabs = ["Completed forms", "Drafts"];
+  const tabs = ["Completed Forms", "Drafts"];
   const activeTabParam = new URLSearchParams(window.location.hash.substring(1)).get("forms:activeTab");
   let activeTabIndex = Math.max(tabs.indexOf(activeTabParam), 0);
   const [ activeTab, setActiveTab ] = useState(activeTabIndex);

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -45,8 +45,8 @@ import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
 function FormView(props) {
   const { questionnaire, expanded, disableHeader, disableAvatar, topPagination, classes } = props;
   
-  const [ title, setTitle ] = useState(typeof(props.title) != 'undefined' ? props.title : "Forms");
-  const [ subtitle, setSubtitle ] = useState();
+  const [ title, setTitle ] = useState(props.title);
+  const [ subtitle, setSubtitle ] = useState(props.subtitle);
   const [ questionnairePath, setQuestionnairePath ] = useState();
   const [ qFetchSent, setQFetchStatus ] = useState(false);
   const [ filtersJsonString, setFiltersJsonString ] = useState(new URLSearchParams(window.location.hash.substring(1)).get("forms:filters"));
@@ -75,7 +75,7 @@ function FormView(props) {
     EditButton
   ]
 
-  const tabs = ["Completed", "Draft"];
+  const tabs = ["Completed forms", "Drafts"];
   const activeTabParam = new URLSearchParams(window.location.hash.substring(1)).get("forms:activeTab");
   let activeTabIndex = Math.max(tabs.indexOf(activeTabParam), 0);
   const [ activeTab, setActiveTab ] = useState(activeTabIndex);
@@ -103,13 +103,26 @@ function FormView(props) {
 
   return (
     <Card className={classes.formView}>
-      {(!expanded || !disableHeader && !disableAvatar && (title || questionnaire)) &&
+      {title &&
+      <CardHeader
+        title={
+          <>
+            {title && <Typography variant="h4">{title}</Typography>}
+            {subtitle && <Typography variant="subtitle1">{subtitle}</Typography>}
+          </>
+        }
+      />
+      }
+      {(!expanded || !disableHeader && !disableAvatar) &&
       <CardHeader
         avatar={!disableAvatar && <Avatar className={classes.formViewAvatar}><DescriptionIcon/></Avatar>}
         title={
           <>
-            <Typography variant="h6">{title}</Typography>
-            <Typography variant="subtitle1">{subtitle}</Typography>
+            <Tabs value={activeTab} onChange={(event, value) => setActiveTab(value)}>
+            { tabs.map((value, index) => {
+              return <Tab label={<Typography variant="h6">{value}</Typography>}  key={"form-" + index} />;
+            })}
+            </Tabs>
           </>
         }
         action={
@@ -124,11 +137,6 @@ function FormView(props) {
         }
       />
       }
-      <Tabs value={activeTab} onChange={(event, value) => setActiveTab(value)}>
-        {tabs.map((value, index) => {
-          return <Tab label={value}  key={"form-" + index} />;
-        })}
-      </Tabs>
       <Divider />
       <CardContent>
         <LiveTable

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -76,7 +76,8 @@ function FormView(props) {
   ]
 
   const tabFilter = {
-    "Completed Forms" : '',
+    "Questionnaires" : '&includeallstatus=true',
+    "Completed" : '',
     "Drafts" : '&fieldname=statusFlags&fieldvalue=INCOMPLETE',
   };
   const tabs = Object.keys(tabFilter);

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -160,7 +160,7 @@ function FormView(props) {
         />
       {expanded &&
         <NewFormDialog presetPath={questionnairePath}>
-          New form
+          New questionnaire
         </NewFormDialog>
       }
       </CardContent>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
@@ -63,6 +63,11 @@ function SubjectTypes(props) {
       "format": (row) => (getTextHierarchy(row['@path'], subjectTypeData)),
     },
     {
+      "key": "subjectListLabel",
+      "label": "Subject list label",
+      "format": "string",
+    },
+    {
       "key": "",
       "label": "Subjects",
       "format": (row) => (row.instanceCount ? <Link to={"/content.html/Subjects#" + row['@name']} title={"Show subjects of type " + row.label}>{row.instanceCount}</Link> : "0"),

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
@@ -174,7 +174,6 @@ function SubjectView(props) {
       {expanded &&
       <>
         <NewItemButton
-           title="New subject"
            onClick={() => {setNewSubjectPopperOpen(true)}}
         />
         <NewSubjectDialog

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
@@ -105,10 +105,6 @@ function SubjectView(props) {
       })
   }
 
-  let formatTabLabel = (name) => {
-    return `${name}s`;
-  }
-
   if (tabsLoading === null) {
     fetchSubjectTypes();
     setTabsLoading(true);
@@ -136,7 +132,7 @@ function SubjectView(props) {
                 return <Tab
                          label={
                            <Typography variant="h6">
-                             {formatTabLabel(subject['label'] || subject['@name'])}
+                             {subject['subjectListLabel'] || subject['label'] || subject['@name']}
                            </Typography>
                          }
                          key={"subject-" + index}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
@@ -105,9 +105,15 @@ function SubjectView(props) {
       })
   }
 
-  if (tabsLoading == null) {
+  let formatTabLabel = (name) => {
+    return `${name}s`;
+  }
+
+  if (tabsLoading === null) {
     fetchSubjectTypes();
     setTabsLoading(true);
+  } else if (tabsLoading === false && !subjectTypes?.length) {
+    return null;
   }
 
   let path;
@@ -120,7 +126,24 @@ function SubjectView(props) {
       {!disableHeader &&
       <CardHeader
         avatar={!disableAvatar && <Avatar className={classes.subjectViewAvatar}><AssignmentIndIcon/></Avatar>}
-        title={<Typography variant="h6">Subjects</Typography>}
+        title={
+          tabsLoading
+          ? <CircularProgress/>
+          : subjectTypes.length < 1 ?
+          <></>
+          : <Tabs value={activeTab} onChange={(event, value) => setActiveTab(value)}>
+              {subjectTypes.map((subject, index) => {
+                return <Tab
+                         label={
+                           <Typography variant="h6">
+                             {formatTabLabel(subject['label'] || subject['@name'])}
+                           </Typography>
+                         }
+                         key={"subject-" + index}
+                       />;
+              })}
+            </Tabs>
+        }
         action={
           !expanded &&
           <Tooltip title="Expand">
@@ -132,17 +155,6 @@ function SubjectView(props) {
           </Tooltip>
         }
       />
-      }
-      {
-        tabsLoading
-          ? <CircularProgress/>
-          : subjectTypes.length <= 1 ?
-          <></>
-          : <Tabs value={activeTab} onChange={(event, value) => setActiveTab(value)}>
-              {subjectTypes.map((subject, index) => {
-                return <Tab label={subject['label'] || subject['@name']} key={"subject-" + index}/>;
-              })}
-            </Tabs>
       }
       <Divider />
       <CardContent>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -151,12 +151,25 @@ const questionnaireStyle = theme => ({
             height: "100%",
             marginTop: theme.spacing(4),
         },
+        "& .MuiCardHeader-root" : {
+            paddingBottom: 0,
+        },
+        "& .MuiCardHeader-avatar" : {
+            zoom: "75%",
+            marginTop: theme.spacing(-1.5),
+        },
         "& .MuiTab-root": {
             width: "auto",
             minWidth: theme.spacing(10),
+            paddingBottom: theme.spacing(1.5),
             paddingLeft: theme.spacing(2),
             paddingRight: theme.spacing(2),
             textTransform: "none",
+            fontSize: "150%",
+            letterSpacing: "unset",
+         },
+         "& .MuiTabs-indicator" : {
+             height: theme.spacing(.5),
          },
          "& .MuiCardContent-root": {
             padding: theme.spacing(3, 0),

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -165,7 +165,7 @@ function Subject(props) {
   return (
     <React.Fragment>
       <NewFormDialog currentSubject={currentSubject}>
-        New form for this Subject
+        { "New questionnaire for this " + (currentSubject?.type?.label || "Subject") }
       </NewFormDialog>
       <Grid container spacing={4} direction="column" className={classes.subjectContainer}>
         <SubjectHeader id={currentSubjectId} key={"SubjectHeader"}  classes={classes} getSubject={handleSubject} history={history} contentOffset={props.contentOffset}/>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -95,7 +95,7 @@ export function getTextHierarchy (node, withType = false) {
 }
 
 // Recursive function to get the list of ancestors as an array
-export function getHierarchyAsList (node) {
+export function getHierarchyAsList (node, includeHomepage) {
   let props = defaultCreator(node);
   let parent = <>{node.type.label} <Link {...props}>{node.identifier}</Link></>;
   if (node["parents"]) {
@@ -103,8 +103,15 @@ export function getHierarchyAsList (node) {
     ancestors.push(parent);
     return ancestors;
   } else {
-    return [parent];
+    let result = [parent];
+    includeHomepage && result.unshift(getHomepageLink(node));
+    return result;
   }
+}
+
+export function getHomepageLink (subjectNode) {
+  let props = defaultCreator({"@path": `/Subjects#subjects:activeTab=${subjectNode?.type?.["@name"]}`});
+  return (<Link {...props}>{subjectNode?.type?.subjectListLabel || "Subjects"}</Link>);
 }
 
 /**
@@ -356,8 +363,7 @@ function SubjectHeader(props) {
                />
             </div>
   );
-  let parentDetails = (subject?.data?.['parents'] && getHierarchyAsList(subject.data['parents']) || []);
-  parentDetails.unshift(<Link to={/((.*)\/Subjects)\/([^.]+)/.exec(location.pathname)[1]}>Subjects</Link>);
+  let parentDetails = (subject?.data?.['parents'] && getHierarchyAsList(subject.data['parents'], true) || [getHomepageLink(subject?.data)]);
 
   return (
     subject?.data &&

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTypeDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTypeDialog.jsx
@@ -29,6 +29,7 @@ function SubjectTypeDialog(props) {
   const [ label, setLabel ] = useState(isEdit ? currentSubjectType.label : "");
   const [ parentSubject, setParentSubject ] = useState(initialParent);
   const [ order, setOrder ] = useState(currentSubjectType && currentSubjectType["cards:defaultOrder"] ? currentSubjectType["cards:defaultOrder"] : 0);
+  const [ subjectListLabel, setSubjectListLabel ] = useState(currentSubjectType?.subjectListLabel || "");
   const [ error, setError ] = useState(null);
   const [ isDuplicateLabel, setIsDuplicateLabel ] = useState(false);
 
@@ -52,6 +53,7 @@ function SubjectTypeDialog(props) {
       formInfo["jcr:primaryType"] = "cards:SubjectType";
       formInfo["label"] = label;
       formInfo["cards:defaultOrder"] = order;
+      formInfo["subjectListLabel"] = subjectListLabel;
 
       formData.append(':contentType', 'json');
       formData.append(':operation', 'import');
@@ -59,13 +61,14 @@ function SubjectTypeDialog(props) {
       formData.append(':content', JSON.stringify(formInfo));
     } else {
       // if nothing changed - just move the node
-      if (currentSubjectType["cards:defaultOrder"] == order && currentSubjectType["label"] === label) {
+      if (currentSubjectType["cards:defaultOrder"] == order && currentSubjectType["label"] === label && currentSubjectType["subjectListLabel"] === subjectListLabel) {
         moveSubjectType();
         return;
       } else {
         // Update all the changes first
         formData.append("cards:defaultOrder", order);
         formData.append("label", label);
+        formData.append("subjectListLabel", subjectListLabel);
       }
     }
 
@@ -113,6 +116,7 @@ function SubjectTypeDialog(props) {
     setLabel("");
     setParentSubject("");
     setOrder(0);
+    setSubjectListLabel("")
     setIsDuplicateLabel(false);
     onClose();
   }
@@ -181,13 +185,28 @@ function SubjectTypeDialog(props) {
               onChange={(event) => { setOrder(event.target.value); setError(""); }}
             />
           </Grid>
+          <Grid item xs={4}>
+            <Typography>Subject list label</Typography>
+          </Grid>
+          <Grid item xs={8}>
+            <TextField
+              fullWidth
+              type="text"
+              value={subjectListLabel}
+              onChange={(event) => { setSubjectListLabel(event.target.value); setError(""); }}
+            />
+          </Grid>
         </Grid>
         {error && <Typography color='error'>{error}</Typography>}
       </DialogContent>
       <DialogActions className={classes.dialogActions}>
         <Button
           disabled={!isEdit && (!label || isDuplicateLabel)
-                  || isEdit && (currentSubjectType["cards:defaultOrder"] == order && initialParent == parentSubject && currentSubjectType["label"] == label)}
+                  || isEdit && (currentSubjectType["cards:defaultOrder"] == order &&
+                                initialParent == parentSubject &&
+                                currentSubjectType["label"] == label &&
+                                currentSubjectType["subjectListLabel"] == subjectListLabel)
+          }
           color="primary"
           variant="contained"
           size="small"

--- a/modules/data-entry/src/main/resources/SLING-INF/content/Extensions/DashboardMenuItems/NewFormDialog.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/Extensions/DashboardMenuItems/NewFormDialog.json
@@ -1,7 +1,7 @@
 {
   "jcr:primaryType": "cards:Extension",
   "cards:extensionPointId": "cards/coreUI/dashboardmenuitems/entry",
-  "cards:extensionName": "Form",
+  "cards:extensionName": "Questionnaire",
   "cards:extensionRenderURL": "asset:cards-dataentry.NewFormDialog.js",
   "cards:defaultOrder": 2
 }

--- a/modules/data-entry/src/main/resources/SLING-INF/content/Extensions/DashboardMenuItems/NewSubjectDialog.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/Extensions/DashboardMenuItems/NewSubjectDialog.json
@@ -1,7 +1,7 @@
 {
   "jcr:primaryType": "cards:Extension",
   "cards:extensionPointId": "cards/coreUI/dashboardmenuitems/entry",
-  "cards:extensionName": "Subject",
+  "cards:extensionName": "Patient or related entry",
   "cards:extensionRenderURL": "asset:cards-dataentry.SubjectSelector.js?component=NewSubjectDialog",
   "cards:defaultOrder": 1
 }

--- a/modules/data-entry/src/main/resources/SLING-INF/content/Extensions/Sidebar/Forms.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/Extensions/Sidebar/Forms.json
@@ -1,7 +1,7 @@
 {
   "jcr:primaryType": "cards:Extension",
   "cards:extensionPointId": "cards/coreUI/sidebar/entry",
-  "cards:extensionName": "Forms",
+  "cards:extensionName": "Questionnaires",
   "cards:targetURL": "/content.html/Forms",
   "cards:icon": "asset:cards-dataentry.formsIcon.js",
   "cards:defaultOrder": 3

--- a/modules/data-entry/src/main/resources/SLING-INF/content/Extensions/Sidebar/Subjects.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/Extensions/Sidebar/Subjects.json
@@ -1,7 +1,7 @@
 {
   "jcr:primaryType": "cards:Extension",
   "cards:extensionPointId": "cards/coreUI/sidebar/entry",
-  "cards:extensionName": "Subjects",
+  "cards:extensionName": "Patients",
   "cards:targetURL": "/content.html/Subjects",
   "cards:icon": "asset:cards-dataentry.subjectsIcon.js",
   "cards:defaultOrder": 1

--- a/modules/data-entry/src/main/resources/SLING-INF/content/SubjectTypes/Patient.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/SubjectTypes/Patient.json
@@ -1,5 +1,6 @@
 {
   "jcr:primaryType": "cards:SubjectType",
   "label": "Patient",
+  "subjectListLabel" : "Patients",
   "cards:defaultOrder": 0
 }

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -839,6 +839,10 @@
   // A description outlining the subject type.
   - description (String)
 
+  // The label/title to display to the user when listing subjects of this tyoe
+  // Usually the plural of label
+  - subjectListLabel (String)
+
   // Any number of parent subject types that are required by this subject type
   - requiredParentType (String) multiple
 

--- a/modules/statistics/src/main/frontend/src/Statistics/Statistic.jsx
+++ b/modules/statistics/src/main/frontend/src/Statistics/Statistic.jsx
@@ -127,7 +127,6 @@ function Statistic(props) {
     chartColours = chartColours.concat(palette("rainbow", numKeys-DEFAULT_PALETTE.length).map((col) => "#" + col));
   }
 
-  let yAxisLabel = `${definition["y-label"]}s`;
   let widgetHeight = 250; // TODO: make mobile friendly
   let legendHeight = 40;
 
@@ -159,7 +158,7 @@ function Statistic(props) {
             <XAxis dataKey="x">
               <Label value={definition["x-label"]} offset={-10} position="insideBottom" />
             </XAxis>
-            <YAxis allowDecimals={false} label={{ value: yAxisLabel, angle: -90, position: 'insideLeft', offset: 10 }} />
+            <YAxis allowDecimals={false} label={{ value: definition["y-label"], angle: -90, position: 'insideLeft', offset: 10 }} />
             <Tooltip />
             {isSplit && <Legend align="right" verticalAlign="top" height={legendHeight} />}
             {allFields.map((field, idx) =>

--- a/modules/statistics/src/main/frontend/src/Statistics/UserStatistics.jsx
+++ b/modules/statistics/src/main/frontend/src/Statistics/UserStatistics.jsx
@@ -99,6 +99,8 @@ function UserStatistics(props) {
             statJson["order"] = fullJson["order"];
             statJson["splitVar"] = fullJson["splitVar"];
             statJson["xVar"] = fullJson["xVar"];
+            // Adjust the y label
+            statJson["y-label"] = stat.yVar.subjectListLabel || statJson["y-label"];
             return setCurrentStatistic(currentStatistic => [...currentStatistic, statJson]);
           })
           .catch(handleError);

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/SubjectTypes/Patient/Visit.json
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/SubjectTypes/Patient/Visit.json
@@ -1,5 +1,6 @@
 {
   "jcr:primaryType": "cards:SubjectType",
   "label": "Visit",
+  "subjectListLabel" : "Visits",
   "cards:defaultOrder": 1
 }


### PR DESCRIPTION
Includes:
- [x] [CARDS-1434](https://phenotips.atlassian.net/browse/CARDS-1434) _"Subjects" box improvements_:
* Removed the “Subjects” title
* Moved the tabs up instead of the title, and used title font
* Made all subject type labels plural
- [x] [CARDS-1438](https://phenotips.atlassian.net/browse/CARDS-1438) _"Forms" box improvements_ and
- [x] [CARDS-1370](https://phenotips.atlassian.net/browse/CARDS-1370) _In addition to Completed and Draft form tabs, include a tab that displays all data (complete and incomplete)_:
* Replaced the term "Forms" with "Questionnaires"
* To match the new “Subjects” box title, replaced the “Forms” box title with tabs: "Questionnaires" (all data), "Completed", "Drafts"
- [x] [CARDS-1442](https://phenotips.atlassian.net/browse/CARDS-1442) _The side bar should list by default "Patients" and "Questionnaires" instead of "Subjects" and "Forms"_
- [x] [CARDS-1445](https://phenotips.atlassian.net/browse/CARDS-1445) _Reword the (+) button titles (on Subject chart, Subjects, Forms) and the default menu items for the Dashboard's (+) button_