### PR TITLE
CARDS-1634: The change password menu item should not be present for users who have logged in with SAML authentication

### DIFF
--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/AdminNavbarLinks.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/AdminNavbarLinks.jsx
@@ -55,7 +55,7 @@ function HeaderLinks (props) {
     if (username && username.length > 0) {
       fetchWithReLogin(globalLoginDisplay, `/system/userManager/user/${username}.json`)
         .then((response) => response.ok ? response.json() : Promise.reject(response))
-        .then((json) => setRemote(json["rep:externalId"] && json["rep:externalId"].length > 0))
+        .then((json) => setRemote((json["rep:externalId"] && json["rep:externalId"].length > 0) || (json["path"] && json["path"].startsWith("/home/users/saml/"))))
         .catch((error) => console.log(error));
     }
   }, [username]);


### PR DESCRIPTION
This PR implements CARDS-1634 by considering all users whose _path_ starts with `/home/users/saml/` as _remote users_ and thus not displaying the _Change Password_ drop-down menu item.

To test:

- Build this `CARDS-1634` branch (`mvn clean install`).
- Follow the instructions in `Utilities/Administration/SAML/SAML_SETUP.md` to setup SAML user authentication with a local Keycloak Docker container.
- Login as `admin`. The _Change Password_ drop-down menu item should be present.
- Login as `myuser@keycloakdemo`. The _Change Password_ drop-down menu item should _NOT_ be present.


Now test that this still works for LDAP:

- Build the `CARDS-1634_ldap_test` branch (`mvn clean install`)
- `cd deployment-configurations`
- `./cards_ldap_test.sh`
- After the `cards_ldap_test.sh` script completes, visit `http://localhost:8080`.
- Login as `admin`. The _Change Password_ drop-down menu item should be present.
- Login as `test`:`secret`. The _Change Password_ drop-down menu item should _NOT_ be present.

Clean up with the following commands:

- `cd compose-cluster`
- `docker-compose down`
- `docker-compose rm`
- `docker volume prune -f`
- `./cleanup.sh`
- `rm ldap_args`