### PR TITLE
CARDS-1070: Changing the question variable name erases the previously entered AnswerOptions

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/AnswerOptions.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/AnswerOptions.jsx
@@ -130,10 +130,19 @@ let AnswerOptions = (props) => {
                                                                                       "label" : "None of the above",
                                                                                       "noneOfTheAbove" : false,
                                                                                       "@path" : path + "/NoneOfTheAbove"});
-  // Update options path on parent path change
+  // Update all options path on parent path change
   useEffect(() => {
     setNotApplicableOption({ ...notApplicableOption, "@path" : path + "/None"});
     setNoneOfTheAboveOption({ ...noneOfTheAboveOption, "@path" : path +  "/NoneOfTheAbove"});
+    setOptions(oldOptions => {
+      let newOptions = oldOptions.slice();
+      newOptions.map(opt => { if (opt.isNew) {
+                                opt["@path"] = path + "/AnswerOption" + stringToHash(opt.value);
+                              }
+                              return opt;
+                            });
+      return newOptions;
+    });
   }, [path])
 
   let specialOptionsInfo = [
@@ -231,7 +240,7 @@ let AnswerOptions = (props) => {
       newOption.value = inputs[0].trim();
       newOption["@path"] = path + "/AnswerOption" + stringToHash(newOption.value);
       newOption.label = inputs[1] ? inputs[1].trim() : "";
-
+      newOption.isNew = true;
       setOptions(oldValue => {
         var value = oldValue.slice();
         value.push(newOption);

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditDialog.jsx
@@ -39,6 +39,7 @@ import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js"
 let EditDialog = (props) => {
   const { data, type, targetExists, isOpen, onClose, onCancel, id, parentDisplayMode } = props;
   let [ targetId, setTargetId ] = useState('');
+  let [ dialogData, setDialogData ] = useState(targetExists ? data : {});
   // Marks that a save operation is in progress
   let [ saveInProgress, setSaveInProgress ] = useState();
   // Indicates whether the form has been saved or not. This has three possible values:
@@ -158,7 +159,7 @@ let EditDialog = (props) => {
         <Grid item xs={8}>{
           targetExists ?
           <Typography>{data["@name"]}</Typography> :
-          <TextField name='' value={targetId} onChange={(event)=> { setTargetId(event.target.value); }} multiline fullWidth/>
+          <TextField name='' value={targetId} onChange={(event)=> { setTargetId(event.target.value); }} required multiline fullWidth/>
         }</Grid>
       </Grid>
     )
@@ -175,7 +176,7 @@ let EditDialog = (props) => {
             <Grid container direction="column" spacing={2}>
               <Grid item>{targetIdField()}</Grid>
               <Fields
-                data={targetExists && data || {}}
+                data={dialogData}
                 JSON={json[0]}
                 edit={true}
                 path={data["@path"] + (targetExists ? "" : `/${targetId}`)}


### PR DESCRIPTION
Each question variable change triggered component re-render which changes the `data` object reference ech time. Since objects are compared by reference, that envoked [`useEffect()`](https://github.com/data-team-uhn/cards/blob/dev/modules/data-entry/src/main/frontend/src/questionnaireEditor/AnswerOptions.jsx#L176-L181) that cleared the state and erased answer options.