### PR TITLE
CARDS-1549: Periodically delete expired tokens

### DIFF
--- a/modules/token-authentication/pom.xml
+++ b/modules/token-authentication/pom.xml
@@ -115,6 +115,10 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.commons.scheduler</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>osgi.cmpn</artifactId>
     </dependency>

--- a/modules/token-authentication/src/main/java/io/uhndata/cards/auth/token/impl/ExpiredTokensCleanupScheduler.java
+++ b/modules/token-authentication/src/main/java/io/uhndata/cards/auth/token/impl/ExpiredTokensCleanupScheduler.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.auth.token.impl;
+
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.commons.scheduler.ScheduleOptions;
+import org.apache.sling.commons.scheduler.Scheduler;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Component(immediate = true)
+public class ExpiredTokensCleanupScheduler
+{
+    /** Default log. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExpiredTokensCleanupScheduler.class);
+
+    /** Provides access to resources. */
+    @Reference
+    private ResourceResolverFactory resolverFactory;
+
+    /** The scheduler for rescheduling jobs. */
+    @Reference
+    private Scheduler scheduler;
+
+    @Activate
+    protected void activate(final ComponentContext componentContext) throws Exception
+    {
+        final ScheduleOptions cleanupOptions = this.scheduler.EXPR("0 0 0 * * ? *");
+        cleanupOptions.name("ExpiredTokensCleanup");
+        cleanupOptions.onSingleInstanceOnly(true);
+        cleanupOptions.canRunConcurrently(false);
+
+        final Runnable cleanupJob = new ExpiredTokensCleanupTask(this.resolverFactory);
+
+        try {
+            this.scheduler.schedule(cleanupJob, cleanupOptions);
+            LOGGER.info("Scheduled ExpiredTokensCleanupTask");
+        } catch (final Exception e) {
+            LOGGER.error("ExpiredTokensCleanupTask Failed to schedule: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/modules/token-authentication/src/main/java/io/uhndata/cards/auth/token/impl/ExpiredTokensCleanupTask.java
+++ b/modules/token-authentication/src/main/java/io/uhndata/cards/auth/token/impl/ExpiredTokensCleanupTask.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.auth.token.impl;
+
+import java.time.ZonedDateTime;
+import java.util.Iterator;
+
+import javax.jcr.query.Query;
+
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExpiredTokensCleanupTask implements Runnable
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExpiredTokensCleanupTask.class);
+
+    private final ResourceResolverFactory rrf;
+
+    ExpiredTokensCleanupTask(final ResourceResolverFactory rrf)
+    {
+        this.rrf = rrf;
+    }
+
+    @Override
+    public void run()
+    {
+        try (ResourceResolver resolver = this.rrf.getServiceResourceResolver(null)) {
+            final Iterator<Resource> resources = resolver.findResources("SELECT * FROM [cards:Token] WHERE ["
+                + CardsTokenImpl.TOKEN_ATTRIBUTE_EXPIRY + "] < '" + ZonedDateTime.now() + "'", Query.JCR_SQL2);
+            resources.forEachRemaining(token -> {
+                try {
+                    resolver.delete(token);
+                } catch (final PersistenceException e) {
+                    LOGGER.warn("Failed to delete expired token {}: {}", token.getPath(), e.getMessage());
+                }
+            });
+            resolver.commit();
+        } catch (final LoginException e) {
+            LOGGER.warn("Invalid setup, service rights not set up for the expired tokens cleanup task");
+        } catch (final PersistenceException e) {
+            LOGGER.warn("Failed to delete expired tokens: {}", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
To test:
- set the system time to 23:50
- start in proms mode with `--dev` enabled
- create 3 visit information forms, set their visit time to yesterday, tomorrow, the day after tomorrow
- generate a token for each of the visits
- go to `/bin/browser.html/_jcr_system/cards%3Atokens/patient` and check that 3 tokens are present
- wait until 00:01
- refresh the bin/browser, check that 2 tokens are present
- change the system time to 23:58 tomorrow
- wait until 00:01
- refresh the bin/browser, check that only 1 token remains
