### PR TITLE
CARDS-1417: Print-friendly styling of forms - implementation based on markdown export (CARDS-1598)

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -394,11 +394,13 @@ function Form (props) {
                     }}
                 >
                   <List>
+                    { isEdit &&
                     <ListItem className={classes.actionsMenuItem}>
                       <Button onClick={() => {setSelectorDialogOpen(true); setActionsMenu(null)}}>
                         Change subject
                       </Button>
                     </ListItem>
+                    }
                     <ListItem className={classes.actionsMenuItem}>
                       <Button onClick={(e) => {
                          // Save before exporting from edit mode to ensure all the data is included

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -354,7 +354,6 @@ function Form (props) {
         fullScreen
         resourcePath={formURL}
         breadcrumb={getTextHierarchy(data?.subject, true)}
-        title={title}
         onClose={() => (history.length > 2 ? history.goBack() : history.push(urlBase + formURL))}
       />
     );

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -59,6 +59,7 @@ import FormPagination from "./FormPagination";
 import { usePageNameWriterContext } from "../themePage/Page.jsx";
 import FormattedText from "../components/FormattedText.jsx";
 import ResourceHeader from "./ResourceHeader.jsx";
+import PrintPreview from "./PrintPreview.jsx";
 
 // TODO Once components from the login module can be imported, open the login Dialog in-page instead of opening a popup window
 
@@ -124,6 +125,7 @@ function Form (props) {
   const formURL = `/Forms/${id}`;
   const urlBase = "/content.html";
   const isEdit = window.location.pathname.endsWith(".edit") || mode == "edit";
+  const isPrint = window.location.pathname.endsWith(".print") || mode == "print";
   const isSummary = window.location.pathname.endsWith(".summary") || mode == "summary";
   let globalLoginDisplay = useContext(GlobalLoginContext);
 
@@ -345,6 +347,19 @@ function Form (props) {
     );
   }
 
+  if (isPrint) {
+    return (
+      <PrintPreview
+        open
+        fullScreen
+        resourcePath={formURL}
+        breadcrumb={getTextHierarchy(data?.subject, true)}
+        title={title}
+        onClose={() => (history.length > 2 ? history.goBack() : history.push(urlBase + formURL))}
+      />
+    );
+  }
+
   let formMenu = (
             <div className={classes.actionsMenu}>
                 {isEdit ?
@@ -382,6 +397,14 @@ function Form (props) {
                     <ListItem className={classes.actionsMenuItem}>
                       <Button onClick={() => {setSelectorDialogOpen(true); setActionsMenu(null)}}>
                         Change subject
+                      </Button>
+                    </ListItem>
+                    <ListItem className={classes.actionsMenuItem}>
+                      <Button onClick={(e) => {
+                         // Save before printing to ensure all the data is included
+                         saveData(e, false, () => history.push(urlBase + formURL + ".print"));
+                        }}>
+                        Print preview
                       </Button>
                     </ListItem>
                     <ListItem className={classes.actionsMenuItem}>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -354,6 +354,7 @@ function Form (props) {
         fullScreen
         resourcePath={formURL}
         breadcrumb={getTextHierarchy(data?.subject, true)}
+        date={moment(data['jcr:created']).format("MMM Do YYYY")}
         onClose={() => (history.length > 2 ? history.goBack() : history.push(urlBase + formURL))}
       />
     );

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -401,16 +401,16 @@ function Form (props) {
                     </ListItem>
                     <ListItem className={classes.actionsMenuItem}>
                       <Button onClick={(e) => {
-                         // Save before printing to ensure all the data is included
-                         saveData(e, false, () => history.push(urlBase + formURL + ".print"));
+                         // Save before exporting from edit mode to ensure all the data is included
+                         isEdit ? saveData(e, false, () => history.push(urlBase + formURL + ".print")) : history.push(urlBase + formURL + ".print");
                         }}>
                         Print preview
                       </Button>
                     </ListItem>
                     <ListItem className={classes.actionsMenuItem}>
                       <Button onClick={(e) => {
-                         // Save before exporting to ensure all the data is included
-                         saveData(e, false, () => {window.open(formURL + ".txt")});
+                         // Save before exporting from edit mode to ensure all the data is included
+                         isEdit ? saveData(e, false, () => window.open(formURL + ".txt")) : window.open(formURL + ".txt");
                          setActionsMenu(null);
                         }}>
                         Export as text

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
@@ -1,0 +1,149 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React, {
+  forwardRef,
+  useState,
+  useEffect,
+  useContext
+} from "react";
+
+import PropTypes from "prop-types";
+
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Typography,
+  makeStyles,
+  useMediaQuery
+} from "@material-ui/core";
+
+import { useTheme } from '@material-ui/core/styles';
+
+import FormattedText from "../components/FormattedText.jsx";
+import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
+
+// Component that renders a form in a format/style ready for printing.
+// Internally, it queries and renders the markdown (.md) export of the form.
+//
+// Required props:
+// resourcePath: String specifying the path of the form to print
+// title: String specifyingthe title to associate with the rendered content.
+//   Note: the .md export doesn't generate a title.
+//
+// Optional props:
+// breadcrumb: String displayed in small fonts above the title, providing some context for the printed resource.
+//   Example usage: the formatted identifier of the subject for this resource.
+// subtitle: String displayed in small fonts under the title, expected to be a relevant date or description 
+// fullScreen: Boolean specifying if the preview is full screen or displayed as a modal
+// onClose: Callback for closing the dialog
+//
+// Any other props are forwarded to the <Dialog> component used to display the preview.
+//
+// Sample usage:
+//<PrintPreview
+//  resourcePath="/Forms/UUID-1235"
+//  title="..."
+//  open={open}
+//  fullScreen
+//  onClose={() => {...}}
+//  />
+//
+
+const useStyles = makeStyles(theme => ({
+  printPreview : {
+    "@media print" : {
+      "& .MuiDialogContent-root" : {
+        paddingTop: theme.spacing(3),
+      },
+      "& .MuiDialogActions-root" : {
+        display: "none",
+      },
+    }
+  },
+}));
+
+const PrintPreview = forwardRef((props, ref) => {
+  const { resourcePath, title, breadcrumb, subtitle, fullScreen, onClose, ...rest } = props;
+
+  const [ content, setContent ] = useState();
+  const [ error, setError ] = useState();
+
+  const classes = useStyles();
+
+  const width = "sm";
+  const theme = useTheme();
+  const isFullScreen = fullScreen || useMediaQuery(theme.breakpoints.down(width));
+
+  let globalLoginDisplay = useContext(GlobalLoginContext);
+
+  useEffect(() => {
+    fetchWithReLogin(globalLoginDisplay, resourcePath + '.md')
+      .then((response) => response.ok ? response.text() : Promise.reject(response))
+      .then(setContent)
+      .catch(response => setError(true));
+  }, []);
+
+  return (
+    <Dialog
+      ref={ref}
+      className={classes.printPreview}
+      maxWidth={width}
+      fullWidth
+      fullScreen={isFullScreen}
+      onClose={onClose}
+      {...rest}
+    >
+      <DialogTitle>
+        { breadcrumb && <Typography variant="overline" color="textSecondary">{breadcrumb}</Typography> }
+        <Typography variant="h4">{title}</Typography>
+        { subtitle && <Typography variant="overline" color="textSecondary">{subtitle}</Typography> }
+      </DialogTitle>
+      <DialogContent dividers>
+        { content ?
+          <FormattedText>{content}</FormattedText>
+          :
+          error ?
+          <Typography color="error">Print preview cannot be loaded</Typography>
+          :
+          <CircularProgress />
+        }
+      </DialogContent>
+      <DialogActions>
+        <Button variant="contained" onClick={onClose}>Close</Button>
+        <Button variant="contained" color="primary" onClick={() => {window.print()}} disabled={!!!content}>Print</Button>
+      </DialogActions>
+    </Dialog>
+  );
+})
+
+PrintPreview.propTypes = {
+  resourcePath: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  breadcrumb: PropTypes.string,
+  subtitle: PropTypes.string,
+  onClose: PropTypes.func,
+}
+
+export default PrintPreview;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
@@ -33,7 +33,6 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  IconButton,
   Typography,
   makeStyles,
   useMediaQuery

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
@@ -85,10 +85,14 @@ const useStyles = makeStyles(theme => ({
       },
     }
   },
+  header : {
+    display: "flex",
+    justifyContent: "space-between",
+  },
 }));
 
 const PrintPreview = forwardRef((props, ref) => {
-  const { resourcePath, title, breadcrumb, subtitle, fullScreen, onClose, ...rest } = props;
+  const { resourcePath, title, breadcrumb, date, subtitle, fullScreen, onClose, ...rest } = props;
 
   const [ content, setContent ] = useState();
   const [ error, setError ] = useState();
@@ -118,9 +122,14 @@ const PrintPreview = forwardRef((props, ref) => {
       onClose={onClose}
       {...rest}
     >
-      { (breadcrumb || title || subtitle) &&
+      { (breadcrumb || date || title || subtitle) &&
       <DialogTitle>
-        { breadcrumb && <Typography variant="overline" color="textSecondary">{breadcrumb}</Typography> }
+        { (breadcrumb || date) &&
+          <div className={classes.header}>
+            <Typography variant="overline" color="textSecondary">{breadcrumb}</Typography>
+            <Typography variant="overline" color="textSecondary">{date}</Typography>
+          </div>
+        }
         { title && <Typography variant="h4">{title}</Typography> }
         { subtitle && <Typography variant="overline" color="textSecondary">{subtitle}</Typography> }
       </DialogTitle>
@@ -147,6 +156,7 @@ PrintPreview.propTypes = {
   resourcePath: PropTypes.string.isRequired,
   title: PropTypes.string,
   breadcrumb: PropTypes.string,
+  date: PropTypes.string,
   subtitle: PropTypes.string,
   onClose: PropTypes.func,
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
@@ -73,6 +73,9 @@ import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js"
 
 const useStyles = makeStyles(theme => ({
   printPreview : {
+    "& .wmde-markdown h1, .wmde-markdown h2" : {
+      borderBottom: "0 none",
+    },
     "@media print" : {
       "& .MuiDialogContent-root" : {
         paddingTop: theme.spacing(3),
@@ -115,11 +118,13 @@ const PrintPreview = forwardRef((props, ref) => {
       onClose={onClose}
       {...rest}
     >
+      { (breadcrumb || title || subtitle) &&
       <DialogTitle>
         { breadcrumb && <Typography variant="overline" color="textSecondary">{breadcrumb}</Typography> }
-        <Typography variant="h4">{title}</Typography>
+        { title && <Typography variant="h4">{title}</Typography> }
         { subtitle && <Typography variant="overline" color="textSecondary">{subtitle}</Typography> }
       </DialogTitle>
+      }
       <DialogContent dividers>
         { content ?
           <FormattedText>{content}</FormattedText>
@@ -140,7 +145,7 @@ const PrintPreview = forwardRef((props, ref) => {
 
 PrintPreview.propTypes = {
   resourcePath: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   breadcrumb: PropTypes.string,
   subtitle: PropTypes.string,
   onClose: PropTypes.func,

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractFormToStringAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractFormToStringAdapterFactory.java
@@ -94,10 +94,10 @@ public abstract class AbstractFormToStringAdapterFactory
      */
     private void generateMetadata(final JsonObject formJson, StringBuilder result)
     {
-        formatMetadata(getSubjectIdentifier(formJson), result);
-        formatMetadata(getQuestionnaireTitle(formJson), result);
-        formatMetadata(getCreationDate(formJson), result);
-        formatMetadata("\n", result);
+        formatSubject(getSubjectIdentifier(formJson), result);
+        formatTitle(getQuestionnaireTitle(formJson), result);
+        formatDate(getCreationDate(formJson), result);
+        formatMetadataSeparator(result);
     }
 
     /**
@@ -293,7 +293,13 @@ public abstract class AbstractFormToStringAdapterFactory
         return "";
     }
 
-    abstract void formatMetadata(String metadata, StringBuilder result);
+    abstract void formatSubject(String metadata, StringBuilder result);
+
+    abstract void formatTitle(String metadata, StringBuilder result);
+
+    abstract void formatDate(String metadata, StringBuilder result);
+
+    abstract void formatMetadataSeparator(StringBuilder result);
 
     abstract void formatSectionTitle(String title, StringBuilder result);
 

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractFormToStringAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractFormToStringAdapterFactory.java
@@ -1,0 +1,311 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.uhndata.cards.dataentry.internal.serialize;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.json.JsonException;
+import javax.json.JsonObject;
+import javax.json.JsonString;
+import javax.json.JsonValue;
+import javax.json.JsonValue.ValueType;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.adapter.AdapterFactory;
+import org.apache.sling.api.resource.Resource;
+
+/**
+ * AdapterFactory that converts forms to plain text.
+ *
+ * @version $Id$
+ */
+public abstract class AbstractFormToStringAdapterFactory
+    implements AdapterFactory
+{
+    @Override
+    public <A> A getAdapter(final Object adaptable, final Class<A> type)
+    {
+        if (adaptable == null) {
+            return null;
+        }
+
+        final Resource originalResource = (Resource) adaptable;
+        if (!originalResource.isResourceType("cards/Form")) {
+            return type.cast(originalResource.getPath());
+        }
+
+        // The proper serialization depends on "deep", "dereference" and "labels", but we may allow other JSON
+        // processors to be enabled/disabled to further customize the data, so we also append the original selectors
+        final String processedPath = originalResource.getPath()
+            + originalResource.getResourceMetadata().getResolutionPathInfo() + ".deep.dereference.labels";
+        final Resource resource = originalResource.getResourceResolver().resolve(processedPath);
+
+        JsonObject result = resource.adaptTo(JsonObject.class);
+        if (result != null) {
+            return type.cast(processForm(result));
+        }
+        return null;
+    }
+
+    /**
+     * Converts the JSON representation of a form into a string.
+     *
+     * @param formJson a form serialized as JSON
+     * @return plain text serialization of the form
+     */
+    private String processForm(final JsonObject formJson)
+    {
+        StringBuilder result = new StringBuilder();
+
+        // Metadata
+        generateMetadata(formJson, result);
+
+        // Answers and sections
+        final Map<String, Integer> sectionCounts = new HashMap<>();
+        processSection(formJson, result, sectionCounts);
+
+        // All done!
+        return result.toString().trim();
+    }
+
+    /**
+     * Converts a JSON fragment (object) to plain text displaying the form's subject it, questionnaire title,
+     * and creation date.
+     *
+     * @param nodeJson a JSON serialization of a node
+     * @param result the string builder where the serialization must be appended
+     */
+    private void generateMetadata(final JsonObject formJson, StringBuilder result)
+    {
+        formatMetadata(getSubjectIdentifier(formJson), result);
+        formatMetadata(getQuestionnaireTitle(formJson), result);
+        formatMetadata(getCreationDate(formJson), result);
+        formatMetadata("\n", result);
+    }
+
+    /**
+     * Retrieves the human readable subject full identifier from the form's JSON.
+     *
+     * @param formJson the JSON serialization of a form
+     * @return a full identifier, in the format {@code Subject Identifier} or
+     *         {@code Parent Subject Identifier / Child Subject Identifier}
+     */
+    private String getSubjectIdentifier(final JsonObject formJson)
+    {
+        return formJson.getJsonObject("subject").getString("fullIdentifier");
+    }
+
+    /**
+     * Retrieves the form's questionnaire title.
+     *
+     * @param formJson the JSON serialization of a form
+     * @return the questionnaire title, in upper case
+     */
+    private String getQuestionnaireTitle(final JsonObject formJson)
+    {
+        return formJson.getJsonObject("questionnaire").getString("title");
+    }
+
+    /**
+     * Retrieves the form's creation date.
+     *
+     * @param formJson the JSON serialization of a form
+     * @return a date in the {@code YYYY-MM-DD} format
+     */
+    private String getCreationDate(final JsonObject formJson)
+    {
+        return StringUtils.substringBefore(formJson.getString("jcr:created"), "T");
+    }
+
+    /**
+     * Converts a JSON fragment (object) to plain text, if it is a simple answer or an answer section. All other kinds
+     * of information is ignored.
+     *
+     * @param nodeJson a JSON serialization of a node
+     * @param result the string builder where the serialization must be appended
+     * @param sectionCounts a map keeping track of the number of instances encountered so far for recurrent sections
+     */
+    private void processElement(final JsonObject nodeJson, final StringBuilder result,
+        final Map<String, Integer> sectionCounts)
+    {
+        final String nodeType = nodeJson.getString("jcr:primaryType");
+        if ("cards:AnswerSection".equals(nodeType)) {
+            processSection(nodeJson, result, sectionCounts);
+        } else if (nodeType.startsWith("cards:") && nodeType.endsWith("Answer")) {
+            processAnswer(nodeJson, nodeType, result);
+        }
+    }
+
+    /**
+     * Converts a JSON serialization of an answer section to plain text. This may add a section title, if present,
+     * followed by all the subsections and answers contained in this answer section.
+     *
+     * @param answerSectionJson a JSON serialization of an answer section
+     * @param result the string builder where the serialization must be appended
+     * @param sectionCounts a map keeping track of the number of instances encountered so far for recurrent sections
+     */
+    private void processSection(final JsonObject answerSectionJson, final StringBuilder result,
+        final Map<String, Integer> sectionCounts)
+    {
+        final String displayMode = getDisplayMode("section", answerSectionJson);
+        if ("summary".equals(displayMode)) {
+            // Do not output summary sections
+            return;
+        }
+        if ("footer".equals(displayMode)) {
+            formatSectionSeparator(result);
+        }
+        final String sectionTitle = getSectionTitle(answerSectionJson, sectionCounts);
+        if (StringUtils.isNotBlank(sectionTitle)) {
+            formatSectionTitle(sectionTitle, result);
+        }
+        answerSectionJson.values().stream()
+            .filter(value -> ValueType.OBJECT.equals(value.getValueType()))
+            .map(JsonValue::asJsonObject)
+            .filter(value -> value.containsKey("jcr:primaryType"))
+            .forEach(value -> processElement(value, result, sectionCounts));
+        if ("header".equals(displayMode)) {
+            formatSectionSeparator(result);
+        }
+    }
+
+    /**
+     * Converts a JSON serialization of an answer to plain text. This adds the question, followed by any answers,
+     * followed by any notes. If there is no answer and no notes, the whole answer is ignored and nothing is added to
+     * the output.
+     *
+     * @param answerJson a JSON serialization of an answer
+     * @param nodeType the type of node, dictating how answers are displayed
+     * @param result the string builder where the serialization must be appended
+     */
+    private void processAnswer(final JsonObject answerJson, final String nodeType, final StringBuilder result)
+    {
+        final String displayMode = getDisplayMode("question", answerJson);
+        if ("hidden".equals(displayMode)) {
+            return;
+        }
+        final JsonValue value = answerJson.get("displayedValue");
+        final String note = answerJson.containsKey("note") ? answerJson.getString("note") : null;
+
+        formatQuestion(answerJson.getJsonObject("question").getString("text"), result);
+        if (value == null) {
+            formatAnswer("—", result);
+        } else if ("cards:PedigreeAnswer".equals(nodeType)) {
+            formatPedigree(((JsonString) value).getString(), result);
+        } else {
+            processAnswerValue(value, result);
+        }
+        if (StringUtils.isNotBlank(note)) {
+            formatNote(note, result);
+        }
+        result.append("\n\n");
+    }
+
+    /**
+     * Converts a JSON serialiization of a textual answer value to plain text.
+     *
+     * @param value the value to be displayed, can be either a single value or an array of values
+     * @param result the string builder where the serialization must be appended
+     */
+    private void processAnswerValue(final JsonValue value, final StringBuilder result)
+    {
+        if (ValueType.ARRAY.equals(value.getValueType())) {
+            value.asJsonArray().forEach(v -> formatAnswer(((JsonString) v).getString(), result));
+        } else {
+            formatAnswer(((JsonString) value).getString(), result);
+        }
+    }
+
+    /**
+     * Retrieves the display mode specified for a section, if any.
+     *
+     * @param element a kind of questionnaire element: question or section
+     * @param answerElementJson a JSON serialization of an answer or answer section
+     * @return the display mode as String. Expected one of: default, header, footer, summary.
+     */
+    private String getDisplayMode(final String element, final JsonObject answerElementJson)
+    {
+        try {
+            return ((JsonString) answerElementJson.getValue("/" + element + "/displayMode")).getString();
+        } catch (JsonException | NullPointerException ex) {
+            // Not there, return
+        }
+        return null;
+    }
+
+    /**
+     * Retrieves the label of an answer section, if any. For recurrent sections, a {@code #number} is also appended to
+     * mark each instance. If the section doesn't have a label, {@code null} is returned.
+     *
+     * @param answerSectionJson a JSON serialization of an answer section
+     * @param sectionCounts a map keeping track of the number of instances encountered so far for recurrent sections
+     * @return a label in the format {@code SECTION LABEL}, {@code SECTION LABEL #1}, or {@code null}
+     */
+    private String getSectionTitle(final JsonObject answerSectionJson, final Map<String, Integer> sectionCounts)
+    {
+        try {
+            String label = ((JsonString) answerSectionJson.getValue("/section/label")).getString();
+            return label + getSectionInstanceSuffix(answerSectionJson, sectionCounts);
+        } catch (JsonException | NullPointerException ex) {
+            // Not there, return
+        }
+        return null;
+    }
+
+    /**
+     * Retrieves the suffix to use for a recurrent section, if needed. If the section is not recurrent, an empty string
+     * is returned. If the section is recurrent, an increasing counter is returned, starting from {@code 1} for the
+     * first instance.
+     *
+     * @param answerSectionJson a JSON serialization of an answer section
+     * @param sectionCounts a map keeping track of the number of instances encountered so far for recurrent sections
+     * @return a string in the format {@code " #1"} (with a leading blank space), or an empty string if the section is
+     *         not recurrent
+     */
+    private String getSectionInstanceSuffix(final JsonObject answerSectionJson,
+        final Map<String, Integer> sectionCounts)
+    {
+        final boolean recurrent = answerSectionJson.getJsonObject("section").getBoolean("recurrent");
+        if (recurrent) {
+            final int instanceNumber =
+                sectionCounts.compute(answerSectionJson.getJsonObject("section").getString("jcr:uuid"),
+                    (k, v) -> v == null ? 1 : v + 1);
+            return " #" + instanceNumber;
+        }
+
+        return "";
+    }
+
+    abstract void formatMetadata(String metadata, StringBuilder result);
+
+    abstract void formatSectionTitle(String title, StringBuilder result);
+
+    abstract void formatSectionSeparator(StringBuilder result);
+
+    abstract void formatQuestion(String question, StringBuilder result);
+
+    abstract void formatEmptyAnswer(StringBuilder result);
+
+    abstract void formatAnswer(String answer, StringBuilder result);
+
+    abstract void formatPedigree(String value, StringBuilder result);
+
+    abstract void formatNote(String note, StringBuilder result);
+}

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractFormToStringAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractFormToStringAdapterFactory.java
@@ -32,7 +32,7 @@ import org.apache.sling.api.adapter.AdapterFactory;
 import org.apache.sling.api.resource.Resource;
 
 /**
- * AdapterFactory that converts forms to plain text.
+ * Base class for adapting a Form resource to a text-based format.
  *
  * @version $Id$
  */
@@ -86,7 +86,7 @@ public abstract class AbstractFormToStringAdapterFactory
     }
 
     /**
-     * Converts a JSON fragment (object) to plain text displaying the form's subject it, questionnaire title,
+     * Converts a JSON fragment (object) to plain text displaying the form's subject, questionnaire title,
      * and creation date.
      *
      * @param nodeJson a JSON serialization of a node
@@ -136,7 +136,7 @@ public abstract class AbstractFormToStringAdapterFactory
 
     /**
      * Converts a JSON fragment (object) to plain text, if it is a simple answer or an answer section. All other kinds
-     * of information is ignored.
+     * of information are ignored.
      *
      * @param nodeJson a JSON serialization of a node
      * @param result the string builder where the serialization must be appended
@@ -238,7 +238,7 @@ public abstract class AbstractFormToStringAdapterFactory
      *
      * @param element a kind of questionnaire element: question or section
      * @param answerElementJson a JSON serialization of an answer or answer section
-     * @return the display mode as String. Expected one of: default, header, footer, summary.
+     * @return the display mode as String, e.g. hidden, default, header, footer, summary.
      */
     private String getDisplayMode(final String element, final JsonObject answerElementJson)
     {

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/FormToMarkdownAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/FormToMarkdownAdapterFactory.java
@@ -18,68 +18,86 @@
  */
 package io.uhndata.cards.dataentry.internal.serialize;
 
-import java.util.Locale;
-
 import org.apache.sling.api.adapter.AdapterFactory;
 import org.osgi.service.component.annotations.Component;
 
 /**
- * AdapterFactory that converts forms to plain text.
+ * AdapterFactory that converts forms to markdown.
  *
  * @version $Id$
  */
 @Component(
     service = { AdapterFactory.class },
-    property = { "adaptables=org.apache.sling.api.resource.Resource", "adapters=java.lang.String" })
-public class FormToTextAdapterFactory
+    property = { "adaptables=org.apache.sling.api.resource.Resource", "adapters=java.lang.CharSequence" })
+public class FormToMarkdownAdapterFactory
     extends AbstractFormToStringAdapterFactory
 {
+
+    private static final String MD_LINE_END = "  \n";
+
     @Override
     void formatMetadata(final String metadata, final StringBuilder result)
     {
-        result.append(metadata.toUpperCase(Locale.ROOT)).append('\n');
+        // Don't output metadata
     }
 
     @Override
     void formatSectionTitle(final String title, final StringBuilder result)
     {
-        result.append(title.toUpperCase(Locale.ROOT)).append("\n\n");
+        result.append("\n\n### ").append(title).append(MD_LINE_END).append('\n');
     }
 
     @Override
     void formatSectionSeparator(final StringBuilder result)
     {
-        result.append("---------------------------------------------").append("\n\n");
+        result.append("----").append(MD_LINE_END).append('\n');
     }
+
 
     @Override
     void formatQuestion(final String question, final StringBuilder result)
     {
-        result.append(question).append('\n');
+        result.append("\n**").append(question).append("**").append(MD_LINE_END);
     }
 
     @Override
     void formatEmptyAnswer(final StringBuilder result)
     {
-        formatAnswer("-", result);
+        formatAnswer("—", result);
     }
-
 
     @Override
     void formatAnswer(final String answer, final StringBuilder result)
     {
-        result.append("  ").append(answer).append('\n');
+        result.append(answer).append(MD_LINE_END);
     }
 
     @Override
     void formatNote(final String note, final StringBuilder result)
     {
-        result.append("\n  NOTES\n  ").append(note.replaceAll("\n", "\n  ")).append('\n');
+        result.append("**Notes**").append(MD_LINE_END).append(note.replaceAll("\n", MD_LINE_END)).append(MD_LINE_END);
     }
 
     @Override
     void formatPedigree(final String image, final StringBuilder result)
     {
-        result.append("  Pedigree provided\n");
+        // TODO:
+        // Wrap the SVG in a div and size the div to fit in the viewport
+        // We're assuming the h/w ratio of the pedigree does not exceed the h/w ratio of the viewport
+        // The wrapper will have:
+        // * width = 90%
+        // * height = 100vw * .9 * svg.height / svg.width
+        // double imgHWRatio = imgH / imgW;
+        double imgHWRatio = 1;
+        result.append("<div style='")
+            .append("display: inline-block; ")
+            .append("width: 90%; ")
+            .append("height: calc(100vw * ").append(0.9 * imgHWRatio).append(");")
+            .append("overflow: hidden;")
+            .append("'>")
+            .append("<svg style='width: 100%' ")
+            .append(image.substring(4))
+            .append("</div>")
+            .append(MD_LINE_END);
     }
 }

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/FormToMarkdownAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/FormToMarkdownAdapterFactory.java
@@ -36,9 +36,27 @@ public class FormToMarkdownAdapterFactory
     private static final String MD_LINE_END = "  \n";
 
     @Override
-    void formatMetadata(final String metadata, final StringBuilder result)
+    void formatSubject(final String subject, final StringBuilder result)
     {
-        // Don't output metadata
+        // Don't output the subject
+    }
+
+    @Override
+    void formatTitle(final String title, final StringBuilder result)
+    {
+        result.append("# ").append(title).append(MD_LINE_END);
+    }
+
+    @Override
+    void formatDate(final String date, final StringBuilder result)
+    {
+        // Don't output the subject
+    }
+
+    @Override
+    void formatMetadataSeparator(final StringBuilder result)
+    {
+        result.append("\n\n\n\n");
     }
 
     @Override
@@ -52,7 +70,6 @@ public class FormToMarkdownAdapterFactory
     {
         result.append("----").append(MD_LINE_END).append('\n');
     }
-
 
     @Override
     void formatQuestion(final String question, final StringBuilder result)

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/FormToTextAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/FormToTextAdapterFactory.java
@@ -64,17 +64,17 @@ public class FormToTextAdapterFactory
         formatAnswer("-", result);
     }
 
-
     @Override
     void formatAnswer(final String answer, final StringBuilder result)
     {
-        result.append("  ").append(answer).append('\n');
+        result.append("  ").append(answer.replaceAll("\n", "\n  ")).append('\n');
     }
 
     @Override
     void formatNote(final String note, final StringBuilder result)
     {
-        result.append("\n  NOTES\n  ").append(note.replaceAll("\n", "\n  ")).append('\n');
+        result.append("\n  NOTES\n");
+        formatAnswer(note, result);
     }
 
     @Override

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/FormToTextAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/FormToTextAdapterFactory.java
@@ -35,9 +35,27 @@ public class FormToTextAdapterFactory
     extends AbstractFormToStringAdapterFactory
 {
     @Override
-    void formatMetadata(final String metadata, final StringBuilder result)
+    void formatSubject(final String subject, final StringBuilder result)
     {
-        result.append(metadata.toUpperCase(Locale.ROOT)).append('\n');
+        result.append(subject).append('\n');
+    }
+
+    @Override
+    void formatTitle(final String title, final StringBuilder result)
+    {
+        result.append(title.toUpperCase(Locale.ROOT)).append('\n');
+    }
+
+    @Override
+    void formatDate(final String date, final StringBuilder result)
+    {
+        result.append(date).append('\n');
+    }
+
+    @Override
+    void formatMetadataSeparator(final StringBuilder result)
+    {
+        result.append("\n\n");
     }
 
     @Override

--- a/modules/data-entry/src/main/resources/SLING-INF/content/libs/cards/Form/md.GET.html
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/libs/cards/Form/md.GET.html
@@ -1,4 +1,4 @@
-<sly data-sly-use.contentType="io.uhndata.cards.scripting.ContentTypeSetter">${contentType.md}</sly>
+<sly data-sly-use.contentType="io.uhndata.cards.scripting.ContentTypeSetter">${contentType.markdown}</sly>
 <!--/*
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file

--- a/modules/data-entry/src/main/resources/SLING-INF/content/libs/cards/Form/md.GET.html
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/libs/cards/Form/md.GET.html
@@ -1,0 +1,23 @@
+<sly data-sly-use.contentType="io.uhndata.cards.scripting.ContentTypeSetter">${contentType.md}</sly>
+<!--/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+*/-->
+<!--/*
+  Custom serialization of resources as markdown.
+*/-->
+<sly data-sly-use.md="java.lang.CharSequence">${md.toString @ context='unsafe'}</sly>

--- a/modules/utils/src/main/java/io/uhndata/cards/scripting/ContentTypeSetter.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/scripting/ContentTypeSetter.java
@@ -71,4 +71,11 @@ public class ContentTypeSetter implements Use
     {
         this.response.setContentType("text/plain;charset=UTF-8");
     }
+
+    /** Set the content type to text/plain. */
+    public void md()
+    {
+        this.response.setContentType("text/plain;charset=UTF-8");
+    }
+
 }

--- a/modules/utils/src/main/java/io/uhndata/cards/scripting/ContentTypeSetter.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/scripting/ContentTypeSetter.java
@@ -72,10 +72,10 @@ public class ContentTypeSetter implements Use
         this.response.setContentType("text/plain;charset=UTF-8");
     }
 
-    /** Set the content type to text/plain. */
-    public void md()
+    /** Set the content type to text/markdown. */
+    public void markdown()
     {
-        this.response.setContentType("text/plain;charset=UTF-8");
+        this.response.setContentType("text/markdown;charset=UTF-8");
     }
 
 }


### PR DESCRIPTION
### Included tasks:
- [x] [CARDS-1598](https://phenotips.atlassian.net/browse/CARDS-1598): _Form resources serialized in Markdown format (.md)_
- [x] [CARDS-1417](https://phenotips.atlassian.net/browse/CARDS-1417): _Print-friendly styling of forms_ - Printing functionality that leverages markdown formatting

### Summary of changes:
Backend:
* New `FormToMarkdownAdapterFactory`, sharing internal functionality fir `FormToTextAdapterFactory`, allowing to export a form as `.md` by accessing `/Forms/<FORM-UUID>.md`
* Now hiding questions with `displayMode=hidden` and sections with `displayMode=summary` in both `.txt` and `.md`
* Now adding a visual separator after sections with `displayMode=header` and before `displayMode=footer` in both `.txt` and `.md`

Frontend:
* New frontend component `PrintPreview` which renders a dialog rendering a form's `.md` export
* New `mode` for forms: `/content.html/Forms/<FORM-UUID>.print` renders the `PrintPreview` component in `fullScreen`
* Added a "Print preview" entry to the form menu, which navigates to `/content.html/Forms/<FORM-UUID>.print`.

### To do:
Backend:
- [ ] Choose/implement a better data type for activating the `.md` adapter
- [ ] Finish implementing the formatting of pedigree answers in `.md`
- [ ] Expand javadoc
- Implement similar serialization for subject resources ([CARDS-1598](https://phenotips.atlassian.net/browse/CARDS-1598), out of scope for this PR)

Frontend:
- Implement similar printing functionality on subject pages ([CARDS-1489](https://phenotips.atlassian.net/browse/CARDS-1489), out of scope for this PR)

### Note on reviewing:
Reviewing the code commit by commit rather than just file by file might make it easier to see how the adapters evolved.