### PR TITLE
CARDS-1481 - PROMs Patient UI: warning icons briefly flashed at the end of the questionnaire set, before acknowledging that the patient completed the questionnaires

### DIFF
--- a/proms-resources/frontend/src/main/frontend/src/QuestionnaireSet.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/QuestionnaireSet.jsx
@@ -157,6 +157,7 @@ function QuestionnaireSet(props) {
   }, [subjectData, questionnaireIds]);
 
   const loadExistingData = () => {
+    setComplete(undefined);
     fetchWithReLogin(globalLoginDisplay, `${subject}.data.deep.json`)
       .then((response) => response.ok ? response.json() : Promise.reject(response))
       .then((json) => {
@@ -351,7 +352,9 @@ function QuestionnaireSet(props) {
     </Grid>
   ];
 
-  let exitScreen = [
+  let exitScreen = (typeof(isComplete) == 'undefined') ? [
+    <CircularProgress />
+  ] : [
     <Typography variant="h4">{title}</Typography>,
     <List>
     { (questionnaireIds || []).map((q, i) => (


### PR DESCRIPTION
The issue is easiest to notice on a slow connection.

To test:
* Navigate to the PROMs patient ui (/Proms.html/Cardio)
* Identify as a patient and start filling out questionnaires. **At least one must be complete**.
* Before clicking save on the last screen of smoking cessation, throttle the network connection from the browser devtools

Before these changes:
* All surveys will be listed and marked as incomplete at first
* After a while the completion status will be updated

After these changes:
* A circular progress will be displayed for a while
* Then all surveys will be listed with the correct completion status