### PR TITLE
CARDS-1619: Proms: automatically delete unsubmitted responses once the visit passed

### DIFF
--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/cleanup/UnsubmittedFormsCleanupScheduler.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/cleanup/UnsubmittedFormsCleanupScheduler.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.proms.internal.cleanup;
+
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.commons.scheduler.ScheduleOptions;
+import org.apache.sling.commons.scheduler.Scheduler;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Schedule the cleanup of unsubmitted past forms every midnight.
+ *
+ * @version $Id$
+ * @since 0.9.2
+ */
+@Component(immediate = true)
+public class UnsubmittedFormsCleanupScheduler
+{
+    /** Default log. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(UnsubmittedFormsCleanupScheduler.class);
+
+    private static final String SCHEDULER_JOB_NAME = "UnsubmittedFormsCleanup";
+
+    /** Provides access to resources. */
+    @Reference
+    private ResourceResolverFactory resolverFactory;
+
+    /** The scheduler for rescheduling jobs. */
+    @Reference
+    private Scheduler scheduler;
+
+    @Activate
+    protected void activate(final ComponentContext componentContext) throws Exception
+    {
+        try {
+            // Every night at midnight
+            final ScheduleOptions options = this.scheduler.EXPR("0 0 0 * * ? *");
+            options.name(SCHEDULER_JOB_NAME);
+            options.canRunConcurrently(false);
+
+            final Runnable cleanupJob = new UnsubmittedFormsCleanupTask(this.resolverFactory);
+            this.scheduler.schedule(cleanupJob, options);
+        } catch (final Exception e) {
+            LOGGER.error("UnsubmittedFormsCleanup failed to schedule: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/cleanup/UnsubmittedFormsCleanupTask.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/cleanup/UnsubmittedFormsCleanupTask.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.proms.internal.cleanup;
+
+import java.time.ZonedDateTime;
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.jcr.query.Query;
+
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Periodically remove visit data forms (except the Visit Information itself) belonging to past visits that haven't been
+ * submitted by the patient.
+ *
+ * @version $Id$
+ * @since 0.9.2
+ */
+public class UnsubmittedFormsCleanupTask implements Runnable
+{
+    /** Default log. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(UnsubmittedFormsCleanupTask.class);
+
+    /** Provides access to resources. */
+    private final ResourceResolverFactory resolverFactory;
+
+    /**
+     * @param resolverFactory a valid ResourceResolverFactory providing access to resources
+     */
+    UnsubmittedFormsCleanupTask(final ResourceResolverFactory resolverFactory)
+    {
+        this.resolverFactory = resolverFactory;
+    }
+
+    @Override
+    public void run()
+    {
+        try (ResourceResolver resolver = this.resolverFactory
+            .getServiceResourceResolver(Map.of(ResourceResolverFactory.SUBSERVICE, "VisitFormsPreparation"))) {
+            // Gather the needed UUIDs to place in the query
+            final String visitInformationQuestionnaire =
+                (String) resolver.getResource("/Questionnaires/Visit information").getValueMap().get("jcr:uuid");
+            final String time =
+                (String) resolver.getResource("/Questionnaires/Visit information/time").getValueMap().get("jcr:uuid");
+            final String submitted = (String) resolver
+                .getResource("/Questionnaires/Visit information/surveys_submitted").getValueMap().get("jcr:uuid");
+
+            // Query:
+            final Iterator<Resource> resources = resolver.findResources(String.format(
+                // select the data forms
+                "select distinct dataForm.*"
+                    + "  from [cards:Form] as dataForm"
+                    // belonging to a visit
+                    + "  inner join [cards:Form] as visitInformation on visitInformation.subject = dataForm.subject"
+                    + "    inner join [cards:Answer] as visitDate on isdescendantnode(visitDate, visitInformation)"
+                    + "    inner join [cards:Answer] as submitted on isdescendantnode(submitted, visitInformation)"
+                    + " where"
+                    // link to the correct Visit Information questionnaire
+                    + "  visitInformation.questionnaire = '%1$s'"
+                    // the visit date is in the past
+                    + "  and visitDate.question = '%2$s'"
+                    + "  and visitDate.value < '%4$s'"
+                    // the visit is not submitted
+                    + "  and submitted.question = '%3$s'"
+                    + "  and (submitted.value <> 1 OR submitted.value IS NULL)"
+                    // exclude the Visit Information form itself
+                    + "  and dataForm.questionnaire <> '%1$s'",
+                visitInformationQuestionnaire, time, submitted, ZonedDateTime.now()),
+                Query.JCR_SQL2);
+            resources.forEachRemaining(form -> {
+                try {
+                    resolver.delete(form);
+                } catch (PersistenceException e) {
+                    LOGGER.warn("Failed to delete expired form {}: {}", form.getPath(), e.getMessage());
+                }
+            });
+            resolver.commit();
+        } catch (LoginException e) {
+            LOGGER.warn("Invalid setup, service rights not set up for the expired forms cleanup task");
+        } catch (PersistenceException e) {
+            LOGGER.warn("Failed to delete expired forms: {}", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
To test:
- start in proms mode
- create visits and data for them of various types:
- past and submitted
- past and unsubmitted
- future and submitted
- future and unsubmitted
- some patient information forms as well
- pass midnight
- make sure all and only past unsubmitted data forms have been deleted
- all visit information forms should still be in place, as well as all the patient information forms