### PR TITLE
CARDS-1374: Convert SignIn (loginForm.js) component to a two-step process - one screen for username entry, one screen for password entry

### DIFF
--- a/Utilities/Administration/SAML/SAML_SETUP.md
+++ b/Utilities/Administration/SAML/SAML_SETUP.md
@@ -32,7 +32,7 @@ and _never_ in production environments.**
 2.3. Create the `myuser` user. Go to _Users_ --> _Add user_ and enter
 the following values:
   - _Username_: `myuser`
-  - _Email_: `myuser@uhn.ca`
+  - _Email_: `myuser@keycloakdemo`
   - _First Name_: `My`
   - _Last Name_: `User`
 then click _Save_. Click on the _Credentials_ tab and enter the
@@ -75,17 +75,25 @@ from the IdP's XML metadata URL. Enter the keystore export password from
 _step 3.2_ and enter `yes` for `Trust this certificate? [no]:`.
 
 3.5. Lastly, copy the file `samlKeystore.p12` into the root directory for
-the CARDS project. You may now start CARDS with _SAML Login Support_
-enabled (`./start_cards.sh --dev --saml`).
+the CARDS project. You may now start CARDS with _SAML Login Support_ and
+the `keycloak_demo` SAML IdP enabled
+(`./start_cards.sh --dev --saml --keycloak_demo`).
 
 4. Enable and configure the SAML login for CARDS by running:
 `python3 add_saml_sp_config.py`.
 
-5. Point your browser to CARDS (`http://localhost:8080` if testing
+5. Start the _keycloak_headermod_http_proxy_ by running:
+```bash
+cd Utilities/Development
+nodejs keycloak_headermod_http_proxy.js
+```
+
+6. Point your browser to CARDS (`http://localhost:9090` if testing
 locally). You should automatically be redirected to the SSO login page
 (Keycloak instance at `localhost:8484` if testing locally). Login with
-your credentials (`myuser`:`password` if using the testing Keycloak
-Docker container). You should now be able to access CARDS as your user.
+your credentials (`myuser@keycloakdemo`:`password` if using the testing
+Keycloak Docker container). You should now be able to access CARDS as
+your user.
 
 ### Security Tests
 
@@ -105,13 +113,13 @@ Keycloak Docker container as an IdP:
     - _Key use_: _sig_
   - Click _Save_
   - Go back to the _Providers_ tab and delete the `rsa-generated` key
-  - Visit `localhost:8080` again and you will be redirected to Keycloak (`localhost:8484`) just as before
+  - Visit `localhost:9090` again and you will be redirected to Keycloak (`localhost:8484`) just as before
   - Attempt to login as `myuser`:`password`
   - You should be shown a page with the error `Signature cryptographic validation not successful`
   - Go back to `http://localhost:8484/auth/admin` and login as `admin`:`admin`
   - Go to _Clients_ --> _http://localhost:8080/_
   - Disable _Sign Documents_ and _Sign Assertions_
   - Click _Save_
-  - Visit `localhost:8080` again and you will be redirected to Keycloak (`localhost:8484`) just as before
+  - Visit `localhost:9090` again and you will be redirected to Keycloak (`localhost:8484`) just as before
   - Attempt to login as `myuser`:`password`
   - You should be shown a page with the error `The SAML Assertion was not signed!`

--- a/Utilities/Administration/SAML/add_saml_sp_config.py
+++ b/Utilities/Administration/SAML/add_saml_sp_config.py
@@ -31,7 +31,7 @@ argparser.add_argument('--entityID', help='SAML Entity ID for this Service Provi
 argparser.add_argument('--acsPath', help='SAML Consumer Endpoint path [default: /sp/consumer]', default='/sp/consumer')
 argparser.add_argument('--saml2userIDAttr', help='SAML claim to be used as the user identifier [default: urn:oid:1.2.840.113549.1.9.1]', default='urn:oid:1.2.840.113549.1.9.1')
 argparser.add_argument('--saml2IDPDestination', help='The URL on the Identity Provider (IdP) that will provide the authentication screen [default: http://localhost:8484/auth/realms/myrealm/protocol/saml]', default='http://localhost:8484/auth/realms/myrealm/protocol/saml')
-argparser.add_argument('--saml2LogoutURL', help='The URL to redirect the client to after logging out [default: http://localhost:8484/]', default='http://localhost:8484/')
+argparser.add_argument('--saml2LogoutURL', help='The URL to redirect the client to after logging out [default: http://localhost:9090/]', default='http://localhost:9090/')
 argparser.add_argument('--jksFileLocation', help='The location of the keystore file containing the SAML decryption and verification keys [default: ./samlKeystore.p12]', default='./samlKeystore.p12')
 argparser.add_argument('--idpCertAlias', help='Keystore identifier for the IdP verification certificate [default: idpsigningalias]', default='idpsigningalias')
 argparser.add_argument('--spKeysAlias', help='Keystore identifier for the SAML IdP response decryption key [default: 1]', default='1')

--- a/Utilities/Administration/SAML/setup_saml_docker.sh
+++ b/Utilities/Administration/SAML/setup_saml_docker.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+python3 create_service_user_mapping.py || { echo "Failed to create service user mapping"; exit -1; }
+python3 create_saml_service_user.py || { echo "Failed to create saml service user"; exit -1; }
+python3 configure_saml_service_user_permissions.py || { echo "Failed to configure saml service user permissions"; exit -1; }
+python3 add_saml_sp_config.py --saml2LogoutURL http://localhost:8080/ || { echo "Failed to add SAML SP configuration"; exit -1; }
+
+echo "CARDS login via SAML now enabled for localhost:8484 using the realm \"myrealm\""

--- a/Utilities/Administration/SAML/setup_saml_docker.sh
+++ b/Utilities/Administration/SAML/setup_saml_docker.sh
@@ -17,9 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-python3 create_service_user_mapping.py || { echo "Failed to create service user mapping"; exit -1; }
-python3 create_saml_service_user.py || { echo "Failed to create saml service user"; exit -1; }
-python3 configure_saml_service_user_permissions.py || { echo "Failed to configure saml service user permissions"; exit -1; }
 python3 add_saml_sp_config.py --saml2LogoutURL http://localhost:8080/ || { echo "Failed to add SAML SP configuration"; exit -1; }
 
 echo "CARDS login via SAML now enabled for localhost:8484 using the realm \"myrealm\""

--- a/Utilities/Administration/SAML/setup_saml_docker_ssl.sh
+++ b/Utilities/Administration/SAML/setup_saml_docker_ssl.sh
@@ -17,9 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-python3 create_service_user_mapping.py || { echo "Failed to create service user mapping"; exit -1; }
-python3 create_saml_service_user.py || { echo "Failed to create saml service user"; exit -1; }
-python3 configure_saml_service_user_permissions.py || { echo "Failed to configure saml service user permissions"; exit -1; }
 python3 add_saml_sp_config.py --saml2LogoutURL https://localhost/ --entityID https://localhost/ || { echo "Failed to add SAML SP configuration"; exit -1; }
 
 echo "CARDS login via SAML now enabled for localhost:8484 using the realm \"myrealm\""

--- a/Utilities/Administration/SAML/setup_saml_docker_ssl.sh
+++ b/Utilities/Administration/SAML/setup_saml_docker_ssl.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+python3 create_service_user_mapping.py || { echo "Failed to create service user mapping"; exit -1; }
+python3 create_saml_service_user.py || { echo "Failed to create saml service user"; exit -1; }
+python3 configure_saml_service_user_permissions.py || { echo "Failed to configure saml service user permissions"; exit -1; }
+python3 add_saml_sp_config.py --saml2LogoutURL https://localhost/ --entityID https://localhost/ || { echo "Failed to add SAML SP configuration"; exit -1; }
+
+echo "CARDS login via SAML now enabled for localhost:8484 using the realm \"myrealm\""

--- a/Utilities/Administration/SAML/test_realm_ssl.json
+++ b/Utilities/Administration/SAML/test_realm_ssl.json
@@ -1,0 +1,2200 @@
+{
+  "id": "myrealm",
+  "realm": "myrealm",
+  "notBefore": 0,
+  "defaultSignatureAlgorithm": "RS256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 0,
+  "clientSessionMaxLifespan": 0,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 5,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "roles": {
+    "realm": [
+      {
+        "id": "2cd37899-caf1-485a-abd7-c3772c6f0c3d",
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "myrealm",
+        "attributes": {}
+      },
+      {
+        "id": "741468cc-fb3a-485a-8040-14fc84a4a359",
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "myrealm",
+        "attributes": {}
+      },
+      {
+        "id": "4219699c-0271-49b0-bd74-4cc0c88a3b1b",
+        "name": "default-roles-myrealm",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "composites": {
+          "realm": [
+            "offline_access",
+            "uma_authorization"
+          ],
+          "client": {
+            "account": [
+              "view-profile",
+              "manage-account"
+            ]
+          }
+        },
+        "clientRole": false,
+        "containerId": "myrealm",
+        "attributes": {}
+      }
+    ],
+    "client": {
+      "realm-management": [
+        {
+          "id": "f076893f-7c1f-4ccf-8ed3-f43ad5bd4cb3",
+          "name": "query-realms",
+          "description": "${role_query-realms}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c441e764-a739-4b8a-832e-2adccf9662a5",
+          "attributes": {}
+        },
+        {
+          "id": "9086e5d6-439b-4996-80a7-0038713cc30d",
+          "name": "manage-authorization",
+          "description": "${role_manage-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c441e764-a739-4b8a-832e-2adccf9662a5",
+          "attributes": {}
+        },
+        {
+          "id": "0d4bec82-44e3-4a70-9374-ecf6e346e18e",
+          "name": "manage-realm",
+          "description": "${role_manage-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c441e764-a739-4b8a-832e-2adccf9662a5",
+          "attributes": {}
+        },
+        {
+          "id": "c11641bb-8661-4587-9e1c-fcf271009930",
+          "name": "manage-identity-providers",
+          "description": "${role_manage-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c441e764-a739-4b8a-832e-2adccf9662a5",
+          "attributes": {}
+        },
+        {
+          "id": "adfed4dd-a8e7-4190-8720-bd4ef133bd7f",
+          "name": "view-realm",
+          "description": "${role_view-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c441e764-a739-4b8a-832e-2adccf9662a5",
+          "attributes": {}
+        },
+        {
+          "id": "123d5f7d-1313-4b1b-b8b9-b615f7ed3ed0",
+          "name": "impersonation",
+          "description": "${role_impersonation}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c441e764-a739-4b8a-832e-2adccf9662a5",
+          "attributes": {}
+        },
+        {
+          "id": "a17875cf-9716-44f9-b037-8991283a46f8",
+          "name": "realm-admin",
+          "description": "${role_realm-admin}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-realms",
+                "manage-authorization",
+                "manage-realm",
+                "manage-identity-providers",
+                "view-realm",
+                "impersonation",
+                "manage-clients",
+                "view-users",
+                "query-clients",
+                "manage-events",
+                "query-users",
+                "manage-users",
+                "view-events",
+                "view-identity-providers",
+                "view-clients",
+                "view-authorization",
+                "query-groups",
+                "create-client"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "c441e764-a739-4b8a-832e-2adccf9662a5",
+          "attributes": {}
+        },
+        {
+          "id": "9449dac7-cb0e-46e4-970c-a8c422b062f8",
+          "name": "manage-clients",
+          "description": "${role_manage-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c441e764-a739-4b8a-832e-2adccf9662a5",
+          "attributes": {}
+        },
+        {
+          "id": "c133e25d-56e4-4fd3-8589-cde735b01890",
+          "name": "manage-events",
+          "description": "${role_manage-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c441e764-a739-4b8a-832e-2adccf9662a5",
+          "attributes": {}
+        },
+        {
+          "id": "988c22f9-72c7-4c74-bed7-75b4801155ef",
+          "name": "query-clients",
+          "description": "${role_query-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c441e764-a739-4b8a-832e-2adccf9662a5",
+          "attributes": {}
+        },
+        {
+          "id": "fdae57aa-e004-4cce-a397-b694f5c80b4b",
+          "name": "query-users",
+          "description": "${role_query-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c441e764-a739-4b8a-832e-2adccf9662a5",
+          "attributes": {}
+        },
+        {
+          "id": "84157595-a1f1-4138-a259-69491ccb2ee6",
+          "name": "view-users",
+          "description": "${role_view-users}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-users",
+                "query-groups"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "c441e764-a739-4b8a-832e-2adccf9662a5",
+          "attributes": {}
+        },
+        {
+          "id": "3d3a84c0-8766-4ada-b6fb-aef4d16545da",
+          "name": "manage-users",
+          "description": "${role_manage-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c441e764-a739-4b8a-832e-2adccf9662a5",
+          "attributes": {}
+        },
+        {
+          "id": "6f8c9708-2213-4f9f-8e5c-d990a903eaed",
+          "name": "view-events",
+          "description": "${role_view-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c441e764-a739-4b8a-832e-2adccf9662a5",
+          "attributes": {}
+        },
+        {
+          "id": "8f78be52-73e7-4497-b3cf-7acf91037965",
+          "name": "view-identity-providers",
+          "description": "${role_view-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c441e764-a739-4b8a-832e-2adccf9662a5",
+          "attributes": {}
+        },
+        {
+          "id": "792c5e68-5127-4eb1-8aac-67bdafc5446e",
+          "name": "view-clients",
+          "description": "${role_view-clients}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "c441e764-a739-4b8a-832e-2adccf9662a5",
+          "attributes": {}
+        },
+        {
+          "id": "6b8756db-e9f4-4488-a9a6-feed83fac81e",
+          "name": "view-authorization",
+          "description": "${role_view-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c441e764-a739-4b8a-832e-2adccf9662a5",
+          "attributes": {}
+        },
+        {
+          "id": "c0216b05-e8ca-4338-8779-a0316a251b44",
+          "name": "query-groups",
+          "description": "${role_query-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c441e764-a739-4b8a-832e-2adccf9662a5",
+          "attributes": {}
+        },
+        {
+          "id": "868c89be-9587-4057-a62c-99219add3818",
+          "name": "create-client",
+          "description": "${role_create-client}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c441e764-a739-4b8a-832e-2adccf9662a5",
+          "attributes": {}
+        }
+      ],
+      "security-admin-console": [],
+      "admin-cli": [],
+      "account-console": [],
+      "broker": [
+        {
+          "id": "25b42ee4-a9e3-4d7b-8603-f5ba6743becb",
+          "name": "read-token",
+          "description": "${role_read-token}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "fc23ae2f-4800-42bb-bd42-ae0e5ee1d3e1",
+          "attributes": {}
+        }
+      ],
+      "https://localhost/": [],
+      "account": [
+        {
+          "id": "474f374e-d402-4cfa-8545-10a17451dc39",
+          "name": "view-consent",
+          "description": "${role_view-consent}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "ae55f14c-6e9c-4f62-86f9-d2f02dbaf513",
+          "attributes": {}
+        },
+        {
+          "id": "c704a6d9-4152-4b8c-9cfb-2a00184c7923",
+          "name": "view-applications",
+          "description": "${role_view-applications}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "ae55f14c-6e9c-4f62-86f9-d2f02dbaf513",
+          "attributes": {}
+        },
+        {
+          "id": "1c1b33b2-c7c0-4b27-a967-d4499d793751",
+          "name": "manage-consent",
+          "description": "${role_manage-consent}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "view-consent"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "ae55f14c-6e9c-4f62-86f9-d2f02dbaf513",
+          "attributes": {}
+        },
+        {
+          "id": "61d78893-5b9c-4fd9-9746-f873ef759c41",
+          "name": "view-profile",
+          "description": "${role_view-profile}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "ae55f14c-6e9c-4f62-86f9-d2f02dbaf513",
+          "attributes": {}
+        },
+        {
+          "id": "d5e2bed5-d21b-4e0b-af5e-bc299ec248b4",
+          "name": "delete-account",
+          "description": "${role_delete-account}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "ae55f14c-6e9c-4f62-86f9-d2f02dbaf513",
+          "attributes": {}
+        },
+        {
+          "id": "01d7ca1c-4952-492b-b1b1-62af9ea645df",
+          "name": "manage-account",
+          "description": "${role_manage-account}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "manage-account-links"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "ae55f14c-6e9c-4f62-86f9-d2f02dbaf513",
+          "attributes": {}
+        },
+        {
+          "id": "087fae1c-f709-4dcf-adc9-297affc9d81b",
+          "name": "manage-account-links",
+          "description": "${role_manage-account-links}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "ae55f14c-6e9c-4f62-86f9-d2f02dbaf513",
+          "attributes": {}
+        }
+      ]
+    }
+  },
+  "groups": [],
+  "defaultRole": {
+    "id": "4219699c-0271-49b0-bd74-4cc0c88a3b1b",
+    "name": "default-roles-myrealm",
+    "description": "${role_default-roles}",
+    "composite": true,
+    "clientRole": false,
+    "containerId": "myrealm"
+  },
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpSupportedApplications": [
+    "FreeOTP",
+    "Google Authenticator"
+  ],
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "scopeMappings": [
+    {
+      "clientScope": "offline_access",
+      "roles": [
+        "offline_access"
+      ]
+    }
+  ],
+  "clientScopeMappings": {
+    "account": [
+      {
+        "client": "account-console",
+        "roles": [
+          "manage-account"
+        ]
+      }
+    ]
+  },
+  "clients": [
+    {
+      "id": "ae55f14c-6e9c-4f62-86f9-d2f02dbaf513",
+      "clientId": "account",
+      "name": "${client_account}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/myrealm/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/myrealm/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "dfe58efe-6aa9-48ec-8e1e-8077accb0543",
+      "clientId": "account-console",
+      "name": "${client_account-console}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/myrealm/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/myrealm/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "65d643e3-1677-447c-99a1-bfacfb390d40",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "f91969d1-209e-4c9f-95f3-bfcab0dcde00",
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "fc23ae2f-4800-42bb-bd42-ae0e5ee1d3e1",
+      "clientId": "broker",
+      "name": "${client_broker}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "2636da63-7071-41f6-996a-1bdc182334dd",
+      "clientId": "https://localhost/",
+      "adminUrl": "/sp/consumer",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "https://localhost/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "saml",
+      "attributes": {
+        "saml.force.post.binding": "true",
+        "saml.multivalued.roles": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "use.refresh.tokens": "true",
+        "saml.signing.certificate": "MIICuzCCAaMCBgF8pJE0kTANBgkqhkiG9w0BAQsFADAhMR8wHQYDVQQDDBZodHRwOi8vbG9jYWxob3N0OjgwODAvMB4XDTIxMTAyMTIwMzQxMloXDTMxMTAyMTIwMzU1MlowITEfMB0GA1UEAwwWaHR0cDovL2xvY2FsaG9zdDo4MDgwLzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAI3JBn87HdQcn6wJRDtE++10plT09gvygfwi9eTxujkwgmlyKg3tJv0+eps3ddd+xAi46EUlYxxv0hwlrirOWy8xKjyK0Be5HHpDXRAyzmusXKNKFZEHumfEiu6hDoGlIjEcQZlMS4pStgDuN8yKPOvvKSb/qoLepYwkbEJu/t2ufAR0u9noygIeCKabS5AsG3ii0d7JnuLVoLRu1SXh+5r1rcnHIADVmeLljhihN02v4puMU+8GfrVX1R++yiPBicaktsT0AdhzzKO7EiHqKZF3n1KhTgXnlRGgl1u0mYFWrWfw1cWnJX+WgIggdcUzKccAHzmF2xQ/ay0+0ORRcnMCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEARXeFKu2EuSq4CSogG3jq3mKEi0SgYdNv1df88pwWREN0i0m1cx7EwprjXeI16bEbyQqIuu3Q0uFqBaLtFLSRUgqNS5l9K/IB/EYGxUegZ6a/vlSj8NrlyMEg1vITzR+9RaY2l/xnhX3grPd1a1bKAZaOJUL3xRPdzPXoKGf5/SST3Rv2+iKEPqQI5UZVOpNFA2gcOPKEpLRngjKV2vsjxdPKdYr5wMjL+EvNFEkdUWgKFwHGkGuNB5McQvFvWV7YpFuHBK36WUBLhXk0AGYLsKXYnuFzo2KNk4umtXq7UEHP8YjmII2fn3494gtQzDO6y0IlmRMMoMyH0QxoHl2YIw==",
+        "oidc.ciba.grant.enabled": "false",
+        "backchannel.logout.session.required": "false",
+        "client_credentials.use_refresh_token": "false",
+        "saml.signature.algorithm": "RSA_SHA256",
+        "require.pushed.authorization.requests": "false",
+        "saml.client.signature": "false",
+        "saml.signing.private.key": "MIIEowIBAAKCAQEAjckGfzsd1ByfrAlEO0T77XSmVPT2C/KB/CL15PG6OTCCaXIqDe0m/T56mzd1137ECLjoRSVjHG/SHCWuKs5bLzEqPIrQF7kcekNdEDLOa6xco0oVkQe6Z8SK7qEOgaUiMRxBmUxLilK2AO43zIo86+8pJv+qgt6ljCRsQm7+3a58BHS72ejKAh4IpptLkCwbeKLR3sme4tWgtG7VJeH7mvWtyccgANWZ4uWOGKE3Ta/im4xT7wZ+tVfVH77KI8GJxqS2xPQB2HPMo7sSIeopkXefUqFOBeeVEaCXW7SZgVatZ/DVxaclf5aAiCB1xTMpxwAfOYXbFD9rLT7Q5FFycwIDAQABAoIBAAwIdY6yu7NWwo5dMvc8wYzDi6JGL+OPr0xwwyGtCjr0TP0Z/Uu1RsvTU6B8snmZfpWm67+CjsjJDLHq2L81SDPXHliJB2QcB7iwouNPDInC1RHepbnrR/yqh4f9DzgdhatZVI/oE7knj97AWOf5C3aSk5GFvTjiIHamWLHCrcqudPIcdEo14VQzubWymqqqqt2XjjQnRqlUqIGAJl4r2SfbkHIzcznN71Dceo+/OUEEwl3TFTzW4XJ7gL3aehfKMCJjefLMeVwaU3j9qYYoi9aznK9EShf4vDzPttf7glqRrQ9ICzNpeiMJswmycjrsEyELbE1F0H9GjkprXw20ljECgYEA85mXnAukbmwyGclc2Yuh9MctpG6P5p5LTUl+aHp5NVOfOOQwRx5N+s1rgzwQTBoYHjOlVcO0vwqRuYBbia+q8y7x2x94ASpxv9S1Y3iZ/6oFsva1Lc+9mNFa0lZB5NBrGV2eU7bBzQ6K+b44dC75AeSojXh0x92gUazzcQLsn2cCgYEAlQCpdsPzAQBg78+ymYrIrUNXuth0ItZiSkwSNs28NKn8UpJgvw1fhtZWccRGIB746WJnitSB+K1mUPN338kKWUIy+wYe7fdjjc6Ce5SBgRz0BdE+0a2cZdtiaf6esRjwYdPGqDF6CD1Rk1XxZiNUqi4TknVkwxOvUik6RuJsSRUCgYEA6duV1NTIcsmj/2V0odSPErL0els6AqgMmpHnrN2G5070GGXYgy3wpsn2YPKUorqaVMQ4AXH0X0MCSxeSyUe/0d5LiZVYW6YntYW67VemX+8VsY1uuiApYD/79NmiQMxlROC/UpaszvMbME8RW1iM7OhbeBUf55A4jLCAtQmdqBkCgYAwKAedH9Vg5Htv5iOl5inXfaVT+PMH81vPAWj9l16Vcr7e/PoRpUPTc2B64mF7ribqXuhyAR6EfZ5M2XNLu1EB6hhJ8v96D3N4eF7JjASS8wWW/7qaz851SQM0mJs3R4UhSO2ynFMBaLf9s1ASn6aUXdHris9nEOyf1D1GfZVbxQKBgGu+K4P7pXs6bp3QT4jyUVXjxe5K/dznqQNm58cmdAbsepO1UxbTQGu2+yDT5l1C7P8zk8YCB4YFEjSKwip9V5pNp9UytuFhDPwYMJHmR26zwsORKOJqQWK8gg4se6kMuQOGS5yBUmLXf9ShHHLF3OUNOQ1iEP4xIiIdW4Tanu4f",
+        "id.token.as.detached.signature": "false",
+        "saml.assertion.signature": "true",
+        "saml.encrypt": "true",
+        "saml.server.signature": "true",
+        "exclude.session.state.from.auth.response": "false",
+        "saml.artifact.binding.identifier": "8DNG6zqZvgJZeQRej6GigcUVlhE=",
+        "saml.artifact.binding": "false",
+        "saml_force_name_id_format": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "true",
+        "display.on.consent.screen": "false",
+        "saml_name_id_format": "email",
+        "saml.onetimeuse.condition": "false",
+        "saml_signature_canonicalization_method": "http://www.w3.org/2001/10/xml-exc-c14n#"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "993e7048-ce2a-4b21-9d6b-555e3696b98e",
+          "name": "X500 surname",
+          "protocol": "saml",
+          "protocolMapper": "saml-user-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "attribute.nameformat": "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
+            "user.attribute": "lastName",
+            "friendly.name": "surname",
+            "attribute.name": "urn:oid:2.5.4.4"
+          }
+        },
+        {
+          "id": "8329df54-af67-49f6-adc8-8170f3b63b87",
+          "name": "X500 email",
+          "protocol": "saml",
+          "protocolMapper": "saml-user-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "attribute.nameformat": "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
+            "user.attribute": "email",
+            "friendly.name": "email",
+            "attribute.name": "urn:oid:1.2.840.113549.1.9.1"
+          }
+        },
+        {
+          "id": "76d33f4a-3d79-4e9e-82d8-b5507ebd7d8a",
+          "name": "X500 givenName",
+          "protocol": "saml",
+          "protocolMapper": "saml-user-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "attribute.nameformat": "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
+            "user.attribute": "firstName",
+            "friendly.name": "givenName",
+            "attribute.name": "urn:oid:2.5.4.42"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "role_list"
+      ],
+      "optionalClientScopes": []
+    },
+    {
+      "id": "c441e764-a739-4b8a-832e-2adccf9662a5",
+      "clientId": "realm-management",
+      "name": "${client_realm-management}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "c7bc94a8-d4ce-492b-8ade-a6563d6a78de",
+      "clientId": "security-admin-console",
+      "name": "${client_security-admin-console}",
+      "rootUrl": "${authAdminUrl}",
+      "baseUrl": "/admin/myrealm/console/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/admin/myrealm/console/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "2fed094e-59c8-4b85-a9ea-caed57545b58",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "id": "a90ad0f1-1acf-474a-b4da-1345c233bceb",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${emailScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "55e9ac42-73a6-4075-bac2-2b5cf3e838f7",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean"
+          }
+        },
+        {
+          "id": "24af8f6a-10d9-4f8c-91cd-7f882371163f",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "a9b7ce98-8813-4d5f-a23e-ae413aa7e78d",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${profileScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "8c4f071e-d741-4da9-8440-5c5edb8bff1d",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "640c469c-1439-4229-86f9-41de383e75b2",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "cbe58f96-56cf-4e13-9003-12af16937304",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "78ea7587-0d59-40e1-bb88-73bf4a31d010",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "506d2196-5f2d-4160-813e-e5c2c531d729",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "95ed9d0e-71c2-4bf3-96c3-6069b21e1e28",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "a49f613f-ee98-421d-bb48-7ce22be8877d",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ec71a5ae-582c-4049-9a40-7ea75675735d",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "618f6699-4b90-456b-baf3-1613d2fa52d5",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "8f45b00d-cdf3-4e29-a1b1-1c215a85c69b",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "efd978cc-7873-4967-a496-8b3dab65d382",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "5ec47dcc-faf6-4298-b3c7-7a754aa3fa06",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "72cfb041-d589-4ec7-b8e5-75abaaab62c9",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "8e5cd05a-ec9d-4317-b28a-0303dd04112b",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "470315aa-589b-4697-bd3d-3d0bfb7cabd5",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "a19c5352-2b9b-43f6-a4dc-8d47774b5808",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
+    },
+    {
+      "id": "9356a3cf-293c-4972-893b-a7ac96bcaf5f",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${phoneScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "14ea12c9-07e0-4f6a-8c43-a0a8a1275bba",
+          "name": "phone number",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumber",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "78eab7b3-1a21-42dc-b0f2-c989e8f1dc7b",
+          "name": "phone number verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumberVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "dcb91a7d-077f-45ef-9fc2-7550c4d9b444",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "bf058784-3caf-4283-9442-5a30f8810955",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "383d3d03-fb31-4081-a89c-8ec71a17c563",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "58270372-2f56-47ae-80c5-f04c32e6acd7",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "5030c545-93a8-46f6-8064-0006750f455e",
+      "name": "address",
+      "description": "OpenID Connect built-in scope: address",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${addressScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "604ed06b-d692-4043-a169-74bbea14e184",
+          "name": "address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-address-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute.formatted": "formatted",
+            "user.attribute.country": "country",
+            "user.attribute.postal_code": "postal_code",
+            "userinfo.token.claim": "true",
+            "user.attribute.street": "street",
+            "id.token.claim": "true",
+            "user.attribute.region": "region",
+            "access.token.claim": "true",
+            "user.attribute.locality": "locality"
+          }
+        }
+      ]
+    },
+    {
+      "id": "2edc525f-e066-44cc-9791-fec0910858d4",
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${rolesScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "708d2e25-135e-4f2f-af1a-d204d01712b1",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        },
+        {
+          "id": "96938a2e-effe-44e2-ab09-fe1b1aea7a87",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "8d5273a2-14e1-47ee-a916-e71714da0f74",
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "0c4e194f-51bb-4e43-ad02-f0673ebe096d",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "id": "03c0f508-f42f-4502-b328-7751c9ad3ab0",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "web-origins",
+    "roles",
+    "role_list",
+    "email",
+    "profile"
+  ],
+  "defaultOptionalClientScopes": [
+    "address",
+    "phone",
+    "microprofile-jwt",
+    "offline_access"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection": "1; mode=block",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "eventsEnabled": false,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [],
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "identityProviders": [],
+  "identityProviderMappers": [],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "7808e180-6195-400a-9ddd-79eaf57c3f7d",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "59f61807-06b3-45c5-a9b2-039e0a72ad83",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "saml-user-property-mapper",
+            "oidc-address-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-full-name-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "saml-role-list-mapper",
+            "saml-user-attribute-mapper"
+          ]
+        }
+      },
+      {
+        "id": "0890b1bb-bfc3-48de-9314-a21f69df8bd5",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "319bdcd4-98bb-465b-8d36-1aa6e1f65fc6",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-address-mapper",
+            "saml-role-list-mapper",
+            "oidc-full-name-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-usermodel-property-mapper",
+            "saml-user-property-mapper",
+            "oidc-sha256-pairwise-sub-mapper"
+          ]
+        }
+      },
+      {
+        "id": "a9effc17-a992-4a74-9b29-f144ccb01e1c",
+        "name": "Trusted Hosts",
+        "providerId": "trusted-hosts",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "host-sending-registration-request-must-match": [
+            "true"
+          ],
+          "client-uris-must-match": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "5b9e89cc-94dd-4c44-a7c0-e2a100f69dd5",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": [
+            "200"
+          ]
+        }
+      },
+      {
+        "id": "f7921902-b74d-4ae8-8f7f-c8e2702b6077",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "5cd22a13-645c-4c78-9556-54e04f59fa6c",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "2826f859-1a5a-4e0e-9032-955da82a4ac6",
+        "name": "rsa-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "keyUse": [
+            "sig"
+          ],
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "71d2db29-e765-4c6a-bf02-0ebfe7325672",
+        "name": "rsa-enc-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "keyUse": [
+            "enc"
+          ],
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "05cdf489-33ed-4713-9a2c-a62713a9e42c",
+        "name": "aes-generated",
+        "providerId": "aes-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "1d6725fe-e62a-48d6-9966-e62f2dc15e17",
+        "name": "hmac-generated",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "HS256"
+          ]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "supportedLocales": [],
+  "authenticationFlows": [
+    {
+      "id": "156b94ba-c041-4a3f-b7f6-312fec8eac91",
+      "alias": "Account verification options",
+      "description": "Method with which to verity the existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-email-verification",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "088ea08b-402c-406b-8094-5357f7831496",
+      "alias": "Authentication Options",
+      "description": "Authentication options.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "basic-auth",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "basic-auth-otp",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "bf6119ff-fefd-4e2e-ab93-abd6de67c9ec",
+      "alias": "Browser - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "a6e7e78a-0006-409a-921c-b59ee1bc0ee0",
+      "alias": "Direct Grant - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "150a7c59-2de0-4db9-bb5d-2b0714f981ba",
+      "alias": "First broker login - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "75395f26-2d09-4d81-9c02-a97bfb74fde0",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "Account verification options",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "5b2da949-6d1d-4d92-8e16-018b9cd0f267",
+      "alias": "Reset - Conditional OTP",
+      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "e6425825-6bdd-4fd2-addf-656678f122eb",
+      "alias": "User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "1b9fcf2e-cbdc-473b-b598-b229eb68bf92",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "flowAlias": "First broker login - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "d631d245-3f55-417f-bc72-d5e31c429dba",
+      "alias": "browser",
+      "description": "browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "flowAlias": "forms",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "3e6fb677-1e33-4664-a54b-68b38d8a8d7c",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-x509",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "97677880-9154-40c7-b855-0ad58be29693",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 30,
+          "flowAlias": "Direct Grant - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "26afa904-4b4c-488f-94b9-e1719c9a11a8",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "0ddbecaf-7098-4dc5-bd71-d152bfb559b8",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "User creation or linking",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "bb660e41-73d4-401e-8a24-0dc7a98a4f44",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "flowAlias": "Browser - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "ecc2505b-ac40-4dec-ab18-20abe1686202",
+      "alias": "http challenge",
+      "description": "An authentication flow based on challenge-response HTTP Authentication Schemes",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "no-cookie-redirect",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "Authentication Options",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "29a4b71f-af3a-4f38-8179-a32a39965dd5",
+      "alias": "registration",
+      "description": "registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "b5431108-35b2-495b-b4f5-ee22b8f78ef0",
+      "alias": "registration form",
+      "description": "registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-profile-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 40,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 60,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "846a267b-330b-483e-a7af-1d25a97f2e5a",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "flowAlias": "Reset - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "baa2f400-1107-4d3a-896c-5d986e36499e",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "6188d75e-2302-4734-af74-38ce9ac31d58",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "92679e5e-df63-4ec5-a974-d26c4636ebb3",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 10,
+      "config": {}
+    },
+    {
+      "alias": "terms_and_conditions",
+      "name": "Terms and Conditions",
+      "providerId": "terms_and_conditions",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 20,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 40,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 50,
+      "config": {}
+    },
+    {
+      "alias": "delete_account",
+      "name": "Delete Account",
+      "providerId": "delete_account",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 60,
+      "config": {}
+    },
+    {
+      "alias": "update_user_locale",
+      "name": "Update User Locale",
+      "providerId": "update_user_locale",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 1000,
+      "config": {}
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaExpiresIn": "120",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "oauth2DeviceCodeLifespan": "600",
+    "oauth2DevicePollingInterval": "5",
+    "parRequestUriLifespan": "60",
+    "cibaInterval": "5"
+  },
+  "keycloakVersion": "15.0.2",
+  "userManagedAccessAllowed": false,
+  "clientProfiles": {
+    "profiles": []
+  },
+  "clientPolicies": {
+    "policies": []
+  }
+}

--- a/Utilities/Development/keycloak_headermod_http_proxy.js
+++ b/Utilities/Development/keycloak_headermod_http_proxy.js
@@ -44,7 +44,10 @@ server.on('request', (s_req, s_res) => {
 			newHeaders.location.startsWith(KEYCLOAK_ENDPOINT + "?SAMLRequest=")
 			&& s_req.url !== "/fetch_requires_saml_login.html") {
 			newHeaders.location = newHeaders.location.replace(KEYCLOAK_ENDPOINT, "http://localhost:" + SERVER_PORT + "/login");
-		}      
+		} else if (c_res.statusCode == 302 &&
+			(s_req.url === "/system/sling/logout" || s_req.url === "/system/console/logout")) {
+			newHeaders['Set-Cookie'] = "sling.formauth=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; HttpOnly";
+		}
 		s_res.writeHead(c_res.statusCode, newHeaders);
 		c_res.pipe(s_res, {end: true});
 	});

--- a/Utilities/Development/keycloak_headermod_http_proxy.js
+++ b/Utilities/Development/keycloak_headermod_http_proxy.js
@@ -1,0 +1,63 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/*
+ * This program provides the necessary HTTP header modifications for
+ * running the keycloak_demo CARDS test without requiring a Docker
+ * container running the Apache HTTP reverse proxy.
+ */
+
+const SERVER_PORT = 9090;
+const CLIENT_PORT = 8080;
+const CLIENT_HOSTNAME = 'localhost';
+const KEYCLOAK_ENDPOINT = 'http://localhost:8484/auth/realms/myrealm/protocol/saml';
+
+const http = require('http');
+
+var server = new http.Server();
+server.on('request', (s_req, s_res) => {
+	let client_opts = {
+		hostname: CLIENT_HOSTNAME,
+		port: CLIENT_PORT,
+		path: s_req.url,
+		method: s_req.method,
+		headers: s_req.headers
+	};
+  var client_req = http.request(client_opts, (c_res) => {
+		let newHeaders = c_res.headers;
+		if (c_res.statusCode == 302 &&
+			newHeaders.location &&
+			newHeaders.location.startsWith(KEYCLOAK_ENDPOINT + "?SAMLRequest=")
+			&& s_req.url !== "/fetch_requires_saml_login.html") {
+			newHeaders.location = newHeaders.location.replace(KEYCLOAK_ENDPOINT, "http://localhost:" + SERVER_PORT + "/login");
+		}      
+		s_res.writeHead(c_res.statusCode, newHeaders);
+		c_res.pipe(s_res, {end: true});
+	});
+	s_req.pipe(client_req, {end: true});
+});
+
+server.listen(SERVER_PORT, '127.0.0.1', function(error) {
+	if (error) {
+		console.log("Proxy failed to start");
+	}
+	else {
+		console.log("Proxy listening on port " + SERVER_PORT);
+		console.log(" - with CARDS at " + CLIENT_HOSTNAME + ":" + CLIENT_PORT);
+		console.log(" - Keycloak login endpoint of: " + KEYCLOAK_ENDPOINT);
+	}
+});

--- a/compose-cluster/proxy/http_000-default.conf
+++ b/compose-cluster/proxy/http_000-default.conf
@@ -16,13 +16,27 @@
 # under the License.
 
 <VirtualHost *:80>
+
 	Header unset WWW-Authenticate
 	ProxyPreserveHost On
-	
-	ProxyPass /ncr/ http://127.0.0.1:8600/
-	ProxyPassReverse /ncr/ http://127.0.0.1:8600/
-	
-	ProxyPass / http://cardsinitial:8080/
-	ProxyPassReverse / http://cardsinitial:8080/
-	
+
+	<Location "/">
+		Header edit Location http://localhost:8484/auth/realms/myrealm/protocol/saml http://localhost:8080/login "expr=(%{REQUEST_STATUS} == 302) && (%{REQUEST_URI} != '/fetch_requires_saml_login.html')"
+		ProxyPass http://cardsinitial:8080/
+		ProxyPassReverse http://cardsinitial:8080/
+	</Location>
+
+	<Location "/ncr/">
+		ProxyPass http://127.0.0.1:8600/
+		ProxyPassReverse http://127.0.0.1:8600/
+	</Location>
+
+	<Location "/system/sling/logout">
+		Header set Set-Cookie "sling.formauth=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; HttpOnly" "expr=%{REQUEST_STATUS} == 302"
+	</Location>
+
+	<Location "/system/console/logout">
+		Header set Set-Cookie "sling.formauth=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; HttpOnly" "expr=%{REQUEST_STATUS} == 302"
+	</Location>
+
 </VirtualHost>

--- a/compose-cluster/proxy/http_saml_000-default.conf
+++ b/compose-cluster/proxy/http_saml_000-default.conf
@@ -16,13 +16,27 @@
 # under the License.
 
 <VirtualHost *:80>
+
 	Header unset WWW-Authenticate
 	ProxyPreserveHost On
-	
-	ProxyPass /ncr/ http://127.0.0.1:8600/
-	ProxyPassReverse /ncr/ http://127.0.0.1:8600/
-	
-	ProxyPass / http://cardsinitial:8080/
-	ProxyPassReverse / http://cardsinitial:8080/
-	
+
+	<Location "/">
+		Header edit Location ${SAML_IDP_DESTINATION} http://${CARDS_HOST_AND_PORT}/login "expr=(%{REQUEST_STATUS} == 302) && (%{REQUEST_URI} != '/fetch_requires_saml_login.html')"
+		ProxyPass http://cardsinitial:8080/
+		ProxyPassReverse http://cardsinitial:8080/
+	</Location>
+
+	<Location "/ncr/">
+		ProxyPass http://127.0.0.1:8600/
+		ProxyPassReverse http://127.0.0.1:8600/
+	</Location>
+
+	<Location "/system/sling/logout">
+		Header set Set-Cookie "sling.formauth=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; HttpOnly" "expr=%{REQUEST_STATUS} == 302"
+	</Location>
+
+	<Location "/system/console/logout">
+		Header set Set-Cookie "sling.formauth=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; HttpOnly" "expr=%{REQUEST_STATUS} == 302"
+	</Location>
+
 </VirtualHost>

--- a/compose-cluster/proxy/https_saml_000-default.conf
+++ b/compose-cluster/proxy/https_saml_000-default.conf
@@ -31,7 +31,7 @@
 	ProxyPreserveHost On
 
 	<Location "/">
-		Header edit Location ${SAML_IDP_DESTINATION} http://${CARDS_HOST_AND_PORT}/login "expr=(%{REQUEST_STATUS} == 302) && (%{REQUEST_URI} != '/fetch_requires_saml_login.html')"
+		Header edit Location ${SAML_IDP_DESTINATION} https://${CARDS_HOST_AND_PORT}/login "expr=(%{REQUEST_STATUS} == 302) && (%{REQUEST_URI} != '/fetch_requires_saml_login.html')"
 		ProxyPass http://cardsinitial:8080/
 		ProxyPassReverse http://cardsinitial:8080/
 	</Location>

--- a/compose-cluster/proxy/https_saml_000-default.conf
+++ b/compose-cluster/proxy/https_saml_000-default.conf
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+<VirtualHost *:443>
+	SSLEngine on
+	SSLProtocol all -TLSv1.1 -TLSv1 -SSLv2 -SSLv3
+	SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:!RC4+RSA:!RC4:+HIGH:!MEDIUM:!LOW
+
+	SSLCertificateFile /etc/cert/certificate.crt
+	SSLCertificateKeyFile /etc/cert/certificatekey.key
+	SSLCertificateChainFile /etc/cert/certificatechain.crt
+
+	Header unset WWW-Authenticate
+	Header always set Strict-Transport-Security "max-age=31536000"
+	Header edit location ^http://(.*)$ https://$1
+	Header edit Set-Cookie ^(.*)$ $1;Secure
+	ProxyPreserveHost On
+
+	<Location "/">
+		Header edit Location ${SAML_IDP_DESTINATION} http://${CARDS_HOST_AND_PORT}/login "expr=(%{REQUEST_STATUS} == 302) && (%{REQUEST_URI} != '/fetch_requires_saml_login.html')"
+		ProxyPass http://cardsinitial:8080/
+		ProxyPassReverse http://cardsinitial:8080/
+	</Location>
+
+	<Location "/ncr/">
+		ProxyPass http://127.0.0.1:8600/
+		ProxyPassReverse http://127.0.0.1:8600/
+	</Location>
+
+	<Location "/system/sling/logout">
+		Header set Set-Cookie "sling.formauth=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; HttpOnly" "expr=%{REQUEST_STATUS} == 302"
+	</Location>
+
+	<Location "/system/console/logout">
+		Header set Set-Cookie "sling.formauth=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; HttpOnly" "expr=%{REQUEST_STATUS} == 302"
+	</Location>
+
+</VirtualHost>

--- a/distribution/docker_entry.sh
+++ b/distribution/docker_entry.sh
@@ -156,7 +156,7 @@ fi
 #Should the SAML OSGi bundle be enabled?
 if [[ "$SAML_AUTH_ENABLED" == "true" ]]
 then
-  featureFlagString="$featureFlagString -f mvn:io.uhndata.cards/cards-saml-support/${CARDS_VERSION}/slingosgifeature/base -C io.dropwizard.metrics:metrics-core:ALL"
+  featureFlagString="$featureFlagString -f mvn:io.uhndata.cards/cards-saml-support/${CARDS_VERSION}/slingosgifeature/base -C io.dropwizard.metrics:metrics-core:ALL -f mvn:io.uhndata.cards/cards-fetch-requires-saml-login/${CARDS_VERSION}/slingosgifeature"
 fi
 
 #Execute the volume_mounted_init.sh script if it is present

--- a/modules/fetch-requires-saml-login/pom.xml
+++ b/modules/fetch-requires-saml-login/pom.xml
@@ -7,9 +7,7 @@
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
-
   http://www.apache.org/licenses/LICENSE-2.0
-
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,40 +20,27 @@
 
   <parent>
     <groupId>io.uhndata.cards</groupId>
-    <artifactId>cards-parent</artifactId>
+    <artifactId>cards-modules</artifactId>
     <version>0.9-SNAPSHOT</version>
   </parent>
 
-  <artifactId>cards-modules</artifactId>
-  <packaging>pom</packaging>
-  <name>CARDS Modules</name>
+  <artifactId>cards-fetch-requires-saml-login</artifactId>
+  <packaging>bundle</packaging>
+  <name>CARDS - Fetch Requires SAML Login</name>
 
-  <modules>
-    <module>startup-customization</module>
-    <module>form-completion-status</module>
-    <module>commons</module>
-    <module>ui-extension</module>
-    <module>login</module>
-    <module>homepage</module>
-    <module>pedigree</module>
-    <module>subjects</module>
-    <module>data-entry</module>
-    <module>ldap-support</module>
-    <module>saml-support</module>
-    <module>utils</module>
-    <module>principals</module>
-    <module>permissions</module>
-    <module>permissions-ownership</module>
-    <module>vocabularies</module>
-    <module>demo-banner</module>
-    <module>versioning</module>
-    <module>favicon</module>
-    <module>upgrade-marker</module>
-    <module>vocabularies-ignore</module>
-    <module>statistics</module>
-    <module>email-notifications</module>
-    <module>token-authentication</module>
-    <module>keycloakdemo-saml</module>
-    <module>fetch-requires-saml-login</module>
-  </modules>
+  <build>
+    <plugins>
+      <!-- This is an OSGi bundle -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Sling-Initial-Content>SLING-INF/content/;path:=/</Sling-Initial-Content>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/modules/fetch-requires-saml-login/src/main/features/feature.json
+++ b/modules/fetch-requires-saml-login/src/main/features/feature.json
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+{
+  "bundles":[
+    {
+      "id":"${project.groupId}:${project.artifactId}:${project.version}",
+      "start-order":"25"
+    }
+  ]
+}

--- a/modules/fetch-requires-saml-login/src/main/resources/SLING-INF/content/fetch_requires_saml_login.html
+++ b/modules/fetch-requires-saml-login/src/main/resources/SLING-INF/content/fetch_requires_saml_login.html
@@ -1,0 +1,36 @@
+<!--/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+*/-->
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <script type="text/javascript">
+      window.setTimeout(function() {
+        self.close();
+      }, 0);
+    </script>
+    <h1>
+      Fetch Requires SAML Login
+    </h1>
+  </body>
+</html>

--- a/modules/fetch-requires-saml-login/src/main/resources/SLING-INF/content/fetch_requires_saml_login.html.json
+++ b/modules/fetch-requires-saml-login/src/main/resources/SLING-INF/content/fetch_requires_saml_login.html.json
@@ -1,0 +1,5 @@
+{
+    "security:acl": [
+        { "principal": "everyone", "granted": ["jcr:read"] }
+    ]
+}

--- a/modules/keycloakdemo-saml/pom.xml
+++ b/modules/keycloakdemo-saml/pom.xml
@@ -7,9 +7,7 @@
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
-
   http://www.apache.org/licenses/LICENSE-2.0
-
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,39 +20,32 @@
 
   <parent>
     <groupId>io.uhndata.cards</groupId>
-    <artifactId>cards-parent</artifactId>
+    <artifactId>cards-modules</artifactId>
     <version>0.9-SNAPSHOT</version>
   </parent>
 
-  <artifactId>cards-modules</artifactId>
-  <packaging>pom</packaging>
-  <name>CARDS Modules</name>
+  <artifactId>cards-keycloakdemo-saml-support</artifactId>
+  <packaging>bundle</packaging>
+  <name>CARDS - Keycloak Demo SAML</name>
 
-  <modules>
-    <module>startup-customization</module>
-    <module>form-completion-status</module>
-    <module>commons</module>
-    <module>ui-extension</module>
-    <module>login</module>
-    <module>homepage</module>
-    <module>pedigree</module>
-    <module>subjects</module>
-    <module>data-entry</module>
-    <module>ldap-support</module>
-    <module>saml-support</module>
-    <module>utils</module>
-    <module>principals</module>
-    <module>permissions</module>
-    <module>permissions-ownership</module>
-    <module>vocabularies</module>
-    <module>demo-banner</module>
-    <module>versioning</module>
-    <module>favicon</module>
-    <module>upgrade-marker</module>
-    <module>vocabularies-ignore</module>
-    <module>statistics</module>
-    <module>email-notifications</module>
-    <module>token-authentication</module>
-    <module>keycloakdemo-saml</module>
-  </modules>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>slingfeature-maven-plugin</artifactId>
+      </plugin>
+
+      <!-- This is an OSGi bundle -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Sling-Initial-Content>SLING-INF/content/;path:=/apps/cards/SAMLDomains/</Sling-Initial-Content>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/modules/keycloakdemo-saml/src/main/features/feature.json
+++ b/modules/keycloakdemo-saml/src/main/features/feature.json
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+{
+  "bundles":[
+    {
+      "id":"${project.groupId}:${project.artifactId}:${project.version}",
+      "start-order":"25"
+    }
+  ]
+}

--- a/modules/keycloakdemo-saml/src/main/resources/SLING-INF/content/keycloakdemo.json
+++ b/modules/keycloakdemo-saml/src/main/resources/SLING-INF/content/keycloakdemo.json
@@ -1,0 +1,4 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "value": "http://localhost:8484/auth/realms/myrealm/protocol/saml"
+}

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -150,16 +150,28 @@ class SignIn extends React.Component {
                             }
                           })
                           .then((data) => {
-                            let popupWidth = 600;
-                            let popupHeight = 600;
-                            let screenLeft = window.screenLeft !== undefined ? window.screenLeft : window.screenX;
-                            let screenTop = window.screenTop !== undefined ? window.screenTop : window.screenY;
-                            let screenWidth = window.innerWidth;
-                            let screenHeight = window.innerHeight;
-                            let systemZoom = screenWidth / window.screen.availWidth;
-                            let left = (screenWidth - popupWidth) / 2 / systemZoom + screenLeft;
-                            let top = (screenHeight - popupHeight) / 2 / systemZoom + screenTop;
-                            data && window.open(data.value + "&username=" + this.state.username, "FederatedLoginPopupWindow", "width=" + (popupWidth / systemZoom) + ",height=" + (popupHeight / systemZoom) + ",top=" + top + ",left=" + left);
+                            if (window.location.pathname === "/login" || window.location.pathname === "/login/") {
+                              // We are logging in at a main login screen
+                              window.location = data.value + window.location.search;
+                            } else {
+                              // We are logging in from a fetchWithReLogin() window
+                              let popupWidth = 600;
+                              let popupHeight = 600;
+                              let screenLeft = window.screenLeft !== undefined ? window.screenLeft : window.screenX;
+                              let screenTop = window.screenTop !== undefined ? window.screenTop : window.screenY;
+                              let screenWidth = window.innerWidth;
+                              let screenHeight = window.innerHeight;
+                              let systemZoom = screenWidth / window.screen.availWidth;
+                              let left = (screenWidth - popupWidth) / 2 / systemZoom + screenLeft;
+                              let top = (screenHeight - popupHeight) / 2 / systemZoom + screenTop;
+                              let loginPopup = data && window.open(window.location.origin + "/fetch_requires_saml_login.html", "FederatedLoginPopupWindow", "width=" + (popupWidth / systemZoom) + ",height=" + (popupHeight / systemZoom) + ",top=" + top + ",left=" + left);
+                              let checkLoginTimer = setInterval(() => {
+                                if (loginPopup.closed === true) {
+                                  clearInterval(checkLoginTimer);
+                                  this.props.handleLogin && this.props.handleLogin(true);
+                                }
+                              }, 1000);
+                            }
                           })
                           .catch((err) => this.setState({failedLogin: "Error occurred while handling third-party identity provider"}))
                         } else {

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -151,18 +151,18 @@ class SignIn extends React.Component {
                     <InputLabel htmlFor="j_password">Password for {this.state.username}</InputLabel>
                     <Input name="j_password" type={this.state.passwordIsMasked ? 'text' : 'password'} id="j_password" autoComplete="current-password" autoFocus onChange={(event) => {this.setState({password: event.target.value});}}
                       endAdornment={
-                      <InputAdornment position="end">
-                        <Tooltip title={this.state.passwordIsMasked ? "Mask Password" : "Show Password"}>
-                          <IconButton
-                            aria-label="Toggle password visibility"
-                            onClick={this.togglePasswordMask}
-                          >
-                            {this.state.passwordIsMasked ? <VisibilityIcon/> : <VisibilityOffIcon/>}
-                          </IconButton>
-                        </Tooltip>
-                      </InputAdornment>
-                    }
-                  />
+                        <InputAdornment position="end">
+                          <Tooltip title={this.state.passwordIsMasked ? "Mask Password" : "Show Password"}>
+                            <IconButton
+                              aria-label="Toggle password visibility"
+                              onClick={this.togglePasswordMask}
+                            >
+                              {this.state.passwordIsMasked ? <VisibilityIcon/> : <VisibilityOffIcon/>}
+                            </IconButton>
+                          </Tooltip>
+                        </InputAdornment>
+                      }
+                    />
                   </FormControl>
                   <Button
                     type="submit"

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -126,9 +126,13 @@ class SignIn extends React.Component {
                         .then((resp) => {
                           if (resp.ok) {
                             this.setState({failedLogin: false});
+                            return resp.json();
                           } else {
                             this.setState({failedLogin: true});
                           }
+                        })
+                        .then((data) => {
+                          data && window.open(data.value + "&username=" + this.state.username, "FederatedLoginPopupWindow", "width=600,height=600");
                         })
                         .catch((err) => this.setState({failedLogin: true}))
                       } else {

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -40,7 +40,7 @@ class SignIn extends React.Component {
 
     this.state = {
       passwordIsMasked: false,
-      failedLogin: false,
+      failedLogin: undefined,
 
       username: "",
       password: "",
@@ -83,14 +83,14 @@ class SignIn extends React.Component {
         throw Error(response.statusText);
         this.props.handleLogin && this.props.handleLogin(false);
       }
-      this.setState({failedLogin: false});
+      this.setState({failedLogin: undefined});
       this.props.handleLogin && this.props.handleLogin(true);
       if (this.props.redirectOnLogin) {
         window.location = this.loginRedirectPath();
       }
     })
     .catch((error) => {
-      this.setState({failedLogin: true});
+      this.setState({failedLogin: "Invalid username or password"});
       this.props.handleLogin && this.props.handleLogin(false);
     });
   }
@@ -101,7 +101,7 @@ class SignIn extends React.Component {
 
     return (
         <div className={classes.main}>
-            {this.state.failedLogin && <Typography component="h2" className={classes.errorMessage}>Invalid username or password</Typography>}
+            {this.state.failedLogin && <Typography component="h2" className={classes.errorMessage}>{this.state.failedLogin}</Typography>}
 
             <form className={classes.form} onSubmit={(event)=>{event.preventDefault(); this.submitLogin();}} >
 
@@ -126,10 +126,10 @@ class SignIn extends React.Component {
                         fetch(window.location.origin + "/apps/cards/SAMLDomains/" + remoteDomain + ".json")
                         .then((resp) => {
                           if (resp.ok) {
-                            this.setState({failedLogin: false});
+                            this.setState({failedLogin: undefined});
                             return resp.json();
                           } else {
-                            this.setState({failedLogin: true});
+                            this.setState({failedLogin: "Unrecognized email domain"});
                           }
                         })
                         .then((data) => {
@@ -144,9 +144,9 @@ class SignIn extends React.Component {
                           let top = (screenHeight - popupHeight) / 2 / systemZoom + screenTop;
                           data && window.open(data.value + "&username=" + this.state.username, "FederatedLoginPopupWindow", "width=" + (popupWidth / systemZoom) + ",height=" + (popupHeight / systemZoom) + ",top=" + top + ",left=" + left);
                         })
-                        .catch((err) => this.setState({failedLogin: true}))
+                        .catch((err) => this.setState({failedLogin: "Error occurred while handling third-party identity provider"}))
                       } else {
-                        this.setState({failedLogin: true});
+                        this.setState({failedLogin: "Invalid email address"});
                       }
                     }}
                   >
@@ -185,6 +185,7 @@ class SignIn extends React.Component {
                         className={classes.submit}
                         onClick={() => {
                           this.setState({
+                            failedLogin: undefined,
                             username: "",
                             password: "",
                             phase: "USERNAME_ENTRY"

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -115,7 +115,26 @@ class SignIn extends React.Component {
                     variant="contained"
                     color="primary"
                     className={classes.submit}
-                    onClick={() => this.setState({phase: "PASSWORD_ENTRY"})}
+                    onClick={() => {
+                      if (this.state.username.split("@").length - 1 == 0) {
+                        this.setState({phase: "PASSWORD_ENTRY"});
+                      } else if (this.state.username.split("@").length - 1 == 1) {
+                        let remoteUser = this.state.username.split("@")[0];
+                        let remoteDomain = this.state.username.split("@")[1];
+                        // Do a fetch() to see if we have a SAML configuration for this domain
+                        fetch(window.location.origin + "/apps/cards/SAMLDomains/" + remoteDomain + ".json")
+                        .then((resp) => {
+                          if (resp.ok) {
+                            this.setState({failedLogin: false});
+                          } else {
+                            this.setState({failedLogin: true});
+                          }
+                        })
+                        .catch((err) => this.setState({failedLogin: true}))
+                      } else {
+                        this.setState({failedLogin: true});
+                      }
+                    }}
                   >
                     Next
                   </Button>

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -133,7 +133,16 @@ class SignIn extends React.Component {
                           }
                         })
                         .then((data) => {
-                          data && window.open(data.value + "&username=" + this.state.username, "FederatedLoginPopupWindow", "width=600,height=600");
+                          let popupWidth = 600;
+                          let popupHeight = 600;
+                          let screenLeft = window.screenLeft !== undefined ? window.screenLeft : window.screenX;
+                          let screenTop = window.screenTop !== undefined ? window.screenTop : window.screenY;
+                          let screenWidth = window.innerWidth;
+                          let screenHeight = window.innerHeight;
+                          let systemZoom = screenWidth / window.screen.availWidth;
+                          let left = (screenWidth - popupWidth) / 2 / systemZoom + screenLeft;
+                          let top = (screenHeight - popupHeight) / 2 / systemZoom + screenTop;
+                          data && window.open(data.value + "&username=" + this.state.username, "FederatedLoginPopupWindow", "width=" + (popupWidth / systemZoom) + ",height=" + (popupHeight / systemZoom) + ",top=" + top + ",left=" + left);
                         })
                         .catch((err) => this.setState({failedLogin: true}))
                       } else {

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -148,8 +148,8 @@ class SignIn extends React.Component {
               { (this.state.phase == "PASSWORD_ENTRY") &&
                 <React.Fragment>
                   <FormControl margin="normal" required fullWidth>
-                    <InputLabel htmlFor="j_password">Password</InputLabel>
-                    <Input name="j_password" type={this.state.passwordIsMasked ? 'text' : 'password'} id="j_password" autoComplete="current-password" onChange={(event) => {this.setState({password: event.target.value});}}
+                    <InputLabel htmlFor="j_password">Password for {this.state.username}</InputLabel>
+                    <Input name="j_password" type={this.state.passwordIsMasked ? 'text' : 'password'} id="j_password" autoComplete="current-password" autoFocus onChange={(event) => {this.setState({password: event.target.value});}}
                       endAdornment={
                       <InputAdornment position="end">
                         <Tooltip title={this.state.passwordIsMasked ? "Mask Password" : "Show Password"}>

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -42,7 +42,9 @@ class SignIn extends React.Component {
       failedLogin: false,
 
       username: "",
-      password: ""
+      password: "",
+
+      phase: "USERNAME_ENTRY"
     };
   }
 
@@ -102,37 +104,54 @@ class SignIn extends React.Component {
 
             <form className={classes.form} onSubmit={(event)=>{event.preventDefault(); this.submitLogin();}} >
 
-              <FormControl margin="normal" required fullWidth>
-                <InputLabel htmlFor="j_username">Username</InputLabel>
-                <Input id="j_username" name="j_username" autoComplete="email" autoFocus onChange={(event) => {this.setState({username: event.target.value});}}/>
-              </FormControl>
+              { (this.state.phase == "USERNAME_ENTRY") &&
+                <React.Fragment>
+                  <FormControl margin="normal" required fullWidth>
+                    <InputLabel htmlFor="j_username">Username</InputLabel>
+                    <Input id="j_username" name="j_username" autoComplete="email" autoFocus onChange={(event) => {this.setState({username: event.target.value});}}/>
+                  </FormControl>
+                  <Button
+                    fullWidth
+                    variant="contained"
+                    color="primary"
+                    className={classes.submit}
+                    onClick={() => this.setState({phase: "PASSWORD_ENTRY"})}
+                  >
+                    Next
+                  </Button>
+                </React.Fragment>
+              }
 
-              <FormControl margin="normal" required fullWidth>
-                <InputLabel htmlFor="j_password">Password</InputLabel>
-                <Input name="j_password" type={this.state.passwordIsMasked ? 'text' : 'password'} id="j_password" autoComplete="current-password" onChange={(event) => {this.setState({password: event.target.value});}}
-                  endAdornment={
-                  <InputAdornment position="end">
-                    <Tooltip title={this.state.passwordIsMasked ? "Mask Password" : "Show Password"}>
-                      <IconButton
-                        aria-label="Toggle password visibility"
-                        onClick={this.togglePasswordMask}
-                      >
-                        {this.state.passwordIsMasked ? <VisibilityIcon/> : <VisibilityOffIcon/>}
-                      </IconButton>
-                    </Tooltip>
-                  </InputAdornment>
-                }
-              />
-              </FormControl>
-              <Button
-                type="submit"
-                fullWidth
-                variant="contained"
-                color="primary"
-                className={classes.submit}
-              >
-                Sign in
-              </Button>
+              { (this.state.phase == "PASSWORD_ENTRY") &&
+                <React.Fragment>
+                  <FormControl margin="normal" required fullWidth>
+                    <InputLabel htmlFor="j_password">Password</InputLabel>
+                    <Input name="j_password" type={this.state.passwordIsMasked ? 'text' : 'password'} id="j_password" autoComplete="current-password" onChange={(event) => {this.setState({password: event.target.value});}}
+                      endAdornment={
+                      <InputAdornment position="end">
+                        <Tooltip title={this.state.passwordIsMasked ? "Mask Password" : "Show Password"}>
+                          <IconButton
+                            aria-label="Toggle password visibility"
+                            onClick={this.togglePasswordMask}
+                          >
+                            {this.state.passwordIsMasked ? <VisibilityIcon/> : <VisibilityOffIcon/>}
+                          </IconButton>
+                        </Tooltip>
+                      </InputAdornment>
+                    }
+                  />
+                  </FormControl>
+                  <Button
+                    type="submit"
+                    fullWidth
+                    variant="contained"
+                    color="primary"
+                    className={classes.submit}
+                  >
+                    Sign in
+                  </Button>
+                </React.Fragment>
+              }
             </form>
         </div>
     );

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -21,6 +21,7 @@ import PropTypes from 'prop-types';
 import {
     Button,
     FormControl,
+    Grid,
     IconButton,
     Input,
     InputAdornment,
@@ -164,15 +165,40 @@ class SignIn extends React.Component {
                       }
                     />
                   </FormControl>
-                  <Button
-                    type="submit"
-                    fullWidth
-                    variant="contained"
-                    color="primary"
-                    className={classes.submit}
-                  >
-                    Sign in
-                  </Button>
+                  <Grid container direction="row" justifyContent="center" alignItems="center">
+                    <Grid item xs={3}>
+                    </Grid>
+                    <Grid item xs={3}>
+                      <Button
+                        fullWidth
+                        variant="contained"
+                        color="primary"
+                        className={classes.submit}
+                        onClick={() => {
+                          this.setState({
+                            username: "",
+                            password: "",
+                            phase: "USERNAME_ENTRY"
+                          });
+                        }}
+                      >
+                        Back
+                      </Button>
+                    </Grid>
+                    <Grid item xs={3}>
+                      <Button
+                        type="submit"
+                        fullWidth
+                        variant="contained"
+                        color="primary"
+                        className={classes.submit}
+                      >
+                        Sign in
+                      </Button>
+                    </Grid>
+                    <Grid item xs={3}>
+                    </Grid>
+                  </Grid>
                 </React.Fragment>
               }
             </form>

--- a/start_cards.sh
+++ b/start_cards.sh
@@ -223,14 +223,14 @@ do
     ARGS_LENGTH=${ARGS_LENGTH}+1
     ARGS[$ARGS_LENGTH]=-f
     ARGS_LENGTH=${ARGS_LENGTH}+1
-    ARGS[$ARGS_LENGTH]=mvn:io.uhndata.cards/cards-fetch-requires-saml-login/0.9-SNAPSHOT/slingosgifeature
+    ARGS[$ARGS_LENGTH]=mvn:io.uhndata.cards/cards-fetch-requires-saml-login/${CARDS_VERSION}/slingosgifeature
     ARGS_LENGTH=${ARGS_LENGTH}+1
   elif [[ ${ARGS[$i]} == '--keycloak_demo' ]]
   then
     unset ARGS[$i]
     ARGS[$ARGS_LENGTH]=-f
     ARGS_LENGTH=${ARGS_LENGTH}+1
-    ARGS[$ARGS_LENGTH]=mvn:io.uhndata.cards/cards-keycloakdemo-saml-support/0.9-SNAPSHOT/slingosgifeature
+    ARGS[$ARGS_LENGTH]=mvn:io.uhndata.cards/cards-keycloakdemo-saml-support/${CARDS_VERSION}/slingosgifeature
     ARGS_LENGTH=${ARGS_LENGTH}+1
   else
     ARGS[$i]=${ARGS[$i]/VERSION/${CARDS_VERSION}}

--- a/start_cards.sh
+++ b/start_cards.sh
@@ -221,6 +221,10 @@ do
     ARGS_LENGTH=${ARGS_LENGTH}+1
     ARGS[$ARGS_LENGTH]=io.dropwizard.metrics:metrics-core:ALL
     ARGS_LENGTH=${ARGS_LENGTH}+1
+    ARGS[$ARGS_LENGTH]=-f
+    ARGS_LENGTH=${ARGS_LENGTH}+1
+    ARGS[$ARGS_LENGTH]=mvn:io.uhndata.cards/cards-fetch-requires-saml-login/0.9-SNAPSHOT/slingosgifeature
+    ARGS_LENGTH=${ARGS_LENGTH}+1
   elif [[ ${ARGS[$i]} == '--keycloak_demo' ]]
   then
     unset ARGS[$i]

--- a/start_cards.sh
+++ b/start_cards.sh
@@ -221,6 +221,13 @@ do
     ARGS_LENGTH=${ARGS_LENGTH}+1
     ARGS[$ARGS_LENGTH]=io.dropwizard.metrics:metrics-core:ALL
     ARGS_LENGTH=${ARGS_LENGTH}+1
+  elif [[ ${ARGS[$i]} == '--keycloak_demo' ]]
+  then
+    unset ARGS[$i]
+    ARGS[$ARGS_LENGTH]=-f
+    ARGS_LENGTH=${ARGS_LENGTH}+1
+    ARGS[$ARGS_LENGTH]=mvn:io.uhndata.cards/cards-keycloakdemo-saml-support/0.9-SNAPSHOT/slingosgifeature
+    ARGS_LENGTH=${ARGS_LENGTH}+1
   else
     ARGS[$i]=${ARGS[$i]/VERSION/${CARDS_VERSION}}
   fi


### PR DESCRIPTION
This PR builds on top of the CARDS-1359 branch and provides the necessary UI and reverse proxy changes so that a user may login to CARDS either as a native Sling user or through a SAML Identity Provider (IdP). If a SAML IdP is configured, a two-step login process will be presented to the user where, the first step involves entering a _username_. If the _username_ is a native Sling user, the second step will be a password prompt for the given username. If the _username_ indicates a SAML login from a configured IdP (eg. `myuser@keycloakdemo`) the user will be redirected to login at the IdP login screen.

To test:

- Build this (`CARDS-1374`) branch.
- Follow the instructions in `Utilities/Administration/SAML/SAML_SETUP.md` to setup a local Keycloak Docker container as an IdP.
- Ensure that, when visiting `http://localhost:9090/`, you are able to login both as a native Apache Sling user (`admin`:`admin`) and as the `myuser@keycloakdemo` SAML user.
- After logging out as the `admin` user, ensure that no subsequent requests to `http://localhost:9090` contain the `sling.formauth` cookie.
- After logging out as the `myuser@keycloakdemo` SAML user, log back in as `myuser@keycloakdemo`. If the Single Sign On (SSO) session has not expired, you will not be prompted by Keycloak for the `myuser@keycloakdemo` _username_ and _password_ but you should still briefly see the Keycloak authentication redirection screen.
- Ensure that `fetchWithReLogin` (popup login dialog) functionality works properly for both a native Apache Sling user as well as a SAML authenticated user.
- Ensure that the _Security Tests_ in `Utilities/Administration/SAML/SAML_SETUP.md` also pass.
- Ensure that if `start_cards.sh` is invoked without the `--keycloak_demo` flag, that the regular one-step login form is presented to the user.