### PR TITLE
CARDS-1653: PROMs: email not imported (bugfix)

### DIFF
--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/PatientLocalStorage.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/PatientLocalStorage.java
@@ -430,8 +430,8 @@ public class PatientLocalStorage
             "last_name", obj -> obj.getJsonObject("name").getString("family"),
             "date_of_birth@cards:DateAnswer", obj -> toCalendar(obj.getString("dob"), "yyyy-MM-dd"),
             "email", obj -> obj.getJsonObject("com").getJsonObject("email").values().stream()
-                .filter(e -> e != null && e != JsonValue.NULL)
-                .map(Object::toString)
+                .filter(e -> e != null && e != JsonValue.NULL && (e.getValueType() == JsonValue.ValueType.STRING))
+                .map(e -> ((JsonString) e).getString())
                 .findFirst().orElse(""),
             "email_ok@cards:BooleanAnswer", obj -> BooleanUtils.toInteger(obj.getBoolean("emailOk", false), 1, 0, -1),
             "fhir_id", obj -> obj.getString(PatientLocalStorage.FHIR_FIELD));


### PR DESCRIPTION
This PR fixes a bug where email addresses would be imported encapsulated with quotes (eg. `"user@mail.com"` instead of `user@mail.com`).

To reproduce the original bug:

- Build the `email-import-quotes_bug-demo` branch
- Start CARDS with the `cards4proms` project enabled (`SLING_COMMONS_CRYPTO_PASSWORD=password ./start_cards.sh --project cards4proms --dev`)
- Edit the `Utilities/Development/mock_torch.js` file and change the line `time: '2022-02-20T10:00:00'` so that it points to a day that is 3 days from now. For example, if today is _2022-02-22_, set it to `time: '2022-02-25T10:00:00'`.
- Start the `mock_torch.js` server (`cd Utilities/Development`, `nodejs mock_torch.js`)
- Point the browser to `http://localhost:8080` and login as `admin`:`admin`
- Visit `http://localhost:8080/system/console/configMgr` and create a new _PROMs import_ configuration (this should be towards the bottom of the page) with the following settings:
  - _Name_: `LocalNodeJS`
  - _Import schedule_: `0 0 0 * * ? *`
  - _days to query_: `3`
  - _Endpoint URL_: `http://localhost:8011`
  - _Authentication URL_: LEAVE THIS BLANK
  - _Vault token_: LEAVE THIS BLANK
  - _Clinic names_: `6012-HC-Congenital Cardiac`
  - _Provider names_: LEAVE THIS BLANK
  - _Vault role name_: LEAVE THIS BLANK
- Trigger an import by visiting `http://localhost:8080/Subjects.importTorch?config=LocalNodeJS`
- Go to the Dashboard and open the `12345: Patient information` Questionnaire
- Observe that the email address is in quotes (`"alice.bob@mail.com"` instead of `alice.bob@mail.com`)

To test the fix:

- Build the `CARDS-1653_email-quotes-fix_test` branch
- Repeat the above steps for reproducing the original bug using the `CARDS-1653_email-quotes-fix_test` build
- The imported email address should _not_ be encapsulated in quotes (`alice.bob@mail.com` and _not_ `"alice.bob@mail.com"`)