### PR TITLE
[misc] JS console warning/error fixes

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -721,7 +721,7 @@ export function displayQuestion(entryDefinition, data, key, classes) {
     }
     return (
       isHidden ? null :
-      <Typography variant="body2" className={classes.formPreviewQuestion} key={key}>
+      <Typography variant="body2" component="div" className={classes.formPreviewQuestion} key={key}>
         {questionTitle}
         <span className={classes.formPreviewSeparator}>–</span>
         <div className={classes.formPreviewAnswer}>{content}</div>

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -215,7 +215,7 @@ class SignIn extends React.Component {
                       }
                     />
                   </FormControl>
-                  <Grid container direction="row" justifyContent="center" alignItems="center">
+                  <Grid container direction="row" justify="center" alignItems="center">
                     {  (!this.state.singleStepEntry) &&
                       <Grid item xs={3}>
                       </Grid>


### PR DESCRIPTION
- [x] **Login page - JS Console complains about unsupported prop** `justifyContent`. Replaced it with `justify`, since `justifyContent` belongs to a newer version of Material UI that we're not on yet.
- [x] **Subject chart - JS console complains about a div inside of a p when there's form data displayed**. Replaced the `p` with another `div`.