### PR TITLE
CARDS-1584: Make certain answers easily available in the form's JSON

### DIFF
--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AnswerCopyProcessor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AnswerCopyProcessor.java
@@ -18,6 +18,9 @@
  */
 package io.uhndata.cards.dataentry.internal.serialize;
 
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Calendar;
 import java.util.function.Function;
 
 import javax.jcr.Node;
@@ -130,9 +133,16 @@ public class AnswerCopyProcessor implements ResourceJsonProcessor
                 final String question = toCopy.get(key, String.class);
                 final Node answer = getAnswer(node, question);
                 if (answer != null && answer.hasProperty("value")) {
-                    final String value = answer.getProperty("value").getString();
-                    if (value != null) {
-                        json.add(key, value);
+                    final Object value = this.formUtils.getValue(answer);
+                    if (value instanceof Long) {
+                        json.add(key, (Long) value);
+                    } else if (value instanceof Double) {
+                        json.add(key, (Double) value);
+                    } else if (value instanceof Calendar) {
+                        json.add(key, DateTimeFormatter.ISO_DATE_TIME.format(OffsetDateTime.ofInstant(
+                            ((Calendar) value).toInstant(), ((Calendar) value).getTimeZone().toZoneId())));
+                    } else if (value != null) {
+                        json.add(key, String.valueOf(value));
                     }
                 }
             } catch (final RepositoryException e) {

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AnswerCopyProcessor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AnswerCopyProcessor.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.uhndata.cards.dataentry.internal.serialize;
+
+import java.util.function.Function;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonValue;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.uhndata.cards.dataentry.api.FormUtils;
+import io.uhndata.cards.serialize.spi.ResourceJsonProcessor;
+
+/**
+ * A processor that copies the values of certain answers to the root of the JSON for easy access from, for example, the
+ * dashboard through the pagination servlet. The answers to copy are configured in
+ * {@code /apps/cards/config/CopyAnswers/[questionnaire name]/} as properties with the desired property name as the key,
+ * and a references to a question as the value. The name of this processor is {@code answerCopy} and it is enabled by
+ * default.
+ *
+ * @version $Id$
+ */
+@Component(immediate = true)
+public class AnswerCopyProcessor implements ResourceJsonProcessor
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(AnswerCopyProcessor.class);
+
+    private static final String CONFIGURATION_NODE = "/apps/cards/config/CopyAnswers";
+
+    private final ThreadLocal<ValueMap> answersToCopy = ThreadLocal.withInitial(() -> ValueMap.EMPTY);
+
+    @Reference
+    private FormUtils formUtils;
+
+    @Override
+    public String getName()
+    {
+        return "answerCopy";
+    }
+
+    @Override
+    public int getPriority()
+    {
+        return 95;
+    }
+
+    @Override
+    public boolean isEnabledByDefault(final Resource resource)
+    {
+        return true;
+    }
+
+    @Override
+    public boolean canProcess(final Resource resource)
+    {
+        // This only works on forms
+        return resource.isResourceType("cards/Form");
+    }
+
+    @Override
+    public void start(final Resource resource)
+    {
+        final Resource allConfigurations = resource.getResourceResolver().getResource(CONFIGURATION_NODE);
+        if (allConfigurations != null) {
+            try {
+                final String questionnaireName =
+                    resource.getValueMap().get(FormUtils.QUESTIONNAIRE_PROPERTY, Property.class).getNode().getName();
+                final Resource configuration = allConfigurations.getChild(questionnaireName);
+                if (configuration != null) {
+                    this.answersToCopy.set(configuration.getValueMap());
+                }
+            } catch (final RepositoryException e) {
+                LOGGER.warn("Cannot access configuration for AnswerCopyProcessor: {}", e.getMessage(), e);
+            }
+        }
+        // TODO Auto-generated method stub
+        ResourceJsonProcessor.super.start(resource);
+    }
+
+    @Override
+    public void leave(final Node node, final JsonObjectBuilder json, final Function<Node, JsonValue> serializeNode)
+    {
+        try {
+            if (this.answersToCopy.get() != null && node.isNodeType(FormUtils.FORM_NODETYPE)) {
+                copyAnswers(node, json);
+            }
+        } catch (final RepositoryException e) {
+            // Should not happen
+        }
+    }
+
+    @Override
+    public void end(final Resource resource)
+    {
+        this.answersToCopy.remove();
+    }
+
+    private void copyAnswers(final Node node, final JsonObjectBuilder json)
+    {
+        final ValueMap toCopy = this.answersToCopy.get();
+        toCopy.keySet().forEach(key -> {
+            try {
+                final String question = toCopy.get(key, String.class);
+                final Node answer = getAnswer(node, question);
+                if (answer != null && answer.hasProperty("value")) {
+                    final String value = answer.getProperty("value").getString();
+                    if (value != null) {
+                        json.add(key, value);
+                    }
+                }
+            } catch (final RepositoryException e) {
+                // Should not happen
+                LOGGER.warn("Failed to access answer {}: {}", key, e.getMessage(), e);
+            }
+        });
+    }
+
+    private Node getAnswer(final Node form, final String question)
+    {
+        return findNode(form, "question", question);
+    }
+
+    private Node findNode(final Node parent, final String property, final String value)
+    {
+        try {
+            if (parent.hasProperty(property)
+                && StringUtils.equals(parent.getProperty(property).getValue().getString(), value)) {
+                return parent;
+            }
+            final NodeIterator children = parent.getNodes();
+            while (children.hasNext()) {
+                final Node child = children.nextNode();
+                final Node result = findNode(child, property, value);
+                if (result != null) {
+                    return result;
+                }
+            }
+        } catch (IllegalStateException | RepositoryException e) {
+            // Not found or not accessible, just return null
+        }
+        return null;
+    }
+}

--- a/proms-resources/clinical-data/pom.xml
+++ b/proms-resources/clinical-data/pom.xml
@@ -47,6 +47,7 @@
               SLING-INF/content/SubjectTypes/Patient/;path:=/SubjectTypes/Patient/;overwrite:=true,
               SLING-INF/content/libs/cards/resources/;path:=/libs/cards/resources/;overwrite:=true,
               SLING-INF/content/libs/cards/conf/;path:=/libs/cards/conf/;overwrite:=true,
+              SLING-INF/content/apps/cards/config/CopyAnswers;path:=/apps/cards/config/CopyAnswers;overwrite:=true,
               SLING-INF/content/Statistics/;path:=/Statistics/;overwrite:=false,
             </Sling-Initial-Content>
           </instructions>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/config/CopyAnswers/AUDITC.json
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/config/CopyAnswers/AUDITC.json
@@ -1,0 +1,4 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "jcr:reference:score": "/Questionnaires/AUDITC/audit_results/audit_score"
+}

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/config/CopyAnswers/EQ5D.json
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/config/CopyAnswers/EQ5D.json
@@ -1,0 +1,4 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "jcr:reference:score": "/Questionnaires/EQ5D/eq5d_results/eq5d_score"
+}

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/config/CopyAnswers/GAD7.json
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/config/CopyAnswers/GAD7.json
@@ -1,0 +1,4 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "jcr:reference:score": "/Questionnaires/GAD7/gad7_results/gad7_score"
+}

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/config/CopyAnswers/PHQ9.json
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/config/CopyAnswers/PHQ9.json
@@ -1,0 +1,4 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "jcr:reference:score": "/Questionnaires/PHQ9/phq9_results/phq9_score"
+}


### PR DESCRIPTION
To test:
- start in `cards4proms` mode
- create new forms, with some data in them
- open the JSON for them, check that there is a "score" property for AUDITC, EQ5D, GAD7, PHQ9
- open the dashboard, in the developer tools check the response for the `Forms.paginate` request, check that there are scores in the JSON response for the forms with scores