### PR TITLE
CARDS-1559: Support building and running different instances in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build
 target
 target-eclipse
+.mvnrepo
 
 # IDEA
 *.iml

--- a/pom.xml
+++ b/pom.xml
@@ -534,6 +534,23 @@
         <artifactId>slingfeature-maven-plugin</artifactId>
         <extensions>true</extensions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <!-- Deploy a copy locally, to avoid coflicts with other builds -->
+        <executions>
+          <execution>
+            <id>local-deploy</id>
+            <phase>install</phase>
+            <goals>
+              <goal>deploy</goal>
+            </goals>
+            <configuration>
+              <altDeploymentRepository>localBuild::default::file://.mvnrepo</altDeploymentRepository>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
@@ -672,6 +689,9 @@
             <filesets>
               <fileset>
                 <directory>src/main/frontend/dist/</directory>
+              </fileset>
+              <fileset>
+                <directory>.mvnrepo/</directory>
               </fileset>
             </filesets>
           </configuration>

--- a/start_cards.sh
+++ b/start_cards.sh
@@ -210,7 +210,7 @@ do
 done
 
 #Start CARDS in the background
-java -Djdk.xml.entityExpansionLimit=0 -Dorg.osgi.service.http.port=${BIND_PORT} -jar distribution/target/dependency/org.apache.sling.feature.launcher.jar -p .cards-data -f distribution/target/cards-*-core_${OAK_STORAGE}_far.far -f mvn:io.uhndata.cards/cards-dataentry/${CARDS_VERSION}/slingosgifeature/permissions_${PERMISSIONS} "${ARGS[@]}" &
+java -Djdk.xml.entityExpansionLimit=0 -Dorg.osgi.service.http.port=${BIND_PORT} -jar distribution/target/dependency/org.apache.sling.feature.launcher.jar -u "file://$(realpath .mvnrepo),file://$(realpath ${HOME}/.m2/repository),https://repo.maven.apache.org/maven2,https://repository.apache.org/content/groups/snapshots" -p .cards-data -f distribution/target/cards-*-core_${OAK_STORAGE}_far.far -f mvn:io.uhndata.cards/cards-dataentry/${CARDS_VERSION}/slingosgifeature/permissions_${PERMISSIONS} "${ARGS[@]}" &
 CARDS_PID=$!
 
 #Check to see if CARDS was able to bind to the TCP port


### PR DESCRIPTION
This may not work as expected on Windows, so please test @sashaandjic and @veronikaslc .

To test that multiple builds work fine:
- clone the repo two times, checkout branch `test-CARDS-1559-a` in one clone, and `test-CARDS-1559-b` in another clone
- build branch a in a clone
- build branch b in the other clone
- start branch a, check that the login dialog says `Username (version A)`
- start branch b on a different port, check that the login dialog says `Username (version B)`