### PR TITLE
CARDS-1581: Proms mode: Clinicians should not be able to create subjects

### DIFF
--- a/proms-resources/feature/src/main/features/feature.json
+++ b/proms-resources/feature/src/main/features/feature.json
@@ -35,7 +35,8 @@
       "service.ranking:Integer":300,
       "scripts": [
         "create user patient \n set ACL for patient \n     allow jcr:read on /Questionnaires,/SubjectTypes \n     deny jcr:all on /Questionnaires restriction(rep:itemNames,audit_intro,audit_results,eq5d_results,gad7_intro,gad7_results,phq9_intro,phq9_results) \n     allow jcr:read,jcr:write,jcr:nodeTypeManagement,jcr:versionManagement on /Forms restriction(cards:sessionSubject) \n     allow jcr:read on /Subjects restriction(cards:sessionSubject) \n     deny jcr:modifyProperties on /Forms restriction(rep:itemNames,subject,questionnaire) \n end",
-        "create service user proms-visit-backend \n set ACL on /Questionnaires,/Subjects,/SubjectTypes \n   allow jcr:read for proms-visit-backend \n end \n set ACL on /Forms \n   allow jcr:read,rep:write,jcr:versionManagement for proms-visit-backend \n end \n"
+        "create service user proms-visit-backend \n set ACL on /Questionnaires,/Subjects,/SubjectTypes \n   allow jcr:read for proms-visit-backend \n end \n set ACL on /Forms \n   allow jcr:read,rep:write,jcr:versionManagement for proms-visit-backend \n end \n",
+        "create group TrustedUsers \n\n set ACL on /Subjects \n   deny rep:write for TrustedUsers \n end"
       ]
     },
     "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~proms":{


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/CARDS-1581)

This also includes a fix to the Subject Selector that was hiding problems when a subject was not created due to a 409 conflict error. 

**To Test**:
- Start CARDs under Proms mode with Trusted Users permissions (`./start_cards.sh --dev -P cards4proms --permissions trusted`)
- From the dashboard, under Administration->Users->Create a user with username `test` and password `asdfzxcv`
- Under Administration->Groups click on the Trusted Users group and add `test` to it
- Log out using the menu at the top right
- Login as `test`/`asdfzxcv`
- Try to create a Subject of any sort
- You should see an error message

![image](https://user-images.githubusercontent.com/4656440/150420932-079ad52a-ab8b-4957-8382-83179e230a62.png)
