### PR TITLE
CARDS-1605: Create the smtpsproxy Docker container for receiving SMTPS connections from CARDS and relaying them as SMTP connections to the host's localhost:25

### DIFF
--- a/compose-cluster/smtps_localhost_proxy/nginx.conf.template
+++ b/compose-cluster/smtps_localhost_proxy/nginx.conf.template
@@ -27,8 +27,8 @@ events {
 
 stream {
   server {
-    listen 8465 ssl;
-    proxy_pass ${DOCKER_HOST_IP}:25;
+    listen ${DOCKER_HOST_IP}:8465 ssl;
+    proxy_pass 127.0.0.1:25;
 
     ssl_certificate /etc/cert/smtps_certificate.crt;
     ssl_certificate_key /etc/cert/smtps_certificatekey.key;

--- a/compose-cluster/smtps_localhost_proxy/nginx.conf.template
+++ b/compose-cluster/smtps_localhost_proxy/nginx.conf.template
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,30 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
-echo "Removing shard directories"
-rm -r shard*
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
 
-echo "Removing docker-compose.yml"
-rm docker-compose.yml
+events {
+  worker_connections 768;
+  # multi_accept on;
+}
 
-echo "Removing initializer/initialize_all.sh"
-rm initializer/initialize_all.sh
+stream {
+  server {
+    listen 8465 ssl;
+    proxy_pass ${DOCKER_HOST_IP}:25;
 
-echo "Removing mongos/mongo-router.conf"
-rm mongos/mongo-router.conf
-
-echo "Removing proxy/000-default.conf"
-rm proxy/000-default.conf
-
-echo "Removing smtps_localhost_proxy/nginx.conf"
-rm smtps_localhost_proxy/nginx.conf
-
-echo "Removing secrets"
-rm -r secrets
-
-# Due permissions issues, we have to first remove all contents of SLING with Docker
-echo "Removing SLING"
-docker run --rm -v $(realpath ./SLING):/sling -it alpine:3.14 sh -c 'cd /sling; find . -delete'
-rm -rf SLING
-
-echo "Done"
+    ssl_certificate /etc/cert/smtps_certificate.crt;
+    ssl_certificate_key /etc/cert/smtps_certificatekey.key;
+  }
+}

--- a/modules/email-notifications/src/main/features/feature.json
+++ b/modules/email-notifications/src/main/features/feature.json
@@ -21,6 +21,7 @@
   "variables":{
     "emailnotifications.smtps.host":"localhost",
     "emailnotifications.smtps.port":"8465",
+    "emailnotifications.smtps.checkserveridentity": "true",
     "emailnotifications.smtps.from":"envelope-from@localhost",
     "emailnotifications.smtps.username":"username",
     "emailnotifications.smtps.password":"DFMeLL3AOICFmg4+uUoOx16clt6Xe0BMdNSBFqcuKiaVKMqfFudz3KOwM5Gj3t/g",
@@ -102,6 +103,7 @@
       "mail.smtps.from": "${emailnotifications.smtps.from}",
       "mail.smtps.host": "${emailnotifications.smtps.host}",
       "mail.smtps.port": "${emailnotifications.smtps.port}",
+      "mail.smtps.ssl.checkserveridentity": "${emailnotifications.smtps.checkserveridentity}",
       "username": "${emailnotifications.smtps.username}",
       "password": "${emailnotifications.smtps.password}",
       "messageIdProvider.target": "(names=default)"


### PR DESCRIPTION
This PR implements CARDS-1605 by providing the `smtps_localhost_proxy` container for receiving SMTPS connections from CARDS and relaying them to `localhost:25`. In addition, this PR also provides, for the `generate_compose_yaml.py` script, the `--smtps` flag for enabling the SMTPS OSGi module for the CARDS container and the `--smtps_localhost_proxy` flag for enabling the `smtps_localhost_proxy` Docker container and instructing CARDS to use this container as its SMTPS server.

To test:

- Build this branch (`mvn clean install`).
- `cd compose-cluster`
- Generate a self-signed SSL certificate for the `smtps_localhost_proxy` container (`openssl req -x509 -newkey rsa:4096 -keyout SSL_CONFIG/smtps_certificatekey.key -out SSL_CONFIG/smtps_certificate.crt -days 365 -nodes`). Use the value `smtps_localhost_proxy` for the value of `Common Name (eg. server FQDN or YOUR name)`. You may leave all other fields blank.
- `python3 generate_compose_yaml.py --cards_project cards4proms --dev_docker_image --composum --oak_filesystem --smtps --smtps_localhost_proxy --subnet 172.99.0.0/16`
- `docker-compose build`
- `docker-compose up -d`
- In a new terminal run the _Python SMTP debugging server_. We'll need `sudo` as we're binding to a port `< 1024` (`sudo python3 -m smtpd -c DebuggingServer -n 127.0.0.1:25`).
- Open your browser to `http://localhost:8080` and login as `admin`:`admin`.
- Point your browser to `http://localhost:8080/content.emailtest?fromEmail=alice@mail.com&fromName=Alice&toEmail=bob@mail.com&toName=Bob`.
- A test email should be received in the SMTP debugging console.