### PR TITLE
CARDS-1355: Review PROMs questionnaires

### DIFF
--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/AUDITC.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/AUDITC.xml
@@ -22,7 +22,7 @@
 	<primaryNodeType>cards:Questionnaire</primaryNodeType>
 	<property>
 		<name>title</name>
-		<value>AUDIT-C</value>
+		<value>Alcohol Use Disorders Identification Test</value>
 		<type>String</type>
 	</property>
 	<property>
@@ -39,7 +39,7 @@
 	</property>
 	<property>
 		<name>description</name>
-		<value>Alcohol Use Disorders Identification Test</value>
+		<value>AUDIT-C</value>
 		<type>String</type>
 	</property>
 	<node>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/EQ5D.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/EQ5D.xml
@@ -22,7 +22,7 @@
 	<primaryNodeType>cards:Questionnaire</primaryNodeType>
 	<property>
 		<name>title</name>
-		<value>EQ-5D</value>
+		<value>Physical Health Assessment</value>
 		<type>String</type>
 	</property>
 	<property>
@@ -55,7 +55,7 @@
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
 				<name>expression</name>
-				<value>return (10 * (+@{eq5d_1:-0} + +@{eq5d_2:-0} + +@{eq5d_3:-0} + +@{eq5d_4:-0} + +@{eq5d_5:-0}) + (100 - +@{eq5d_6:-0}))</value>
+				<value>return (+@{eq5d_1:-0} + +@{eq5d_2:-0} + +@{eq5d_3:-0} + +@{eq5d_4:-0} + +@{eq5d_5:-0})</value>
 				<type>String</type>
 			</property>
 			<property>
@@ -88,11 +88,15 @@
 	<node>
 		<name>eq5d_survey</name>
 		<primaryNodeType>cards:Section</primaryNodeType>
-		<property>
-			<name>label</name>
-			<value>Under each heading, please tick the ONE box that best describes your health TODAY.</value>
-			<type>String</type>
-		</property>
+		<node>
+			<name>eq5d_instructions</name>
+			<primaryNodeType>cards:Information</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>#### Under each heading, please tick the ONE box that best describes your health TODAY.</value>
+				<type>String</type>
+			</property>
+		</node>
 		<node>
 			<name>eq5d_1</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
@@ -136,7 +140,7 @@
 				</property>
 				<property>
 					<name>value</name>
-					<value>2</value>
+					<value>0</value>
 					<type>String</type>
 				</property>
 			</node>
@@ -174,7 +178,7 @@
 				</property>
 				<property>
 					<name>value</name>
-					<value>0</value>
+					<value>2</value>
 					<type>String</type>
 				</property>
 			</node>
@@ -222,7 +226,7 @@
 				</property>
 				<property>
 					<name>value</name>
-					<value>2</value>
+					<value>0</value>
 					<type>String</type>
 				</property>
 			</node>
@@ -260,7 +264,7 @@
 				</property>
 				<property>
 					<name>value</name>
-					<value>0</value>
+					<value>2</value>
 					<type>String</type>
 				</property>
 			</node>
@@ -313,7 +317,7 @@
 				</property>
 				<property>
 					<name>value</name>
-					<value>2</value>
+					<value>0</value>
 					<type>String</type>
 				</property>
 			</node>
@@ -351,7 +355,7 @@
 				</property>
 				<property>
 					<name>value</name>
-					<value>0</value>
+					<value>2</value>
 					<type>String</type>
 				</property>
 			</node>
@@ -399,7 +403,7 @@
 				</property>
 				<property>
 					<name>value</name>
-					<value>2</value>
+					<value>0</value>
 					<type>String</type>
 				</property>
 			</node>
@@ -437,7 +441,7 @@
 				</property>
 				<property>
 					<name>value</name>
-					<value>0</value>
+					<value>2</value>
 					<type>String</type>
 				</property>
 			</node>
@@ -485,7 +489,7 @@
 				</property>
 				<property>
 					<name>value</name>
-					<value>2</value>
+					<value>0</value>
 					<type>String</type>
 				</property>
 			</node>
@@ -523,7 +527,7 @@
 				</property>
 				<property>
 					<name>value</name>
-					<value>0</value>
+					<value>2</value>
 					<type>String</type>
 				</property>
 			</node>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/EQ5D.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/EQ5D.xml
@@ -39,7 +39,7 @@
 	</property>
 	<property>
 		<name>description</name>
-		<value>Health  Questionnaire</value>
+		<value>EQ-5D</value>
 		<type>String</type>
 	</property>
 	<node>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
@@ -39,7 +39,7 @@
 	</property>
 	<property>
 		<name>description</name>
-		<value>Measures severity of anxiety</value>
+		<value>GAD-7</value>
 		<type>String</type>
 	</property>
 	<node>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/GAD7.xml
@@ -22,7 +22,7 @@
 	<primaryNodeType>cards:Questionnaire</primaryNodeType>
 	<property>
 		<name>title</name>
-		<value>General Anxiety Disorder</value>
+		<value>General Anxiety Disorder-7</value>
 		<type>String</type>
 	</property>
 	<property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/PHQ9.xml
@@ -39,7 +39,7 @@
 	</property>
 	<property>
 		<name>description</name>
-		<value>Objectifies degree of depression severity</value>
+		<value>PHQ-9</value>
 		<type>String</type>
 	</property>
 	<node>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/SC.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/SC.xml
@@ -406,7 +406,7 @@
 			<primaryNodeType>cards:Information</primaryNodeType>
 			<property>
 				<name>text</name>
-				<value>## Quitting is an important part of heath care.
+				<value>## Quitting is an important part of health care.
 
 ### The benefits start right away and can last a long time.
 

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/SC.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/SC.xml
@@ -1473,7 +1473,7 @@ Click on the program you want to register in.</value>
 			<property>
 				<name>expression</name>
 				<value>
-return @{smoking_history_v2_program_referral_requested_by_patient:-"none"} != "none" ?
+return @{smoking_history_v2_program_referral_requested_by_patient:-none} != "none" ?
        "You have selected **" + @{smoking_history_v2_program_referral_requested_by_patient} + "**. Someone from the program will call you to share more details and finish registering you in the program. Your health care team will also be informed that you have registered.\n\nFor more details read the UHN pamphlet *Smoking: It’s never too late to quit*"
      : "You have selected not to be referred to a program. Your health care team will be informed of your choice.\n\nFor more details read the UHN pamphlet on quitting smoking during your cancer treatment."
 				</value>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/SC.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/SC.xml
@@ -66,7 +66,7 @@
 			<type>Boolean</type>
 		</property>
 		<node>
-			<name>smoking-history-v1-has-patient-used-tobacco-products-in-past-6-months</name>
+			<name>smoking_history_v1_has_patient_used_tobacco_products_in_past_6_months</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
 				<name>minAnswers</name>
@@ -364,7 +364,7 @@
 				<property>
 					<name>value</name>
 					<values>
-						<value>smoking-history-v1-has-patient-used-tobacco-products-in-past-6-months</value>
+						<value>smoking_history_v1_has_patient_used_tobacco_products_in_past_6months</value>
 					</values>
 					<type>String</type>
 				</property>
@@ -693,7 +693,7 @@ After:
 				<property>
 					<name>value</name>
 					<values>
-						<value>smoking-history-v1-has-patient-used-tobacco-products-in-past-6-months</value>
+						<value>smoking_history_v1_has_patient_used_tobacco_products_in_past_6_months</value>
 					</values>
 					<type>String</type>
 				</property>
@@ -787,7 +787,7 @@ After:
 				<property>
 					<name>value</name>
 					<values>
-						<value>smoking-history-v1-has-patient-used-tobacco-products-in-past-6-months</value>
+						<value>smoking_history_v1_has_patient_used_tobacco_products_in_past_6_months</value>
 					</values>
 					<type>String</type>
 				</property>
@@ -1088,7 +1088,7 @@ Click on the program you want to register in.</value>
 					<property>
 						<name>value</name>
 						<values>
-							<value>smoking-history-v1-has-patient-used-tobacco-products-in-past-6-months</value>
+							<value>smoking_history_v1_has_patient_used_tobacco_products_in_past_6_months</value>
 						</values>
 						<type>String</type>
 					</property>
@@ -1257,7 +1257,7 @@ Click on the program you want to register in.</value>
 				<property>
 					<name>value</name>
 					<values>
-						<value>smoking-history-v1-has-patient-used-tobacco-products-in-past-6-months</value>
+						<value>smoking_history_v1_has_patient_used_tobacco_products_in_past_6_months</value>
 					</values>
 					<type>String</type>
 				</property>
@@ -1440,7 +1440,7 @@ Click on the program you want to register in.</value>
 				<property>
 					<name>value</name>
 					<values>
-						<value>smoking-history-v1-has-patient-used-tobacco-products-in-past-6-months</value>
+						<value>smoking_history_v1_has_patient_used_tobacco_products_in_past_6_months</value>
 					</values>
 					<type>String</type>
 				</property>
@@ -1473,7 +1473,8 @@ Click on the program you want to register in.</value>
 			<property>
 				<name>expression</name>
 				<value>
-return @{smoking_history_v2_program_referral_requested_by_patient:-none} != "none" ?
+return @{smoking_history_v1_has_patient_used_tobacco_products_in_past_6_months:-0} == 0 ? null :
+     @{smoking_history_v2_program_referral_requested_by_patient:-none} != "none" ?
        "You have selected **" + @{smoking_history_v2_program_referral_requested_by_patient} + "**. Someone from the program will call you to share more details and finish registering you in the program. Your health care team will also be informed that you have registered.\n\nFor more details read the UHN pamphlet *Smoking: It’s never too late to quit*"
      : "You have selected not to be referred to a program. Your health care team will be informed of your choice.\n\nFor more details read the UHN pamphlet on quitting smoking during your cancer treatment."
 				</value>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/SC.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/SC.xml
@@ -90,7 +90,7 @@
 			</property>
 			<property>
 				<name>compact</name>
-				<value>False</value>
+				<value>True</value>
 				<type>Boolean</type>
 			</property>
 			<property>
@@ -221,7 +221,7 @@
 				</property>
 				<property>
 					<name>text</name>
-					<value>Check all that apply:</value>
+					<value>Others using tobacco products at home</value>
 					<type>String</type>
 				</property>
 				<property>
@@ -406,9 +406,9 @@
 			<primaryNodeType>cards:Information</primaryNodeType>
 			<property>
 				<name>text</name>
-				<value>## Quitting is an important part of cancer treatment.
+				<value>## Quitting is an important part of heath care.
 
-### For people who have cancer or have finished treatment for cancer, the benefits start right away and can last a long time.**
+### The benefits start right away and can last a long time.**
 
 We know that quitting can be difficult. Your healthcare team is here to support you.
 

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/SC.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/SC.xml
@@ -408,7 +408,7 @@
 				<name>text</name>
 				<value>## Quitting is an important part of heath care.
 
-### The benefits start right away and can last a long time.**
+### The benefits start right away and can last a long time.
 
 We know that quitting can be difficult. Your healthcare team is here to support you.
 


### PR DESCRIPTION
[CARDS-1355](https://phenotips.atlassian.net/browse/CARDS-1355): _Review PROMs questionnaires_

#### EQ5D 
- Updated the displayed title
- Instructions for filling out the form no longer displayed in view mode (turned section label into an info card)
- Fixed the option values (fewer difficulties should have lower score)
- Updated the score formula

#### GAD7
- Added "-7" to the displayed title, for consistency with PHQ9

#### SC
- Made all boolean questions compact
- Improved label ([CARDS-1579](https://phenotips.atlassian.net/browse/CARDS-1579): _Better name for "Check all that apply" field_)
- Reworded info card to be less cancer-specific
- Fixed wrongly formatted default value