### PR TITLE
CARDS-1346: Configure permissions to prevent patient users from accessing the computed interpretation of their answers

### DIFF
--- a/modules/data-entry/src/main/features/feature.json
+++ b/modules/data-entry/src/main/features/feature.json
@@ -70,6 +70,11 @@
     "org.apache.sling.jcr.repoinit.RepositoryInitializer~forms":{
       "service.ranking:Integer":150,
       "scripts":["create path (cards:dataQuery) /query \n\n # Allow all users to query; the actual results will obey their access rights \n set ACL for everyone \n   allow  jcr:read  on /query \n end \n\n create path (cards:QuestionnairesHomepage) /Questionnaires \n create path (cards:FormsHomepage) /Forms \n create path (cards:SubjectsHomepage) /Subjects \n create path (cards:SubjectTypesHomepage) /SubjectTypes "]
+    },
+    "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~computedAnswers":{
+      "user.mapping":[
+        "io.uhndata.cards.dataentry:computedAnswers=[sling-readall]"
+      ]
     }
   }
 }

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/ComputedAnswersEditorProvider.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/ComputedAnswersEditorProvider.java
@@ -16,15 +16,12 @@
  */
 package io.uhndata.cards.dataentry.internal;
 
-import javax.jcr.Session;
-
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.commit.Editor;
 import org.apache.jackrabbit.oak.spi.commit.EditorProvider;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
-import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.FieldOption;
@@ -62,12 +59,9 @@ public class ComputedAnswersEditorProvider implements EditorProvider
         throws CommitFailedException
     {
         if (this.rrf != null) {
-            final ResourceResolver myResolver = this.rrf.getThreadResourceResolver();
-            if (myResolver != null) {
-                // Each ComputedEditor maintains a state, so a new instance must be returned each time
-                return new ComputedAnswersEditor(builder, myResolver.adaptTo(Session.class),
-                    this.questionnaireUtils, this.formUtils, this.expressionUtils);
-            }
+            // Each ComputedEditor maintains a state, so a new instance must be returned each time
+            return new ComputedAnswersEditor(builder, this.rrf,
+                this.questionnaireUtils, this.formUtils, this.expressionUtils);
         }
         return null;
     }

--- a/proms-resources/feature/src/main/features/feature.json
+++ b/proms-resources/feature/src/main/features/feature.json
@@ -25,5 +25,11 @@
       "id":"${project.groupId}:proms-frontend:${project.version}",
       "start-order":"26"
     }
-  ]
+  ],
+  "configurations":{
+    "org.apache.sling.jcr.repoinit.RepositoryInitializer~proms":{
+      "service.ranking:Integer":300,
+      "scripts":["create group patients \n set ACL for patients \n     deny jcr:all on /Questionnaires restriction(rep:itemNames,audit_intro,audit_results,eq5d_results,gad7_intro,gad7_results,phq9_intro,phq9_results) \n end"]
+    }
+  }
 }


### PR DESCRIPTION
To test:

- create a new user
- add it to the Patients group
- log in as the new user
- fill in forms
- intros and scores should not be shown
- save
- log in as admin
- open the patient created forms in view mode
- check that scores are already computed and shown

Also: 

- create a new user, but don't add to the Patients group
- log in as this new user
- fill in forms
- intros and scores should be shown
