### PR TITLE
CARDS-1475: PROMs dashboard: one Appointments box + 5 more boxes, one per questionnaire, with the score displayed as one of the columns

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -148,7 +148,7 @@ const questionnaireStyle = theme => ({
     dashboardEntry: {
         "& > *": {
             height: "100%",
-            marginTop: theme.spacing(4),
+            top: theme.spacing(4),
         },
         "& .MuiCardHeader-root" : {
             paddingBottom: 0,
@@ -171,7 +171,7 @@ const questionnaireStyle = theme => ({
              height: theme.spacing(.5),
          },
          "& .MuiCardContent-root": {
-            padding: theme.spacing(3, 0),
+            padding: theme.spacing(3, 0, 1, 0),
          },
          "& .MuiTableCell-body": {
             padding: theme.spacing(0, 2),

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -148,7 +148,7 @@ const questionnaireStyle = theme => ({
     dashboardEntry: {
         "& > *": {
             height: "100%",
-            top: theme.spacing(4),
+            marginTop: theme.spacing(4),
         },
         "& .MuiCardHeader-root" : {
             paddingBottom: 0,
@@ -171,7 +171,7 @@ const questionnaireStyle = theme => ({
              height: theme.spacing(.5),
          },
          "& .MuiCardContent-root": {
-            padding: theme.spacing(3, 0, 1, 0),
+            padding: theme.spacing(3, 0),
          },
          "& .MuiTableCell-body": {
             padding: theme.spacing(0, 2),

--- a/proms-resources/frontend/src/main/frontend/src/proms/PromsDashboard.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PromsDashboard.jsx
@@ -51,10 +51,12 @@ const useStyles = makeStyles(theme => ({
   withMargin: {
     marginRight: "320px",
   },
+  dashboardContainer: {
+    marginTop: theme.spacing(2),
+  },
   dashboardEntry: {
     "& > *": {
       height: "100%",
-      marginTop: theme.spacing(4),
     },
     "& .MuiCardHeader-root" : {
       paddingBottom: 0,
@@ -75,7 +77,7 @@ const useStyles = makeStyles(theme => ({
       height: theme.spacing(.5),
     },
     "& .MuiCardContent-root": {
-      padding: theme.spacing(3, 0),
+      padding: theme.spacing(3, 0, 1, 0),
     },
   },
 }));
@@ -156,7 +158,7 @@ function PromsDashboard(props) {
     <>
       <Typography variant="h4" className={classes.dashboardTitle + (appbarExpanded ? ' ' + classes.withMargin : '')}>{title}</Typography>
       { description && <Typography variant="overline">{description}</Typography>}
-      <Grid container spacing={3}>
+      <Grid container spacing={4} className={classes.dashboardContainer}>
         {
           dashboardExtensions.map((extension, index) => {
             let Extension = extension["cards:extensionRender"];


### PR DESCRIPTION
Smaller spacing at the bottom of the pagination controls

To test go to the `.../content.html/Dashboard/PMCC-ACHD` and observe the widgets and pagination spacing.