### PR TITLE
CARDS-1456: Forms are not checked back in when they are filled out using the PROMs UI

### DIFF
--- a/proms-resources/frontend/src/main/frontend/src/QuestionnaireSet.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/QuestionnaireSet.jsx
@@ -265,6 +265,24 @@ function QuestionnaireSet(props) {
       });
   }
 
+  let onFormComplete = () => {
+    const URL = "/Forms/" + crtFormId;
+    var request_data = new FormData();
+    request_data.append(":checkin", "true");
+    fetchWithReLogin(globalLoginDisplay, URL, { method: 'POST', body: request_data })
+      .then( (response) => {
+        if (response.ok) {
+          // Advance to the next step
+          nextQuestionnaire ? launchNextForm() : nextStep()
+        } else {
+          return(Promise.reject(response));
+        }
+      })
+      .catch((response) => {
+        setError(`Saving data failed with error code ${response.status}: ${response.statusText}`);
+      });
+  }
+
   // Load all questionnaires that need to be filled out
   if (typeof questionnaireIds === "undefined") {
     loadQuestionnaireSet();
@@ -344,7 +362,7 @@ function QuestionnaireSet(props) {
           disableHeader
           doneIcon={nextQuestionnaire ? <NextStepIcon /> : <DoneIcon />}
           doneLabel={nextQuestionnaire ? `Continue to ${nextQuestionnaire?.title}` : "Finish"}
-          onDone={nextQuestionnaire ? launchNextForm : nextStep}
+          onDone={onFormComplete}
           doneButtonStyle={{position: "relative", right: 0, bottom: "unset", textAlign: "center"}}
           contentOffset={contentOffset}
         />


### PR DESCRIPTION
To test:
- start in proms mode
- access the user view on `/Proms.html/Cardio`
- fill in forms while checking the forms status
- in a separate tab, open Composum at `/bin/browser.html/Forms` and check the status of forms
- refresh the Forms node after filling in each form, making sure that while editing only one form is checked out
- leave one form incomplete
- at the end, make sure no forms are checked out
- start filling in the incomplete form, make sure it is checked out while editing
- also test in normal admin editing that a form stays checked out while editing, and gets checked in when navigating away or save&close

![image](https://user-images.githubusercontent.com/88663/138962180-370c60ef-945a-4eef-8ae1-6311765b9a81.png)
