### PR TITLE
CARDS-1511: Patients can see information about upcoming appointments

### DIFF
--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Visit information.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Visit information.xml
@@ -118,6 +118,15 @@
 		</property>
 	</node>
 	<node>
+		<name>location</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Location</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
 		<name>status</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>

--- a/proms-resources/frontend/src/main/frontend/src/QuestionnaireSet.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/QuestionnaireSet.jsx
@@ -419,9 +419,14 @@ function QuestionnaireSet(props) {
     return `Good ${timeOfDay}, ${name}`;
   }
 
+  const getVisitInformation = (questionName) => {
+    let question = visitInformation?.questionnaire?.[questionName]?.["jcr:uuid"];
+    let answer = Object.values(visitInformation).find(value => value.question?.["jcr:uuid"] == question)?.value || null;
+    return answer;
+  }
+
   const getVisitDate = () => {
-    let dateQuestion = visitInformation?.questionnaire?.time?.["jcr:uuid"];
-    let dateAnswer = Object.values(visitInformation).find(value => value.question?.["jcr:uuid"] == dateQuestion)?.value || null;
+    let dateAnswer = getVisitInformation("time");
     return dateAnswer == null ? null : DateQuestionUtilities.amendMoment(DateQuestionUtilities.stripTimeZone(dateAnswer));
   }
 
@@ -429,6 +434,19 @@ function QuestionnaireSet(props) {
     let date = getVisitDate();
     return date == null ? ""
       : date.formatWithJDF("EEEE, MMMM d, yyyy h:mma");
+  }
+
+  let appointmentAlert = () => {
+    const location = getVisitInformation("location");
+    const provider = getVisitInformation("provider");
+    return visitInformation?.questionnaire?.time ?
+      <Alert severity="info">
+        <AlertTitle>Upcoming appointment</AlertTitle>
+        {appointmentDate()}
+        {location ? <><br />{location}</> : null}
+        {provider ? <><br />{provider}</> : null}
+      </Alert>
+      : null
   }
 
   const diffString = (startDate, endDate, division, result, modulus = null) => {
@@ -471,12 +489,7 @@ function QuestionnaireSet(props) {
 
   let welcomeScreen = [
     <Typography variant="h4" key="welcome-greeting">{ greet(username) }</Typography>,
-    visitInformation?.questionnaire?.time ?
-      <Alert severity="info">
-        <AlertTitle>Upcoming appointment</AlertTitle>
-        {appointmentDate()}
-      </Alert>
-      : null,
+    appointmentAlert(),
     isComplete && isSubmitted || questionnaireIds.length == 0 ?
       <Typography color="textSecondary" variant="subtitle1" key="welcome-message">
         You have no pending surveys to fill out for your next appointment.

--- a/proms-resources/frontend/src/main/frontend/src/QuestionnaireSet.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/QuestionnaireSet.jsx
@@ -68,10 +68,9 @@ const useStyles = makeStyles(theme => ({
     }
   },
   stepIndicator : {
-    border: "3px solid " + theme.palette.primary.main,
+    border: "1px solid " + theme.palette.text.secondary,
     background: "transparent",
-    color: theme.palette.primary.main,
-    fontWeight: 800,
+    color: theme.palette.text.secondary,
   },
   incompleteIndicator : {
     border: "1px solid " + theme.palette.secondary.main,
@@ -79,7 +78,7 @@ const useStyles = makeStyles(theme => ({
     color: theme.palette.secondary.main,
   },
   doneIndicator : {
-    background: theme.palette.primary.main,
+    background: theme.palette.success.main,
   },
   survey : {
     alignItems: "stretch",
@@ -566,20 +565,20 @@ function QuestionnaireSet(props) {
   // Are there any response interpretations to display to the patient?
   let hasInterpretations = (questionnaireIds || []).some(q => questionnaires?.[q]?.hasInterpretation);
 
+  let disclaimer = (
+      <Alert severity="warning">
+Please note that your responses may not be reviewed by your care team until the day of your next appointment. If your symptoms are
+worsening while waiting for your next appointment, please proceed to your nearest Emergency Department today, or call 911.
+      </Alert>
+  )
+
   let summaryScreen = hasInterpretations ? [
       <Typography variant="h4">Thank you for your submission</Typography>,
-      <Typography color="textSecondary">Please note:</Typography>,
-      <ul>
-        <li key="0"><Typography color="textSecondary">
+      <Typography color="textSecondary">
 For your privacy and security, once this screen is closed the information below will not be accessible until the day of
 your appointment with your provider. Please print or note this information for your reference.
-        </Typography></li>
-        <li key="1"><Typography color="textSecondary">
-Your responses may not be reviewed by your care team until the day of your next appointment. If your symptoms are
-worsening while waiting for your next appointment, please proceed to your nearest Emergency Department today, or call
-911.
-        </Typography></li>
-      </ul>,
+      </Typography>,
+      disclaimer,
       <Typography variant="h4">Interpreting your results</Typography>,
       <Typography color="textSecondary">There are different actions you can take now depending on how you have scored
 your symptoms. Please see below for a summary of your scores and suggested actions.</Typography>,
@@ -599,10 +598,7 @@ your symptoms. Please see below for a summary of your scores and suggested actio
       </Grid>
     ] : [
       <Typography variant="h4">Thank you for your submission</Typography>,
-      <Typography color="textSecondary">
-Please note that your responses may not be reviewed by your care team until the day of your next appointment. If your symptoms are
-worsening while waiting for your next appointment, please proceed to your nearest Emergency Department today, or call 911.
-      </Typography>
+      disclaimer
     ];
 
   let loadingScreen = [ <CircularProgress /> ];

--- a/proms-resources/frontend/src/main/frontend/src/QuestionnaireSet.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/QuestionnaireSet.jsx
@@ -443,8 +443,8 @@ function QuestionnaireSet(props) {
       <Alert severity="info">
         <AlertTitle>Upcoming appointment</AlertTitle>
         {appointmentDate()}
-        {location ? <><br />{location}</> : null}
-        {provider ? <><br />{provider}</> : null}
+        {location ? <> at {location}</> : null}
+        {provider ? <> with {provider}</> : null}
       </Alert>
       : null
   }
@@ -487,17 +487,18 @@ function QuestionnaireSet(props) {
     return result;
   }
 
-  let welcomeScreen = [
+  let welcomeScreen = (isComplete && isSubmitted || questionnaireIds.length == 0) ? [
     <Typography variant="h4" key="welcome-greeting">{ greet(username) }</Typography>,
     appointmentAlert(),
-    isComplete && isSubmitted || questionnaireIds.length == 0 ?
-      <Typography color="textSecondary" variant="subtitle1" key="welcome-message">
+    <Typography color="textSecondary" variant="subtitle1" key="welcome-message">
         You have no pending surveys to fill out for your next appointment.
-      </Typography>
-    :
-      <Typography paragraph key="welcome-message">
-        Tell us about your symptoms prior to your appointment.{expiryDate()}
-      </Typography>,
+    </Typography>
+  ] : [
+    <Typography variant="h4" key="welcome-greeting">{ greet(username) }</Typography>,
+    appointmentAlert(),
+    <Typography paragraph key="welcome-message">
+        Tell us about your symptoms prior to your appointment.
+    </Typography>,
     <List key="welcome-surveys">
     { (questionnaireIds || []).map((q, i) => (
       <ListItem key={q+"Welcome"}>
@@ -510,7 +511,9 @@ function QuestionnaireSet(props) {
       </ListItem>
     ))}
     </List>,
-    isComplete && isSubmitted ? <></> :
+    <Typography paragraph key="expiry-message" color="textSecondary">
+        {expiryDate()}
+    </Typography>,
     nextQuestionnaire && <Fab variant="extended" color="primary" onClick={launchNextForm} key="welcome-action">Begin</Fab>
   ];
 


### PR DESCRIPTION
As a patient, I can see information about my upcoming appointment after
entering valid identification data

- Add information about token expiry date and visit time to the welcome screen

Testing:
- Using the standard CARDS ui (http://localhost:8080) create a patient information form and a visit information form
  - Subjects should be one of the mock users (https://github.com/data-team-uhn/cards/pull/753)
  - The visit information form's `time`, `provider` and `location` answers are used in this PR
- Make some additional questionnaires for that visit, either using the standard CARDS ui or by using composum to set the visit information form's `survey` answer to `Cardio`
- Navigate to the PROMs ui and sign in as the mock user (http://localhost:8080/Proms.html/Cardio)
- Verify that the information box shows time, location and provider if entered and that the survey expiry message is displayed