### PR TITLE
CARDS-1475: PROMs Dashboard - More accurate title and label

### DIFF
--- a/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/Sidebar/PMCC-ACHD.json
+++ b/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/Sidebar/PMCC-ACHD.json
@@ -1,8 +1,8 @@
 {
   "jcr:primaryType": "cards:Extension",
   "cards:extensionPointId": "cards/coreUI/sidebar/entry",
-  "cards:extensionName": "PMCC",
-  "cards:targetURL": "/content.html/Dashboard/PMCC",
+  "cards:extensionName": "PMCC - ACHD",
+  "cards:targetURL": "/content.html/Dashboard/PMCC-ACHD",
   "cards:icon": "asset:proms-homepage.pmccIcon.js",
   "cards:defaultOrder": 10
 }

--- a/proms-resources/frontend/src/main/resources/SLING-INF/content/apps/cards/ExtensionPoints/DashboardViewsPMCC-ACHD.json
+++ b/proms-resources/frontend/src/main/resources/SLING-INF/content/apps/cards/ExtensionPoints/DashboardViewsPMCC-ACHD.json
@@ -1,0 +1,8 @@
+{
+  "jcr:primaryType": "cards:ExtensionPoint",
+  "cards:extensionPointId": "proms/dashboard/pmcc",
+  "cards:extensionPointName": "PMCC-ACHD pre-appointment questionnaires dashboard",
+  "title" : "Adult Congenital Heart Disease Clinic",
+  "description" : "Peter Munk Cardiac Centre",
+  "surveys" : "Cardio"
+}

--- a/proms-resources/frontend/src/main/resources/SLING-INF/content/apps/cards/ExtensionPoints/DashboardViewsPMCC.json
+++ b/proms-resources/frontend/src/main/resources/SLING-INF/content/apps/cards/ExtensionPoints/DashboardViewsPMCC.json
@@ -1,8 +1,0 @@
-{
-  "jcr:primaryType": "cards:ExtensionPoint",
-  "cards:extensionPointId": "proms/dashboard/pmcc",
-  "cards:extensionPointName": "PMCC pre-appointment questionnaires dashboard",
-  "title" : "Peter Munk Cardiac Centre",
-  "description" : "Pre-appointment questionnaires",
-  "surveys" : "Cardio"
-}


### PR DESCRIPTION
Updated sidebar entry and Dashboard title to reflect the name of the onboarded clinich rather than of the whole centre.

Before:
![image](https://user-images.githubusercontent.com/651980/151720901-d132aa27-9e3a-4883-bd6c-552c0f5dface.png)


After:
![image](https://user-images.githubusercontent.com/651980/151720858-cd2b5339-d349-4627-ad75-7f130ec4f39a.png)
