### PR TITLE
CARDS-1361: Specify installation details

### DIFF
--- a/distribution/docker_entry.sh
+++ b/distribution/docker_entry.sh
@@ -31,7 +31,13 @@ STORAGE=tar
 #If (inside a docker-compose environment), we are supposed to wait for http://cardsinitial:8080/ to start
 [ -z $WAIT_FOR_CARDSINIT ] || (while true; do (wget -S --spider http://cardsinitial:8080/ 2>&1 | grep 'HTTP/1.1 200 OK') && break; sleep 10; done)
 
-PERMISSIONS="${PERMISSIONS:-open}"
+#If SAML is enabled, default to "trusted" permissions. Otherwise, default to "open" permissions.
+if [[ "$SAML_AUTH_ENABLED" == "true" ]]
+then
+  PERMISSIONS="${PERMISSIONS:-trusted}"
+else
+  PERMISSIONS="${PERMISSIONS:-open}"
+fi
 
 PROJECT_ARTIFACTID=$1
 PROJECT_VERSION=$2

--- a/start_cards.sh
+++ b/start_cards.sh
@@ -151,6 +151,7 @@ declare -i ARGS_LENGTH=${#ARGS[@]}
 declare OAK_STORAGE="tar"
 # Permissions scheme: default is open, allow switching to something else
 declare PERMISSIONS="open"
+declare PERMISSIONS_EXPLICITLY_SET="false"
 get_cards_version
 
 for ((i=0; i<${ARGS_LENGTH}; ++i));
@@ -174,6 +175,7 @@ do
     ARGS[$i]=${ARGS[$i]#,}
   elif [[ ${ARGS[$i]} == '--permissions' ]]
   then
+    PERMISSIONS_EXPLICITLY_SET="true"
     unset ARGS[$i]
     i=${i}+1
     PERMISSIONS=${ARGS[$i]}
@@ -206,6 +208,10 @@ do
     ARGS_LENGTH=${ARGS_LENGTH}+1
   elif [[ ${ARGS[$i]} == '--saml' ]]
   then
+    if [[ ${PERMISSIONS_EXPLICITLY_SET} == 'false' ]]
+    then
+      PERMISSIONS="trusted"
+    fi
     unset ARGS[$i]
     ARGS[$ARGS_LENGTH]=-f
     ARGS_LENGTH=${ARGS_LENGTH}+1


### PR DESCRIPTION
**Please note that this PR is based on `CARDS-1359` and should only be merged once `CARDS-1359` has been merged into `dev`**

This Pull Request causes the default permissions mode to be `trusted` if SAML authentication is enabled. This differs from the normal behavior of defaulting to `open` permissions when SAML is not enabled.

To test (without Docker):

- Build this branch with `mvn clean install`

- Start CARDS using the `start_cards.sh` script without enabling SAML (eg. no `--saml`). CARDS should be using the _open_ permissions mode.

- Start CARDS using the `start_cards.sh` script without enabling SAML (eg. no `--saml`) and specify the `--permissions trusted` option. CARDS should be using the _trusted_ permissions mode.

- Start CARDS using the `start_cards.sh` script and enable SAML (add the `--saml` flag). CARDS should be using the _trusted_ permissions mode.

- Start CARDS using the `start_cards.sh` script, enable SAML (add the `--saml` flag) and specify the `--permissions open` option. CARDS should be using the _open_ permissions mode.

To test (with Docker):

- Ensure that you have built a `cards/cards:latest` Docker image from this branch using `mvn clean install`

- Test that the _permissions mode_ defaults to `open` when SAML is not specified.
  - `cd compose-cluster`
  - `python3 generate_compose_yaml.py --oak_filesystem`
  - `docker-compose build`
  - `docker-compose up -d`
  - Visit `http://localhost:8080/` and ensure that CARDS is using _open permissions_.
  - Clean up ...
  - `docker-compose down`
  - `docker-compose rm`
  - `docker volume prune -f`
  - `./cleanup.sh`

- Test that the _permissions mode_ can be overridden to `trusted` when SAML is not specified.
  - `cd compose-cluster`
  - `python3 generate_compose_yaml.py --oak_filesystem`
  - Edit `docker-compose.yml` and add the environment variable `PERMISSIONS=trusted` to the `cardsinitial` container.
  - `docker-compose build`
  - `docker-compose up -d`
  - Visit `http://localhost:8080/` and ensure that CARDS is using _trusted permissions_.
  - Clean up ...
  - `docker-compose down`
  - `docker-compose rm`
  - `docker volume prune -f`
  - `./cleanup.sh`

- Test that the _permissions mode_ defaults to `trusted` when SAML is enabled.
  - `cd compose-cluster`
  - `python3 generate_compose_yaml.py --oak_filesystem --saml`
  - `docker-compose build`
  - `docker-compose up -d`
  - Visit `http://localhost:8080/` and ensure that CARDS is using _trusted permissions_.
  - Clean up ...
  - `docker-compose down`
  - `docker-compose rm`
  - `docker volume prune -f`
  - `./cleanup.sh`

- Test that the _permissions mode_ can be overridden to `open` when SAML is enabled.
  - `cd compose-cluster`
  - `python3 generate_compose_yaml.py --oak_filesystem --saml`
  - Edit `docker-compose.yml` and add the environment variable `PERMISSIONS=open` to the `cardsinitial` container.
  - `docker-compose build`
  - `docker-compose up -d`
  - Visit `http://localhost:8080/` and ensure that CARDS is using _open permissions_.
  - Clean up ...
  - `docker-compose down`
  - `docker-compose rm`
  - `docker volume prune -f`
  - `./cleanup.sh`