### PR TITLE
CARDS-1601: Remove cancer wording from smoking cessation survey

### DIFF
--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/SC.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/SC.xml
@@ -416,8 +416,8 @@ We know that quitting can be difficult. Your healthcare team is here to support 
 * help your body respond better to radiation and chemotherapy treatments
 * make your surgery safe and help you heal faster
 * improve some of your side effects
-* lower your risk of getting a cancer
-* lower your risk of cancer recurring</value>
+* lower your risk of getting cancer
+* lower your risk of a cancer coming back (recurring)</value>
 				<type>String</type>
 			</property>
 		</node>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/SC.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/SC.xml
@@ -416,8 +416,8 @@ We know that quitting can be difficult. Your healthcare team is here to support 
 * help your body respond better to radiation and chemotherapy treatments
 * make your surgery safe and help you heal faster
 * improve some of your side effects
-* lower your risk of your cancer coming back (recurring)
-* lower your risk of getting a second cancer</value>
+* lower your risk of getting a cancer
+* lower your risk of cancer recurring</value>
 				<type>String</type>
 			</property>
 		</node>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/SC.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/SC.xml
@@ -1476,7 +1476,7 @@ Click on the program you want to register in.</value>
 return @{smoking_history_v1_has_patient_used_tobacco_products_in_past_6_months:-0} == 0 ? null :
      @{smoking_history_v2_program_referral_requested_by_patient:-none} != "none" ?
        "You have selected **" + @{smoking_history_v2_program_referral_requested_by_patient} + "**. Someone from the program will call you to share more details and finish registering you in the program. Your health care team will also be informed that you have registered.\n\nFor more details read the UHN pamphlet *Smoking: It’s never too late to quit*"
-     : "You have selected not to be referred to a program. Your health care team will be informed of your choice.\n\nFor more details read the UHN pamphlet on quitting smoking during your cancer treatment."
+     : "You have selected not to be referred to a program. Your health care team will be informed of your choice.\n\nFor more details read the UHN pamphlet on quitting smoking during your treatment."
 				</value>
 				<type>String</type>
 			</property>


### PR DESCRIPTION
Removed instance of cancer where sentence still made sense without the word, as per guidelines given