### PR TITLE
CARDS-1339: Patient users should only be able to access the PROMs ui

### DIFF
--- a/modules/commons/src/main/features/feature-repoinit.txt
+++ b/modules/commons/src/main/features/feature-repoinit.txt
@@ -31,6 +31,6 @@ set ACL for everyone
 end
 
 set properties on /RedirectURL
-  set RedirectURL to "/Proms.html/Cardio"
+  set RedirectURL to "/content.html/Questionnaires/User"
   set RedirectLabel to "Go to the dashboard"
 end


### PR DESCRIPTION
Bugfix: all users are redirected to the PROMS UI from the 404 error page