### PR TITLE
[misc] Remove unused & deprecated dependency that was pulling in an old log4j jar during the build

### DIFF
--- a/modules/token-authentication/pom.xml
+++ b/modules/token-authentication/pom.xml
@@ -100,12 +100,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>
-      <artifactId>org.apache.sling.jcr.jackrabbit.server</artifactId>
-      <version>2.0.6</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.api</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
To test:
- `rm -rf ~/.m2/repository/log4j/log4j`
- build
- start in proms mode
- create a new Visit subject, a new Patient Information with DoB and MRN
- generate a token
- log in with the token as a patient, expect no errors up until this point
- check that there is no jar in `~/.m2/repository/log4j/log4j` (but it's OK to have a `*.pom` file in there)