### PR TITLE
CARDS-1494: Filtering by numerical values does not work

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -149,7 +149,6 @@ function FormView(props) {
           columns={props.columns || columns}
           customUrl={`/Forms.paginate?descending=true${qFilter}${tabFilter[tabs[activeTab]]}`}
           defaultLimit={10}
-          joinChildren="cards:Answer"
           filters
           questionnaire={questionnaire}
           entryType={"Form"}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -43,7 +43,7 @@ function LiveTable(props) {
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Define the component's state
 
-  const { customUrl, columns, defaultLimit, joinChildren, updateData, classes,
+  const { customUrl, columns, defaultLimit, updateData, classes,
     filters, entryType, actions, admin, disableTopPagination, disableBottomPagination,
     onDataReceived, onFiltersChange, filtersJsonString, ...rest } = props;
   const [tableData, setTableData] = useState();
@@ -116,7 +116,6 @@ function LiveTable(props) {
 
     // Add the filters (if they exist)
     if (filters != null) {
-      url.searchParams.set("joinchildren", joinChildren);
       filters["fields"].forEach((field) => {url.searchParams.append("filternames", field)});
       filters["comparators"].forEach((comparator) => {url.searchParams.append("filtercomparators", comparator)});
       filters["values"].forEach((value) => {url.searchParams.append("filtervalues", value)});

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
@@ -164,7 +164,6 @@ function SubjectView(props) {
               actions={actions}
               disableTopPagination={!topPagination}
               filters
-              joinChildren="cards:Answer"
               onFiltersChange={(str) => setFiltersJsonString(str)}
               filtersJsonString={filtersJsonString}
             />

--- a/modules/data-entry/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
@@ -7,18 +7,244 @@
     "includedPaths": ["/Forms"],
     "indexRules" : {
         "jcr:primaryType": "nt:unstructured",
-        "cards:Answer": {
+        "cards:BooleanAnswer": {
             "jcr:primaryType": "nt:unstructured",
             "properties": {
                 "jcr:primaryType": "nt:unstructured",
                 "question": {
                     "name": "question",
                     "propertyIndex": true,
+                    "type": "String",
+                    "analyzed": false,
                     "jcr:primaryType": "nt:unstructured"
                 },
                 "value": {
                     "name": "value",
                     "propertyIndex": true,
+                    "type": "Long",
+                    "analyzed": true,
+                    "notNullCheckEnabled": true,
+                    "nullCheckEnabled": true,
+                    "jcr:primaryType": "nt:unstructured"
+                }
+            }
+        },
+        "cards:TextAnswer": {
+            "jcr:primaryType": "nt:unstructured",
+            "properties": {
+                "jcr:primaryType": "nt:unstructured",
+                "question": {
+                    "name": "question",
+                    "propertyIndex": true,
+                    "type": "String",
+                    "analyzed": false,
+                    "jcr:primaryType": "nt:unstructured"
+                },
+                "value": {
+                    "name": "value",
+                    "propertyIndex": true,
+                    "type": "String",
+                    "analyzed": true,
+                    "notNullCheckEnabled": true,
+                    "nullCheckEnabled": true,
+                    "jcr:primaryType": "nt:unstructured"
+                }
+            }
+        },
+        "cards:LongAnswer": {
+            "jcr:primaryType": "nt:unstructured",
+            "properties": {
+                "jcr:primaryType": "nt:unstructured",
+                "question": {
+                    "name": "question",
+                    "propertyIndex": true,
+                    "type": "String",
+                    "analyzed": false,
+                    "jcr:primaryType": "nt:unstructured"
+                },
+                "value": {
+                    "name": "value",
+                    "propertyIndex": true,
+                    "type": "Long",
+                    "analyzed": true,
+                    "notNullCheckEnabled": true,
+                    "nullCheckEnabled": true,
+                    "jcr:primaryType": "nt:unstructured"
+                }
+            }
+        },
+        "cards:DoubleAnswer": {
+            "jcr:primaryType": "nt:unstructured",
+            "properties": {
+                "jcr:primaryType": "nt:unstructured",
+                "question": {
+                    "name": "question",
+                    "propertyIndex": true,
+                    "type": "String",
+                    "analyzed": false,
+                    "jcr:primaryType": "nt:unstructured"
+                },
+                "value": {
+                    "name": "value",
+                    "propertyIndex": true,
+                    "type": "Double",
+                    "analyzed": true,
+                    "notNullCheckEnabled": true,
+                    "nullCheckEnabled": true,
+                    "jcr:primaryType": "nt:unstructured"
+                }
+            }
+        },
+        "cards:DecimalAnswer": {
+            "jcr:primaryType": "nt:unstructured",
+            "properties": {
+                "jcr:primaryType": "nt:unstructured",
+                "question": {
+                    "name": "question",
+                    "propertyIndex": true,
+                    "type": "String",
+                    "analyzed": false,
+                    "jcr:primaryType": "nt:unstructured"
+                },
+                "value": {
+                    "name": "value",
+                    "propertyIndex": true,
+                    "type": "Decimal",
+                    "analyzed": true,
+                    "notNullCheckEnabled": true,
+                    "nullCheckEnabled": true,
+                    "jcr:primaryType": "nt:unstructured"
+                }
+            }
+        },
+        "cards:DateAnswer": {
+            "jcr:primaryType": "nt:unstructured",
+            "properties": {
+                "jcr:primaryType": "nt:unstructured",
+                "question": {
+                    "name": "question",
+                    "propertyIndex": true,
+                    "type": "String",
+                    "analyzed": false,
+                    "jcr:primaryType": "nt:unstructured"
+                },
+                "value": {
+                    "name": "value",
+                    "propertyIndex": true,
+                    "type": "Date",
+                    "analyzed": true,
+                    "notNullCheckEnabled": true,
+                    "nullCheckEnabled": true,
+                    "jcr:primaryType": "nt:unstructured"
+                }
+            }
+        },
+        "cards:TimeAnswer": {
+            "jcr:primaryType": "nt:unstructured",
+            "properties": {
+                "jcr:primaryType": "nt:unstructured",
+                "question": {
+                    "name": "question",
+                    "propertyIndex": true,
+                    "type": "String",
+                    "analyzed": false,
+                    "jcr:primaryType": "nt:unstructured"
+                },
+                "value": {
+                    "name": "value",
+                    "propertyIndex": true,
+                    "type": "String",
+                    "analyzed": true,
+                    "notNullCheckEnabled": true,
+                    "nullCheckEnabled": true,
+                    "jcr:primaryType": "nt:unstructured"
+                }
+            }
+        },
+        "cards:PedigreeAnswer": {
+            "jcr:primaryType": "nt:unstructured",
+            "properties": {
+                "jcr:primaryType": "nt:unstructured",
+                "question": {
+                    "name": "question",
+                    "propertyIndex": true,
+                    "type": "String",
+                    "analyzed": false,
+                    "jcr:primaryType": "nt:unstructured"
+                },
+                "value": {
+                    "name": "value",
+                    "propertyIndex": true,
+                    "type": "String",
+                    "analyzed": true,
+                    "notNullCheckEnabled": true,
+                    "nullCheckEnabled": true,
+                    "jcr:primaryType": "nt:unstructured"
+                }
+            }
+        },
+        "cards:VocabularyAnswer": {
+            "jcr:primaryType": "nt:unstructured",
+            "properties": {
+                "jcr:primaryType": "nt:unstructured",
+                "question": {
+                    "name": "question",
+                    "propertyIndex": true,
+                    "type": "String",
+                    "analyzed": false,
+                    "jcr:primaryType": "nt:unstructured"
+                },
+                "value": {
+                    "name": "value",
+                    "propertyIndex": true,
+                    "type": "String",
+                    "analyzed": true,
+                    "notNullCheckEnabled": true,
+                    "nullCheckEnabled": true,
+                    "jcr:primaryType": "nt:unstructured"
+                }
+            }
+        },
+        "cards:FileResourceAnswer": {
+            "jcr:primaryType": "nt:unstructured",
+            "properties": {
+                "jcr:primaryType": "nt:unstructured",
+                "question": {
+                    "name": "question",
+                    "propertyIndex": true,
+                    "type": "String",
+                    "analyzed": false,
+                    "jcr:primaryType": "nt:unstructured"
+                },
+                "value": {
+                    "name": "value",
+                    "propertyIndex": true,
+                    "type": "String",
+                    "analyzed": true,
+                    "notNullCheckEnabled": true,
+                    "nullCheckEnabled": true,
+                    "jcr:primaryType": "nt:unstructured"
+                }
+            }
+        },
+        "cards:ChromosomeAnswer": {
+            "jcr:primaryType": "nt:unstructured",
+            "properties": {
+                "jcr:primaryType": "nt:unstructured",
+                "question": {
+                    "name": "question",
+                    "propertyIndex": true,
+                    "type": "String",
+                    "analyzed": false,
+                    "jcr:primaryType": "nt:unstructured"
+                },
+                "value": {
+                    "name": "value",
+                    "propertyIndex": true,
+                    "type": "String",
+                    "analyzed": true,
+                    "notNullCheckEnabled": true,
+                    "nullCheckEnabled": true,
                     "jcr:primaryType": "nt:unstructured"
                 }
             }
@@ -48,7 +274,7 @@
                     "boost": 1,
                     "nodeScopeIndex": false,
                     "useInExcerpt": true,
-                    "ordered": true,
+                    "ordered": false,
                     "propertyIndex": true
                 },
                 "created": {


### PR DESCRIPTION
To test both correctness and speed with 1k...10k forms.

Also to check: in `sling/logs/error.log` is the "traversed 10000 nodes" message printed?

Note: indexing 10k forms takes a little while after the upload is done, so wait until `sling/logs/error.log` stops printing messages about indexing nodes.