### PR TITLE
CARDS-1507: As a patient, I have access to a high-level interpretation of my survey responses

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -216,7 +216,7 @@ let ComputedQuestion = (props) => {
   }, [unitOfMeasurement])
 
   useEffect(() => {
-    let formatted = (displayMode === "formatted" || displayMode === "review");
+    let formatted = (displayMode === "formatted" || displayMode === "summary");
     if (formatted !== isFormatted) {
       changeIsFormatted(formatted)
     };

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -216,7 +216,7 @@ let ComputedQuestion = (props) => {
   }, [unitOfMeasurement])
 
   useEffect(() => {
-    let formatted = (displayMode === "formatted");
+    let formatted = (displayMode === "formatted" || displayMode === "review");
     if (formatted !== isFormatted) {
       changeIsFormatted(formatted)
     };

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -124,7 +124,7 @@ function Form (props) {
   const formURL = `/Forms/${id}`;
   const urlBase = "/content.html";
   const isEdit = window.location.pathname.endsWith(".edit") || mode == "edit";
-  const isReview = window.location.pathname.endsWith(".review") || mode == "review";
+  const isSummary = window.location.pathname.endsWith(".summary") || mode == "summary";
   let globalLoginDisplay = useContext(GlobalLoginContext);
 
   useEffect(() => {
@@ -494,7 +494,7 @@ function Form (props) {
                     visibleCallback={pageResult.callback}
                     pageActive={pageResult.page.visible}
                     isEdit={isEdit}
-                    isReview={isReview}
+                    isSummary={isSummary}
                     contentOffset={{top: formContentOffsetTop, bottom: formContentOffsetBottom}}
                   />
                 })

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -124,6 +124,7 @@ function Form (props) {
   const formURL = `/Forms/${id}`;
   const urlBase = "/content.html";
   const isEdit = window.location.pathname.endsWith(".edit") || mode == "edit";
+  const isReview = window.location.pathname.endsWith(".review") || mode == "review";
   let globalLoginDisplay = useContext(GlobalLoginContext);
 
   useEffect(() => {
@@ -493,6 +494,7 @@ function Form (props) {
                     visibleCallback={pageResult.callback}
                     pageActive={pageResult.page.visible}
                     isEdit={isEdit}
+                    isReview={isReview}
                     contentOffset={{top: formContentOffsetTop, bottom: formContentOffsetBottom}}
                   />
                 })

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -132,7 +132,7 @@ let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, o
  * @param {string} key the node name of the section definition JCR node
  * @returns a React component that renders the section
  */
-let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onChange, visibleCallback, pageActive, isEdit, instanceId, contentOffset) => {
+let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onChange, visibleCallback, pageActive, isEdit, isReview, instanceId, contentOffset) => {
   // Find the existing AnswerSection for this section, if available
   const existingQuestionAnswer = existingAnswer && Object.entries(existingAnswer)
     .filter(([key, value]) => value["sling:resourceType"] == "cards/AnswerSection"
@@ -149,6 +149,7 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onCha
       visibleCallback={visibleCallback}
       pageActive={pageActive}
       isEdit={isEdit}
+      isReview={isReview}
       instanceId={instanceId || ''}
       contentOffset={contentOffset}
       />
@@ -184,14 +185,23 @@ let displayInformation = (infoDefinition, key, classes, pageActive, isEdit) => {
  * @returns a React component that renders the section
  */
  export default function FormEntry(props) {
-  let { classes, entryDefinition, path, depth, existingAnswers, keyProp, onAddedAnswerPath, sectionAnswersState, onChange, visibleCallback, pageActive, isEdit, instanceId, contentOffset} = props;
+  let { classes, entryDefinition, path, depth, existingAnswers, keyProp, onAddedAnswerPath, sectionAnswersState, onChange, visibleCallback, pageActive, isEdit, isReview, instanceId, contentOffset} = props;
+  // TODO: Implement a more in depth review display mode.
+  // This works for the PROMS release, but may not work for other situations.
+  if (isReview) {
+    if (!("review" === entryDefinition["@name"] || entryDefinition["@name"].startsWith("review"))) {
+      return null;
+    } else if (entryDefinition.displayMode == "hidden") {
+      entryDefinition.displayMode = "formatted";
+    }
+  }
   // TODO: As before, I'm writing something that's basically an if statement
   // this should instead be via a componentManager
   if (QUESTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
     if (visibleCallback) visibleCallback(true);
     return displayQuestion(entryDefinition, path, existingAnswers, keyProp, classes, onAddedAnswerPath, sectionAnswersState, onChange, pageActive, isEdit, instanceId);
   } else if (SECTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
-    return displaySection(entryDefinition, path, depth, existingAnswers, keyProp, onChange, visibleCallback, pageActive, isEdit, instanceId, contentOffset);
+    return displaySection(entryDefinition, path, depth, existingAnswers, keyProp, onChange, visibleCallback, pageActive, isEdit, isReview, instanceId, contentOffset);
   } else if (INFO_TYPES.includes(entryDefinition["jcr:primaryType"])) {
     return displayInformation(entryDefinition, keyProp, classes, pageActive, isEdit);
   }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -58,7 +58,7 @@ export const ENTRY_TYPES = QUESTION_TYPES.concat(SECTION_TYPES).concat(INFO_TYPE
  * @param {Object} classes style classes
  * @returns a React component that renders the question
  */
-let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, onAddedAnswerPath, sectionAnswersState, onChange, pageActive, isEdit, instanceId) => {
+let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, onAddedAnswerPath, sectionAnswersState, onChange, pageActive, isEdit, isReview, instanceId) => {
   const [ doHighlight, setDoHighlight ] = useState();
   const [ anchor, setAnchor ] = useState();
 
@@ -99,7 +99,8 @@ let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, o
   if (doHighlight) {
     gridClasses.push(classes.focusedQuestionnaireItem);
   }
-  if (pageActive === false || questionDefinition.displayMode == 'hidden') {
+  let displayMode = questionDefinition.displayMode;
+  if (pageActive === false || displayMode == 'hidden' || (isReview && displayMode !== "review") || (!isReview && displayMode === "review")) {
     gridClasses.push(classes.hiddenQuestion);
   }
 
@@ -133,6 +134,10 @@ let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, o
  * @returns a React component that renders the section
  */
 let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onChange, visibleCallback, pageActive, isEdit, isReview, instanceId, contentOffset) => {
+  if (isReview && sectionDefinition.displayMode !== "review") {
+    return null;
+  }
+
   // Find the existing AnswerSection for this section, if available
   const existingQuestionAnswer = existingAnswer && Object.entries(existingAnswer)
     .filter(([key, value]) => value["sling:resourceType"] == "cards/AnswerSection"
@@ -186,20 +191,11 @@ let displayInformation = (infoDefinition, key, classes, pageActive, isEdit) => {
  */
  export default function FormEntry(props) {
   let { classes, entryDefinition, path, depth, existingAnswers, keyProp, onAddedAnswerPath, sectionAnswersState, onChange, visibleCallback, pageActive, isEdit, isReview, instanceId, contentOffset} = props;
-  // TODO: Implement a more in depth review display mode.
-  // This works for the PROMS release, but may not work for other situations.
-  if (isReview) {
-    if (!("review" === entryDefinition["@name"] || entryDefinition["@name"].startsWith("review"))) {
-      return null;
-    } else if (entryDefinition.displayMode == "hidden") {
-      entryDefinition.displayMode = "formatted";
-    }
-  }
   // TODO: As before, I'm writing something that's basically an if statement
   // this should instead be via a componentManager
   if (QUESTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
     if (visibleCallback) visibleCallback(true);
-    return displayQuestion(entryDefinition, path, existingAnswers, keyProp, classes, onAddedAnswerPath, sectionAnswersState, onChange, pageActive, isEdit, instanceId);
+    return displayQuestion(entryDefinition, path, existingAnswers, keyProp, classes, onAddedAnswerPath, sectionAnswersState, onChange, pageActive, isEdit, isReview, instanceId);
   } else if (SECTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
     return displaySection(entryDefinition, path, depth, existingAnswers, keyProp, onChange, visibleCallback, pageActive, isEdit, isReview, instanceId, contentOffset);
   } else if (INFO_TYPES.includes(entryDefinition["jcr:primaryType"])) {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -58,7 +58,7 @@ export const ENTRY_TYPES = QUESTION_TYPES.concat(SECTION_TYPES).concat(INFO_TYPE
  * @param {Object} classes style classes
  * @returns a React component that renders the question
  */
-let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, onAddedAnswerPath, sectionAnswersState, onChange, pageActive, isEdit, isReview, instanceId) => {
+let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, onAddedAnswerPath, sectionAnswersState, onChange, pageActive, isEdit, isSummary, instanceId) => {
   const [ doHighlight, setDoHighlight ] = useState();
   const [ anchor, setAnchor ] = useState();
 
@@ -100,7 +100,7 @@ let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, o
     gridClasses.push(classes.focusedQuestionnaireItem);
   }
   let displayMode = questionDefinition.displayMode;
-  if (pageActive === false || displayMode == 'hidden' || (isReview && displayMode !== "review") || (!isReview && displayMode === "review")) {
+  if (pageActive === false || displayMode == 'hidden' || (isSummary && displayMode !== "summary") || (!isSummary && displayMode === "summary")) {
     gridClasses.push(classes.hiddenQuestion);
   }
 
@@ -133,8 +133,8 @@ let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, o
  * @param {string} key the node name of the section definition JCR node
  * @returns a React component that renders the section
  */
-let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onChange, visibleCallback, pageActive, isEdit, isReview, instanceId, contentOffset) => {
-  if (isReview && sectionDefinition.displayMode !== "review") {
+let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onChange, visibleCallback, pageActive, isEdit, isSummary, instanceId, contentOffset) => {
+  if (isSummary && sectionDefinition.displayMode !== "summary") {
     return null;
   }
 
@@ -154,7 +154,7 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onCha
       visibleCallback={visibleCallback}
       pageActive={pageActive}
       isEdit={isEdit}
-      isReview={isReview}
+      isSummary={isSummary}
       instanceId={instanceId || ''}
       contentOffset={contentOffset}
       />
@@ -190,14 +190,14 @@ let displayInformation = (infoDefinition, key, classes, pageActive, isEdit) => {
  * @returns a React component that renders the section
  */
  export default function FormEntry(props) {
-  let { classes, entryDefinition, path, depth, existingAnswers, keyProp, onAddedAnswerPath, sectionAnswersState, onChange, visibleCallback, pageActive, isEdit, isReview, instanceId, contentOffset} = props;
+  let { classes, entryDefinition, path, depth, existingAnswers, keyProp, onAddedAnswerPath, sectionAnswersState, onChange, visibleCallback, pageActive, isEdit, isSummary, instanceId, contentOffset} = props;
   // TODO: As before, I'm writing something that's basically an if statement
   // this should instead be via a componentManager
   if (QUESTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
     if (visibleCallback) visibleCallback(true);
-    return displayQuestion(entryDefinition, path, existingAnswers, keyProp, classes, onAddedAnswerPath, sectionAnswersState, onChange, pageActive, isEdit, isReview, instanceId);
+    return displayQuestion(entryDefinition, path, existingAnswers, keyProp, classes, onAddedAnswerPath, sectionAnswersState, onChange, pageActive, isEdit, isSummary, instanceId);
   } else if (SECTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
-    return displaySection(entryDefinition, path, depth, existingAnswers, keyProp, onChange, visibleCallback, pageActive, isEdit, isReview, instanceId, contentOffset);
+    return displaySection(entryDefinition, path, depth, existingAnswers, keyProp, onChange, visibleCallback, pageActive, isEdit, isSummary, instanceId, contentOffset);
   } else if (INFO_TYPES.includes(entryDefinition["jcr:primaryType"])) {
     return displayInformation(entryDefinition, keyProp, classes, pageActive, isEdit);
   }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -64,7 +64,7 @@ function createTitle(label, idx, isRecurrent) {
  * @param {Object} sectionDefinition the section definition JSON
  */
 function Section(props) {
-  const { classes, depth, existingAnswer, path, sectionDefinition, onChange, visibleCallback, pageActive, isEdit, isReview, instanceId, contentOffset } = props;
+  const { classes, depth, existingAnswer, path, sectionDefinition, onChange, visibleCallback, pageActive, isEdit, isSummary, instanceId, contentOffset } = props;
   const isRecurrent = sectionDefinition['recurrent'];
   const { displayMode } = sectionDefinition;
   const [ focus, setFocus ] = useState(false);
@@ -266,7 +266,7 @@ function Section(props) {
                         classes={classes}
                         onChange={onChange}
                         isEdit={isEdit}
-                        isReview={isReview}
+                        isSummary={isSummary}
                         contentOffset={contentOffset}
                         pageActive={pageActive}
                         sectionAnswersState={removableAnswers}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -64,7 +64,7 @@ function createTitle(label, idx, isRecurrent) {
  * @param {Object} sectionDefinition the section definition JSON
  */
 function Section(props) {
-  const { classes, depth, existingAnswer, path, sectionDefinition, onChange, visibleCallback, pageActive, isEdit, instanceId, contentOffset } = props;
+  const { classes, depth, existingAnswer, path, sectionDefinition, onChange, visibleCallback, pageActive, isEdit, isReview, instanceId, contentOffset } = props;
   const isRecurrent = sectionDefinition['recurrent'];
   const { displayMode } = sectionDefinition;
   const [ focus, setFocus ] = useState(false);
@@ -266,6 +266,7 @@ function Section(props) {
                         classes={classes}
                         onChange={onChange}
                         isEdit={isEdit}
+                        isReview={isReview}
                         contentOffset={contentOffset}
                         pageActive={pageActive}
                         sectionAnswersState={removableAnswers}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/TextQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/TextQuestion.jsx
@@ -90,7 +90,7 @@ TextQuestion.propTypes = {
     text: PropTypes.string.isRequired,
     minAnswers: PropTypes.number,
     maxAnswers: PropTypes.number,
-    displayMode: PropTypes.oneOf([undefined, "input", "textbox", "list", "list+input"]),
+    displayMode: PropTypes.oneOf([undefined, "input", "textbox", "list", "list+input", "hidden"]),
     regexp: PropTypes.string,
   }).isRequired,
   text: PropTypes.string,

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -29,7 +29,8 @@
             "displayMode" : {
               "input" : {},
               "formatted" : {},
-              "hidden": {}
+              "hidden": {},
+              "review": {}
             }
           }
         }

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -30,7 +30,7 @@
               "input" : {},
               "formatted" : {},
               "hidden": {},
-              "review": {}
+              "summary": {}
             }
           }
         }

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Section.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Section.json
@@ -8,7 +8,8 @@
         "initialNumberOfInstances" : "long"
       },
       "header" : {},
-      "footer" : {}
+      "footer" : {},
+      "review" : {}
     }
   }
 ]

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Section.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Section.json
@@ -9,7 +9,7 @@
       },
       "header" : {},
       "footer" : {},
-      "review" : {}
+      "summary" : {}
     }
   }
 ]

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/AUDITC.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/AUDITC.xml
@@ -149,6 +149,11 @@ disorder. AUDIT-C has been validated in mental health and primary care clinics.
 	<node>
 		<name>review</name>
 		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>displayMode</name>
+			<value>review</value>
+			<type>String</type>
+		</property>
 		<node>
 			<name>review_score</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
@@ -178,7 +183,7 @@ disorder. AUDIT-C has been validated in mental health and primary care clinics.
 			</property>
 			<property>
 				<name>displayMode</name>
-				<value>hidden</value>
+				<value>review</value>
 				<type>String</type>
 			</property>
 			<property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/AUDITC.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/AUDITC.xml
@@ -147,15 +147,15 @@ disorder. AUDIT-C has been validated in mental health and primary care clinics.
 		</property>
 	</node>
 	<node>
-		<name>review</name>
+		<name>summary</name>
 		<primaryNodeType>cards:Section</primaryNodeType>
 		<property>
 			<name>displayMode</name>
-			<value>review</value>
+			<value>summary</value>
 			<type>String</type>
 		</property>
 		<node>
-			<name>review_score</name>
+			<name>summary_score</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
 				<name>expression</name>
@@ -170,7 +170,7 @@ disorder. AUDIT-C has been validated in mental health and primary care clinics.
 						(
 							"male" === @{sex:-""}.toLowerCase() ? maleText
 								: "female" === @{sex:-""}.toLowerCase() ? femaleText
-									: "For Males:\n\n" + maleText + "\n\n For Females:\n\n" + femaleText
+									: "If you are a man:\n\n" + maleText + "\n\n If you are a woman:\n\n" + femaleText
 						)
 					)
 				</value>
@@ -178,12 +178,12 @@ disorder. AUDIT-C has been validated in mental health and primary care clinics.
 			</property>
 			<property>
 				<name>text</name>
-				<value>AUDIT-C Alcohol Use Questionnaire</value>
+				<value>AUDIT-C Interpretation</value>
 				<type>String</type>
 			</property>
 			<property>
 				<name>displayMode</name>
-				<value>review</value>
+				<value>summary</value>
 				<type>String</type>
 			</property>
 			<property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/AUDITC.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/AUDITC.xml
@@ -128,6 +128,67 @@ disorder. AUDIT-C has been validated in mental health and primary care clinics.
 		</node>
 	</node>
 	<node>
+		<name>sex</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Sex</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>hidden</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+	</node>
+	<node>
+		<name>review</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<node>
+			<name>review_score</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>expression</name>
+				<value>
+					let maleText = 4 >= @{audit_score} ? "If your symptoms result in a score of 0 - 4, consider accessing self-care resources available on [Peter Munk Cardiac Centre's website](https://www.uhn.ca/PMCC/Clinics/Adult_Congenital_Cardiac#information) for how to manage those symptoms."
+							: "If your symptoms result in a score of 5 or more, make sure to bring them up to your provider at your next appointment as further assessment of alcohol use may be required. Note that if your symptoms are severe (for example 8 - 12), you should consider telling your health care team right away or go to the closest emergency department."
+					let femaleText = 3 >= @{audit_score} ? "If your symptoms result in a score of 0 - 3, consider accessing self-care resources available on [Peter Munk Cardiac Centre's website](https://www.uhn.ca/PMCC/Clinics/Adult_Congenital_Cardiac#information) for how to manage those symptoms."
+							: "If your symptoms result in a score of 4 or more, make sure to bring them up to your provider at your next appointment as further assessment of alcohol use may be required. Note that if your symptoms are severe (for example 8 - 12), you should consider telling your health care team right away or go to the closest emergency department."
+					return (
+						"Your Score: " + @{audit_score}
+						+ "\n\n" +
+						(
+							"male" === @{sex:-""}.toLowerCase() ? maleText
+								: "female" === @{sex:-""}.toLowerCase() ? femaleText
+									: "For Males:\n\n" + maleText + "\n\n For Females:\n\n" + femaleText
+						)
+					)
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>AUDIT-C Alcohol Use Questionnaire</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
 		<name>audit_survey</name>
 		<primaryNodeType>cards:Section</primaryNodeType>
 		<node>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
@@ -251,6 +251,11 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 	<node>
 		<name>review</name>
 		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>displayMode</name>
+			<value>review</value>
+			<type>String</type>
+		</property>
 		<node>
 			<name>review_score</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
@@ -274,7 +279,7 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 			</property>
 			<property>
 				<name>displayMode</name>
-				<value>hidden</value>
+				<value>review</value>
 				<type>String</type>
 			</property>
 			<property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
@@ -249,6 +249,42 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 		</node>
 	</node>
 	<node>
+		<name>review</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<node>
+			<name>review_score</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>expression</name>
+				<value>
+					return (
+						"Your Score: " + @{gad7_score}
+						+ "\n\n" +
+						( 10 >= @{gad7_score} ? "If your symptoms result in a score of 0 - 10, consider accessing self-care resources available on [Peter Munk Cardiac Centre's website](https://www.uhn.ca/PMCC/Clinics/Adult_Congenital_Cardiac#information) for how to manage those symptoms."
+							: "If your symptoms result in a score of 11 or more, make sure to bring them up to your provider at your next appointment as further assessment of anxiety symptoms may be required. Note that if your symptoms are severe (for example 15 - 21), you should consider telling your health care team right away or go to the closest emergency department."
+						)
+					)
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>GAD-7 Anxiety Questionnaire</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
 		<name>gad7_survey</name>
 		<primaryNodeType>cards:Section</primaryNodeType>
 		<property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
@@ -249,15 +249,15 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 		</node>
 	</node>
 	<node>
-		<name>review</name>
+		<name>summary</name>
 		<primaryNodeType>cards:Section</primaryNodeType>
 		<property>
 			<name>displayMode</name>
-			<value>review</value>
+			<value>summary</value>
 			<type>String</type>
 		</property>
 		<node>
-			<name>review_score</name>
+			<name>summary_score</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
 				<name>expression</name>
@@ -274,12 +274,12 @@ Objectively determine initial symptoms severity and monitor symptom changes/effe
 			</property>
 			<property>
 				<name>text</name>
-				<value>GAD-7 Anxiety Questionnaire</value>
+				<value>GAD-7 Interpretation</value>
 				<type>String</type>
 			</property>
 			<property>
 				<name>displayMode</name>
-				<value>review</value>
+				<value>summary</value>
 				<type>String</type>
 			</property>
 			<property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
@@ -276,6 +276,11 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 	<node>
 		<name>review</name>
 		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>displayMode</name>
+			<value>review</value>
+			<type>String</type>
+		</property>
 		<node>
 			<name>review_risk_assessment</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
@@ -310,7 +315,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			</property>
 			<property>
 				<name>displayMode</name>
-				<value>hidden</value>
+				<value>review</value>
 				<type>String</type>
 			</property>
 			<property>
@@ -342,7 +347,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			</property>
 			<property>
 				<name>displayMode</name>
-				<value>hidden</value>
+				<value>review</value>
 				<type>String</type>
 			</property>
 			<property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
@@ -274,6 +274,85 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 		</node>
 	</node>
 	<node>
+		<name>review</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<node>
+			<name>review_risk_assessment</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>expression</name>
+				<value><![CDATA[
+					return (
+						( 0 < @{phq9_9} ? "Your responses indicate that you are having thoughts of hurting yourself. We strongly encourage you to seek immediate help from a professional mental health provider using the below resources."
+							+ "\n\n" + "**Crisis Services Canada**"
+							+ "\n\n" + "Call [1-833-456-4566](tel:1-833-456-4566)"
+							+ "\n" + "- Suicide Prevention Services are available 24/7/365"
+							+ "\n" + "- Can connect you to responders immediately"
+							+ "\n" + "- Online chat and text options are also available"
+							+ "\n" + "For more information, see [Crisis Services Canada's website](https://www.crisisservicescanada.ca/en/)."
+							+ "\n\n" + "**Telehealth Ontario (across Ontario)**"
+							+ "\n\n" + "Call [1-866-797-0000](tel:1-866-797-0000)"
+							+ "\n" + "- Telehealth is available 24/7/365 and can provide you with immediate assistance"
+							+ "\n" + "- Free, confidential service provided by a Registered Nurse"
+							+ "\n" + "For more information, see [Telehealth Ontario's website](https://www.ontario.ca/page/get-medical-advice-telehealth-ontario)."
+							+ "\n\n" + "**Immediate Assistance**"
+							+ "\n\n" + "If you need immediate assistance, please proceed to your nearest Emergency Department or call 911."
+							: null
+						)
+					)]]>
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>PHQ-9 Risk Assessment</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>review_score</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>expression</name>
+				<value>
+					return (
+						"Your Score: " + @{phq9_score}
+						+ "\n\n" +
+						( 14 >= @{phq9_score} ? "If your symptoms result in a score of 0 - 14, consider accessing self-care resources available on [Peter Munk Cardiac Centre's website](https://www.uhn.ca/PMCC/Clinics/Adult_Congenital_Cardiac#information) for how to manage those symptoms."
+							: "If your symptoms result in a score of 15 or more, make sure to bring them up to your provider at your next appointment as further assessment of depressive symptoms may be required. Note that if your symptoms are severe (for example 20 - 27), you should consider telling your health care team right away or go to the closest emergency department."
+						)
+					)
+				</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>PHQ-9 Depression Questionnaire</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>hidden</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
 		<name>phq9_survey</name>
 		<primaryNodeType>cards:Section</primaryNodeType>
 		<property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
@@ -274,15 +274,15 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 		</node>
 	</node>
 	<node>
-		<name>review</name>
+		<name>summary</name>
 		<primaryNodeType>cards:Section</primaryNodeType>
 		<property>
 			<name>displayMode</name>
-			<value>review</value>
+			<value>summary</value>
 			<type>String</type>
 		</property>
 		<node>
-			<name>review_risk_assessment</name>
+			<name>summary_risk_assessment</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
 				<name>expression</name>
@@ -295,13 +295,13 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 							+ "\n" + "- Can connect you to responders immediately"
 							+ "\n" + "- Online chat and text options are also available"
 							+ "\n" + "For more information, see [Crisis Services Canada's website](https://www.crisisservicescanada.ca/en/)."
-							+ "\n\n" + "**Telehealth Ontario (across Ontario)**"
+							+ "\n\n" + "**Telehealth Ontario** (across Ontario)"
 							+ "\n\n" + "Call [1-866-797-0000](tel:1-866-797-0000)"
 							+ "\n" + "- Telehealth is available 24/7/365 and can provide you with immediate assistance"
 							+ "\n" + "- Free, confidential service provided by a Registered Nurse"
 							+ "\n" + "For more information, see [Telehealth Ontario's website](https://www.ontario.ca/page/get-medical-advice-telehealth-ontario)."
 							+ "\n\n" + "**Immediate Assistance**"
-							+ "\n\n" + "If you need immediate assistance, please proceed to your nearest Emergency Department or call 911."
+							+ "\n\n" + "**If you need immediate assistance, please proceed to your nearest Emergency Department or call 911.**"
 							: null
 						)
 					)]]>
@@ -315,7 +315,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			</property>
 			<property>
 				<name>displayMode</name>
-				<value>review</value>
+				<value>summary</value>
 				<type>String</type>
 			</property>
 			<property>
@@ -325,7 +325,7 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			</property>
 		</node>
 		<node>
-			<name>review_score</name>
+			<name>summary_score</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
 				<name>expression</name>
@@ -342,12 +342,12 @@ Objectively determines severity of initial symptoms, and also monitors symptom c
 			</property>
 			<property>
 				<name>text</name>
-				<value>PHQ-9 Depression Questionnaire</value>
+				<value>PHQ-9 Interpretation</value>
 				<type>String</type>
 			</property>
 			<property>
 				<name>displayMode</name>
-				<value>review</value>
+				<value>summary</value>
 				<type>String</type>
 			</property>
 			<property>

--- a/proms-resources/frontend/src/main/frontend/src/QuestionnaireSet.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/QuestionnaireSet.jsx
@@ -150,7 +150,7 @@ function QuestionnaireSet(props) {
     if (!questionnaireIds || crtStep < questionnaireIds.length) return;
     setEndReached(true);
     loadExistingData();
-  }, [crtStep, questionnaireIds]);
+  }, [crtStep, questionnaireSetIds]);
 
   // Determine if all surveys have been filled out
   useEffect(() => {
@@ -346,13 +346,42 @@ function QuestionnaireSet(props) {
     ))}
     </List>,
     isComplete ?
-      <Typography color="textSecondary">Your data has been submitted.</Typography>
+      <>
+        <Typography variant="h4">Thank you for your submission.</Typography>
+        <Typography color="textSecondary">Please note:</Typography>
+        <ul>
+          <li><Typography color="textSecondary">
+For your privacy and security, once this screen is closed the information below will not be accessible until the day of
+your appointment with your provider. Please print or note this information for your reference.
+          </Typography></li>
+          <li><Typography color="textSecondary">
+Your responses may not be reviewed by your care team until the day of your next appointment. If your symptoms are
+worsening while waiting for your next appointment, please proceed to your nearest Emergency Department today, or call
+911.
+          </Typography></li>
+        </ul>
+        <Typography variant="h4">Interpreting your results</Typography>
+        <Typography color="textSecondary">There are different actions you can take now depending on how you have scored
+your symptoms. Please see below for a summary of your scores and suggested actions.</Typography>
+        <Grid item>
+        {/* This is failing to display the review: Debug why */}
+          { (questionnaireIds || []).map((q, i) => (
+            <Form
+              key={i}
+              id={subjectData[q]['@name']}
+              mode="review"
+              disableHeader
+              disableButton
+              contentOffset={contentOffset}
+            />
+          ))}
+        </Grid>
+      </>
       :
-      <Typography color="error">Your answers are incomplete. Please return to the main screen and check for any mandatory questions you may have missed.</Typography>,
-    isComplete?
-      <Typography variant="h4">Thank you</Typography>
-      :
-      <Fab variant="extended" color="primary" onClick={() => {setCrtStep(-1)}}>Update answers</Fab>
+      <>
+        <Typography color="error">Your answers are incomplete. Please return to the main screen and check for any mandatory questions you may have missed.</Typography>
+        <Fab variant="extended" color="primary" onClick={() => {setCrtStep(-1)}}>Update answers</Fab>
+      </>
   ];
 
   return (

--- a/proms-resources/frontend/src/main/frontend/src/QuestionnaireSet.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/QuestionnaireSet.jsx
@@ -330,58 +330,57 @@ function QuestionnaireSet(props) {
     </Grid>
   ];
 
-  let exitScreen = (typeof(isComplete) == 'undefined') ? [
-    <CircularProgress />
-  ] : [
-    <Typography variant="h4">{title}</Typography>,
-    <List>
-    { (questionnaireIds || []).map((q, i) => (
-      <ListItem key={q}>
-        <ListItemAvatar>{isFormComplete(q) ? doneIndicator : incompleteIndicator}</ListItemAvatar>
-        <ListItemText
-          primary={questionnaires[q]?.title}
-          secondary={!isFormComplete(q) && "Incomplete"}
-        />
-      </ListItem>
-    ))}
-    </List>,
-    isComplete ?
-      <>
-        <Typography variant="h4">Thank you for your submission.</Typography>
-        <Typography color="textSecondary">Please note:</Typography>
-        <ul>
-          <li><Typography color="textSecondary">
+  let summaryScreen = [
+      <Typography variant="h4">Thank you for your submission.</Typography>,
+      <Typography color="textSecondary">Please note:</Typography>,
+      <ul>
+        <li><Typography color="textSecondary">
 For your privacy and security, once this screen is closed the information below will not be accessible until the day of
 your appointment with your provider. Please print or note this information for your reference.
-          </Typography></li>
-          <li><Typography color="textSecondary">
+        </Typography></li>
+        <li><Typography color="textSecondary">
 Your responses may not be reviewed by your care team until the day of your next appointment. If your symptoms are
 worsening while waiting for your next appointment, please proceed to your nearest Emergency Department today, or call
 911.
-          </Typography></li>
-        </ul>
-        <Typography variant="h4">Interpreting your results</Typography>
-        <Typography color="textSecondary">There are different actions you can take now depending on how you have scored
-your symptoms. Please see below for a summary of your scores and suggested actions.</Typography>
-        <Grid item>
-        {/* This is failing to display the review: Debug why */}
-          { (questionnaireIds || []).map((q, i) => (
-            <Form
-              key={i}
-              id={subjectData[q]['@name']}
-              mode="review"
-              disableHeader
-              disableButton
-              contentOffset={contentOffset}
+        </Typography></li>
+      </ul>,
+      <Typography variant="h4">Interpreting your results</Typography>,
+      <Typography color="textSecondary">There are different actions you can take now depending on how you have scored
+your symptoms. Please see below for a summary of your scores and suggested actions.</Typography>,
+      <Grid item>
+      { (questionnaireIds || []).map((q, i) => (
+        <Form
+          key={i}
+          id={subjectData[q]['@name']}
+          mode="summary"
+          disableHeader
+          disableButton
+          contentOffset={contentOffset}
+        />
+      ))}
+      </Grid>
+    ];
+
+  let exitScreen = (typeof(isComplete) == 'undefined') ? [
+    <CircularProgress />
+  ] : [
+    isComplete ? summaryScreen
+      : [
+        <Typography variant="h4">{title}</Typography>,
+        <List>
+        { (questionnaireIds || []).map((q, i) => (
+          <ListItem key={q}>
+            <ListItemAvatar>{isFormComplete(q) ? doneIndicator : incompleteIndicator}</ListItemAvatar>
+            <ListItemText
+              primary={questionnaires[q]?.title}
+              secondary={!isFormComplete(q) && "Incomplete"}
             />
-          ))}
-        </Grid>
-      </>
-      :
-      <>
-        <Typography color="error">Your answers are incomplete. Please return to the main screen and check for any mandatory questions you may have missed.</Typography>
+          </ListItem>
+        ))}
+        </List>,
+        <Typography color="error">Your answers are incomplete. Please return to the main screen and check for any mandatory questions you may have missed.</Typography>,
         <Fab variant="extended" color="primary" onClick={() => {setCrtStep(-1)}}>Update answers</Fab>
-      </>
+      ]
   ];
 
   return (


### PR DESCRIPTION
- Implement review questions for AUDIT-C, PHQ9 and GAD-7 questionnaires
  - Hidden when filling out forms, visible on the final patient UI page
  
Note: the implementation assumes that the `sex` variable in AUDIT-C is populated at the time of creating the form, from the variable with the same name from Patient information. This will be done as part of #839 . For testing purposes, set that variable manually to one of the supported values `Male`, `Female`, `Other`.