### PR TITLE
CARDS-1599: Subject resources can be serialized in Text (.txt) and Markdown (.md) formats

### DIFF
--- a/modules/data-entry/pom.xml
+++ b/modules/data-entry/pom.xml
@@ -49,6 +49,7 @@
               SLING-INF/content/apps/cards/config/;path:=/apps/cards/config/;overwrite:=false,
               SLING-INF/content/libs/cards/dataQuery/;path:=/libs/cards/dataQuery/;overwrite:=true,
               SLING-INF/content/libs/cards/Form/;path:=/libs/cards/Form/;overwrite:=true,
+              SLING-INF/content/libs/cards/Subject/;path:=/libs/cards/Subject/;overwrite:=true,
               SLING-INF/content/libs/cards/Questionnaire/;path:=/libs/cards/Questionnaire/;overwrite:=true,
               SLING-INF/content/oak%3Aindex/;path:=/oak:index/;overwrite:=true,
               SLING-INF/content/Extensions/AdminDashboard/;path:=/Extensions/AdminDashboard/;overwrite:=true,

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractFormToStringSerializer.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractFormToStringSerializer.java
@@ -189,14 +189,15 @@ public abstract class AbstractFormToStringSerializer
         if ("hidden".equals(displayMode)) {
             return;
         }
-        final String questionText = answerJson.getJsonObject("question").getString("text");
-        if (StringUtils.isBlank(questionText)) {
-            return;
-        }
+
         final JsonValue value = answerJson.get("displayedValue");
         final String note = answerJson.containsKey("note") ? answerJson.getString("note") : null;
 
-        formatQuestion(questionText, result);
+        final String questionText = answerJson.getJsonObject("question").getString("text");
+        if (StringUtils.isNotBlank(questionText)) {
+            formatQuestion(questionText, result);
+        }
+
         if (value == null) {
             formatAnswer("—", result);
         } else if ("cards:PedigreeAnswer".equals(nodeType)) {

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractFormToStringSerializer.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractFormToStringSerializer.java
@@ -189,10 +189,14 @@ public abstract class AbstractFormToStringSerializer
         if ("hidden".equals(displayMode)) {
             return;
         }
+        final String questionText = answerJson.getJsonObject("question").getString("text");
+        if (StringUtils.isBlank(questionText)) {
+            return;
+        }
         final JsonValue value = answerJson.get("displayedValue");
         final String note = answerJson.containsKey("note") ? answerJson.getString("note") : null;
 
-        formatQuestion(answerJson.getJsonObject("question").getString("text"), result);
+        formatQuestion(questionText, result);
         if (value == null) {
             formatAnswer("—", result);
         } else if ("cards:PedigreeAnswer".equals(nodeType)) {

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractFormToStringSerializer.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractFormToStringSerializer.java
@@ -28,7 +28,6 @@ import javax.json.JsonValue;
 import javax.json.JsonValue.ValueType;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.api.adapter.AdapterFactory;
 import org.apache.sling.api.resource.Resource;
 
 /**
@@ -36,21 +35,10 @@ import org.apache.sling.api.resource.Resource;
  *
  * @version $Id$
  */
-public abstract class AbstractFormToStringAdapterFactory
-    implements AdapterFactory
+public abstract class AbstractFormToStringSerializer
 {
-    @Override
-    public <A> A getAdapter(final Object adaptable, final Class<A> type)
+    protected String toString(final Resource originalResource)
     {
-        if (adaptable == null) {
-            return null;
-        }
-
-        final Resource originalResource = (Resource) adaptable;
-        if (!originalResource.isResourceType("cards/Form")) {
-            return type.cast(originalResource.getPath());
-        }
-
         // The proper serialization depends on "deep", "dereference" and "labels", but we may allow other JSON
         // processors to be enabled/disabled to further customize the data, so we also append the original selectors
         final String processedPath = originalResource.getPath()
@@ -59,7 +47,7 @@ public abstract class AbstractFormToStringAdapterFactory
 
         JsonObject result = resource.adaptTo(JsonObject.class);
         if (result != null) {
-            return type.cast(processForm(result));
+            return processForm(result);
         }
         return null;
     }

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractFormToStringSerializer.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractFormToStringSerializer.java
@@ -194,12 +194,15 @@ public abstract class AbstractFormToStringSerializer
         final String note = answerJson.containsKey("note") ? answerJson.getString("note") : null;
 
         final String questionText = answerJson.getJsonObject("question").getString("text");
-        if (StringUtils.isNotBlank(questionText)) {
+        final boolean questionHasText = StringUtils.isNotBlank(questionText);
+        if (questionHasText) {
             formatQuestion(questionText, result);
         }
 
         if (value == null) {
-            formatAnswer("—", result);
+            if (questionHasText) {
+                formatAnswer("—", result);
+            }
         } else if ("cards:PedigreeAnswer".equals(nodeType)) {
             formatPedigree(((JsonString) value).getString(), result);
         } else {

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractFormToStringSerializer.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractFormToStringSerializer.java
@@ -211,7 +211,6 @@ public abstract class AbstractFormToStringSerializer
         if (StringUtils.isNotBlank(note)) {
             formatNote(note, result);
         }
-        result.append("\n\n");
     }
 
     /**

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractSubjectToStringAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractSubjectToStringAdapterFactory.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional insubjectation
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.uhndata.cards.dataentry.internal.serialize;
+
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.json.JsonValue;
+import javax.json.JsonValue.ValueType;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.adapter.AdapterFactory;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+
+/**
+ * Base class for adapting a Subject resource to a text-based format.
+ *
+ * @version $Id$
+ */
+public abstract class AbstractSubjectToStringAdapterFactory
+    implements AdapterFactory
+{
+    private ThreadLocal<ResourceResolver> resolver = new ThreadLocal<>();
+
+    @Override
+    public <A> A getAdapter(final Object adaptable, final Class<A> type)
+    {
+        if (adaptable == null) {
+            return null;
+        }
+
+        final Resource originalResource = (Resource) adaptable;
+        if (!originalResource.isResourceType("cards/Subject")) {
+            return type.cast(originalResource.getPath());
+        }
+
+        this.resolver.set(originalResource.getResourceResolver());
+
+        // The proper serialization depends on "deep", "dereference" and "labels", but we may allow other JSON
+        // processors to be enabled/disabled to further customize the data, so we also append the original selectors
+        final String subjectPath = originalResource.getPath()
+            + originalResource.getResourceMetadata().getResolutionPathInfo();
+        final Resource resource = this.resolver.get().resolve(subjectPath + ".deep.dereference.labels");
+
+        JsonObject result = resource.adaptTo(JsonObject.class);
+        if (result != null) {
+            return type.cast(processSubject(result, subjectPath));
+        }
+        return null;
+    }
+
+    /**
+     * Converts the JSON representation of a subject into a string.
+     * @param subjectJson a JSON serialization of a node
+     * @param subjectPath processed subject path
+     *
+     * @param subjectJson a subject serialized as JSON
+     * @return plain text serialization of the subject
+     */
+    private String processSubject(final JsonObject subjectJson, String subjectPath)
+    {
+        StringBuilder result = new StringBuilder();
+        generateMetadata(subjectJson, result);
+        processSubjectForms(subjectJson, result, subjectPath);
+        return result.toString().trim();
+    }
+
+    /**
+     * Converts a JSON fragment (object) to plain text displaying the subject parent, id and creation date.
+     *
+     * @param subjectJson a JSON serialization of a node
+     * @param result the string builder where the serialization must be appended
+     */
+    private void generateMetadata(final JsonObject subjectJson, StringBuilder result)
+    {
+        String parent = getSubjectFullIdentifier(subjectJson);
+        if (parent != null) {
+            formatMetadata(getSubjectFullIdentifier(subjectJson), result);
+        }
+        formatMetadata("\n", result);
+        formatType(getSubjectType(subjectJson), result);
+        formatMetadata(getSubjectIdentifier(subjectJson), result);
+        formatMetadata("\n", result);
+        formatMetadata(getCreationDate(subjectJson), result);
+        formatMetadata("\n", result);
+    }
+
+    /**
+     * Retrieves the human readable subject's parent full identifier from the subject's JSON.
+     *
+     * @param subjectJson the JSON serialization of a subject
+     * @return a full parent identifier, in the format {@code Subject Identifier} or
+     *         {@code Parent Subject Identifier / Child Subject Identifier} or null
+     */
+    private String getSubjectFullIdentifier(final JsonObject subjectJson)
+    {
+        JsonObject parent = subjectJson.getJsonObject("parents");
+        if (parent != null) {
+            return parent.getString("fullIdentifier");
+        }
+        return null;
+    }
+
+    /**
+     * Retrieves the subject identifier from the subject's JSON.
+     *
+     * @param subjectJson the JSON serialization of a subject
+     * @return an identifier, in the format {@code Subject Identifier}
+     */
+    private String getSubjectIdentifier(final JsonObject subjectJson)
+    {
+        return subjectJson.getString("identifier");
+    }
+
+    /**
+     * Retrieves the subject's type.
+     *
+     * @param subjectJson the JSON serialization of a subject
+     * @return the type, in upper case
+     */
+    private String getSubjectType(final JsonObject subjectJson)
+    {
+        return subjectJson.getJsonObject("type").getString("@name");
+    }
+
+    /**
+     * Retrieves the subject's creation date.
+     *
+     * @param subjectJson the JSON serialization of a subject
+     * @return a date in the {@code YYYY-MM-DD} format
+     */
+    private String getCreationDate(final JsonObject subjectJson)
+    {
+        return StringUtils.substringBefore(subjectJson.getString("jcr:created"), "T");
+    }
+
+    private void processSubjectForms(final JsonObject subjectJson, StringBuilder result, String processedPath)
+    {
+        final Resource resource = this.resolver.get().resolve(processedPath + ".data.deep.json");
+
+        JsonObject data = resource.adaptTo(JsonObject.class);
+        if (result != null) {
+            data.values().stream()
+            .filter(value -> ValueType.ARRAY.equals(value.getValueType()))
+            .map(JsonValue::asJsonArray)
+            .forEach(value -> processQuestionnaireArray(value, result));
+        }
+    }
+
+    private void processQuestionnaireArray(JsonArray data, StringBuilder result)
+    {
+        data.stream()
+        .filter(value -> ValueType.OBJECT.equals(value.getValueType()))
+        .map(JsonValue::asJsonObject)
+        .filter(value -> value.containsKey("jcr:primaryType"))
+            .forEach(value -> processForm(value, result));
+    }
+
+    private void processForm(final JsonObject nodeJson, final StringBuilder result)
+    {
+        final String nodeType = nodeJson.getString("jcr:primaryType");
+        if (!"cards:Form".equals(nodeType)) {
+            return;
+        }
+        // Process form
+        String formPath = nodeJson.getString("@path");
+        final Resource formResource = this.resolver.get().resolve(formPath + ".deep.dereference.labels");
+
+        formatForm(formResource, result);
+    }
+
+    abstract void formatMetadata(String metadata, StringBuilder result);
+
+    abstract void formatType(String metadata, StringBuilder result);
+
+    abstract void formatForm(Resource resource, StringBuilder result);
+}

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractSubjectToStringSerializer.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractSubjectToStringSerializer.java
@@ -24,7 +24,6 @@ import javax.json.JsonValue;
 import javax.json.JsonValue.ValueType;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.api.adapter.AdapterFactory;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 
@@ -33,23 +32,12 @@ import org.apache.sling.api.resource.ResourceResolver;
  *
  * @version $Id$
  */
-public abstract class AbstractSubjectToStringAdapterFactory
-    implements AdapterFactory
+public abstract class AbstractSubjectToStringSerializer
 {
     private ThreadLocal<ResourceResolver> resolver = new ThreadLocal<>();
 
-    @Override
-    public <A> A getAdapter(final Object adaptable, final Class<A> type)
+    protected String toString(final Resource originalResource)
     {
-        if (adaptable == null) {
-            return null;
-        }
-
-        final Resource originalResource = (Resource) adaptable;
-        if (!originalResource.isResourceType("cards/Subject")) {
-            return type.cast(originalResource.getPath());
-        }
-
         this.resolver.set(originalResource.getResourceResolver());
 
         // The proper serialization depends on "deep", "dereference" and "labels", but we may allow other JSON
@@ -60,16 +48,16 @@ public abstract class AbstractSubjectToStringAdapterFactory
 
         JsonObject result = resource.adaptTo(JsonObject.class);
         if (result != null) {
-            return type.cast(processSubject(result, subjectPath));
+            return processSubject(result, subjectPath);
         }
         return null;
     }
 
     /**
      * Converts the JSON representation of a subject into a string.
+     *
      * @param subjectJson a JSON serialization of a node
      * @param subjectPath processed subject path
-     *
      * @param subjectJson a subject serialized as JSON
      * @return plain text serialization of the subject
      */

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractSubjectToStringSerializer.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractSubjectToStringSerializer.java
@@ -79,14 +79,10 @@ public abstract class AbstractSubjectToStringSerializer
     {
         String parent = getSubjectFullIdentifier(subjectJson);
         if (parent != null) {
-            formatMetadata(getSubjectFullIdentifier(subjectJson), result);
+            formatParent(getSubjectFullIdentifier(subjectJson), result);
         }
-        formatMetadata("\n", result);
-        formatType(getSubjectType(subjectJson), result);
-        formatMetadata(getSubjectIdentifier(subjectJson), result);
-        formatMetadata("\n", result);
-        formatMetadata(getCreationDate(subjectJson), result);
-        formatMetadata("\n", result);
+        formatSubjectTitle(getSubjectType(subjectJson), getSubjectIdentifier(subjectJson), result);
+        formatCreationDate(getCreationDate(subjectJson), result);
     }
 
     /**
@@ -173,9 +169,11 @@ public abstract class AbstractSubjectToStringSerializer
         formatForm(formResource, result);
     }
 
-    abstract void formatMetadata(String metadata, StringBuilder result);
+    abstract void formatParent(String metadata, StringBuilder result);
 
-    abstract void formatType(String metadata, StringBuilder result);
+    abstract void formatSubjectTitle(String type, String identifier, StringBuilder result);
+
+    abstract void formatCreationDate(String date, StringBuilder result);
 
     abstract void formatForm(Resource resource, StringBuilder result);
 }

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractSubjectToStringSerializer.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AbstractSubjectToStringSerializer.java
@@ -166,6 +166,7 @@ public abstract class AbstractSubjectToStringSerializer
         String formPath = nodeJson.getString("@path");
         final Resource formResource = this.resolver.get().resolve(formPath + ".deep.dereference.labels");
 
+        formatResourceSeparator(result);
         formatForm(formResource, result);
     }
 
@@ -174,6 +175,8 @@ public abstract class AbstractSubjectToStringSerializer
     abstract void formatSubjectTitle(String type, String identifier, StringBuilder result);
 
     abstract void formatCreationDate(String date, StringBuilder result);
+
+    abstract void formatResourceSeparator(StringBuilder result);
 
     abstract void formatForm(Resource resource, StringBuilder result);
 }

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/FormToMarkdownProcessor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/FormToMarkdownProcessor.java
@@ -31,7 +31,7 @@ import io.uhndata.cards.serialize.spi.ResourceMarkdownProcessor;
 @Component(service = ResourceMarkdownProcessor.class)
 public class FormToMarkdownProcessor extends AbstractFormToStringSerializer implements ResourceMarkdownProcessor
 {
-    private static final String MD_LINE_END = "  \n";
+    private static final String MD_LINE_BREAK = "  \n";
 
     @Override
     public boolean canProcess(final Resource resource)
@@ -54,7 +54,7 @@ public class FormToMarkdownProcessor extends AbstractFormToStringSerializer impl
     @Override
     void formatTitle(final String title, final StringBuilder result)
     {
-        result.append("# ").append(title).append(MD_LINE_END);
+        result.append("# ").append(title).append('\n');
     }
 
     @Override
@@ -66,25 +66,25 @@ public class FormToMarkdownProcessor extends AbstractFormToStringSerializer impl
     @Override
     void formatMetadataSeparator(final StringBuilder result)
     {
-        result.append("\n\n\n\n");
+        // Don't output additional separation
     }
 
     @Override
     void formatSectionTitle(final String title, final StringBuilder result)
     {
-        result.append("\n\n### ").append(title).append(MD_LINE_END).append('\n');
+        result.append("\n### ").append(title).append('\n');
     }
 
     @Override
     void formatSectionSeparator(final StringBuilder result)
     {
-        result.append("----").append(MD_LINE_END).append('\n');
+        result.append('\n').append("----").append('\n');
     }
 
     @Override
     void formatQuestion(final String question, final StringBuilder result)
     {
-        result.append("\n**").append(question).append("**").append(MD_LINE_END);
+        result.append("\n**").append(question).append("**  ");
     }
 
     @Override
@@ -96,13 +96,13 @@ public class FormToMarkdownProcessor extends AbstractFormToStringSerializer impl
     @Override
     void formatAnswer(final String answer, final StringBuilder result)
     {
-        result.append(answer).append(MD_LINE_END);
+        result.append('\n').append(answer).append('\n');
     }
 
     @Override
     void formatNote(final String note, final StringBuilder result)
     {
-        result.append("**Notes**").append(MD_LINE_END).append(note.replaceAll("\n", MD_LINE_END)).append(MD_LINE_END);
+        result.append("\n**Notes**").append(MD_LINE_BREAK).append(note.replaceAll("\n", MD_LINE_BREAK)).append('\n');
     }
 
     @Override
@@ -125,6 +125,6 @@ public class FormToMarkdownProcessor extends AbstractFormToStringSerializer impl
             .append("<svg style='width: 100%' ")
             .append(image.substring(4))
             .append("</div>")
-            .append(MD_LINE_END);
+            .append('\n');
     }
 }

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/FormToMarkdownProcessor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/FormToMarkdownProcessor.java
@@ -18,22 +18,32 @@
  */
 package io.uhndata.cards.dataentry.internal.serialize;
 
-import org.apache.sling.api.adapter.AdapterFactory;
+import org.apache.sling.api.resource.Resource;
 import org.osgi.service.component.annotations.Component;
 
+import io.uhndata.cards.serialize.spi.ResourceMarkdownProcessor;
+
 /**
- * AdapterFactory that converts forms to markdown.
+ * Markdown serializer that can process Forms.
  *
  * @version $Id$
  */
-@Component(
-    service = { AdapterFactory.class },
-    property = { "adaptables=org.apache.sling.api.resource.Resource", "adapters=java.lang.CharSequence" })
-public class FormToMarkdownAdapterFactory
-    extends AbstractFormToStringAdapterFactory
+@Component(service = ResourceMarkdownProcessor.class)
+public class FormToMarkdownProcessor extends AbstractFormToStringSerializer implements ResourceMarkdownProcessor
 {
-
     private static final String MD_LINE_END = "  \n";
+
+    @Override
+    public boolean canProcess(final Resource resource)
+    {
+        return resource.isResourceType("cards/Form");
+    }
+
+    @Override
+    public String serialize(Resource resource)
+    {
+        return toString(resource);
+    }
 
     @Override
     void formatSubject(final String subject, final StringBuilder result)

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/FormToTextAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/FormToTextAdapterFactory.java
@@ -66,25 +66,25 @@ public class FormToTextAdapterFactory extends AbstractFormToStringSerializer imp
     @Override
     void formatMetadataSeparator(final StringBuilder result)
     {
-        result.append("\n\n");
+        // Don't output additional separation
     }
 
     @Override
     void formatSectionTitle(final String title, final StringBuilder result)
     {
-        result.append(title.toUpperCase(Locale.ROOT)).append("\n\n");
+        result.append('\n').append(title.toUpperCase(Locale.ROOT)).append('\n');
     }
 
     @Override
     void formatSectionSeparator(final StringBuilder result)
     {
-        result.append("---------------------------------------------").append("\n\n");
+        result.append('\n').append("---------------------------------------------").append('\n');
     }
 
     @Override
     void formatQuestion(final String question, final StringBuilder result)
     {
-        result.append(question).append('\n');
+        result.append('\n').append(question);
     }
 
     @Override
@@ -96,19 +96,19 @@ public class FormToTextAdapterFactory extends AbstractFormToStringSerializer imp
     @Override
     void formatAnswer(final String answer, final StringBuilder result)
     {
-        result.append("  ").append(answer.replaceAll("\n", "\n  ")).append('\n');
+        result.append('\n').append("  ").append(answer.replaceAll("\n", "\n  ")).append('\n');
     }
 
     @Override
     void formatNote(final String note, final StringBuilder result)
     {
-        result.append("\n  NOTES\n");
+        result.append("\n  NOTES");
         formatAnswer(note, result);
     }
 
     @Override
     void formatPedigree(final String image, final StringBuilder result)
     {
-        result.append("  Pedigree provided\n");
+        formatAnswer("Pedigree provided", result);
     }
 }

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/FormToTextAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/FormToTextAdapterFactory.java
@@ -20,20 +20,31 @@ package io.uhndata.cards.dataentry.internal.serialize;
 
 import java.util.Locale;
 
-import org.apache.sling.api.adapter.AdapterFactory;
+import org.apache.sling.api.resource.Resource;
 import org.osgi.service.component.annotations.Component;
 
+import io.uhndata.cards.serialize.spi.ResourceTextProcessor;
+
 /**
- * AdapterFactory that converts forms to plain text.
+ * Plain text serializer that can process Forms.
  *
  * @version $Id$
  */
-@Component(
-    service = { AdapterFactory.class },
-    property = { "adaptables=org.apache.sling.api.resource.Resource", "adapters=java.lang.String" })
-public class FormToTextAdapterFactory
-    extends AbstractFormToStringAdapterFactory
+@Component(service = ResourceTextProcessor.class)
+public class FormToTextAdapterFactory extends AbstractFormToStringSerializer implements ResourceTextProcessor
 {
+    @Override
+    public boolean canProcess(final Resource resource)
+    {
+        return resource.isResourceType("cards/Form");
+    }
+
+    @Override
+    public String serialize(Resource resource)
+    {
+        return toString(resource);
+    }
+
     @Override
     void formatSubject(final String subject, final StringBuilder result)
     {

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToMarkdownAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToMarkdownAdapterFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.uhndata.cards.dataentry.internal.serialize;
+
+import java.util.Locale;
+
+import org.apache.sling.api.adapter.AdapterFactory;
+import org.apache.sling.api.resource.Resource;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * AdapterFactory that converts Subject to markdown.
+ *
+ * @version $Id$
+ */
+@Component(
+    service = { AdapterFactory.class },
+    property = { "adaptables=org.apache.sling.api.resource.Resource", "adapters=java.lang.CharSequence" })
+public class SubjectToMarkdownAdapterFactory
+    extends AbstractSubjectToStringAdapterFactory
+{
+
+    private static final String MD_LINE_END = "  \n";
+
+    @Override
+    void formatMetadata(final String metadata, final StringBuilder result)
+    {
+        result.append(metadata.toUpperCase(Locale.ROOT)).append(MD_LINE_END).append('\n');
+    }
+
+    @Override
+    void formatType(final String type, final StringBuilder result)
+    {
+        result.append("\n\n### ").append(type).append(MD_LINE_END).append('\n');
+    }
+
+    @Override
+    void formatForm(final Resource resource, final StringBuilder result)
+    {
+        result.append("\n\n### ").append(resource.adaptTo(CharSequence.class)).append(MD_LINE_END).append('\n');
+    }
+}

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToMarkdownAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToMarkdownAdapterFactory.java
@@ -18,8 +18,6 @@
  */
 package io.uhndata.cards.dataentry.internal.serialize;
 
-import java.util.Locale;
-
 import org.apache.sling.api.resource.Resource;
 import org.osgi.service.component.annotations.Component;
 
@@ -37,6 +35,24 @@ public class SubjectToMarkdownAdapterFactory extends AbstractSubjectToStringSeri
     private static final String MD_LINE_END = "  \n";
 
     @Override
+    void formatSubjectTitle(String type, String identifier, StringBuilder result)
+    {
+        // Don't output the subject
+    }
+
+    @Override
+    void formatCreationDate(String metadata, StringBuilder result)
+    {
+        // Don't output the subject
+    }
+
+    @Override
+    void formatParent(String metadata, StringBuilder result)
+    {
+        // Don't output the subject
+    }
+
+    @Override
     public boolean canProcess(final Resource resource)
     {
         return resource.isResourceType("cards/Subject");
@@ -46,18 +62,6 @@ public class SubjectToMarkdownAdapterFactory extends AbstractSubjectToStringSeri
     public String serialize(Resource resource)
     {
         return toString(resource);
-    }
-
-    @Override
-    void formatMetadata(final String metadata, final StringBuilder result)
-    {
-        result.append(metadata.toUpperCase(Locale.ROOT)).append(MD_LINE_END).append('\n');
-    }
-
-    @Override
-    void formatType(final String type, final StringBuilder result)
-    {
-        result.append("\n\n### ").append(type).append(MD_LINE_END).append('\n');
     }
 
     @Override

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToMarkdownAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToMarkdownAdapterFactory.java
@@ -49,7 +49,7 @@ public class SubjectToMarkdownAdapterFactory extends AbstractSubjectToStringSeri
     @Override
     void formatParent(String metadata, StringBuilder result)
     {
-        // Don't output the subject
+        // Don't output the parent subject
     }
 
     @Override

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToMarkdownAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToMarkdownAdapterFactory.java
@@ -63,6 +63,6 @@ public class SubjectToMarkdownAdapterFactory extends AbstractSubjectToStringSeri
     @Override
     void formatForm(final Resource resource, final StringBuilder result)
     {
-        result.append("\n\n### ").append(resource.adaptTo(CharSequence.class)).append(MD_LINE_END).append('\n');
+        result.append(resource.adaptTo(CharSequence.class)).append(MD_LINE_END).append('\n');
     }
 }

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToMarkdownAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToMarkdownAdapterFactory.java
@@ -35,6 +35,18 @@ public class SubjectToMarkdownAdapterFactory extends AbstractSubjectToStringSeri
     private static final String MD_LINE_END = "  \n";
 
     @Override
+    public boolean canProcess(final Resource resource)
+    {
+        return resource.isResourceType("cards/Subject");
+    }
+
+    @Override
+    public String serialize(Resource resource)
+    {
+        return toString(resource);
+    }
+
+    @Override
     void formatSubjectTitle(String type, String identifier, StringBuilder result)
     {
         // Don't output the subject
@@ -50,18 +62,6 @@ public class SubjectToMarkdownAdapterFactory extends AbstractSubjectToStringSeri
     void formatParent(String metadata, StringBuilder result)
     {
         // Don't output the parent subject
-    }
-
-    @Override
-    public boolean canProcess(final Resource resource)
-    {
-        return resource.isResourceType("cards/Subject");
-    }
-
-    @Override
-    public String serialize(Resource resource)
-    {
-        return toString(resource);
     }
 
     @Override

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToMarkdownAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToMarkdownAdapterFactory.java
@@ -20,23 +20,33 @@ package io.uhndata.cards.dataentry.internal.serialize;
 
 import java.util.Locale;
 
-import org.apache.sling.api.adapter.AdapterFactory;
 import org.apache.sling.api.resource.Resource;
 import org.osgi.service.component.annotations.Component;
 
+import io.uhndata.cards.serialize.spi.ResourceMarkdownProcessor;
+
 /**
- * AdapterFactory that converts Subject to markdown.
+ * Markdown serializer that can process Subjects.
  *
  * @version $Id$
  */
-@Component(
-    service = { AdapterFactory.class },
-    property = { "adaptables=org.apache.sling.api.resource.Resource", "adapters=java.lang.CharSequence" })
-public class SubjectToMarkdownAdapterFactory
-    extends AbstractSubjectToStringAdapterFactory
+@Component(service = ResourceMarkdownProcessor.class)
+public class SubjectToMarkdownAdapterFactory extends AbstractSubjectToStringSerializer
+    implements ResourceMarkdownProcessor
 {
-
     private static final String MD_LINE_END = "  \n";
+
+    @Override
+    public boolean canProcess(final Resource resource)
+    {
+        return resource.isResourceType("cards/Subject");
+    }
+
+    @Override
+    public String serialize(Resource resource)
+    {
+        return toString(resource);
+    }
 
     @Override
     void formatMetadata(final String metadata, final StringBuilder result)

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToMarkdownAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToMarkdownAdapterFactory.java
@@ -32,7 +32,6 @@ import io.uhndata.cards.serialize.spi.ResourceMarkdownProcessor;
 public class SubjectToMarkdownAdapterFactory extends AbstractSubjectToStringSerializer
     implements ResourceMarkdownProcessor
 {
-    private static final String MD_LINE_END = "  \n";
 
     @Override
     public boolean canProcess(final Resource resource)
@@ -47,26 +46,32 @@ public class SubjectToMarkdownAdapterFactory extends AbstractSubjectToStringSeri
     }
 
     @Override
-    void formatSubjectTitle(String type, String identifier, StringBuilder result)
-    {
-        // Don't output the subject
-    }
-
-    @Override
-    void formatCreationDate(String metadata, StringBuilder result)
-    {
-        // Don't output the subject
-    }
-
-    @Override
-    void formatParent(String metadata, StringBuilder result)
+    void formatParent(String parent, StringBuilder result)
     {
         // Don't output the parent subject
     }
 
     @Override
+    void formatSubjectTitle(String type, String identifier, StringBuilder result)
+    {
+        // Don't output the subject title
+    }
+
+    @Override
+    void formatCreationDate(String date, StringBuilder result)
+    {
+        // Don't output the date
+    }
+
+    @Override
+    void formatResourceSeparator(StringBuilder result)
+    {
+        result.append("\n\n");
+    }
+
+    @Override
     void formatForm(final Resource resource, final StringBuilder result)
     {
-        result.append(resource.adaptTo(CharSequence.class)).append(MD_LINE_END).append('\n');
+        result.append(resource.adaptTo(CharSequence.class));
     }
 }

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToTextAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToTextAdapterFactory.java
@@ -46,15 +46,21 @@ public class SubjectToTextAdapterFactory extends AbstractSubjectToStringSerializ
     }
 
     @Override
-    void formatMetadata(final String metadata, final StringBuilder result)
+    void formatSubjectTitle(String type, String identifier, StringBuilder result)
     {
-        result.append(metadata.toUpperCase(Locale.ROOT)).append('\n');
+        result.append(type).append("  ").append(identifier).append("\n");
     }
 
     @Override
-    void formatType(final String type, final StringBuilder result)
+    void formatCreationDate(String date, StringBuilder result)
     {
-        result.append(type.toUpperCase(Locale.ROOT)).append("\n\n");
+        result.append(date).append("\n\n");
+    }
+
+    @Override
+    void formatParent(String metadata, StringBuilder result)
+    {
+        result.append(metadata.toUpperCase(Locale.ROOT)).append("\n");
     }
 
     @Override

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToTextAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToTextAdapterFactory.java
@@ -48,7 +48,7 @@ public class SubjectToTextAdapterFactory extends AbstractSubjectToStringSerializ
     @Override
     void formatSubjectTitle(String type, String identifier, StringBuilder result)
     {
-        result.append(type).append("  ").append(identifier).append("\n");
+        result.append(type).append(" ").append(identifier).append("\n");
     }
 
     @Override

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToTextAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToTextAdapterFactory.java
@@ -18,8 +18,6 @@
  */
 package io.uhndata.cards.dataentry.internal.serialize;
 
-import java.util.Locale;
-
 import org.apache.sling.api.resource.Resource;
 import org.osgi.service.component.annotations.Component;
 
@@ -46,6 +44,12 @@ public class SubjectToTextAdapterFactory extends AbstractSubjectToStringSerializ
     }
 
     @Override
+    void formatParent(String parent, StringBuilder result)
+    {
+        // Don't output the parent
+    }
+
+    @Override
     void formatSubjectTitle(String type, String identifier, StringBuilder result)
     {
         result.append(type).append(" ").append(identifier).append("\n");
@@ -54,18 +58,18 @@ public class SubjectToTextAdapterFactory extends AbstractSubjectToStringSerializ
     @Override
     void formatCreationDate(String date, StringBuilder result)
     {
-        result.append(date).append("\n\n");
+        result.append(date).append("\n");
     }
 
     @Override
-    void formatParent(String metadata, StringBuilder result)
+    void formatResourceSeparator(final StringBuilder result)
     {
-        result.append(metadata.toUpperCase(Locale.ROOT)).append("\n");
+        result.append("\n\n\n\n");
     }
 
     @Override
     void formatForm(final Resource resource, final StringBuilder result)
     {
-        result.append(resource.adaptTo(String.class)).append("\n\n");
+        result.append(resource.adaptTo(String.class));
     }
 }

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToTextAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToTextAdapterFactory.java
@@ -20,21 +20,31 @@ package io.uhndata.cards.dataentry.internal.serialize;
 
 import java.util.Locale;
 
-import org.apache.sling.api.adapter.AdapterFactory;
 import org.apache.sling.api.resource.Resource;
 import org.osgi.service.component.annotations.Component;
 
+import io.uhndata.cards.serialize.spi.ResourceTextProcessor;
+
 /**
- * AdapterFactory that converts Subject to plain text.
+ * Plain text serializer that can process Subjects.
  *
  * @version $Id$
  */
-@Component(
-    service = { AdapterFactory.class },
-    property = { "adaptables=org.apache.sling.api.resource.Resource", "adapters=java.lang.String" })
-public class SubjectToTextAdapterFactory
-    extends AbstractSubjectToStringAdapterFactory
+@Component(service = ResourceTextProcessor.class)
+public class SubjectToTextAdapterFactory extends AbstractSubjectToStringSerializer implements ResourceTextProcessor
 {
+    @Override
+    public boolean canProcess(final Resource resource)
+    {
+        return resource.isResourceType("cards/Subject");
+    }
+
+    @Override
+    public String serialize(Resource resource)
+    {
+        return toString(resource);
+    }
+
     @Override
     void formatMetadata(final String metadata, final StringBuilder result)
     {

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToTextAdapterFactory.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/SubjectToTextAdapterFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.uhndata.cards.dataentry.internal.serialize;
+
+import java.util.Locale;
+
+import org.apache.sling.api.adapter.AdapterFactory;
+import org.apache.sling.api.resource.Resource;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * AdapterFactory that converts Subject to plain text.
+ *
+ * @version $Id$
+ */
+@Component(
+    service = { AdapterFactory.class },
+    property = { "adaptables=org.apache.sling.api.resource.Resource", "adapters=java.lang.String" })
+public class SubjectToTextAdapterFactory
+    extends AbstractSubjectToStringAdapterFactory
+{
+    @Override
+    void formatMetadata(final String metadata, final StringBuilder result)
+    {
+        result.append(metadata.toUpperCase(Locale.ROOT)).append('\n');
+    }
+
+    @Override
+    void formatType(final String type, final StringBuilder result)
+    {
+        result.append(type.toUpperCase(Locale.ROOT)).append("\n\n");
+    }
+
+    @Override
+    void formatForm(final Resource resource, final StringBuilder result)
+    {
+        result.append(resource.adaptTo(String.class)).append("\n\n");
+    }
+}

--- a/modules/data-entry/src/main/resources/SLING-INF/content/libs/cards/Subject/md.GET.html
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/libs/cards/Subject/md.GET.html
@@ -1,0 +1,23 @@
+<sly data-sly-use.contentType="io.uhndata.cards.scripting.ContentTypeSetter">${contentType.markdown}</sly>
+<!--/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+*/-->
+<!--/*
+  Custom serialization of resources as markdown.
+*/-->
+<sly data-sly-use.md="java.lang.CharSequence">${md.toString @ context='unsafe'}</sly>

--- a/modules/data-entry/src/main/resources/SLING-INF/content/libs/cards/Subject/txt.GET.html
+++ b/modules/data-entry/src/main/resources/SLING-INF/content/libs/cards/Subject/txt.GET.html
@@ -1,0 +1,23 @@
+<sly data-sly-use.contentType="io.uhndata.cards.scripting.ContentTypeSetter">${contentType.text}</sly>
+<!--/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+*/-->
+<!--/*
+  Custom serialization of resources as plain text.
+*/-->
+<sly data-sly-use.txt="java.lang.String">${txt @ context='unsafe'}</sly>

--- a/modules/utils/src/main/java/io/uhndata/cards/serialize/ResourceToMarkdownAdapterFactory.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/serialize/ResourceToMarkdownAdapterFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.uhndata.cards.serialize;
+
+import java.util.List;
+
+import org.apache.sling.api.adapter.AdapterFactory;
+import org.apache.sling.api.resource.Resource;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.FieldOption;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+
+import io.uhndata.cards.serialize.spi.ResourceMarkdownProcessor;
+
+/**
+ * AdapterFactory that converts Apache Sling resources to Markdown text. This is just a shell, the actual serialization
+ * is provided by implementations of the {@link ResourceMarkdownProcessor} service.
+ *
+ * @version $Id$
+ */
+@Component(
+    service = { AdapterFactory.class },
+    property = { "adaptables=org.apache.sling.api.resource.Resource", "adapters=java.lang.CharSequence" })
+public class ResourceToMarkdownAdapterFactory
+    implements AdapterFactory
+{
+    /** A list of all available processors. */
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, fieldOption = FieldOption.REPLACE,
+        policy = ReferencePolicy.DYNAMIC)
+    private volatile List<ResourceMarkdownProcessor> allProcessors;
+
+    @Override
+    public <A> A getAdapter(final Object adaptable, final Class<A> type)
+    {
+        if (adaptable == null) {
+            return null;
+        }
+        final Resource resource = (Resource) adaptable;
+        final String result = this.allProcessors.stream()
+            .filter(p -> p.canProcess(resource))
+            .findFirst()
+            .map(p -> p.serialize(resource))
+            .orElse(resource.getPath());
+
+        return type.cast(result);
+    }
+}

--- a/modules/utils/src/main/java/io/uhndata/cards/serialize/ResourceToTextAdapterFactory.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/serialize/ResourceToTextAdapterFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.uhndata.cards.serialize;
+
+import java.util.List;
+
+import org.apache.sling.api.adapter.AdapterFactory;
+import org.apache.sling.api.resource.Resource;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.FieldOption;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+
+import io.uhndata.cards.serialize.spi.ResourceTextProcessor;
+
+/**
+ * AdapterFactory that converts Apache Sling resources to plain text. This is just a shell, the actual serialization is
+ * provided by implementations of the {@link ResourceTextProcessor} service.
+ *
+ * @version $Id$
+ */
+@Component(
+    service = { AdapterFactory.class },
+    property = { "adaptables=org.apache.sling.api.resource.Resource", "adapters=java.lang.String" })
+public class ResourceToTextAdapterFactory
+    implements AdapterFactory
+{
+    /** A list of all available processors. */
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, fieldOption = FieldOption.REPLACE,
+        policy = ReferencePolicy.DYNAMIC)
+    private volatile List<ResourceTextProcessor> allProcessors;
+
+    @Override
+    public <A> A getAdapter(final Object adaptable, final Class<A> type)
+    {
+        if (adaptable == null) {
+            return null;
+        }
+        final Resource resource = (Resource) adaptable;
+        final String result = this.allProcessors.stream()
+            .filter(p -> p.canProcess(resource))
+            .findFirst()
+            .map(p -> p.serialize(resource))
+            .orElse(resource.getPath());
+
+        return type.cast(result);
+    }
+}

--- a/modules/utils/src/main/java/io/uhndata/cards/serialize/spi/ResourceMarkdownProcessor.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/serialize/spi/ResourceMarkdownProcessor.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.uhndata.cards.serialize.spi;
+
+import org.apache.sling.api.resource.Resource;
+
+/**
+ * A service that can help serialize a node to Markdown text. Implementations of this interface will be invoked by
+ * {@link io.uhndata.cards.serialize.ResourceToMarkdownAdapterFactory} when serializing a resource as
+ * {@code CharSequence}. When serializing a resource, each enabled processors will be asked if they
+ * {@link #canProcess(Resource) can process} the resource, and the first one to answer {@code true} will have it's
+ * {@link #serialize(Resource)} method invoked with the resource as a parameter.
+ *
+ * @version $Id$
+ */
+public interface ResourceMarkdownProcessor
+{
+    /**
+     * Checks if the given resource can be serialized by this processor. This method is only invoked for the top level
+     * resource being serialized, not for each of its children/descendants. If this method returns {@code true}, this
+     * processor will be the only one invoked to serialize the resource. The default implementation returns
+     * {@code false} for all resources, implementations must override it to select which resources can be processed.
+     *
+     * @param resource the resource being serialized
+     * @return {@code true} if this processor can be serialize this resource, {@code false} otherwise
+     */
+    default boolean canProcess(final Resource resource)
+    {
+        return false;
+    }
+
+    /**
+     * Called for serializing a resource to Markdown.
+     *
+     * @param resource the resource to serialize
+     * @return the resource serialization as Markdown text, may be empty
+     */
+    String serialize(Resource resource);
+}

--- a/modules/utils/src/main/java/io/uhndata/cards/serialize/spi/ResourceTextProcessor.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/serialize/spi/ResourceTextProcessor.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.uhndata.cards.serialize.spi;
+
+import org.apache.sling.api.resource.Resource;
+
+/**
+ * A service that can help serialize a node to plain text. Implementations of this interface will be invoked by
+ * {@link io.uhndata.cards.serialize.ResourceToTextAdapterFactory} when serializing a resource as {@code String}. When
+ * serializing a resource, each enabled processors will be asked if they {@link #canProcess(Resource) can process} the
+ * resource, and the first one to answer {@code true} will have it's {@link #serialize(Resource)} method invoked with
+ * the resource as a parameter.
+ *
+ * @version $Id$
+ */
+public interface ResourceTextProcessor
+{
+    /**
+     * Checks if the given resource can be serialized by this processor. This method is only invoked for the top level
+     * resource being serialized, not for each of its children/descendants. If this method returns {@code true}, this
+     * processor will be the only one invoked to serialize the resource. The default implementation returns
+     * {@code false} for all resources, implementations must override it to select which resources can be processed.
+     *
+     * @param resource the resource being serialized
+     * @return {@code true} if this processor can be serialize this resource, {@code false} otherwise
+     */
+    default boolean canProcess(final Resource resource)
+    {
+        return false;
+    }
+
+    /**
+     * Called for serializing a resource to plain text.
+     *
+     * @param resource the resource to serialize
+     * @return the resource serialization as text, may be empty
+     */
+    String serialize(Resource resource);
+}


### PR DESCRIPTION
### Specifications:
[CARDS-1599](https://phenotips.atlassian.net/browse/CARDS-1599)

### Testing instructions:
* Create a subject
* Add some forms with answers to it
* navigate to `localhost:8080/Subjects/FULL/SUBJECT/ID.txt` to see the text serialization
* navigate to `localhost:8080/Subjects/FULL/SUBJECT/ID.md` to see the markdown serialization
* To ensure there are no regressions, also test individual form serialization by navigating to:
`localhost:8080/Forms/FORM-ID.txt` to see the text serialization
`localhost:8080/Forms/FORM-ID.md` to see the markdown serialization