### PR TITLE
CARDS-1430: Regression: Vocabulary term displayed value is its id instead of the label

### DIFF
--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/labels/AnswerOptionsLabelProcessor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/labels/AnswerOptionsLabelProcessor.java
@@ -47,8 +47,7 @@ public class AnswerOptionsLabelProcessor extends SimpleAnswerLabelProcessor impl
     public void leave(Node node, JsonObjectBuilder json, Function<Node, JsonValue> serializeNode)
     {
         try {
-            if (node.isNodeType("cards:Answer") && !node.isNodeType("cards:VocabularyAnswer")
-                && hasAnswerOption(getQuestionNode(node))) {
+            if (node.isNodeType("cards:Answer") && hasAnswerOption(getQuestionNode(node))) {
                 addProperty(node, json, serializeNode);
             }
         } catch (RepositoryException e) {
@@ -58,10 +57,11 @@ public class AnswerOptionsLabelProcessor extends SimpleAnswerLabelProcessor impl
 
     /**
      * Returns true if the input node has an answer option.
+     *
      * @param question a question Node object to check
      * @return True if there is at least one answer option
      */
-    protected boolean hasAnswerOption(final Node question)
+    private boolean hasAnswerOption(final Node question)
     {
         try {
             NodeIterator childNodes = question.getNodes();

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/labels/AnswerOptionsLabelProcessor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/labels/AnswerOptionsLabelProcessor.java
@@ -47,7 +47,8 @@ public class AnswerOptionsLabelProcessor extends SimpleAnswerLabelProcessor impl
     public void leave(Node node, JsonObjectBuilder json, Function<Node, JsonValue> serializeNode)
     {
         try {
-            if (node.isNodeType("cards:Answer") && hasAnswerOption(getQuestionNode(node))) {
+            if (node.isNodeType("cards:Answer") && !node.isNodeType("cards:VocabularyAnswer")
+                && hasAnswerOption(getQuestionNode(node))) {
                 addProperty(node, json, serializeNode);
             }
         } catch (RepositoryException e) {
@@ -60,7 +61,7 @@ public class AnswerOptionsLabelProcessor extends SimpleAnswerLabelProcessor impl
      * @param question a question Node object to check
      * @return True if there is at least one answer option
      */
-    private boolean hasAnswerOption(final Node question)
+    protected boolean hasAnswerOption(final Node question)
     {
         try {
             NodeIterator childNodes = question.getNodes();

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/labels/SimpleAnswerLabelProcessor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/labels/SimpleAnswerLabelProcessor.java
@@ -116,7 +116,7 @@ public abstract class SimpleAnswerLabelProcessor implements ResourceJsonProcesso
     }
 
     /**
-     * Basic method to get get the answer label associated with the question.
+     * Basic method to get the answer label associated with the question.
      *
      * @param node the node being serialized, may be other than the top resource
      * @param question the question node that is an answer's child

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/labels/VocabularyLabelProcessor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/labels/VocabularyLabelProcessor.java
@@ -96,7 +96,7 @@ public class VocabularyLabelProcessor extends AnswerOptionsLabelProcessor implem
         for (String value : propsMap.keySet()) {
             if (value.startsWith("/Vocabularies/") && node.getSession().nodeExists(value)) {
                 Node term = node.getSession().getNode(value);
-                String label = term.getProperty("label").getValue().toString();
+                String label = term.getProperty(PROP_LABEL).getValue().toString();
                 if (label != null) {
                     propsMap.put(value, label);
                 }

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/labels/VocabularyLabelProcessor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/labels/VocabularyLabelProcessor.java
@@ -74,7 +74,10 @@ public class VocabularyLabelProcessor extends AnswerOptionsLabelProcessor implem
             }
 
             processVocabularyLabels(node, question, propsMap);
-            super.processOptions(question, propsMap);
+
+            if (super.hasAnswerOption(getQuestionNode(node))) {
+                super.processOptions(question, propsMap);
+            }
 
             if (propsMap.size() == 1) {
                 return Json.createValue((String) propsMap.values().toArray()[0]);

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/labels/VocabularyLabelProcessor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/labels/VocabularyLabelProcessor.java
@@ -75,9 +75,7 @@ public class VocabularyLabelProcessor extends AnswerOptionsLabelProcessor implem
 
             processVocabularyLabels(node, question, propsMap);
 
-            if (super.hasAnswerOption(getQuestionNode(node))) {
-                super.processOptions(question, propsMap);
-            }
+            super.processOptions(question, propsMap);
 
             if (propsMap.size() == 1) {
                 return Json.createValue((String) propsMap.values().toArray()[0]);

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/labels/VocabularyLabelProcessor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/labels/VocabularyLabelProcessor.java
@@ -55,6 +55,12 @@ public class VocabularyLabelProcessor extends AnswerOptionsLabelProcessor implem
     }
 
     @Override
+    public int getPriority()
+    {
+        return 90;
+    }
+
+    @Override
     public JsonValue getAnswerLabel(final Node node, final Node question)
     {
         try {

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/labels/VocabularyOptionsLabelProcessor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/labels/VocabularyOptionsLabelProcessor.java
@@ -36,7 +36,7 @@ import org.osgi.service.component.annotations.Component;
 import io.uhndata.cards.serialize.spi.ResourceJsonProcessor;
 
 /**
- * Class with shared processor functionality to get the human-readable question answer options.
+ * Adds a label to Answer Option nodes in a questionnaire's JSON.
  *
  * @version $Id$
  */
@@ -49,7 +49,7 @@ public class VocabularyOptionsLabelProcessor extends SimpleAnswerLabelProcessor 
         try {
             if (node.isNodeType("cards:AnswerOption")
                 && "vocabulary".equals(node.getParent().getProperty("dataType").getString())
-                && !node.hasProperty("label")) {
+                && !node.hasProperty(PROP_LABEL)) {
                 json.add(PROP_LABEL, getAnswerLabel(node));
             }
         } catch (RepositoryException e) {
@@ -80,8 +80,8 @@ public class VocabularyOptionsLabelProcessor extends SimpleAnswerLabelProcessor 
             for (String value : new LinkedHashSet<>(propsMap.keySet())) {
                 if (value.startsWith("/Vocabularies/") && node.getSession().nodeExists(value)) {
                     Node term = node.getSession().getNode(value);
-                    if (term.hasProperty("label")) {
-                        String label = term.getProperty("label").getValue().toString();
+                    if (term.hasProperty(PROP_LABEL)) {
+                        String label = term.getProperty(PROP_LABEL).getValue().toString();
                         propsMap.put(value, label);
                     }
                 }


### PR DESCRIPTION
The problem appeared to be with the priorities order of the `ResourceJsonProcessors`. `AnswerOptionsLabelProcessor` was always running after `VocabularyLabelProcessor` overwriting the right processed json label value with the term id instead of the value. 

However there is a room for the same regression in future. `AnswerOptionsLabelProcessor` can run on any answer node with options, its conditions are not unique. Every processor that extends it has to be explicitly excluded from it's `leave()` function condition like in this PR, by filtering out corresponding node, to avoid double-running. Even explicit numerical priorities setting is not the optimal solution cause many processors can still run for the same answer overwridig results of each other.