### PR TITLE
CARDS-1641: Make the PROM Vault login process configurable

### DIFF
--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportConfigDefinition.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportConfigDefinition.java
@@ -42,6 +42,9 @@ public @interface ImportConfigDefinition
     /** Cron-readable import schedule. */
     String NIGHTLY_IMPORT_SCHEDULE = "0 0 0 * * ? *";
 
+    /** Vault role to login to. */
+    String VAULT_ROLE = "prom_role";
+
     @AttributeDefinition(name = "Name", description = "Configuration name")
     String name();
 
@@ -68,4 +71,9 @@ public @interface ImportConfigDefinition
     @AttributeDefinition(name = "Provider names",
         description = "List of names of providers to query. If empty, all providers will be fetched.", required = false)
     String[] provider_names();
+
+    @AttributeDefinition(name = "Vault role name",
+        description = "Name of the role to login to Vault with. If not given, skip the Vault login process.",
+        required = false)
+    String vault_role();
 }

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportEndpoint.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportEndpoint.java
@@ -75,7 +75,8 @@ public class ImportEndpoint extends SlingSafeMethodsServlet
 
         // Load configuration from environment variables
         final Runnable importJob = new ImportTask(this.resolverFactory, config.auth_url(), config.endpoint_url(),
-            config.days_to_query(), config.vault_token(), config.clinic_names(), config.provider_names());
+            config.days_to_query(), config.vault_token(), config.clinic_names(), config.provider_names(),
+            config.vault_role());
         final Thread thread = new Thread(importJob);
         thread.start();
         writeSuccess(response);

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportTask.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportTask.java
@@ -101,34 +101,11 @@ public class ImportTask implements Runnable
     @Override
     public void run()
     {
-        final String token = loginWithJWT();
+        final String token = "Bearer " + this.vaultToken;
         // Iterate over every clinic name
         for (int i = 0; i < this.clinicNames.length; i++) {
             getUpcomingAppointments(token, this.daysToQuery, this.clinicNames[i]);
         }
-    }
-
-    /**
-     * Obtain an authentication token for use in querying the Torch server. Currently, this sends a JWT Login request to
-     * Vault, which authorizes our JWT token to query the server. This should be called before performing
-     * {@code getUpcomingAppointments}.
-     *
-     * @return an authentication token to be passed onto as a header, typically begins with "Bearer " or an empty string
-     *         if no token could be obtained.
-     */
-    private String loginWithJWT()
-    {
-        String token = "";
-        final String postRequest = "{ \"role\": \"prom_role\", \"jwt\":\"" + this.vaultToken + "\" }";
-
-        try {
-            getPostResponse(this.authURL, postRequest);
-            token = "Bearer " + this.vaultToken;
-        } catch (final Exception e) {
-            LOGGER.error("Failed to activate authentication token: {}", e.getMessage(), e);
-        }
-
-        return token;
     }
 
     /**

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/NightlyImport.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/NightlyImport.java
@@ -73,7 +73,8 @@ public class NightlyImport
                 newConfig.getConfig().days_to_query(),
                 newConfig.getConfig().vault_token(),
                 newConfig.getConfig().clinic_names(),
-                newConfig.getConfig().provider_names());
+                newConfig.getConfig().provider_names(),
+                newConfig.getConfig().vault_role());
         try {
             if (importJob != null) {
                 this.scheduler.schedule(importJob, options);


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/CARDS-1641)

This PR adds the Vault role name as a configuration option, to enable/disable/configure it while live. If not given, the vault authentication step is skipped (and it uses the Vault JWT token without performing the login step).

![image](https://user-images.githubusercontent.com/4656440/154106231-a46ea0a2-f0ce-4be7-a37a-4720127bfad3.png)

I also attempted to add some logging when a POST request fails, but could not test it.