### PR TITLE
CARDS-1339: Patient users should only be able to access the PROMs ui

### DIFF
--- a/modules/commons/src/main/features/feature-repoinit.txt
+++ b/modules/commons/src/main/features/feature-repoinit.txt
@@ -31,6 +31,6 @@ set ACL for everyone
 end
 
 set properties on /RedirectURL
-  set RedirectURL to "/content.html/Questionnaires/User"
-  set RedirectLabel to "Go to the dashboard"
+  default RedirectURL to "/content.html/Questionnaires/User"
+  default RedirectLabel to "Go to the dashboard"
 end


### PR DESCRIPTION
Bugfix: restarting the app causes the redirect for patients to go back to the dashboard

To test:
- start with `-P cards4proms --permissions trusted`
- create Patient Information and Visit Information forms
- generate a token for the visit
- log in with the token, go to a 404 page, notice the label and the new location on the page
- stop the server
- start it again
- access the 404 page again, make sure the label and location are still pointing to the surveys
- log in as admin, create a new user, make it trusted
- log in with the new trusted user
- access a 404 page, make sure the label and location point to the dashboard