### PR TITLE
CARDS-1457: Enable emailing functionality in Sling

### DIFF
--- a/modules/email-notifications/pom.xml
+++ b/modules/email-notifications/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>jakarta.mail</groupId>
       <artifactId>jakarta.mail-api</artifactId>
-      <version>1.6.7</version>
+      <version>2.0.1</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.commons.messaging.mail</artifactId>
-      <version>1.0.0</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>

--- a/modules/email-notifications/pom.xml
+++ b/modules/email-notifications/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.uhndata.cards</groupId>
+    <artifactId>cards-modules</artifactId>
+    <version>0.9-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>cards-email-notifications</artifactId>
+  <packaging>bundle</packaging>
+  <name>CARDS - Email Notifications</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>slingfeature-maven-plugin</artifactId>
+      </plugin>
+
+      <!-- This is an OSGi bundle -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>jakarta.mail</groupId>
+      <artifactId>jakarta.mail-api</artifactId>
+      <version>1.6.7</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.commons.messaging.mail</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.servlets.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/modules/email-notifications/src/main/features/feature.json
+++ b/modules/email-notifications/src/main/features/feature.json
@@ -28,11 +28,15 @@
   },
   "bundles":[
     {
-      "id":"jakarta.mail:jakarta.mail-api:1.6.7",
+      "id":"jakarta.mail:jakarta.mail-api:2.0.1",
       "start-order":"25"
     },
     {
-      "id":"com.sun.mail:javax.mail:1.6.2",
+      "id":"jakarta.activation:jakarta.activation-api:2.0.1",
+      "start-order":"25"
+    },
+    {
+      "id":"com.sun.mail:jakarta.mail:2.0.1",
       "start-order":"25"
     },
     {
@@ -48,7 +52,7 @@
       "start-order":"25"
     },
     {
-      "id":"org.apache.sling:org.apache.sling.commons.messaging.mail:1.0.0",
+      "id":"org.apache.sling:org.apache.sling.commons.messaging.mail:2.0.0",
       "start-order":"25"
     },
     {

--- a/modules/email-notifications/src/main/features/feature.json
+++ b/modules/email-notifications/src/main/features/feature.json
@@ -69,7 +69,7 @@
       "names":[
         "default"
       ],
-      "name":"MAIL_SERVER_PASSWORD"
+      "name":"SLING_COMMONS_CRYPTO_PASSWORD"
     },
     "org.apache.sling.commons.crypto.jasypt.internal.JasyptRandomIvGeneratorRegistrar~default":{
       "algorithm": "SHA1PRNG"

--- a/modules/email-notifications/src/main/features/feature.json
+++ b/modules/email-notifications/src/main/features/feature.json
@@ -1,0 +1,108 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+{
+  "title": "CARDS - Email notification support - base settings",
+  "description": "Feature enabling support for email notifications",
+  "variables":{
+    "emailnotifications.smtps.host":"localhost",
+    "emailnotifications.smtps.port":"8465",
+    "emailnotifications.smtps.from":"envelope-from@localhost",
+    "emailnotifications.smtps.username":"username",
+    "emailnotifications.smtps.password":"DFMeLL3AOICFmg4+uUoOx16clt6Xe0BMdNSBFqcuKiaVKMqfFudz3KOwM5Gj3t/g",
+    "emailnotifications.messageidprovider.host": "localhost"
+  },
+  "bundles":[
+    {
+      "id":"jakarta.mail:jakarta.mail-api:1.6.7",
+      "start-order":"25"
+    },
+    {
+      "id":"com.sun.mail:javax.mail:1.6.2",
+      "start-order":"25"
+    },
+    {
+      "id":"org.jasypt:jasypt:1.9.3",
+      "start-order":"25"
+    },
+    {
+      "id":"org.apache.servicemix.bundles:org.apache.servicemix.bundles.jasypt:1.9.3_1",
+      "start-order":"25"
+    },
+    {
+      "id":"org.apache.sling:org.apache.sling.api:2.23.6",
+      "start-order":"25"
+    },
+    {
+      "id":"org.apache.sling:org.apache.sling.commons.messaging.mail:1.0.0",
+      "start-order":"25"
+    },
+    {
+      "id":"org.apache.sling:org.apache.sling.commons.messaging:1.0.2",
+      "start-order":"25"
+    },
+    {
+      "id":"org.apache.sling:org.apache.sling.commons.crypto:1.1.0",
+      "start-order":"25"
+    },
+    {
+      "id":"${project.groupId}:${project.artifactId}:${project.version}",
+      "start-order":"25"
+    }
+  ],
+  "configurations":{
+    "org.apache.sling.commons.crypto.internal.EnvironmentVariablePasswordProvider~default":{
+      "names":[
+        "default"
+      ],
+      "name":"MAIL_SERVER_PASSWORD"
+    },
+    "org.apache.sling.commons.crypto.jasypt.internal.JasyptRandomIvGeneratorRegistrar~default":{
+      "algorithm": "SHA1PRNG"
+    },
+    "org.apache.sling.commons.crypto.jasypt.internal.JasyptRandomSaltGeneratorRegistrar~default":{
+      "algorithm": "SHA1PRNG"
+    },
+    "org.apache.sling.commons.crypto.jasypt.internal.JasyptStandardPbeStringCryptoService~default":{
+      "algorithm": "PBEWITHHMACSHA512ANDAES_256",
+      "securityProviderName": "",
+      "keyObtentionIterations": 1000,
+      "names": [
+        "default"
+      ],
+      "stringOutputType": "base64"
+    },
+    "org.apache.sling.commons.messaging.mail.internal.SimpleMailService~default":{
+      "names": [
+        "default"
+      ],
+      "threadpool.name": "default",
+      "mail.smtps.from": "${emailnotifications.smtps.from}",
+      "mail.smtps.host": "${emailnotifications.smtps.host}",
+      "mail.smtps.port": "${emailnotifications.smtps.port}",
+      "username": "${emailnotifications.smtps.username}",
+      "password": "${emailnotifications.smtps.password}",
+      "messageIdProvider.target": "(names=default)"
+    },
+    "org.apache.sling.commons.messaging.mail.internal.SimpleMessageIdProvider~default":{
+      "host": "${emailnotifications.messageidprovider.host}",
+      "names": [
+        "default"
+      ]
+    }
+  }
+}

--- a/modules/email-notifications/src/main/java/io/uhndata/cards/emailnotifications/EmailTestEndpoint.java
+++ b/modules/email-notifications/src/main/java/io/uhndata/cards/emailnotifications/EmailTestEndpoint.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.emailnotifications;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import javax.servlet.Servlet;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.apache.sling.commons.messaging.mail.MailService;
+import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(service = { Servlet.class })
+@SlingServletResourceTypes(
+    resourceTypes = { "cards/Homepage" },
+    selectors = { "emailtest" })
+public final class EmailTestEndpoint extends SlingSafeMethodsServlet
+{
+    @Reference
+    private MailService mailService;
+
+    @Override
+    public void doGet(final SlingHttpServletRequest request, final SlingHttpServletResponse response) throws IOException
+    {
+        final Writer out = response.getWriter();
+        final String subject = "CARDS-UHN Test Message";
+        final String text = "Here is a test message from CARDS at the University Health Network";
+
+        //Ensure that this can only be run when logged in as admin
+        final String remoteUser = request.getRemoteUser();
+        if (remoteUser == null || !"admin".equals(remoteUser)) {
+            //admin login required
+            response.setStatus(403);
+            out.write("Only admin can perform this operation.");
+            return;
+        }
+
+        final String fromEmail = request.getParameter("fromEmail");
+        final String fromName = request.getParameter("fromName");
+        final String toEmail = request.getParameter("toEmail");
+        final String toName = request.getParameter("toName");
+        if (fromEmail == null || fromName == null || toEmail == null || toName == null) {
+            //Missing parameters
+            response.setStatus(400);
+            out.write("Missing required URL parameters");
+            return;
+        }
+
+        try {
+            MimeMessage message = this.mailService.getMessageBuilder()
+                .from(fromEmail, fromName)
+                .to(toEmail, toName)
+                .replyTo(fromEmail)
+                .subject(subject)
+                .text(text)
+                .build();
+
+            this.mailService.sendMessage(message);
+            response.setStatus(200);
+            out.write("Email prepared for sending");
+        } catch (MessagingException e) {
+            response.setStatus(500);
+            out.write("Server error");
+        }
+    }
+}

--- a/modules/email-notifications/src/main/java/io/uhndata/cards/emailnotifications/EmailTestEndpoint.java
+++ b/modules/email-notifications/src/main/java/io/uhndata/cards/emailnotifications/EmailTestEndpoint.java
@@ -19,8 +19,6 @@ package io.uhndata.cards.emailnotifications;
 import java.io.IOException;
 import java.io.Writer;
 
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeMessage;
 import javax.servlet.Servlet;
 
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -30,6 +28,9 @@ import org.apache.sling.commons.messaging.mail.MailService;
 import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 
 @Component(service = { Servlet.class })
 @SlingServletResourceTypes(

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -52,5 +52,6 @@
     <module>upgrade-marker</module>
     <module>vocabularies-ignore</module>
     <module>statistics</module>
+    <module>email-notifications</module>
   </modules>
 </project>


### PR DESCRIPTION
**Please note that this PR is based on `CARDS-469` and therefore should not be merged until `CARDS-469` is merged into `dev`. Once `CARDS-469` is merged into `dev`, the base of this PR should be changed from `CARDS-469` to `dev` before merging.**

This PR enables CARDS to connect to a SMTPS mail server and send emails. For testing and debugging purposes, an endpoint `/content.emailtest?fromEmail=alice@mail.com&fromName=Alice&toEmail=bob@mail.com&toName=Bob` is made available which sends a test email to the configured SMTPS server upon receiving a HTTP GET request from the Sling _admin_ user.

Testing Instructions
---------------------------

1. Generate a self-signed SSL certificate for `localhost`.
```bash
mkdir ~/cards-1457-test
cd ~/cards-1457-test
openssl req -newkey rsa:4096 -nodes -keyout cert.key -x509 -days 365 -out cert.pem

# You may leave all fields blank except for "Common Name (e.g. server FQDN or YOUR name) []:", set that to "localhost"

cat cert.pem cert.key > completecert.key
```
2. Create a backup of Java's CA Certificates Keystore as we do not want to permanently store the self-signed `localhost` certificate there.
```bash
sudo cp /etc/ssl/certs/java/cacerts /etc/ssl/certs/java/BACKUP_cacerts
```

3. Import the self-signed `localhost` certificate into Java's CA Certificates Keystore.
```bash
sudo keytool -import -trustcacerts -file cert.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit -noprompt
```

4. Start a Socat SSL-termination relay.
```bash
socat -d -d -v OPENSSL-LISTEN:8465,verify=0,cert=completecert.key,reuseaddr,fork TCP6-CONNECT:localhost:8025
```

5. In a new terminal window, start the SMTP debugging server.
```bash
python3 -m smtpd -c DebuggingServer -n localhost:8025
```

6. In a new terminal window, build, run, and test the `CARDS-1457` branch.
```bash
# Ensure that you have entered the directory of the CARDS git repository and have checkout out the CARDS-1457 branch

# Build
mvn clean install

# Start
SLING_COMMONS_CRYPTO_PASSWORD=password ./start_cards.sh -f mvn:io.uhndata.cards/cards-email-notifications/0.9-SNAPSHOT/slingosgifeature
```

7. Test that the following works:
  - When logged in as `admin`, sending a HTTP GET request to `/content.emailtest?fromEmail=alice@mail.com&fromName=Alice&toEmail=bob@mail.com&toName=Bob` should display a test message in the SMTP debugging server terminal window.
  - When logged in as `admin`, if any of the above parameters are missing (`fromEmail`, `fromName`, `toEmail`, `toName`), CARDS should reply with _HTTP 400 Bad Request_ and no email should be sent to the SMTP debugging server.
  - When attempting to make a _HTTP GET_ request to `/content.emailtest` as any Sling user other than `admin`, a _HTTP 403 Forbidden_ response should be given and no email should be sent to the SMTP debugging server.
  - A non-default SMTPS server can be specified through the `emailnotifications.smtps.host` and `emailnotifications.smtps.port` variables. Similarly, the `MAIL FROM` address can be changed through the `emailnotifications.smtps.from` variable. These variables can be specified in the invocation of the `./start_cards.sh` command through the `-V flag` (eg. `-V emailnotifications.smtps.port=8468`)
  - When the self-signed `localhost` SSL certificate is not present in Java's CA Certificates Keystore, connections to the SMTP server should fail. This should be visible in the _socat_ terminal window where a SSL error is printed to the console. 

8. Clean up by restoring the original Java CA Certificates Keystore.
```bash
sudo mv /etc/ssl/certs/java/BACKUP_cacerts /etc/ssl/certs/java/cacerts
```