### PR TITLE
[misc] Bugfix: accessing the Users or Groups administration causes stacktraces to be printed in the logs

### DIFF
--- a/modules/principals/src/main/java/io/uhndata/cards/principals/PrincipalsServlet.java
+++ b/modules/principals/src/main/java/io/uhndata/cards/principals/PrincipalsServlet.java
@@ -132,7 +132,8 @@ public class PrincipalsServlet extends SlingSafeMethodsServlet
         final long offset = getLongValueOrDefault(request.getParameter("offset"), 0);
         Session session = request.getResourceResolver().adaptTo(Session.class);
 
-        try (Writer out = response.getWriter(); JsonGenerator jsonGen = Json.createGenerator(out)) {
+        try (Writer out = response.getWriter()) {
+            JsonGenerator jsonGen = Json.createGenerator(out);
             if (session == null || !(session instanceof JackrabbitSession)) {
                 writeBlankJson(jsonGen);
             } else {


### PR DESCRIPTION
To test:
- log in as admin
- open Administration -> Users, everything should still be in place
- check `.cards-data/logs/error.log`, make sure there's no error about response already being closed