### PR TITLE
CARDS-1463: Computed questions should have a data type

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -83,7 +83,6 @@ let ComputedQuestion = (props) => {
     }
     changeBaseValue(input);
     let newDisplayedValue = input;
-    // let newAnswer = input;
     if (dataType === "boolean") {
       switch (input) {
         case 1:

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -226,14 +226,13 @@ let ComputedQuestion = (props) => {
   // Performance improvement? Only compute if inputs have changed
   evaluateExpression();
 
-  let answerType, answerNodeType, newFieldType;
+  let capitalizedDataType = dataType.substring(0, 1).toUpperCase() + dataType.substring(1);
+  let answerType, answerNodeType = `cards:${capitalizedDataType}Answer`, newFieldType;
   switch (dataType) {
     case "boolean":
       answerType = "Long"; // Long, not Boolean
-      answerNodeType = "cards:BooleanAnswer";
       break;
     case "date":
-      answerNodeType = "cards:DateAnswer";
       newFieldType = DateQuestionUtilities.getFieldType(dateFormat);
       setFieldType(newFieldType);
       switch (newFieldType) {
@@ -249,30 +248,20 @@ let ComputedQuestion = (props) => {
       }
       break;
     case "long":
-      answerType = "Long";
-      answerNodeType = "cards:LongAnswer";
-      break;
     case "double":
-      answerType = "Double";
-      answerNodeType = "cards:DoubleAnswer";
-      break;
     case "decimal":
-      answerType = "Decimal";
-      answerNodeType = "cards:DecimalAnswer";
+      answerType = capitalizedDataType;
       break;
     case "vocabulary":
       answerType = "String";
-      answerNodeType = "cards:VocabularyAnswer";
       break;
     case "time":
       answerType = "String";
-      answerNodeType = "cards:TimeAnswer";
       newFieldType = Time.timeQuestionFieldType(dateFormat);
       setFieldType(newFieldType);
       break;
     case "text":
       answerType = "String";
-      answerNodeType = "cards:TextAnswer";
       break;
     case "computed": // Fallthrough default to string computed
     default:

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -328,7 +328,7 @@ const StyledComputedQuestion = withStyles(QuestionnaireStyle)(ComputedQuestion);
 export default StyledComputedQuestion;
 
 AnswerComponentManager.registerAnswerComponent((definition) => {
-  if (definition.dataType === "computed" || definition.entryMode === "computed") {
+  if (definition.entryMode === "computed") {
     return [StyledComputedQuestion, 80];
   }
 });

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionFull.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionFull.jsx
@@ -119,12 +119,6 @@ function DateQuestionFull(props) {
     ? "datetime-local"
     : "date";
 
-  let momentToString = (date) => {
-    return (!date || !date.isValid()) ? "" :
-    textFieldType === "date" ? date.format(moment.HTML5_FMT.DATE) :
-    date.format(moment.HTML5_FMT.DATETIME_LOCAL);
-  }
-
   let outputStart = getSlingDate(false);
   let outputEnd = getSlingDate(true);
   let outputAnswers = outputStart && outputStart !== "Invalid date" ? [["date", outputStart]] : [];
@@ -161,12 +155,12 @@ function DateQuestionFull(props) {
       {...props}
       >
       {error && <Typography color='error'>{errorMessage}</Typography>}
-      {getTextField(false, momentToString(startDate))}
+      {getTextField(false, DateQuestionUtilities.momentToString(startDate, textFieldType))}
       { /* If this is an interval, allow the user to select a second date */
       type === DateQuestionUtilities.INTERVAL_TYPE &&
       <React.Fragment>
         <span className={classes.mdash}>&mdash;</span>
-        {getTextField(true, momentToString(endDate))}
+        {getTextField(true, DateQuestionUtilities.momentToString(endDate, textFieldType))}
       </React.Fragment>
       }
       <Answer

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
@@ -65,6 +65,26 @@ export default class DateQuestionUtilities {
     return this.DEFAULT_DATE_TYPE;
   }
 
+  static getFieldType(dateFormat) {
+    let dateType = this.getDateType(dateFormat)
+    let result;
+    switch (dateType) {
+      case this.YEAR_DATE_TYPE:
+        result = "long";
+        break;
+      case this.MONTH_DATE_TYPE:
+        result = "string";
+        break;
+      case this.DATETIME_TYPE:
+        result = "datetime-local";
+        break;
+      default:
+        result = "date"
+        break;
+    }
+    return result;
+  }
+
   // Truncates fields in the given moment object or date string
   // according to the given format string
   static amendMoment(date, format) {
@@ -99,6 +119,12 @@ export default class DateQuestionUtilities {
     }
 
     return(new_date.startOf(truncateTo));
+  }
+
+  static momentToString(date, textFieldType) {
+    return (!date || !date.isValid()) ? "" :
+    textFieldType === "date" ? date.format(moment.HTML5_FMT.DATE) :
+    date.format(moment.HTML5_FMT.DATETIME_LOCAL);
   }
 
   // Convert a moment string to a month display

--- a/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
@@ -30,7 +30,7 @@ import TextQuestion from "./TextQuestion";
 
 import AnswerComponentManager from "./AnswerComponentManager";
 
-class Time {
+export class Time {
   constructor (timeString, isMinuteSeconds = true) {
     if (typeof(timeString) === "string" && timeString.length === 5 && timeString.charAt(2) === ':') {
       let values = timeString.split(":");
@@ -61,6 +61,14 @@ class Time {
   valueOf() {
     return this.isValid ? (this.first*60 + this.second) * (this.isMinuteSeconds ? 1 : 60) : undefined;
   }
+
+  static formatIsMinuteSeconds(dateFormat) {
+    return typeof(dateFormat) === "string" && dateFormat.toLowerCase() === "mm:ss";
+  }
+
+  static timeQuestionFieldType(dateFormat) {
+    return this.formatIsMinuteSeconds(dateFormat) ? "string" : "time";
+  }
 }
 
 // Component that renders a time question
@@ -89,7 +97,7 @@ function TimeQuestion(props) {
   const [error, setError] = useState(undefined);
   const defaultErrorMessage = errorText || "Please enter a valid time";
   const [errorMessage, setErrorMessage] = useState(defaultErrorMessage);
-  const isMinuteSeconds = typeof(dateFormat) === "string" && dateFormat.toLowerCase() === "mm:ss";
+  const isMinuteSeconds = Time.formatIsMinuteSeconds(dateFormat);
   const lowerTime = new Time(lowerLimit, isMinuteSeconds);
   const upperTime = new Time(upperLimit, isMinuteSeconds);
   const minuteSecondTest = new RegExp(/([0-5]\d):([0-5]\d)/);
@@ -121,7 +129,7 @@ function TimeQuestion(props) {
       {error && <Typography color='error'>{errorMessage}</Typography>}
       <TextField
         /* time input is hh:mm or hh:mm:ss only */
-        type={isMinuteSeconds ? "text" : "time"}
+        type={Time.timeQuestionFieldType(dateFormat)}
         className={classes.textField + " " + classes.answerField}
         InputLabelProps={{
           shrink: true,

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -222,15 +222,6 @@
           }
         }
       },
-      "computed": {
-        "expression": "string",
-        "displayMode" : {
-          "input" : {},
-          "formatted" : {},
-          "hidden": {}
-        },
-        "unitOfMeasurement" : "string"
-      },
       "time": {
         "minAnswers": {"0":{}, "1":{}},
         "dateFormat": "string",

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -4,9 +4,9 @@
     "description": "markdown",
     "dataType": {
       "text" : {
-        "minAnswers": "long",
         "entryMode": {
           "user": {
+            "minAnswers": "long",
             "maxAnswers": "long",
             "validationRegexp": "string",
             "enableSeparatorDetection": "boolean",
@@ -24,6 +24,7 @@
             }
           },
           "computed": {
+            "minAnswers": {"0":{}, "1":{}},
             "expression": "string",
             "displayMode" : {
               "input" : {},
@@ -70,10 +71,10 @@
         }
       },
       "long": {
-        "minAnswers": "long",
         "unitOfMeasurement" : "string",
         "entryMode": {
           "user": {
+            "minAnswers": "long",
             "maxAnswers": "long",
             "minValue": "double",
             "maxValue": "double",
@@ -100,6 +101,7 @@
             }
           },
           "computed": {
+            "minAnswers": {"0":{}, "1":{}},
             "expression": "string",
             "displayMode" : {
               "input" : {},
@@ -110,10 +112,10 @@
         }
       },
       "decimal": {
-        "minAnswers": "long",
         "unitOfMeasurement" : "string",
         "entryMode": {
           "user": {
+            "minAnswers": "long",
             "maxAnswers": "long",
             "minValue": "double",
             "maxValue": "double",
@@ -140,6 +142,7 @@
             }
           },
           "computed": {
+            "minAnswers": {"0":{}, "1":{}},
             "expression": "string",
             "displayMode" : {
               "input" : {},
@@ -150,10 +153,10 @@
         }
       },
       "double": {
-        "minAnswers": "long",
         "unitOfMeasurement" : "string",
         "entryMode": {
           "user": {
+            "minAnswers": "long",
             "maxAnswers": "long",
             "minValue": "double",
             "maxValue": "double",
@@ -172,6 +175,7 @@
             }
           },
           "computed": {
+            "minAnswers": {"0":{}, "1":{}},
             "expression": "string",
             "displayMode" : {
               "input" : {},
@@ -195,9 +199,9 @@
           "orderProperty": "cards:Vocabulary",
           "identifierProperty": "identifier"
         },
-        "minAnswers": "long",
         "entryMode": {
           "user": {
+            "minAnswers": "long",
             "maxAnswers": "long",
             "enableNotes": "boolean",
             "displayMode": {
@@ -213,6 +217,7 @@
             }
           },
           "computed": {
+            "minAnswers": {"0":{}, "1":{}},
             "expression": "string",
             "displayMode" : {
               "input" : {},

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -4,20 +4,32 @@
     "description": "markdown",
     "dataType": {
       "text" : {
-        "validationRegexp": "string",
-        "enableSeparatorDetection": "boolean",
         "minAnswers": "long",
-        "maxAnswers": "long",
-        "displayMode": {
-          "input": {},
-          "textbox": {},
-          "list": {
-            "compact" : "boolean",
-            "answerOptions" : "textOptions"
+        "entryMode": {
+          "user": {
+            "maxAnswers": "long",
+            "validationRegexp": "string",
+            "enableSeparatorDetection": "boolean",
+            "displayMode": {
+              "input": {},
+              "textbox": {},
+              "list": {
+                "compact" : "boolean",
+                "answerOptions" : "textOptions"
+              },
+              "list+input" : {
+                "compact" : "boolean",
+                "answerOptions" : "textOptions"
+              }
+            }
           },
-          "list+input" : {
-            "compact" : "boolean",
-            "answerOptions" : "textOptions"
+          "computed": {
+            "expression": "string",
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
           }
         }
       },
@@ -27,85 +39,145 @@
         "noLabel": "string",
         "enableUnknown": "boolean",
         "unknownLabel": "string",
-        "compact" : "boolean"
+        "compact" : "boolean",
+        "entryMode": {
+          "user": {
+          },
+          "computed": {
+            "expression": "string",
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
+          }
+        }
       },
       "date" : {
         "minAnswers": {"0":{}, "1":{}},
-        "dateFormat": "string"
+        "dateFormat": "string",
+        "entryMode": {
+          "user": {
+          },
+          "computed": {
+            "expression": "string",
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
+          }
+        }
       },
       "long": {
-        "minValue": "double",
-        "maxValue": "double",
         "minAnswers": "long",
-        "maxAnswers": "long",
         "unitOfMeasurement" : "string",
-        "displayMode": {
-          "input": {
-            "isRange" : "boolean"
+        "entryMode": {
+          "user": {
+            "maxAnswers": "long",
+            "minValue": "double",
+            "maxValue": "double",
+            "displayMode": {
+              "input": {
+                "isRange" : "boolean"
+              },
+              "list": {
+                "compact" : "boolean",
+                "answerOptions" : "numberOptions"
+              },
+              "list+input" : {
+                "compact" : "boolean",
+                "answerOptions" : "numberOptions"
+              },
+              "slider": {
+                "isRange" : "boolean",
+                "minValueLabel" : "string",
+                "maxValueLabel" : "string",
+                "sliderStep": "double",
+                "sliderMarkStep": "double",
+                "sliderOrientation": {"horizontal" : {}, "vertical": {}}
+              }
+            }
           },
-          "list": {
-            "compact" : "boolean",
-            "answerOptions" : "numberOptions"
-          },
-          "list+input" : {
-            "compact" : "boolean",
-            "answerOptions" : "numberOptions"
-          },
-          "slider": {
-            "isRange" : "boolean",
-            "minValueLabel" : "string",
-            "maxValueLabel" : "string",
-            "sliderStep": "double",
-            "sliderMarkStep": "double",
-            "sliderOrientation": {"horizontal" : {}, "vertical": {}}
+          "computed": {
+            "expression": "string",
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
           }
         }
       },
       "decimal": {
-        "minValue": "double",
-        "maxValue": "double",
         "minAnswers": "long",
-        "maxAnswers": "long",
         "unitOfMeasurement" : "string",
-        "displayMode": {
-          "input": {
-            "isRange" : "boolean"
+        "entryMode": {
+          "user": {
+            "maxAnswers": "long",
+            "minValue": "double",
+            "maxValue": "double",
+            "displayMode": {
+              "input": {
+                "isRange" : "boolean"
+              },
+              "list": {
+                "compact" : "boolean",
+                "answerOptions" : "numberOptions"
+              },
+              "list+input" : {
+                "compact" : "boolean",
+                "answerOptions" : "numberOptions"
+              },
+              "slider": {
+                "isRange" : "boolean",
+                "minValueLabel" : "string",
+                "maxValueLabel" : "string",
+                "sliderStep": "double",
+                "sliderMarkStep": "double",
+                "sliderOrientation": {"horizontal" : {}, "vertical": {}}
+              }
+            }
           },
-          "list": {
-            "compact" : "boolean",
-            "answerOptions" : "numberOptions"
-          },
-          "list+input" : {
-            "compact" : "boolean",
-            "answerOptions" : "numberOptions"
-          },
-          "slider": {
-            "isRange" : "boolean",
-            "minValueLabel" : "string",
-            "maxValueLabel" : "string",
-            "sliderStep": "double",
-            "sliderMarkStep": "double",
-            "sliderOrientation": {"horizontal" : {}, "vertical": {}}
+          "computed": {
+            "expression": "string",
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
           }
         }
       },
       "double": {
-        "minValue": "double",
-        "maxValue": "double",
         "minAnswers": "long",
-        "maxAnswers": "long",
         "unitOfMeasurement" : "string",
-        "displayMode": {
-          "input": {
-            "isRange" : "boolean"
+        "entryMode": {
+          "user": {
+            "maxAnswers": "long",
+            "minValue": "double",
+            "maxValue": "double",
+            "displayMode": {
+              "input": {
+                "isRange" : "boolean"
+              },
+              "slider": {
+                "isRange" : "boolean",
+                "minValueLabel" : "string",
+                "maxValueLabel" : "string",
+                "sliderStep": "double",
+                "sliderMarkStep": "double",
+                "sliderOrientation": {"horizontal" : {}, "vertical": {}}
+              }
+            }
           },
-          "slider": {
-            "isRange" : "boolean",
-            "minValueLabel" : "string",
-            "maxValueLabel" : "string",
-            "sliderStep": "double",
-            "sliderMarkStep": "double",
-            "sliderOrientation": {"horizontal" : {}, "vertical": {}}
+          "computed": {
+            "expression": "string",
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
           }
         }
       },
@@ -124,19 +196,31 @@
           "identifierProperty": "identifier"
         },
         "minAnswers": "long",
-        "maxAnswers": "long",
-        "displayMode": {
-          "input": {},
-          "list": {
-            "compact" : "boolean",
-            "answerOptions" : "textOptions"
+        "entryMode": {
+          "user": {
+            "maxAnswers": "long",
+            "enableNotes": "boolean",
+            "displayMode": {
+              "input": {},
+              "list": {
+                "compact" : "boolean",
+                "answerOptions" : "textOptions"
+              },
+              "list+input" : {
+                "compact" : "boolean",
+                "answerOptions" : "textOptions"
+              }
+            }
           },
-          "list+input" : {
-            "compact" : "boolean",
-            "answerOptions" : "textOptions"
+          "computed": {
+            "expression": "string",
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
           }
-        },
-        "enableNotes": "boolean"
+        }
       },
       "computed": {
         "expression": "string",
@@ -148,11 +232,23 @@
         "unitOfMeasurement" : "string"
       },
       "time": {
-        "lowerLimit": "string",
-        "upperLimit": "string",
         "minAnswers": {"0":{}, "1":{}},
-        "errorText": "string",
-        "dateFormat": "string"
+        "dateFormat": "string",
+        "entryMode": {
+          "user": {
+            "lowerLimit": "string",
+            "upperLimit": "string",
+            "errorText": "string"
+          },
+          "computed": {
+            "expression": "string",
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
+          }
+        }
       },
       "pedigree" : {
         "minAnswers": {"0":{}, "1":{}}

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/api/ExpressionUtils.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/api/ExpressionUtils.java
@@ -74,7 +74,8 @@ public interface ExpressionUtils
      * @param question the question node
      * @param values the other values in the form
      * @param type the expected type of the result
-     * @return a string representation of the result, may be {@code null} if the expression has unmet dependencies
+     * @return a representation of the evaluation result, forced into the desired data type; may be {@code null} if the
+     *         expression has unmet dependencies or the actual evaluation result cannot be converted to the desired type
      */
     Object evaluate(Node question, Map<String, Object> values, Type<?> type);
 }

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/api/ExpressionUtils.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/api/ExpressionUtils.java
@@ -21,6 +21,8 @@ import java.util.Set;
 
 import javax.jcr.Node;
 
+import org.apache.jackrabbit.oak.api.Type;
+
 /**
  * Utility class for parsing and evaluating an expression.
  *
@@ -61,5 +63,18 @@ public interface ExpressionUtils
      * @param values the other values in the form
      * @return a string representation of the result, may be {@code null} if the expression has unmet dependencies
      */
-    String evaluate(Node question, Map<String, Object> values);
+    default String evaluate(Node question, Map<String, Object> values)
+    {
+        return String.valueOf(evaluate(question, values, Type.STRING));
+    }
+
+    /**
+     * Evaluate a computed answer based on the other values present in the context.
+     *
+     * @param question the question node
+     * @param values the other values in the form
+     * @param type the expected type of the result
+     * @return a string representation of the result, may be {@code null} if the expression has unmet dependencies
+     */
+    Object evaluate(Node question, Map<String, Object> values, Type<?> type);
 }

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/api/QuestionnaireUtils.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/api/QuestionnaireUtils.java
@@ -102,6 +102,15 @@ public interface QuestionnaireUtils
     boolean isQuestion(Node node);
 
     /**
+     * Check if the given node is a Question node for a computed question.
+     *
+     * @param node the node to check, a JCR Node, may be {@code null}
+     * @return {@code true} if the node is not {@code null}, is computed and is of type {@code cards:Question},
+     *         {@code false} otherwise
+     */
+    boolean isComputedQuestion(Node node);
+
+    /**
      * Retrieve the Question with the given UUID.
      *
      * @param identifier an UUID that references a question.

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/ComputedAnswersEditor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/ComputedAnswersEditor.java
@@ -278,15 +278,11 @@ public class ComputedAnswersEditor extends DefaultEditor
             } else if (this.formUtils.isAnswer(currentNode)) {
                 String questionName = this.questionnaireUtils.getQuestionName(this.formUtils.getQuestion(currentNode));
                 Object value = this.formUtils.getValue(currentNode);
-                if (questionName != null && value != null) {
+                if (questionName != null && value != null && !currentAnswers.containsKey(questionName)) {
                     // Found an answer. Store it using the question's name to easily compare with
                     // saved answer nodes to avoid duplicating existing answers
-                    if (currentAnswers.containsKey(questionName)) {
-                        // Question has multiple answers. Ignore this answer, just keep previous.
-                        // TODO: Implement better recurrent section handling
-                    } else {
-                        currentAnswers.put(questionName, value);
-                    }
+                    // TODO: Implement better recurrent section handling
+                    currentAnswers.put(questionName, value);
                 }
 
             }

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/ComputedAnswersEditor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/ComputedAnswersEditor.java
@@ -335,7 +335,7 @@ public class ComputedAnswersEditor extends DefaultEditor
                     currentNode.setProperty("jcr:primaryType", types.getPrimaryType(), Type.NAME);
                     currentNode.setProperty("sling:resourceSuperType", FormUtils.ANSWER_RESOURCE, Type.STRING);
                     currentNode.setProperty("sling:resourceType", types.getResourceType(), Type.STRING);
-                    currentNode.setProperty("statusFlags", "", Type.STRING);
+                    currentNode.setProperty("statusFlags", Collections.emptyList(), Type.STRINGS);
                 }
                 return Collections.singletonMap(questionTree, currentNode);
             } else {
@@ -347,7 +347,7 @@ public class ComputedAnswersEditor extends DefaultEditor
                     currentNode.setProperty("jcr:primaryType", FormUtils.ANSWER_SECTION_NODETYPE, Type.NAME);
                     currentNode.setProperty("sling:resourceSuperType", "cards/Resource", Type.STRING);
                     currentNode.setProperty("sling:resourceType", FormUtils.ANSWER_SECTION_RESOURCE, Type.STRING);
-                    currentNode.setProperty("statusFlags", "", Type.STRING);
+                    currentNode.setProperty("statusFlags", Collections.emptyList(), Type.STRINGS);
                 }
                 Map<String, List<NodeBuilder>> childNodesByReference = getChildNodesByReference(currentNode);
                 return createChildrenNodes(questionTree, childNodesByReference, currentNode);

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/ComputedAnswersEditor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/ComputedAnswersEditor.java
@@ -95,7 +95,7 @@ public class ComputedAnswersEditor extends DefaultEditor
      * @param expressionUtils for evaluating the computed questions
      */
     public ComputedAnswersEditor(final NodeBuilder nodeBuilder, final ResourceResolverFactory rrf,
-        final QuestionnaireUtils questionnaireUtils, FormUtils formUtils, final ExpressionUtils expressionUtils)
+        final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils, final ExpressionUtils expressionUtils)
     {
         this.currentNodeBuilder = nodeBuilder;
         this.rrf = rrf;
@@ -107,7 +107,7 @@ public class ComputedAnswersEditor extends DefaultEditor
     }
 
     @Override
-    public Editor childNodeAdded(String name, NodeState after)
+    public Editor childNodeAdded(final String name, final NodeState after)
     {
         if (this.isFormNode) {
             // Found a modified form. Flag for the current editor to checking computed answers.
@@ -122,13 +122,13 @@ public class ComputedAnswersEditor extends DefaultEditor
     }
 
     @Override
-    public Editor childNodeChanged(String name, NodeState before, NodeState after)
+    public Editor childNodeChanged(final String name, final NodeState before, final NodeState after)
     {
         return childNodeAdded(name, after);
     }
 
     @Override
-    public void leave(NodeState before, NodeState after)
+    public void leave(final NodeState before, final NodeState after)
     {
         if (!this.formEditorHasChanged) {
             return;
@@ -136,7 +136,7 @@ public class ComputedAnswersEditor extends DefaultEditor
 
         final Map<String, Object> parameters =
             Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "computedAnswers");
-        ResourceResolver sessionResolver = this.rrf.getThreadResourceResolver();
+        final ResourceResolver sessionResolver = this.rrf.getThreadResourceResolver();
         try (ResourceResolver serviceResolver = this.rrf.getServiceResourceResolver(parameters)) {
             if (sessionResolver != null && serviceResolver != null) {
                 this.currentSession = sessionResolver.adaptTo(Session.class);
@@ -148,31 +148,31 @@ public class ComputedAnswersEditor extends DefaultEditor
         }
     }
 
-    private void computeMissingAnswers(NodeState form)
+    private void computeMissingAnswers(final NodeState form)
     {
         // Get a list of all current answers for the form for use in computing answers
-        Map<String, Object> answersByQuestionName = getNodeAnswers(form);
+        final Map<String, Object> answersByQuestionName = getNodeAnswers(form);
 
         // Get a list of all unanswered computed questions that need to be calculated
-        Node questionnaireNode = getQuestionnaire();
+        final Node questionnaireNode = getQuestionnaire();
         if (questionnaireNode == null) {
             return;
         }
-        QuestionTree computedQuestionsTree = getUnansweredComputedQuestions(questionnaireNode);
+        final QuestionTree computedQuestionsTree = getUnansweredComputedQuestions(questionnaireNode);
 
         // There are missing computed questions, let's create them!
         if (computedQuestionsTree != null) {
             // Create the missing structure, i.e. AnswerSection and Answer nodes
-            Map<QuestionTree, NodeBuilder> answersToCompute =
+            final Map<QuestionTree, NodeBuilder> answersToCompute =
                 createMissingNodes(computedQuestionsTree, this.currentNodeBuilder);
 
             // Try to determine the right order in which answers should be computed, so that the answers that depend on
             // other computed answers are evaluated after all their dependencies have been evaluated
-            Set<String> questionNames = answersToCompute.keySet().stream()
+            final Set<String> questionNames = answersToCompute.keySet().stream()
                 .map(QuestionTree::getNode)
                 .map(this.questionnaireUtils::getQuestionName)
                 .collect(Collectors.toSet());
-            Map<String, Set<String>> computedAnswerDependencies =
+            final Map<String, Set<String>> computedAnswerDependencies =
                 answersToCompute.keySet().stream().map(question -> {
                     Set<String> dependencies = this.expressionUtils.getDependencies(question.getNode());
                     dependencies.retainAll(questionNames);
@@ -194,10 +194,11 @@ public class ComputedAnswersEditor extends DefaultEditor
         }
     }
 
-    private void computeAnswer(Map.Entry<QuestionTree, NodeBuilder> entry, Map<String, Object> answersByQuestionName)
+    private void computeAnswer(final Map.Entry<QuestionTree, NodeBuilder> entry,
+        final Map<String, Object> answersByQuestionName)
     {
-        QuestionTree question = entry.getKey();
-        NodeBuilder answer = entry.getValue();
+        final QuestionTree question = entry.getKey();
+        final NodeBuilder answer = entry.getValue();
         Type<?> resultType = Type.STRING;
         try {
             AnswerNodeTypes types = new AnswerNodeTypes(question.getNode());
@@ -228,7 +229,7 @@ public class ComputedAnswersEditor extends DefaultEditor
 
     private Node getQuestionnaire()
     {
-        String questionnaireId = this.currentNodeBuilder.getProperty("questionnaire").getValue(Type.REFERENCE);
+        final String questionnaireId = this.currentNodeBuilder.getProperty("questionnaire").getValue(Type.REFERENCE);
         try {
             return this.serviceSession.getNodeByIdentifier(questionnaireId);
         } catch (RepositoryException e) {
@@ -245,8 +246,8 @@ public class ComputedAnswersEditor extends DefaultEditor
         return result;
     }
 
-    private void addAnswer(String answer, Map<String, Set<String>> dependencies, List<String> orderedAnswersToCompute,
-        Set<String> processedAnswers)
+    private void addAnswer(final String answer, final Map<String, Set<String>> dependencies,
+        final List<String> orderedAnswersToCompute, final Set<String> processedAnswers)
     {
         if (!processedAnswers.contains(answer)) {
             processedAnswers.add(answer);
@@ -256,9 +257,9 @@ public class ComputedAnswersEditor extends DefaultEditor
         }
     }
 
-    private Map<String, Object> getNodeAnswers(NodeState currentNode)
+    private Map<String, Object> getNodeAnswers(final NodeState currentNode)
     {
-        Map<String, Object> currentAnswers = new HashMap<>();
+        final Map<String, Object> currentAnswers = new HashMap<>();
         if (currentNode.exists()) {
             if (this.formUtils.isAnswerSection(currentNode) || this.formUtils.isForm(currentNode)) {
                 // Found a section: Recursively get all of this section's answers
@@ -281,7 +282,7 @@ public class ComputedAnswersEditor extends DefaultEditor
     }
 
     // Returns a QuestionTree if any children of this node contains an unanswered computed question, else null
-    private QuestionTree getUnansweredComputedQuestions(Node currentNode)
+    private QuestionTree getUnansweredComputedQuestions(final Node currentNode)
     {
         QuestionTree currentTree = null;
 
@@ -318,8 +319,8 @@ public class ComputedAnswersEditor extends DefaultEditor
         return currentTree;
     }
 
-    private Map<QuestionTree, NodeBuilder> createMissingNodes(QuestionTree questionTree,
-        NodeBuilder currentNode)
+    private Map<QuestionTree, NodeBuilder> createMissingNodes(final QuestionTree questionTree,
+        final NodeBuilder currentNode)
     {
         try {
             if (questionTree.isQuestion()) {
@@ -358,7 +359,7 @@ public class ComputedAnswersEditor extends DefaultEditor
         }
     }
 
-    private Map<String, List<NodeBuilder>> getChildNodesByReference(NodeBuilder nodeBuilder)
+    private Map<String, List<NodeBuilder>> getChildNodesByReference(final NodeBuilder nodeBuilder)
     {
         Map<String, List<NodeBuilder>> result = new HashMap<>();
         for (String childNodeName : nodeBuilder.getChildNodeNames()) {
@@ -381,9 +382,8 @@ public class ComputedAnswersEditor extends DefaultEditor
         return result;
     }
 
-    private Map<QuestionTree, NodeBuilder> createChildrenNodes(QuestionTree computedQuestionTree,
-        Map<String, List<NodeBuilder>> childNodesByReference,
-        NodeBuilder nodeBuilder)
+    private Map<QuestionTree, NodeBuilder> createChildrenNodes(final QuestionTree computedQuestionTree,
+        final Map<String, List<NodeBuilder>> childNodesByReference, final NodeBuilder nodeBuilder)
     {
         Map<QuestionTree, NodeBuilder> result = new HashMap<>();
         for (Map.Entry<String, QuestionTree> childQuestion : computedQuestionTree.getChildren().entrySet()) {
@@ -508,7 +508,7 @@ public class ComputedAnswersEditor extends DefaultEditor
 
         private boolean isQuestion;
 
-        QuestionTree(Node node, boolean isQuestion)
+        QuestionTree(final Node node, final boolean isQuestion)
         {
             this.isQuestion = isQuestion;
             this.node = node;
@@ -548,7 +548,7 @@ public class ComputedAnswersEditor extends DefaultEditor
         private Type<?> dataType;
 
         @SuppressWarnings("checkstyle:CyclomaticComplexity")
-        AnswerNodeTypes(Node questionNode) throws RepositoryException
+        AnswerNodeTypes(final Node questionNode) throws RepositoryException
         {
             final String dataTypeString = questionNode.getProperty("dataType").getString();
             final String capitalizedType = StringUtils.capitalize(dataTypeString);

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/ExpressionUtilsImpl.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/ExpressionUtilsImpl.java
@@ -67,12 +67,7 @@ public final class ExpressionUtilsImpl implements ExpressionUtils
     }
 
     @Override
-    public String evaluate(final Node question, final Map<String, Object> values)
-    {
-        return String.valueOf(evaluate(question, values, Type.STRING));
-    }
-
-    static Object evaluate(final Node question, final Map<String, Object> values, Type type)
+    public Object evaluate(final Node question, final Map<String, Object> values, Type<?> type)
     {
         try {
             String expression = getExpressionFromQuestion(question);
@@ -175,7 +170,7 @@ public final class ExpressionUtilsImpl implements ExpressionUtils
 
     private static final class ValueFormatter
     {
-        static Object formatResult(Object rawResult, Type type)
+        static Object formatResult(Object rawResult, Type<?> type)
         {
             if (rawResult == null || (rawResult instanceof String && "null".equals(rawResult))) {
                 return null;

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/ExpressionUtilsImpl.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/ExpressionUtilsImpl.java
@@ -67,7 +67,7 @@ public final class ExpressionUtilsImpl implements ExpressionUtils
     }
 
     @Override
-    public Object evaluate(final Node question, final Map<String, Object> values, Type<?> type)
+    public Object evaluate(final Node question, final Map<String, Object> values, final Type<?> type)
     {
         try {
             String expression = getExpressionFromQuestion(question);
@@ -81,9 +81,6 @@ public final class ExpressionUtilsImpl implements ExpressionUtils
             Bindings env = engine.createBindings();
             parsedExpression.getInputs().forEach((key, value) -> env.put(key, value));
             Object result = engine.eval("(function(){" + parsedExpression.getExpression() + "})()", env);
-            if (type == Type.DOUBLE) {
-                LOGGER.error(String.valueOf(result));
-            }
             return ValueFormatter.formatResult(result, type);
         } catch (ScriptException e) {
             LOGGER.warn("Evaluating the expression for question {} failed: {}", question,
@@ -170,7 +167,7 @@ public final class ExpressionUtilsImpl implements ExpressionUtils
 
     private static final class ValueFormatter
     {
-        static Object formatResult(Object rawResult, Type<?> type)
+        static Object formatResult(final Object rawResult, final Type<?> type)
         {
             if (rawResult == null || (rawResult instanceof String && "null".equals(rawResult))) {
                 return null;
@@ -187,7 +184,7 @@ public final class ExpressionUtilsImpl implements ExpressionUtils
             }
         }
 
-        static Long formatToLong(Object rawResult)
+        static Long formatToLong(final Object rawResult)
         {
             if (rawResult instanceof String) {
                 return Long.valueOf((String) rawResult);
@@ -201,7 +198,7 @@ public final class ExpressionUtilsImpl implements ExpressionUtils
             }
         }
 
-        static Double formatToDouble(Object rawResult)
+        static Double formatToDouble(final Object rawResult)
         {
             if (rawResult instanceof String) {
                 return Double.valueOf((String) rawResult);
@@ -213,7 +210,7 @@ public final class ExpressionUtilsImpl implements ExpressionUtils
             }
         }
 
-        static BigDecimal formatToDecimal(Object rawResult)
+        static BigDecimal formatToDecimal(final Object rawResult)
         {
             if (rawResult instanceof String) {
                 return new BigDecimal((String) rawResult);
@@ -227,7 +224,7 @@ public final class ExpressionUtilsImpl implements ExpressionUtils
             }
         }
 
-        static String formatToString(Object rawResult)
+        static String formatToString(final Object rawResult)
         {
             String formattedResult = String.valueOf(rawResult);
 

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/QuestionnaireUtilsImpl.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/QuestionnaireUtilsImpl.java
@@ -69,6 +69,19 @@ public final class QuestionnaireUtilsImpl extends AbstractNodeUtils implements Q
         return isNodeType(node, QUESTION_NODETYPE);
     }
 
+
+    @Override
+    public boolean isComputedQuestion(Node node)
+    {
+        try {
+            return isQuestion(node)
+                && ("computed".equals(node.getProperty("dataType").getString())
+                || "computed".equals(node.getProperty("entryMode").getString()));
+        } catch (RepositoryException e) {
+            return false;
+        }
+    }
+
     @Override
     public Node getQuestion(final String identifier)
     {

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -240,6 +240,11 @@
   // We allow users to place these answers in a Notes section
   - enableNotes (boolean)
 
+  // Specifies what method is used to fill out this question
+  // - user: Filled out by an end user
+  // - computed: Automatically calculated based on user's other inputs
+  - entryMode (string) = 'user' autocreated
+
   // For computed answers, the expression used to calculate the value
   - expression (string)
 

--- a/pom.xml
+++ b/pom.xml
@@ -559,7 +559,7 @@
             <dependency>
               <groupId>org.phenotips</groupId>
               <artifactId>phenotips-checkstyle-configuration</artifactId>
-              <version>1.12</version>
+              <version>1.13</version>
             </dependency>
           </dependencies>
           <configuration>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/AUDITC.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/AUDITC.xml
@@ -83,6 +83,11 @@ disorder. AUDIT-C has been validated in mental health and primary care clinics.
 			</property>
 			<property>
 				<name>dataType</name>
+				<value>long</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>
 			</property>
@@ -116,7 +121,7 @@ disorder. AUDIT-C has been validated in mental health and primary care clinics.
 				<type>String</type>
 			</property>
 			<property>
-				<name>dataType</name>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>
 			</property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/EQ5D.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/EQ5D.xml
@@ -70,6 +70,11 @@
 			</property>
 			<property>
 				<name>dataType</name>
+				<value>long</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>
 			</property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
@@ -96,6 +96,11 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 			</property>
 			<property>
 				<name>dataType</name>
+				<value>long</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>
 			</property>
@@ -125,7 +130,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<type>String</type>
 			</property>
 			<property>
-				<name>dataType</name>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>
 			</property>
@@ -237,7 +242,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 				<type>String</type>
 			</property>
 			<property>
-				<name>dataType</name>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>
 			</property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
@@ -98,6 +98,11 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			</property>
 			<property>
 				<name>dataType</name>
+				<value>long</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>
 			</property>
@@ -128,7 +133,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<type>String</type>
 			</property>
 			<property>
-				<name>dataType</name>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>
 			</property>
@@ -262,7 +267,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 				<type>String</type>
 			</property>
 			<property>
-				<name>dataType</name>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>
 			</property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/SC.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/SC.xml
@@ -1490,7 +1490,7 @@ return @{smoking_history_v2_program_referral_requested_by_patient:-"none"} != "n
 				<type>String</type>
 			</property>
 			<property>
-				<name>dataType</name>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>
 			</property>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ComputedTest.xml
@@ -27,7 +27,7 @@
 	</property>
 	<property>
 		<name>description</name>
-		<value>CARDS-317, CARDS-699, CARDS-1302</value>
+		<value>CARDS-317, CARDS-699, CARDS-1302, CARDS-1463</value>
 		<type>String</type>
 	</property>
 	<property>
@@ -38,35 +38,43 @@
 		<type>Reference</type>
 	</property>
 	<node>
-		<name>q1</name>
-		<primaryNodeType>cards:Question</primaryNodeType>
+		<name>computedAnswerTest</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
 		<property>
-			<name>text</name>
-			<value>Write something:</value>
+			<name>label</name>
+			<value>Computed Answer Test</value>
 			<type>String</type>
 		</property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
-		<property>
-			<name>dataType</name>
-			<value>text</value>
-			<type>String</type>
-		</property>
-	</node>
-	<node>
-		<name>q2</name>
-		<primaryNodeType>cards:Question</primaryNodeType>
-		<property>
-			<name>text</name>
-			<value>Computed, plain</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>description</name>
-			<value>
+		<node>
+			<name>computedAnswerInput</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Write something:</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>text</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>computedAnswerBasicText</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Computed, plain</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>
 Expected output:
 
 > You wrote [text from previous question]
@@ -74,60 +82,60 @@ Expected output:
 or
 
 > You wrote nothing
-			</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>dataType</name>
-			<value>computed</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>expression</name>
-			<value>return "You wrote " + @{q1:-nothing}</value>
-			<type>String</type>
-		</property>
-	</node>
-	<node>
-		<name>q3</name>
-		<primaryNodeType>cards:Question</primaryNodeType>
-		<property>
-			<name>text</name>
-			<value>Computed, hidden</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>description</name>
-			<value>This should not appear in the form</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>dataType</name>
-			<value>computed</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>displayMode</name>
-			<value>hidden</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>expression</name>
-			<value>return "You wrote " + @{q1:-nothing}</value>
-			<type>String</type>
-		</property>
-	</node>
-	<node>
-		<name>q4</name>
-		<primaryNodeType>cards:Question</primaryNodeType>
-		<property>
-			<name>text</name>
-			<value>Computed, formatted</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>description</name>
-			<value>
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return "You wrote " + @{computedAnswerInput:-nothing}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>computedAnswerhidden</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Computed, hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>This should not appear in the form</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return "You wrote " + @{computedAnswerInput:-nothing}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>computedAnswerFormattedText</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Computed, formatted</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>
 Expected output:
 
 > You **wrote** *[text from question 1]*
@@ -137,36 +145,36 @@ or
 > You **wrote** *nothing*
 
 **Note**: How the text from question 1 is displayed may be affected by formatting characters if it contains markdown formatting characters.
-			</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>dataType</name>
-			<value>computed</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>displayMode</name>
-			<value>formatted</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>expression</name>
-			<value>return "You **wrote** *" + @{q1:-nothing} + "*"</value>
-			<type>String</type>
-		</property>
-	</node>
-	<node>
-		<name>q5</name>
-		<primaryNodeType>cards:Question</primaryNodeType>
-		<property>
-			<name>text</name>
-			<value>Computed, formatted multiline</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>description</name>
-			<value>
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>formatted</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return "You **wrote** *" + @{computedAnswerInput:-nothing} + "*"</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>computedAnswerFormattedMultiline</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Computed, formatted multiline</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>
 Expected output:
 
 > * You wrote *[text from question 1]*...
@@ -177,25 +185,1511 @@ or
 > You **wrote**: *nothing*
 
 **Note**: How the text from question 1 is displayed may be affected by formatting characters if it contains markdown formatting characters.
-			</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>dataType</name>
-			<value>computed</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>displayMode</name>
-			<value>formatted</value>
-			<type>String</type>
-		</property>
-		<property>
-			<name>expression</name>
-			<value>return (@{q1:-} ? ("* You wrote *" + @{q1} + "*...\n* ...and **nothing else**") : "You wrote nothing")</value>
-			<type>String</type>
-		</property>
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>formatted</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return (@{computedAnswerInput:-} ? ("* You wrote *" + @{computedAnswerInput} + "*...\n* ...and **nothing else**") : "You wrote nothing")</value>
+				<type>String</type>
+			</property>
+		</node>
 	</node>
+	<node>
+		<name>textAnswerTest</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>label</name>
+			<value>Text Answer Test</value>
+			<type>String</type>
+		</property>
+		<node>
+			<name>textAnswerInput</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Write something:</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>text</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>textAnswerBasicText</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Computed, plain</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>
+Expected output:
 
+> You wrote [text from previous question]
 
+or
+
+> You wrote nothing
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>text</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return "You wrote " + @{textAnswerInput:-nothing}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>textAnswerHidden</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Computed, hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>This should not appear in the form</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>text</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return "You wrote " + @{textAnswerInput:-nothing}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>textAnswerFormattedText</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Computed, formatted</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>
+Expected output:
+
+> You **wrote** *[text from question 1]*
+
+or
+
+> You **wrote** *nothing*
+
+**Note**: How the text from question 1 is displayed may be affected by formatting characters if it contains markdown formatting characters.
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>text</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>formatted</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return "You **wrote** *" + @{textAnswerInput:-nothing} + "*"</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>textAnswerFormattedMultiline</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Computed text, formatted multiline</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>
+Expected output:
+
+> * You wrote *[text from question 1]*...
+> * ...and **nothing else**
+
+or
+
+> You **wrote**: *nothing*
+
+**Note**: How the text from question 1 is displayed may be affected by formatting characters if it contains markdown formatting characters.
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>text</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>formatted</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return (@{textAnswerInput:-} ? ("* You wrote *" + @{textAnswerInput} + "*...\n* ...and **nothing else**") : "You wrote nothing")</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
+		<name>boolAnswerTest</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>label</name>
+			<value>Boolean Answer Test</value>
+			<type>String</type>
+		</property>
+		<node>
+			<name>booleanAnswerInputBoolean</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Yes or No?</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>boolean</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>enableUnknown</name>
+				<value>True</value>
+				<type>Boolean</type>
+			</property>
+		</node>
+		<node>
+			<name>boolAnswerBasic</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Boolean, plain</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>boolean</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{booleanAnswerInputBoolean}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>boolAnswerLabeled</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Boolean, labelled</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection, but with slightly different labels</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>boolean</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{booleanAnswerInputBoolean}</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>yesLabel</name>
+				<value>Yes Label</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>noLabel</name>
+				<value>No Label</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>unknownLabel</name>
+				<value>Unknown Label</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>boolAnswerHidden</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Boolean, hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>boolean</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{booleanAnswerInputBoolean}</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
+		<name>dateAnswerTest</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>label</name>
+			<value>Date Answer Test</value>
+			<type>String</type>
+		</property>
+		<node>
+			<name>dateAnswerInput</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Pick a date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>dateAnswerBasic</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Date, plain</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>yyyy-MM-DD</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{dateAnswerInput}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>dateAnswerBasicHidden</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Date, plain hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>yyyy-MM-DD</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{dateAnswerInput}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>dateAnswerYearInput</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Pick a year</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>yyyy</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+		</node>
+		<node>
+			<name>dateAnswerYear</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Date, year only</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{dateAnswerYearInput}</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>yyyy</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>dateAnswerYearHidden</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Date, year only hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{dateAnswerYearInput}</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>yyyy</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>dateAnswerMonthYearInput</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Pick a month and year</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>MM/yyyy</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+		</node>
+		<node>
+			<name>dateAnswerMonthYear</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Date, month and year</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{dateAnswerMonthYearInput}</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>MM/yyyy</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>dateAnswerMonthYearHidden</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Date, month and year hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{dateAnswerMonthYearInput}</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>MM/yyyy</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>dateAnswerHourMinuteInput</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Pick a date and time</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>yyyy-MM-DD HH:mm</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+		</node>
+		<node>
+			<name>dateAnswerHourMinute</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Date, include hour and minute</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{dateAnswerHourMinuteInput}</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>yyyy-MM-DD HH:mm</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>dateAnswerHourMinuteHidden</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Date, include hour and minute hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{dateAnswerHourMinuteInput}</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>yyyy-MM-DD HH:mm</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>dateAnswerHourMinuteSecondInput</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Pick a date and time down to seconds</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>yyyy-MM-DD HH:mm:ss</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+		</node>
+		<node>
+			<name>dateAnswerHourMinuteSecond</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Date, include time down to seconds</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{dateAnswerHourMinuteSecondInput}</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>yyyy-MM-DD HH:mm:ss</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>dateAnswerHourMinuteSecondHidden</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Date, include time down to seconds hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{dateAnswerHourMinuteSecondInput}</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>yyyy-MM-DD HH:mm:ss</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
+		<name>longAnswerTest</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>label</name>
+			<value>Long Answer Test</value>
+			<type>String</type>
+		</property>
+		<node>
+			<name>longAnswerInput</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Pick a number?</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>long</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>longAnswerBasic</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Long, plain</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>long</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{longAnswerInput}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>longAnswerBasicHidden</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Long, plain hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>long</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{longAnswerInput}</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
+		<name>doubleAnswerTest</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>label</name>
+			<value>Double Answer Test</value>
+			<type>String</type>
+		</property>
+		<node>
+			<name>doubleAnswerInput</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Pick a number</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>double</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>doubleAnswerBasic</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Double, plain</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>double</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{doubleAnswerInput}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>doubleAnswerHidden</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Double, plain hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>double</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{doubleAnswerInput}</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
+		<name>decimalAnswerTest</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>label</name>
+			<value>Decimal Answer Test</value>
+			<type>String</type>
+		</property>
+		<node>
+			<name>decimalAnswerInput</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Pick a number?</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>decimal</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>decimalAnswerBasic</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Decimal, plain</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>decimal</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{decimalAnswerInput}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>decimalAnswerHidden</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Decimal, plain hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>decimal</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{decimalAnswerInput}</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
+		<name>vocabAnswerTest</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>label</name>
+			<value>Vocabulary Answer Test</value>
+			<type>String</type>
+		</property>
+		<node>
+			<name>vocabularyAnswerInput</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Enter an ancestry (Requires HANCESTRO)</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>vocabulary</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>sourceVocabularies</name>
+				<values>
+					<value>HANCESTRO</value>
+				</values>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>vocabularyAnswerBasic</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Vocabulary, plain</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>vocabulary</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>sourceVocabularies</name>
+				<values>
+					<value>HANCESTRO</value>
+				</values>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{vocabularyAnswerInput}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>vocabularyAnswerHidden</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Vocabulary, plain hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>vocabulary</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>sourceVocabularies</name>
+				<values>
+					<value>HANCESTRO</value>
+				</values>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{vocabularyAnswerInput}</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
+		<name>timeAnswerTest</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>label</name>
+			<value>Time Answer Test</value>
+			<type>String</type>
+		</property>
+		<node>
+			<name>timeAnswerInput</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Pick a time</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>time</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>timeAnswerBasic</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Time, plain</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>time</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{timeAnswerInput}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>timeAnswerHidden</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Time, plain hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>time</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{timeAnswerInput}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>timeAnswerHourMinuteSecondInput</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Pick a time down to seconds</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>time</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>hh:mm:ss</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>timeAnswerHourMinuteSecond</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Time, down to seconds</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>time</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{timeAnswerHourMinuteSecondInput}</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>hh:mm:ss</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>timeAnswerHourMinuteSecondHidden</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Time, down to seconds hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>time</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{timeAnswerHourMinuteSecondInput}</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>hh:mm:ss</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>timeAnswerMinuteSecondInput</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Pick an amount of minutes and seconds</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>time</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>mm:ss</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>timeAnswerMinuteSecond</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Time, minutes and seconds</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>time</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{timeAnswerMinuteSecondInput}</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>mm:ss</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>timeAnswerMinuteSecondHidden</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Time, minutes and seconds hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: Same as your selection</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>time</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{timeAnswerMinuteSecondInput}</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>mm:ss</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
 </node>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ComputedTest.xml
@@ -86,7 +86,7 @@ or
 				<type>String</type>
 			</property>
 			<property>
-				<name>dataType</name>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>
 			</property>
@@ -110,7 +110,7 @@ or
 				<type>String</type>
 			</property>
 			<property>
-				<name>dataType</name>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>
 			</property>
@@ -149,7 +149,7 @@ or
 				<type>String</type>
 			</property>
 			<property>
-				<name>dataType</name>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>
 			</property>
@@ -189,7 +189,7 @@ or
 				<type>String</type>
 			</property>
 			<property>
-				<name>dataType</name>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>
 			</property>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ServersideComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ServersideComputedTest.xml
@@ -336,7 +336,7 @@
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
 			<name>text</name>
-			<value>Enter a time with minutes and questions:</value>
+			<value>Enter a time with minutes and seconds:</value>
 			<type>String</type>
 		</property>
 		<property>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ServersideComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ServersideComputedTest.xml
@@ -27,7 +27,7 @@
 	</property>
 	<property>
 		<name>description</name>
-		<value>CARDS-1347</value>
+		<value>CARDS-1347, CARDS-1463</value>
 		<type>String</type>
 	</property>
 	<property>
@@ -57,11 +57,11 @@
 		</property>
 	</node>
 	<node>
-		<name>numberQuestion</name>
+		<name>booleanQuestion</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
 			<name>text</name>
-			<value>Enter a number:</value>
+			<value>Yes or No?</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -71,8 +71,13 @@
 		</property>
 		<property>
 			<name>dataType</name>
-			<value>long</value>
+			<value>boolean</value>
 			<type>String</type>
+		</property>
+		<property>
+			<name>enableUnknown</name>
+			<value>True</value>
+			<type>Boolean</type>
 		</property>
 	</node>
 	<node>
@@ -100,11 +105,190 @@
 		</property>
 	</node>
 	<node>
+		<name>dateQuestionYear</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Enter a year:</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>date</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>yyyy</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>dateQuestionMonth</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Enter a month:</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>date</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>MM/yyyy</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>dateQuestionTime</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Enter a datetime:</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>date</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>yyyy/MM/DD HH:mm</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>dateQuestionSeconds</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Enter a datetime with seconds:</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>date</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>yyyy/MM/DD HH:mm:ss</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>longQuestion</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Enter a long:</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>long</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>doubleQuestion</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Enter a double:</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>double</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>decimalQuestion</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Enter a decimal:</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>decimal</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>vocabularyQuestion</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Enter an ancestry (HANCESTRO)</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>vocabulary</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>sourceVocabularies</name>
+			<values>
+				<value>HANCESTRO</value>
+			</values>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
 		<name>timeQuestion</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
 			<name>text</name>
-			<value>Enter a time:</value>
+			<value>Enter a time with hours and minutes:</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -124,11 +308,11 @@
 		</property>
 	</node>
 	<node>
-		<name>boolQuestion</name>
+		<name>timeQuestionSeconds</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
 			<name>text</name>
-			<value>Yes or no:</value>
+			<value>Enter a time with hours, minutes and seconds:</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -138,7 +322,36 @@
 		</property>
 		<property>
 			<name>dataType</name>
-			<value>boolean</value>
+			<value>time</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>hh:mm:ss</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>timeQuestionMinutes</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Enter a time with minutes and questions:</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>time</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>mm:ss</value>
 			<type>String</type>
 		</property>
 	</node>
@@ -244,7 +457,7 @@
 			</node>
 		</node>
 		<node>
-			<name>conditionalQuestion1a</name>
+			<name>conditionalQuestionComputed1</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
 				<name>text</name>
@@ -276,7 +489,7 @@ or
 			</property>
 		</node>
 		<node>
-			<name>conditionalQuestion1b</name>
+			<name>conditionalQuestionComputed2</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
 				<name>text</name>
@@ -297,12 +510,12 @@ This question should copy the previous question
 			</property>
 			<property>
 				<name>expression</name>
-				<value>return @{conditionalQuestion1a}</value>
+				<value>return @{conditionalQuestionComputed1}</value>
 				<type>String</type>
 			</property>
 		</node>
 		<node>
-			<name>conditionalQuestionNumber</name>
+			<name>conditionalQuestionText1</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
 				<name>text</name>
@@ -314,18 +527,58 @@ This question should copy the previous question
 				<value>
 Expected output:
 
-> 1 + [entered number] = [1 + entered number]
+> You wrote [text from previous question]
+
+or
+
+> You wrote nothing
 				</value>
 				<type>String</type>
 			</property>
 			<property>
 				<name>dataType</name>
+				<value>text</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>
 			</property>
 			<property>
 				<name>expression</name>
-				<value>return "1 + " + @{numberQuestion} + " = " + (1 + @{numberQuestion})</value>
+				<value>return "You wrote " + @{textQuestion:-nothing}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>conditionalQuestionText2</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Computed, plain</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>
+This question should copy the previous question
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>text</value>
+				<type>String</type>0
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{conditionalQuestionText2}</value>
 				<type>String</type>
 			</property>
 		</node>
@@ -342,18 +595,23 @@ Expected output:
 				<value>
 Expected output:
 
-> You entered the boolean [0/1]
+The entered boolean [0/1/-1]
 				</value>
 				<type>String</type>
 			</property>
 			<property>
 				<name>dataType</name>
+				<value>boolean</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>
 			</property>
 			<property>
 				<name>expression</name>
-				<value>return "You entered the boolean " + @{boolQuestion}</value>
+				<value>return @{booleanQuestion}</value>
 				<type>String</type>
 			</property>
 		</node>
@@ -370,18 +628,319 @@ Expected output:
 				<value>
 Expected output:
 
-> You entered the date [entered date]
+The entered basic date
 				</value>
 				<type>String</type>
 			</property>
 			<property>
 				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>MM/dd/yyyy</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{dateQuestion}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>conditionalQuestionDateYear</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Computed, plain</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>
+Expected output:
+
+The entered year
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>yyyy</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{dateQuestionYear}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>conditionalQuestionDateMonth</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Computed, plain</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>
+Expected output:
+
+The entered month
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>MM/yyyy</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{dateQuestionMonth}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>conditionalQuestionDateTime</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Computed, plain</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>
+Expected output:
+
+The entered datetime
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>MM/dd/yyyy HH:mm</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{dateQuestionTime}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>conditionalQuestionDateSeconds</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Computed, plain</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>
+Expected output:
+
+The entered datetime with seconds
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>date</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>MM/dd/yyyy HH:mm:ss</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{dateQuestionSeconds}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>conditionalQuestionLong</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Computed, plain</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>
+Expected output:
+
+1 + the entered number
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>long</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>
 			</property>
 			<property>
 				<name>expression</name>
-				<value>return "You entered the date " + @{dateQuestion}</value>
+				<value>return 1 + @{longQuestion}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>conditionalQuestionDouble</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Computed, plain</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>
+Expected output:
+
+1.5 + the entered number
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>double</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return 1.5 + @{doubleQuestion}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>conditionalQuestionDecimal</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Computed, plain</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>
+Expected output:
+
+1.5 + the entered number
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>decimal</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return 1.5 + @{decimalQuestion}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>conditionalQuestionVocabulary</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Computed, plain</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>
+Expected output:
+
+The entered vocabulary term
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>vocabulary</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>sourceVocabularies</name>
+				<values>
+					<value>HANCESTRO</value>
+				</values>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{vocabularyQuestion}</value>
 				<type>String</type>
 			</property>
 		</node>
@@ -398,18 +957,106 @@ Expected output:
 				<value>
 Expected output:
 
-> You entered the time [entered time]
+The entered time
 				</value>
 				<type>String</type>
 			</property>
 			<property>
 				<name>dataType</name>
+				<value>vocabulary</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>sourceVocabularies</name>
+				<values>
+					<value>HANCESTRO</value>
+				</values>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>
 			</property>
 			<property>
 				<name>expression</name>
-				<value>return "You entered the time " + @{timeQuestion}</value>
+				<value>return @{timeQuestion}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>conditionalQuestionTimeSeconds</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Computed, plain</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>
+Expected output:
+
+The entered time with seconds
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>time</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>hh:mm:ss</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{timeQuestionSeconds}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>conditionalQuestionTimeMinutes</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Computed, plain</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>
+Expected output:
+
+The entered minutes
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>time</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>mm:ss</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value>return @{timeQuestionMinutes}</value>
 				<type>String</type>
 			</property>
 		</node>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ServersideComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ServersideComputedTest.xml
@@ -963,14 +963,12 @@ The entered time
 			</property>
 			<property>
 				<name>dataType</name>
-				<value>vocabulary</value>
+				<value>time</value>
 				<type>String</type>
 			</property>
 			<property>
-				<name>sourceVocabularies</name>
-				<values>
-					<value>HANCESTRO</value>
-				</values>
+				<name>dateFormat</name>
+				<value>HH:MM (AM/PM)</value>
 				<type>String</type>
 			</property>
 			<property>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ServersideComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ServersideComputedTest.xml
@@ -578,7 +578,7 @@ This question should copy the previous question
 			</property>
 			<property>
 				<name>expression</name>
-				<value>return @{conditionalQuestionText2}</value>
+				<value>return @{conditionalQuestionText1}</value>
 				<type>String</type>
 			</property>
 		</node>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ServersideComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ServersideComputedTest.xml
@@ -478,7 +478,7 @@ or
 				<type>String</type>
 			</property>
 			<property>
-				<name>dataType</name>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>
 			</property>
@@ -504,7 +504,7 @@ This question should copy the previous question
 				<type>String</type>
 			</property>
 			<property>
-				<name>dataType</name>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>0
 			</property>
@@ -1074,7 +1074,7 @@ The entered minutes
 				<type>String</type>
 			</property>
 			<property>
-				<name>dataType</name>
+				<name>entryMode</name>
 				<value>computed</value>
 				<type>String</type>
 			</property>
@@ -1129,7 +1129,7 @@ or
 					<type>String</type>
 				</property>
 				<property>
-					<name>dataType</name>
+					<name>entryMode</name>
 					<value>computed</value>
 					<type>String</type>
 				</property>
@@ -1180,7 +1180,7 @@ or
 					<type>String</type>
 				</property>
 				<property>
-					<name>dataType</name>
+					<name>entryMode</name>
 					<value>computed</value>
 					<type>String</type>
 				</property>
@@ -1231,7 +1231,7 @@ or
 					<type>String</type>
 				</property>
 				<property>
-					<name>dataType</name>
+					<name>entryMode</name>
 					<value>computed</value>
 					<type>String</type>
 				</property>


### PR DESCRIPTION
- Add an "entryMode" flag, with default mode "user" and secondary mode
  "computed"
- Add computed field support for most dataTypes:
  - boolean
  - date (year, date and datetime)
  - long
  - double
  - decimal
  - vocabulary
  - time (hh:mm, mm:ss)
  - text
- Add tests for each dataType to ServersideComputedTest and ComputedTest