### PR TITLE
CARDS-1589: Only consider same clinic visits for form frequency

### DIFF
--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/FormUtilsImpl.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/FormUtilsImpl.java
@@ -210,7 +210,7 @@ public final class FormUtilsImpl extends AbstractNodeUtils implements FormUtils
     @Override
     public boolean isAnswer(final Node node)
     {
-        return isNodeType(node, ANSWER_SECTION_NODETYPE);
+        return isNodeType(node, ANSWER_NODETYPE);
     }
 
     @Override

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -526,6 +526,9 @@
   // We allow users to place these answers in a Note section
   - note (string)
 
+  // A potentially empty list of status flags for the answer
+  - statusFlags (STRING) autocreated multiple
+
   // We don't define any subchildren.
 
 //-----------------------------------------------------------------------------
@@ -719,6 +722,7 @@
   // Hardcode the resource supertype: each form is a resource.
   - sling:resourceSuperType (STRING) = "cards/Resource" mandatory autocreated protected
 
+  // A potentially empty list of status flags for the form
   - statusFlags (STRING) = "INCOMPLETE" mandatory autocreated multiple
 
   // A reference to the questionnaire being filled in.


### PR DESCRIPTION
- When creating new forms for a visit, ignore forms for different clinics
  - Clinics determined by visit information 'surveys' field
- Copy patient information sex field into AUDITC for interpretation purposes
- Fixed backend created answers not generating statusFlags property
- Fixed bug in FormUtilsImpl that was incorrectly comparing Answer Nodes to the
  AnswerSection node type
  
  For testing, the [CARDS-1589_test branch](https://github.com/data-team-uhn/cards/tree/CARDS-1589_test) has been created which adds a partial implementation of the Mood questionnaire set.
  
  Things to verify:
  - When a `visit information` form is created with a `time` and `surveys`, it should only apply to visits with the same `surveys` value (`Cardio` or `Mood`)
    - The `surveys` field has to be filled out through composum as it is a hidden field
  - When an `AUDITC` form is automatically created for a patient with a `sex` answer in the `patient information` form, that answer should be populated to the `AUDITC` form as well
    - This field in `AUDITC` is hidden, so the value can be found using composum (easier) or by checking the `AUDITC` summary through the PROMs patient UI (0-4 or more than 4 for `male`, 0-3 or more than 3 for `female`, both for any other value)