### PR TITLE
CARDS-1628 - Regression fix

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -41,7 +41,7 @@ function Forms(props) {
   }, [entry]);
 
   if (entry) {
-    return <Form id={entry[1]} key={location.pathname} contentOffset={props.contentOffset} key={entry[1]} />;
+    return <Form id={entry[1]} key={location.pathname} contentOffset={props.contentOffset} />;
   }
 
   const columns = [


### PR DESCRIPTION
Reverting the addition of `key` to the `<Form> `component, since it's not only unrelated to 1628 but it also introduces a regression: switching between form edit and view mode no longer works as expected.