### PR TITLE
CARDS-1459: Rework form pagination to prevent rendering non-active pages instead of rendering and hiding them

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -97,7 +97,8 @@ function Form (props) {
   let [ errorMessage, setErrorMessage ] = useState("");
   let [ errorDialogDisplayed, setErrorDialogDisplayed ] = useState(false);
   let [ pages, setPages ] = useState(null);
-  let [ paginationEnabled, setPaginationEnabled ] = useState(false);
+  // To prevent the entire form from rendering itself for the first frame, assume pagination until told otherwise
+  let [ paginationEnabled, setPaginationEnabled ] = useState(true);
   let [ removeWindowHandlers, setRemoveWindowHandlers ] = useState();
   let [ actionsMenu, setActionsMenu ] = useState(null);
   let [ formContentOffsetTop, setFormContentOffsetTop ] = useState(contentOffset);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -145,22 +145,8 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onCha
     .filter(([key, value]) => value["sling:resourceType"] == "cards/AnswerSection"
       && value["section"]["jcr:uuid"] === sectionDefinition["jcr:uuid"]);
 
-  // We want to render nothing if the page is not active
-  // However, certain upstream components might need to know if the section is eligible to be visible
-  // So, we determine its visibility here
-  if (visibleCallback) {
-    const formContext = useFormReaderContext();
-    visibleCallback(
-      ConditionalComponentManager.evaluateCondition(
-        sectionDefinition,
-        formContext
-      )
-    );
-  }
-
   return (
-    <>
-      {<Section
+    <Section
         key={key}
         depth={depth}
         sectionDefinition={sectionDefinition}
@@ -173,9 +159,7 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onCha
         instanceId={instanceId || ''}
         contentOffset={contentOffset}
         />
-      }
-    </>
-  );
+    );
 }
 
 let displayInformation = (infoDefinition, key, classes, pageActive, isEdit) => {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -24,8 +24,6 @@ import { useLocation } from 'react-router-dom';
 import { Card, CardContent, Grid } from "@material-ui/core";
 
 import AnswerComponentManager from "./AnswerComponentManager";
-import ConditionalComponentManager from "./ConditionalComponentManager";
-import { useFormReaderContext } from "./FormContext";
 import Section from "./Section";
 
 // FIXME In order for the questions to be registered, they need to be loaded, and the only way to do that at the moment is to explicitly invoke them here. Find a way to automatically load all question types, possibly using self-declaration in a node, like the assets, or even by filtering through assets.
@@ -135,7 +133,7 @@ let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, o
  * @param {string} key the node name of the section definition JCR node
  * @returns a React component that renders the section
  */
-let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onChange, visibleCallback, pageActive, isEdit, isSummary, instanceId, contentOffset, ) => {
+let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onChange, visibleCallback, pageActive, isEdit, isSummary, instanceId, contentOffset) => {
   if (isSummary && sectionDefinition.displayMode !== "summary") {
     return null;
   }
@@ -147,19 +145,20 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onCha
 
   return (
     <Section
-        key={key}
-        depth={depth}
-        sectionDefinition={sectionDefinition}
-        existingAnswer={existingQuestionAnswer}
-        path={path}
-        onChange={onChange}
-        pageActive={pageActive}
-        isEdit={isEdit}
-        isSummary={isSummary}
-        instanceId={instanceId || ''}
-        contentOffset={contentOffset}
-        />
-    );
+      key={key}
+      depth={depth}
+      sectionDefinition={sectionDefinition}
+      existingAnswer={existingQuestionAnswer}
+      path={path}
+      onChange={onChange}
+      visibleCallback={visibleCallback}
+      pageActive={pageActive}
+      isEdit={isEdit}
+      isSummary={isSummary}
+      instanceId={instanceId || ''}
+      contentOffset={contentOffset}
+      />
+  );
 }
 
 let displayInformation = (infoDefinition, key, classes, pageActive, isEdit) => {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -160,7 +160,7 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onCha
 
   return (
     <>
-      {pageActive && <Section
+      {<Section
         key={key}
         depth={depth}
         sectionDefinition={sectionDefinition}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -167,7 +167,6 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onCha
         existingAnswer={existingQuestionAnswer}
         path={path}
         onChange={onChange}
-        visibleCallback={visibleCallback}
         pageActive={pageActive}
         isEdit={isEdit}
         isSummary={isSummary}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -145,7 +145,7 @@ function FormPagination (props) {
 
   if (saveInProgress && pendingSubmission) {
     setPendingSubmission(false);
-    if (activePage === lastValidPage()) {
+    if (activePage === lastValidPage() && direction === "next") {
       setSavedLastPage(true);
       onDone && onDone();
     } else {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -54,6 +54,7 @@ function FormPagination (props) {
   let [ pendingSubmission, setPendingSubmission ] = useState(false);
   let [ pages, setPages ] = useState([]);
   let [ activePage, setActivePage ] = useState(0);
+  let [ direction, setDirection ] = useState("next");
 
   let previousEntryType;
   let questionIndex = 0;
@@ -110,25 +111,26 @@ function FormPagination (props) {
 
   let handleNext = () => {
     setPendingSubmission(true);
+    setDirection("next");
   }
 
   let handleBack = () => {
     setPendingSubmission(true);
-    if (activePage > 0) {
-      handlePageChange("back");
-    }
+    setDirection("back");
+    console.log("Going back");
   }
 
-  let handlePageChange = (direction) => {
+  let handlePageChange = () => {
     let change = (direction === "next" ? 1 : -1);
     let nextPage = activePage;
-    while ((change === 1 || nextPage > 0) && (change === -1 || nextPage < lastValidPage())) {
+    while ((change === 1 || nextPage >= 0) && (change === -1 || nextPage < lastValidPage())) {
       nextPage += change;
       if (pages[nextPage].canBeVisible) break;
     }
     if (nextPage !== activePage) {
       window.scrollTo(0, 0);
     }
+    console.log("Switch to " + nextPage);
     setActivePage(nextPage);
   }
 
@@ -139,7 +141,7 @@ function FormPagination (props) {
       onDone && onDone();
     } else {
       setSavedLastPage(false);
-      handlePageChange("next");
+      handlePageChange();
     }
   }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -126,7 +126,12 @@ function FormPagination (props) {
       setDirection(changeDirection);
     } else {
       // If saving is not enabled, we can call handlePageChange directly
+      // And call the onDone() if we're on the last page
       handlePageChange(changeDirection);
+      if (activePage === lastValidPage() && changeDirection === "next") {
+        setSavedLastPage(true);
+        onDone && onDone();
+      }
     }
   }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -54,7 +54,9 @@ function FormPagination (props) {
   let [ pendingSubmission, setPendingSubmission ] = useState(false);
   let [ pages, setPages ] = useState([]);
   let [ activePage, setActivePage ] = useState(0);
-  let [ direction, setDirection ] = useState("next");
+  let [ direction, setDirection ] = useState();
+
+  const DIRECTION_NEXT = 1, DIRECTION_PREV = -1;
 
   let previousEntryType;
   let questionIndex = 0;
@@ -110,11 +112,11 @@ function FormPagination (props) {
   }
 
   let handleNext = () => {
-    initChangePage("next");
+    initChangePage(DIRECTION_NEXT);
   }
 
   let handleBack = () => {
-    initChangePage("back");
+    initChangePage(DIRECTION_PREV);
   }
 
   // Change the page in the given direction
@@ -128,7 +130,7 @@ function FormPagination (props) {
       // If saving is not enabled, we can call handlePageChange directly
       // And call the onDone() if we're on the last page
       handlePageChange(changeDirection);
-      if (activePage === lastValidPage() && changeDirection === "next") {
+      if (activePage === lastValidPage() && changeDirection === DIRECTION_NEXT) {
         setSavedLastPage(true);
         onDone && onDone();
       }
@@ -136,9 +138,9 @@ function FormPagination (props) {
   }
 
   let handlePageChange = (overrideDirection) => {
-    let change = ((overrideDirection || direction) === "next" ? 1 : -1);
+    let change = (overrideDirection || direction);
     let nextPage = activePage;
-    while ((change === 1 || nextPage >= 0) && (change === -1 || nextPage < lastValidPage())) {
+    while ((change === DIRECTION_NEXT || nextPage >= 0) && (change === DIRECTION_PREV || nextPage < lastValidPage())) {
       nextPage += change;
       if (pages[nextPage].canBeVisible) break;
     }
@@ -150,7 +152,7 @@ function FormPagination (props) {
 
   if (saveInProgress && pendingSubmission) {
     setPendingSubmission(false);
-    if (activePage === lastValidPage() && direction === "next") {
+    if (activePage === lastValidPage() && direction === DIRECTION_NEXT) {
       setSavedLastPage(true);
       onDone && onDone();
     } else {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -110,18 +110,28 @@ function FormPagination (props) {
   }
 
   let handleNext = () => {
-    setPendingSubmission(true);
-    setDirection("next");
+    initChangePage("next");
   }
 
   let handleBack = () => {
-    setPendingSubmission(true);
-    setDirection("back");
-    console.log("Going back");
+    initChangePage("back");
   }
 
-  let handlePageChange = () => {
-    let change = (direction === "next" ? 1 : -1);
+  // Change the page in the given direction
+  let initChangePage = (changeDirection) => {
+    if (enableSave) {
+      // If we must save the page before going, we make sure to not call handlePageChange
+      // until the submission process is complete.
+      setPendingSubmission(true);
+      setDirection(changeDirection);
+    } else {
+      // If saving is not enabled, we can call handlePageChange directly
+      handlePageChange(changeDirection);
+    }
+  }
+
+  let handlePageChange = (overrideDirection) => {
+    let change = ((overrideDirection || direction) === "next" ? 1 : -1);
     let nextPage = activePage;
     while ((change === 1 || nextPage >= 0) && (change === -1 || nextPage < lastValidPage())) {
       nextPage += change;
@@ -130,7 +140,6 @@ function FormPagination (props) {
     if (nextPage !== activePage) {
       window.scrollTo(0, 0);
     }
-    console.log("Switch to " + nextPage);
     setActivePage(nextPage);
   }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -110,13 +110,6 @@ function FormPagination (props) {
 
   let handleNext = () => {
     setPendingSubmission(true);
-    if (activePage === lastValidPage()) {
-      setSavedLastPage(true);
-      onDone && onDone();
-    } else {
-      setSavedLastPage(false);
-      handlePageChange("next");
-    }
   }
 
   let handleBack = () => {
@@ -124,10 +117,6 @@ function FormPagination (props) {
     if (activePage > 0) {
       handlePageChange("back");
     }
-  }
-
-  if (saveInProgress && pendingSubmission) {
-    setPendingSubmission(false);
   }
 
   let handlePageChange = (direction) => {
@@ -141,6 +130,17 @@ function FormPagination (props) {
       window.scrollTo(0, 0);
     }
     setActivePage(nextPage);
+  }
+
+  if (saveInProgress && pendingSubmission) {
+    setPendingSubmission(false);
+    if (activePage === lastValidPage()) {
+      setSavedLastPage(true);
+      onDone && onDone();
+    } else {
+      setSavedLastPage(false);
+      handlePageChange("next");
+    }
   }
 
   let saveButton =

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -64,7 +64,7 @@ function createTitle(label, idx, isRecurrent) {
  * @param {Object} sectionDefinition the section definition JSON
  */
 function Section(props) {
-  const { classes, depth, existingAnswer, path, sectionDefinition, onChange, pageActive, isEdit, isSummary, instanceId, contentOffset } = props;
+  const { classes, depth, existingAnswer, path, sectionDefinition, onChange, visibleCallback, pageActive, isEdit, isSummary, instanceId, contentOffset } = props;
   const isRecurrent = sectionDefinition['recurrent'];
   const { displayMode } = sectionDefinition;
   const [ focus, setFocus ] = useState(false);
@@ -132,6 +132,8 @@ function Section(props) {
   // Do not display summary questions outside of summary mode, or regular questions in summary mode.
   const isDisplayed = (isEdit && conditionIsMet || !isEdit && (hasAnswers || isFlagged))
     && (isSummary && "summary" === displayMode || !isSummary && displayMode !== "summary");
+
+  if (visibleCallback) visibleCallback(conditionIsMet);
 
   let closeDialog = () => {
     setSelectedUUID(undefined);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -172,7 +172,7 @@ function Section(props) {
   // mountOnEnter and unmountOnExit force the inputs and children to be outside of the DOM during form submission
   // if it is not currently visible
   return useCallback(
-  <React.Fragment>
+  pageActive && <React.Fragment>
     {/* if conditional is true, the collapse component is rendered and displayed.
         else, the corresponding input tag to the conditional section is deleted  */}
     { isDisplayed

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { Button, Collapse, Dialog, DialogActions, DialogTitle, Grid, IconButton, Tooltip, Typography, withStyles } from "@material-ui/core";
 import Add from "@material-ui/icons/Add";
@@ -98,6 +98,14 @@ function Section(props) {
   const [ selectedUUID, setSelectedUUID ] = useState();
   const [ uuid ] = useState(uuidv4());  // To keep our IDs separate from any other sections
   const [ removableAnswers, setRemovableAnswers ] = useState({[ID_STATE_KEY]: 1});
+  const [ cached, setCached ] = useState(pageActive);
+
+  // We want to cache this section (i.e. keep it in DOM but do not render it) if we were ever the active page in the past
+  useEffect(() => {
+    if (!cached && pageActive) {
+      setCached(true);
+    }
+  }, [pageActive]);
 
   // Determine if we have any conditionals in our definition that would cause us to be hidden
   const conditionIsMet = ConditionalComponentManager.evaluateCondition(
@@ -172,7 +180,7 @@ function Section(props) {
   // mountOnEnter and unmountOnExit force the inputs and children to be outside of the DOM during form submission
   // if it is not currently visible
   return useCallback(
-  pageActive && <React.Fragment>
+  (pageActive || cached) && <React.Fragment>
     {/* if conditional is true, the collapse component is rendered and displayed.
         else, the corresponding input tag to the conditional section is deleted  */}
     { isDisplayed

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -64,7 +64,7 @@ function createTitle(label, idx, isRecurrent) {
  * @param {Object} sectionDefinition the section definition JSON
  */
 function Section(props) {
-  const { classes, depth, existingAnswer, path, sectionDefinition, onChange, visibleCallback, pageActive, isEdit, isSummary, instanceId, contentOffset } = props;
+  const { classes, depth, existingAnswer, path, sectionDefinition, onChange, pageActive, isEdit, isSummary, instanceId, contentOffset } = props;
   const isRecurrent = sectionDefinition['recurrent'];
   const { displayMode } = sectionDefinition;
   const [ focus, setFocus ] = useState(false);
@@ -124,8 +124,6 @@ function Section(props) {
   // Do not display summary questions outside of summary mode, or regular questions in summary mode.
   const isDisplayed = (isEdit && conditionIsMet || !isEdit && (hasAnswers || isFlagged))
     && (isSummary && "summary" === displayMode || !isSummary && displayMode !== "summary");
-
-  if (visibleCallback) visibleCallback(conditionIsMet);
 
   let closeDialog = () => {
     setSelectedUUID(undefined);


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/CARDS-1459)

This change removes non-active pages from the DOM. This includes both pages not seen and pages removed via their conditions no longer being active, but pages of a paginated form that have been written to this session will need to remain in the DOM (although they will be invisible).

Example DOM in `dev`, in Smoking Cessation, as viewed through Google Chrome's Inspector:
![image](https://user-images.githubusercontent.com/4656440/154579473-bf755580-68c7-4429-8fa7-57d72c309a50.png)

Example DOM after this branch:
![image](https://user-images.githubusercontent.com/4656440/154578941-c6f712c5-5a6e-4d4b-b068-c7f6e13827ba.png)

**To test**: Both unpaginated forms and paginated forms will need to be tested, in both preview and edit mode. Smoking Cessation is nice due to its conditional forms. The functionality of the paginated forms should be identical to `dev`, except for the DOM as viewed in the screenshots above (this is a speedup update, as those hidden `divs` were causing slowdowns on exceptionally large `Questionnaires`