### PR TITLE
Revert CARDS-1459: Rework form pagination to prevent rendering non-active pages

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -97,8 +97,7 @@ function Form (props) {
   let [ errorMessage, setErrorMessage ] = useState("");
   let [ errorDialogDisplayed, setErrorDialogDisplayed ] = useState(false);
   let [ pages, setPages ] = useState(null);
-  // To prevent the entire form from rendering itself for the first frame, assume pagination until told otherwise
-  let [ paginationEnabled, setPaginationEnabled ] = useState(true);
+  let [ paginationEnabled, setPaginationEnabled ] = useState(false);
   let [ removeWindowHandlers, setRemoveWindowHandlers ] = useState();
   let [ actionsMenu, setActionsMenu ] = useState(null);
   let [ formContentOffsetTop, setFormContentOffsetTop ] = useState(contentOffset);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -54,9 +54,6 @@ function FormPagination (props) {
   let [ pendingSubmission, setPendingSubmission ] = useState(false);
   let [ pages, setPages ] = useState([]);
   let [ activePage, setActivePage ] = useState(0);
-  let [ direction, setDirection ] = useState();
-
-  const DIRECTION_NEXT = 1, DIRECTION_PREV = -1;
 
   let previousEntryType;
   let questionIndex = 0;
@@ -112,35 +109,31 @@ function FormPagination (props) {
   }
 
   let handleNext = () => {
-    initChangePage(DIRECTION_NEXT);
-  }
-
-  let handleBack = () => {
-    initChangePage(DIRECTION_PREV);
-  }
-
-  // Change the page in the given direction
-  let initChangePage = (changeDirection) => {
-    if (enableSave) {
-      // If we must save the page before going, we make sure to not call handlePageChange
-      // until the submission process is complete.
-      setPendingSubmission(true);
-      setDirection(changeDirection);
+    setPendingSubmission(true);
+    if (activePage === lastValidPage()) {
+      setSavedLastPage(true);
+      onDone && onDone();
     } else {
-      // If saving is not enabled, we can call handlePageChange directly
-      // And call the onDone() if we're on the last page
-      handlePageChange(changeDirection);
-      if (activePage === lastValidPage() && changeDirection === DIRECTION_NEXT) {
-        setSavedLastPage(true);
-        onDone && onDone();
-      }
+      setSavedLastPage(false);
+      handlePageChange("next");
     }
   }
 
-  let handlePageChange = (overrideDirection) => {
-    let change = (overrideDirection || direction);
+  let handleBack = () => {
+    setPendingSubmission(true);
+    if (activePage > 0) {
+      handlePageChange("back");
+    }
+  }
+
+  if (saveInProgress && pendingSubmission) {
+    setPendingSubmission(false);
+  }
+
+  let handlePageChange = (direction) => {
+    let change = (direction === "next" ? 1 : -1);
     let nextPage = activePage;
-    while ((change === DIRECTION_NEXT || nextPage >= 0) && (change === DIRECTION_PREV || nextPage < lastValidPage())) {
+    while ((change === 1 || nextPage > 0) && (change === -1 || nextPage < lastValidPage())) {
       nextPage += change;
       if (pages[nextPage].canBeVisible) break;
     }
@@ -148,17 +141,6 @@ function FormPagination (props) {
       window.scrollTo(0, 0);
     }
     setActivePage(nextPage);
-  }
-
-  if (saveInProgress && pendingSubmission) {
-    setPendingSubmission(false);
-    if (activePage === lastValidPage() && direction === DIRECTION_NEXT) {
-      setSavedLastPage(true);
-      onDone && onDone();
-    } else {
-      setSavedLastPage(false);
-      handlePageChange();
-    }
   }
 
   let saveButton =

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useState } from "react";
 import PropTypes from "prop-types";
 import { Button, Collapse, Dialog, DialogActions, DialogTitle, Grid, IconButton, Tooltip, Typography, withStyles } from "@material-ui/core";
 import Add from "@material-ui/icons/Add";
@@ -98,14 +98,6 @@ function Section(props) {
   const [ selectedUUID, setSelectedUUID ] = useState();
   const [ uuid ] = useState(uuidv4());  // To keep our IDs separate from any other sections
   const [ removableAnswers, setRemovableAnswers ] = useState({[ID_STATE_KEY]: 1});
-  const [ cached, setCached ] = useState(pageActive);
-
-  // We want to cache this section (i.e. keep it in DOM but do not render it) if we were ever the active page in the past
-  useEffect(() => {
-    if (!cached && pageActive) {
-      setCached(true);
-    }
-  }, [pageActive]);
 
   // Determine if we have any conditionals in our definition that would cause us to be hidden
   const conditionIsMet = ConditionalComponentManager.evaluateCondition(
@@ -182,7 +174,7 @@ function Section(props) {
   // mountOnEnter and unmountOnExit force the inputs and children to be outside of the DOM during form submission
   // if it is not currently visible
   return useCallback(
-  (pageActive || cached) && <React.Fragment>
+  <React.Fragment>
     {/* if conditional is true, the collapse component is rendered and displayed.
         else, the corresponding input tag to the conditional section is deleted  */}
     { isDisplayed


### PR DESCRIPTION
This reverts all commits from the CARDS-1459_new2 branch, until the encountered errors are fixed (the new method of [hiding answers instead of sections] won't need any of the commits from this branch anyway)