### PR TITLE
CARDS-1651: The SAMLRequest URL parameter should not be present in the address bar at the /login page

### DIFF
--- a/Utilities/Development/keycloak_headermod_http_proxy.js
+++ b/Utilities/Development/keycloak_headermod_http_proxy.js
@@ -37,13 +37,17 @@ server.on('request', (s_req, s_res) => {
 		method: s_req.method,
 		headers: s_req.headers
 	};
-  var client_req = http.request(client_opts, (c_res) => {
+	if (client_opts.path == "/goto_saml_login") {
+		client_opts.path = "/";
+	}
+	var client_req = http.request(client_opts, (c_res) => {
 		let newHeaders = c_res.headers;
 		if (c_res.statusCode == 302 &&
 			newHeaders.location &&
 			newHeaders.location.startsWith(KEYCLOAK_ENDPOINT + "?SAMLRequest=")
-			&& s_req.url !== "/fetch_requires_saml_login.html") {
-			newHeaders.location = newHeaders.location.replace(KEYCLOAK_ENDPOINT, "http://localhost:" + SERVER_PORT + "/login");
+			&& s_req.url !== "/fetch_requires_saml_login.html"
+			&& s_req.url !== "/goto_saml_login") {
+			newHeaders.location = "http://localhost:" + SERVER_PORT + "/login";
 		} else if (c_res.statusCode == 302 &&
 			(s_req.url === "/system/sling/logout" || s_req.url === "/system/console/logout")) {
 			newHeaders['Set-Cookie'] = "sling.formauth=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; HttpOnly";

--- a/compose-cluster/proxy/http_saml_000-default.conf
+++ b/compose-cluster/proxy/http_saml_000-default.conf
@@ -21,7 +21,12 @@
 	ProxyPreserveHost On
 
 	<Location "/">
-		Header edit Location ${SAML_IDP_DESTINATION} http://${CARDS_HOST_AND_PORT}/login "expr=(%{REQUEST_STATUS} == 302) && (%{REQUEST_URI} != '/fetch_requires_saml_login.html')"
+		Header edit Location ${SAML_IDP_DESTINATION}.* http://${CARDS_HOST_AND_PORT}/login "expr=(%{REQUEST_STATUS} == 302) && (%{REQUEST_URI} != '/fetch_requires_saml_login.html') && (%{REQUEST_URI} != '/goto_saml_login')"
+		ProxyPass http://cardsinitial:8080/
+		ProxyPassReverse http://cardsinitial:8080/
+	</Location>
+
+	<Location "/goto_saml_login">
 		ProxyPass http://cardsinitial:8080/
 		ProxyPassReverse http://cardsinitial:8080/
 	</Location>

--- a/compose-cluster/proxy/https_saml_000-default.conf
+++ b/compose-cluster/proxy/https_saml_000-default.conf
@@ -31,7 +31,12 @@
 	ProxyPreserveHost On
 
 	<Location "/">
-		Header edit Location ${SAML_IDP_DESTINATION} https://${CARDS_HOST_AND_PORT}/login "expr=(%{REQUEST_STATUS} == 302) && (%{REQUEST_URI} != '/fetch_requires_saml_login.html')"
+		Header edit Location ${SAML_IDP_DESTINATION}.* https://${CARDS_HOST_AND_PORT}/login "expr=(%{REQUEST_STATUS} == 302) && (%{REQUEST_URI} != '/fetch_requires_saml_login.html') && (%{REQUEST_URI} != '/goto_saml_login')"
+		ProxyPass http://cardsinitial:8080/
+		ProxyPassReverse http://cardsinitial:8080/
+	</Location>
+
+	<Location "/goto_saml_login">
 		ProxyPass http://cardsinitial:8080/
 		ProxyPassReverse http://cardsinitial:8080/
 	</Location>

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -128,6 +128,9 @@ class SignIn extends React.Component {
           }
         })
         .then((data) => {
+          if (!data) {
+            return;
+          }
           if (window.location.pathname === "/login" || window.location.pathname === "/login/") {
             // We are logging in at a main login screen
             window.location = window.location.origin + "/goto_saml_login";

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -130,7 +130,7 @@ class SignIn extends React.Component {
         .then((data) => {
           if (window.location.pathname === "/login" || window.location.pathname === "/login/") {
             // We are logging in at a main login screen
-            window.location = data.value + window.location.search;
+            window.location = window.location.origin + "/goto_saml_login";
           } else {
             // We are logging in from a fetchWithReLogin() window
             let popupWidth = 600;


### PR DESCRIPTION
This PR implements CARDS-1651 by making the SAML request by using the new `/goto_saml_login` endpoint upon user login.

To test:

- For the non-Docker (development) tests, follow the instructions at https://github.com/data-team-uhn/cards/pull/815#issue-1043998342 and ensure that the test passes.

- For the Docker (production) tests, follow the instructions at https://github.com/data-team-uhn/cards/pull/815#issuecomment-971914228 and ensure that both the _HTTP+SAML_ and _HTTPS+SAML_ tests pass.
