### PR TITLE
CARDS-1629: Create an OSGi module for listing fs.uhn.ca as a valid SAML identity provider

### DIFF
--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -56,6 +56,7 @@
     <module>email-notifications</module>
     <module>token-authentication</module>
     <module>keycloakdemo-saml</module>
+    <module>uhn-saml</module>
     <module>fetch-requires-saml-login</module>
   </modules>
 </project>

--- a/modules/uhn-saml/pom.xml
+++ b/modules/uhn-saml/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.uhndata.cards</groupId>
+    <artifactId>cards-modules</artifactId>
+    <version>0.9-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>cards-uhn-saml-support</artifactId>
+  <packaging>bundle</packaging>
+  <name>CARDS - UHN SAML</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>slingfeature-maven-plugin</artifactId>
+      </plugin>
+
+      <!-- This is an OSGi bundle -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Sling-Initial-Content>SLING-INF/content/;path:=/apps/cards/SAMLDomains/</Sling-Initial-Content>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/modules/uhn-saml/src/main/features/feature.json
+++ b/modules/uhn-saml/src/main/features/feature.json
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+{
+  "bundles":[
+    {
+      "id":"${project.groupId}:${project.artifactId}:${project.version}",
+      "start-order":"25"
+    }
+  ]
+}

--- a/modules/uhn-saml/src/main/resources/SLING-INF/content/uhn.ca.json
+++ b/modules/uhn-saml/src/main/resources/SLING-INF/content/uhn.ca.json
@@ -1,0 +1,4 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "value": "https://fs.uhn.ca/adfs/ls/"
+}

--- a/start_cards.sh
+++ b/start_cards.sh
@@ -242,6 +242,13 @@ do
     ARGS_LENGTH=${ARGS_LENGTH}+1
     ARGS[$ARGS_LENGTH]=mvn:io.uhndata.cards/cards-keycloakdemo-saml-support/${CARDS_VERSION}/slingosgifeature
     ARGS_LENGTH=${ARGS_LENGTH}+1
+  elif [[ ${ARGS[$i]} == '--uhn_ad_fs' ]]
+  then
+    unset ARGS[$i]
+    ARGS[$ARGS_LENGTH]=-f
+    ARGS_LENGTH=${ARGS_LENGTH}+1
+    ARGS[$ARGS_LENGTH]=mvn:io.uhndata.cards/cards-uhn-saml-support/${CARDS_VERSION}/slingosgifeature
+    ARGS_LENGTH=${ARGS_LENGTH}+1
   else
     ARGS[$i]=${ARGS[$i]/VERSION/${CARDS_VERSION}}
   fi


### PR DESCRIPTION
This PR adds `uhn.ca` to the list of SAML identity providers stored in the JCR under `/apps/cards/SAMLDomains/`.

To test:

- Build this branch (`mvn clean install`)
- `./start_cards.sh --dev --saml --uhn_ad_fs`
- Visit `http://localhost:8080`. You should be shown the two-step login process. Enter a `@uhn.ca` email address and you should be redirected to a login page. This login page will display an error but that is okay for the purpose of this test.
- Stop CARDS
- `rm -rf .cards-data`
- `./start_cards.sh --dev --saml`.
- Visit `http://localhost:8080`. You should be shown the single-step login process.