### PR TITLE
CARDS-1611: Proms printing: include the header on every page

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
@@ -155,8 +155,18 @@ function PrintPreview(props) {
         className={classes.printPreview + " " + classes.printTarget}
         >
         <CardContent>
-          { header }
-          <FormattedText>{content}</FormattedText>
+          <table>
+            <thead>
+              <tr><td>
+                { header }
+              </td></tr>
+            </thead>
+            <tbody>
+              <tr><td>
+                <FormattedText>{content}</FormattedText>
+              </td></tr>
+            </tbody>
+          </table>
         </CardContent>
       </Card>
     }


### PR DESCRIPTION
After countless attempts to utilise `position: fixed` with margins/paddings of `@print` or `@page`, the  only solution that worked was an old-school, 1994 table layout, robust and cross-browser reliable.
Tested in Chrome and Firefox. IE did not show login page.