### PR TITLE
CARDS-1514: Add support for value comparison for Double questions

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/NumericFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/NumericFilter.jsx
@@ -71,7 +71,7 @@ const StyledNumericFilter = withStyles(QuestionnaireStyle)(NumericFilter)
 export default StyledNumericFilter;
 
 FilterComponentManager.registerFilterComponent((questionDefinition) => {
-  if (questionDefinition.dataType == 'decimal' || questionDefinition.dataType == 'long') {
+  if (questionDefinition.dataType == 'decimal' || questionDefinition.dataType == 'double' || questionDefinition.dataType == 'long') {
     return [COMPARATORS, StyledNumericFilter, 50];
   }
 });

--- a/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
@@ -521,13 +521,21 @@ public class PaginationServlet extends SlingSafeMethodsServlet
                 // Update the source name in the filter, e.g. "childf1_1"
                 filter.source = filterType.sourcePrefix + questionnairesToFormSource.get(questionnaire) + "_" + fcount;
                 // Update the source node type in the filter, e.g. "cards:BooleanAnswer"
-                filter.nodeType = getAnswerNodeType(filter.type);
+                filter.nodeType = getAnswerNodeType(filter, session);
             }
         }
     }
 
-    private String getAnswerNodeType(final String valueType)
+    private String getAnswerNodeType(final Filter filter, final Session session)
     {
+        String valueType = filter.type;
+        if (StringUtils.isBlank(valueType)) {
+            try {
+                valueType = session.getNodeByIdentifier(filter.name).getProperty("dataType").getString();
+            } catch (RepositoryException e) {
+                LOGGER.warn("{}", e.getMessage(), e);
+            }
+        }
         return StringUtils.isBlank(valueType) ? "cards:Answer"
             : "cards:" + valueType.substring(0, 1).toUpperCase(Locale.ROOT) + valueType.substring(1)
                 + "Answer";

--- a/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
@@ -372,6 +372,9 @@ public class PaginationServlet extends SlingSafeMethodsServlet
         final boolean sortDescending = Boolean.valueOf(request.getParameter("descending"));
         query.append(" order by n.'jcr:created'").append(sortDescending ? " DESC" : " ASC");
 
+        // Force using the lucene indexes
+        query.append(" option(index tag cards)");
+
         // All done!
         String finalquery = query.toString();
         LOGGER.debug("Computed final query: {}", finalquery);

--- a/modules/data-entry/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
@@ -5,6 +5,7 @@
     "async": "async",
     "evaluatePathRestrictions": true,
     "includedPaths": ["/Forms"],
+    "tags": ["cards"],
     "indexRules" : {
         "jcr:primaryType": "nt:unstructured",
         "cards:BooleanAnswer": {

--- a/modules/data-entry/src/main/resources/SLING-INF/content/oak%3Aindex/subjects.json
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/oak%3Aindex/subjects.json
@@ -5,6 +5,7 @@
     "async": "async",
     "evaluatePathRestrictions": true,
     "includedPaths": ["/Subjects"],
+    "tags": ["cards"],
     "indexRules" : {
         "jcr:primaryType": "nt:unstructured",
         "cards:Subject" : {


### PR DESCRIPTION
To test:
- create a new questionnaire with 3 questions of types `long`, `decimal`, `double`
- create some forms for them
- make sure filtering correctly works on all 3 types, except for decimal where string comparison is actually in use (so 10 < 5)
- make sure `is empty` and `is not empty` work correctly
- make sure `double = 5` and `double = 5.0` both correctly show a form where the value is `5.0`
- make sure multivalued and singlevalued questions/answers work
- also could use testing: vocabulary, boolean, text,date filters still work, for example on Patient Information forms