### PR TITLE
CARDS-1628: Sometimes visit forms are also shown under patient in the patient's chart

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -41,7 +41,7 @@ function Forms(props) {
   }, [entry]);
 
   if (entry) {
-    return <Form id={entry[1]} key={location.pathname} contentOffset={props.contentOffset}/>;
+    return <Form id={entry[1]} key={location.pathname} contentOffset={props.contentOffset} key={entry[1]} />;
   }
 
   const columns = [

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
@@ -39,7 +39,7 @@ function Subjects(props) {
   }, [entry]);
 
   if (entry) {
-    return <Subject id={entry} contentOffset={props.contentOffset} />;
+    return <Subject id={entry} contentOffset={props.contentOffset} key={entry} />;
   }
 
   const columns = [


### PR DESCRIPTION
To test:
- start in proms mode
- create new Patient Information and Visit Information forms (for the same patient)
- open the Visit chart
- open the Patient chart by clicking on the breadcrumb for it
- make sure the PI form is shown under the patient, and the VI form is shown under the visit
- open the Visit chart by clicking on it from the chart
- make sure the VI is shown