### PR TITLE
[misc] Bugfix: importing Visit Information forms from CSV may cause errors to be logged

### DIFF
--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/VisitChangeListener.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/VisitChangeListener.java
@@ -561,7 +561,7 @@ public class VisitChangeListener implements ResourceChangeListener
                 return;
             }
 
-            final Node surveysCompletedAnswer =
+            Node surveysCompletedAnswer =
                 this.formUtils.getAnswer(visitInformationForm, surveysCompleteQuestion);
             // Check if the value is already the correct one
             if (surveysCompletedAnswer != null
@@ -583,6 +583,12 @@ public class VisitChangeListener implements ResourceChangeListener
                     // Checkout
                     versionManager.checkout(formPath);
 
+                    if (surveysCompletedAnswer == null) {
+                        // No answer node yet, create one
+                        surveysCompletedAnswer =
+                            visitInformationForm.addNode(UUID.randomUUID().toString(), "cards:BooleanAnswer");
+                        surveysCompletedAnswer.setProperty(FormUtils.QUESTION_PROPERTY, surveysCompleteQuestion);
+                    }
                     // Set the new value
                     surveysCompletedAnswer.setProperty("value", newValue);
                     session.save();


### PR DESCRIPTION
To test:
- import Visit Information forms from a CSV that doesn't have the `surveys_complete` column
- create and fill in another data form for the visit
- open the Visit Information form, check that the form now has the "patient completed surveys" answer set to `true`
- check that there's no error in `.cards-data/logs/error.log`