### PR TITLE
CARDS-1529: A --dev_docker_image flag should be available for generate_compose_yaml.py

### DIFF
--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -32,6 +32,7 @@ argparser.add_argument('--replicas', help='Number of MongoDB replicas per shard 
 argparser.add_argument('--config_replicas', help='Number of MongoDB cluster configuration servers (must be an odd number)', default=3, type=int)
 argparser.add_argument('--custom_env_file', help='Enable a custom file with environment variables')
 argparser.add_argument('--cards_project', help='The CARDS project to deploy (eg. cards4care, cards4lfs, etc...')
+argparser.add_argument('--dev_docker_image', help='Indicate that the CARDS Docker image being used was built for development, not production.', action='store_true')
 argparser.add_argument('--enable_ncr', help='Add a Neural Concept Recognizer service to the cluster', action='store_true')
 argparser.add_argument('--oak_filesystem', help='Use the filesystem (instead of MongoDB) as the back-end for Oak/JCR', action='store_true')
 argparser.add_argument('--external_mongo', help='Use an external MongoDB instance instead of providing our own', action='store_true')
@@ -234,6 +235,8 @@ except FileExistsError:
   print("Warning: SLING directory exists - will leave unmodified.")
 
 yaml_obj['services']['cardsinitial']['volumes'] = ["./SLING:/opt/cards/.cards-data"]
+if args.dev_docker_image:
+  yaml_obj['services']['cardsinitial']['volumes'].append("{}:/root/.m2:ro".format(os.path.join(os.environ['HOME'], '.m2')))
 
 if args.custom_env_file:
   yaml_obj['services']['cardsinitial']['env_file'] = args.custom_env_file


### PR DESCRIPTION
When the `--dev_docker_image` flag is present in the calling of `generate_compose_yaml.py`, the host's `~/.m2` directory is _read-only_ mounted to the `cardsinitial` container's `/root/.m2` directory.

To test:

- Build this branch with `mvn clean install`. This will produce a Docker image that is _not_ self-contained and thus requires mounting the host's `~/.m2` directory into the container.
- `cd compose-cluster`
- `python3 generate_compose_yaml.py --oak_filesystem --dev_docker_image`
- `docker-compose build`
- `docker-compose up -d`
- CARDS should work all as expected. If the `--dev_docker_image` flag was not present in the invocation of `generate_compose_yaml.py` then CARDS would fail to start.