### PR TITLE
CARDS-1459: Rework form pagination to prevent rendering non-active pages

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -35,7 +35,7 @@ export const IS_DEFAULT_ANSWER_POS = 4;
 // Holds answers and automatically generates hidden inputs
 // for form submission
 function Answer (props) {
-  let { answers, answerMetadata, answerNodeType, existingAnswer, path, questionName, questionDefinition, valueType, isMultivalued, onChangeNote, noteComponent, noteProps, onAddedAnswerPath, onDecidedOutputPath, sectionAnswersState } = props;
+  let { answers, answerMetadata, answerNodeType, existingAnswer, pageActive, path, questionName, questionDefinition, valueType, isMultivalued, onChangeNote, noteComponent, noteProps, onAddedAnswerPath, onDecidedOutputPath, sectionAnswersState } = props;
   let { enableNotes } = { ...props, ...questionDefinition };
   let { onAddSuggestion } = { ...props, ...noteProps };
   let [ answerID ] = useState((existingAnswer && existingAnswer[0]) || uuidv4());
@@ -110,6 +110,7 @@ function Answer (props) {
           answerPath={answerPath}
           onChangeNote={onChangeNote}
           onAddSuggestion={onAddSuggestion}
+          pageActive={pageActive}
           {...noteProps}
           />
       }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -123,14 +123,16 @@ Answer.propTypes = {
   answerNodeType: PropTypes.string,
   valueType: PropTypes.string,
   isMultivalued: PropTypes.bool,
-  noteComponent: PropTypes.elementType
+  noteComponent: PropTypes.elementType,
+  pageActive: PropTypes.bool
 };
 
 Answer.defaultProps = {
   answerNodeType: "cards:TextAnswer",
   valueType: 'String',
   isMultivalued: false,
-  noteComponent: Note
+  noteComponent: Note,
+  pageActive: true
 };
 
 export default Answer;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -299,6 +299,7 @@ let ComputedQuestion = (props) => {
         existingAnswer={existingAnswer}
         answerNodeType={answerNodeType}
         valueType={answerType}
+        pageActive={pageActive}
         {...rest}
         />
     </Question>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -50,7 +50,7 @@ import { MakeRequest } from "../vocabQuery/util.jsx";
 //  expression="if (@{question_b} === 0) setError('Can not divide by 0'); return @{question_a}/@{question_b}"
 //  />
 let ComputedQuestion = (props) => {
-  const { existingAnswer, classes, questionDefinition, ...rest} = props;
+  const { existingAnswer, classes, pageActive, questionDefinition, ...rest} = props;
   const { text, expression, unitOfMeasurement, dataType, displayMode, dateFormat, yesLabel, noLabel, unknownLabel } = {...props.questionDefinition, ...props};
   const [error, changeError] = useState(false);
   const [errorMessage, changeErrorMessage] = useState(false);
@@ -275,19 +275,23 @@ let ComputedQuestion = (props) => {
       currentAnswers={typeof(displayValue) !== "undefined" && displayValue !== "" ? 1 : 0}
       {...props}
       >
-      {error && <Typography color='error'>{errorMessage}</Typography>}
-      { isFormatted ? <FormattedText>
-          {displayValue + (unitOfMeasurement ? (" " + unitOfMeasurement) : '')}
-        </FormattedText>
-      :
-      <TextField
-        type={fieldType}
-        dateFormat={(fieldType === "date" || fieldType === "time" && dateFormat) || null}
-        disabled={true}
-        className={classes.textField + " " + classes.answerField}
-        value={displayValue}
-        InputProps={muiInputProps}
-      />
+      {
+        pageActive && <>
+          {error && <Typography color='error'>{errorMessage}</Typography>}
+          { isFormatted ? <FormattedText>
+              {displayValue + (unitOfMeasurement ? (" " + unitOfMeasurement) : '')}
+            </FormattedText>
+          :
+          <TextField
+            type={fieldType}
+            dateFormat={(fieldType === "date" || fieldType === "time" && dateFormat) || null}
+            disabled={true}
+            className={classes.textField + " " + classes.answerField}
+            value={displayValue}
+            InputProps={muiInputProps}
+          />
+          }
+        </>
       }
       <Answer
         answers={answer}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionFull.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionFull.jsx
@@ -52,7 +52,7 @@ import DateQuestionUtilities from "./DateQuestionUtilities";
 //  type="timestamp"
 //  />
 function DateQuestionFull(props) {
-  let {existingAnswer, classes, ...rest} = props;
+  let {existingAnswer, classes, pageActive, ...rest} = props;
   let {text, dateFormat, minAnswers, type, lowerLimit, upperLimit} = {dateFormat: "yyyy-MM-dd", minAnswers: 0, type: DateQuestionUtilities.TIMESTAMP_TYPE, ...props.questionDefinition, ...props};
 
   let startValues = existingAnswer && existingAnswer[1].value || "";
@@ -154,14 +154,18 @@ function DateQuestionFull(props) {
       currentAnswers={DateQuestionUtilities.isAnswerComplete(outputAnswers, type) ? 1 : 0}
       {...props}
       >
-      {error && <Typography color='error'>{errorMessage}</Typography>}
-      {getTextField(false, DateQuestionUtilities.momentToString(startDate, textFieldType))}
-      { /* If this is an interval, allow the user to select a second date */
-      type === DateQuestionUtilities.INTERVAL_TYPE &&
-      <React.Fragment>
-        <span className={classes.mdash}>&mdash;</span>
-        {getTextField(true, DateQuestionUtilities.momentToString(endDate, textFieldType))}
-      </React.Fragment>
+      {
+        pageActive && <>
+          {error && <Typography color='error'>{errorMessage}</Typography>}
+          {getTextField(false, DateQuestionUtilities.momentToString(startDate, textFieldType))}
+          { /* If this is an interval, allow the user to select a second date */
+          type === DateQuestionUtilities.INTERVAL_TYPE &&
+          <React.Fragment>
+            <span className={classes.mdash}>&mdash;</span>
+            {getTextField(true, DateQuestionUtilities.momentToString(endDate, textFieldType))}
+          </React.Fragment>
+          }
+        </>
       }
       <Answer
         answers={outputAnswers}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionFull.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionFull.jsx
@@ -173,6 +173,7 @@ function DateQuestionFull(props) {
         existingAnswer={existingAnswer}
         answerNodeType="cards:DateAnswer"
         valueType="Date"
+        pageActive={pageActive}
         {...rest}
         />
     </Question>);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionMonth.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionMonth.jsx
@@ -214,6 +214,7 @@ function DateQuestionMonth(props) {
         existingAnswer={existingAnswer}
         answerNodeType="cards:DateAnswer"
         valueType="Date"
+        pageActive={pageActive}
         {...rest}
         />
     </Question>);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionMonth.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionMonth.jsx
@@ -51,7 +51,7 @@ import DateQuestionUtilities from "./DateQuestionUtilities";
 //  type="timestamp"
 //  />
 function DateQuestionMonth(props) {
-  let {existingAnswer, classes, ...rest} = props;
+  let {existingAnswer, classes, pageActive, ...rest} = props;
   let {text, dateFormat, minAnswers, type, lowerLimit, upperLimit} = {dateFormat: "yyyy/MM", minAnswers: 0, type: DateQuestionUtilities.TIMESTAMP_TYPE, ...props.questionDefinition, ...props};
 
   let startValues = existingAnswer && existingAnswer[1].value || "";
@@ -197,15 +197,17 @@ function DateQuestionMonth(props) {
       currentAnswers={DateQuestionUtilities.isAnswerComplete(outputAnswers, type) ? 1 : 0}
       {...props}
       >
-      {error && <Typography color='error'>{errorMessage}</Typography>}
-      {getTextField(false, displayedDate)}
-      { /* If this is an interval, allow the user to select a second date */
-      type === DateQuestionUtilities.INTERVAL_TYPE &&
-      <React.Fragment>
-        <span className={classes.mdash}>&mdash;</span>
-        {getTextField(true, displayedEndDate)}
-      </React.Fragment>
-      }
+      {pageActive && <>
+        {error && <Typography color='error'>{errorMessage}</Typography>}
+        {getTextField(false, displayedDate)}
+        { /* If this is an interval, allow the user to select a second date */
+        type === DateQuestionUtilities.INTERVAL_TYPE &&
+        <React.Fragment>
+          <span className={classes.mdash}>&mdash;</span>
+          {getTextField(true, displayedEndDate)}
+        </React.Fragment>
+        }
+      </>}
       <Answer
         answers={outputAnswers}
         questionDefinition={props.questionDefinition}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FileQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FileQuestion.jsx
@@ -43,7 +43,7 @@ import AnswerComponentManager from "./AnswerComponentManager";
 // Sample usage:
 // (TODO)
 function FileQuestion(props) {
-  const { classes, existingAnswer, ...rest } = props;
+  const { classes, existingAnswer, pageActive, ...rest } = props;
   const { maxAnswers, minAnswers, namePattern } = { ...props.questionDefinition, ...props }
   let initialValues =
     // Check whether or not we have an initial value
@@ -347,6 +347,7 @@ function FileQuestion(props) {
         onDecidedOutputPath={setAnswerPath}
         valueType="path"
         isMultivalued={maxAnswers != 1}
+        pageActive={pageActive}
         {...rest}
         />
     </Question>);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FileQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FileQuestion.jsx
@@ -291,50 +291,54 @@ function FileQuestion(props) {
       defaultDisplayFormatter={defaultDisplayFormatter}
       {...props}
       >
-      { uploadInProgress && (
-        <Grid item className={classes.root}>
-          <LinearProgress color="primary" />
-        </Grid>
-      ) }
-      <DragAndDrop
-        handleDrop={addFiles}
-        multifile={maxAnswers != 1}
-        error={error}
-        disabled={disableUploads}
-        />
-      { uploadedFiles && Object.values(uploadedFiles).length > 0 && <ul className={classes.answerField + " " + classes.fileResourceAnswerList}>
-        {Object.keys(uploadedFiles).map((filepath, idx) =>
-          <li key={idx}>
-            <div>
-              <span>File </span>
-              <Link href={fixFileURL(uploadedFiles[filepath], filepath)} target="_blank" rel="noopener" download>
-                {filepath}
-              </Link>:
-              <IconButton
-                onClick={() => {deletePath(idx)}}
-                className={classes.deleteButton + " " + classes.fileResourceDeleteButton}
-                color="secondary"
-                title="Delete"
-              >
-                <Delete color="action" className={classes.deleteIcon}/>
-              </IconButton>
-            </div>
-            { namePattern &&
-              <span>
-                {varNames.map((name, nameIdx) => (
-                  <TextField
-                    label={name}
-                    value={knownAnswers?.[filepath]?.[nameIdx]}
-                    className={classes.fileDetail + " " + classes.fileResourceAnswerInput}
-                    key={nameIdx}
-                    readOnly
-                  />
-                ))}
-              </span>
-            }
-          </li>
-        )}
-      </ul>}
+      {
+        pageActive && <>
+          { uploadInProgress && (
+            <Grid item className={classes.root}>
+              <LinearProgress color="primary" />
+            </Grid>
+          ) }
+          <DragAndDrop
+            handleDrop={addFiles}
+            multifile={maxAnswers != 1}
+            error={error}
+            disabled={disableUploads}
+            />
+          { uploadedFiles && Object.values(uploadedFiles).length > 0 && <ul className={classes.answerField + " " + classes.fileResourceAnswerList}>
+            {Object.keys(uploadedFiles).map((filepath, idx) =>
+              <li key={idx}>
+                <div>
+                  <span>File </span>
+                  <Link href={fixFileURL(uploadedFiles[filepath], filepath)} target="_blank" rel="noopener" download>
+                    {filepath}
+                  </Link>:
+                  <IconButton
+                    onClick={() => {deletePath(idx)}}
+                    className={classes.deleteButton + " " + classes.fileResourceDeleteButton}
+                    color="secondary"
+                    title="Delete"
+                  >
+                    <Delete color="action" className={classes.deleteIcon}/>
+                  </IconButton>
+                </div>
+                { namePattern &&
+                  <span>
+                    {varNames.map((name, nameIdx) => (
+                      <TextField
+                        label={name}
+                        value={knownAnswers?.[filepath]?.[nameIdx]}
+                        className={classes.fileDetail + " " + classes.fileResourceAnswerInput}
+                        key={nameIdx}
+                        readOnly
+                      />
+                    ))}
+                  </span>
+                }
+              </li>
+            )}
+          </ul>}
+        </>
+      }
       <Answer
         answers={answers}
         questionDefinition={props.questionDefinition}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -97,7 +97,8 @@ function Form (props) {
   let [ errorMessage, setErrorMessage ] = useState("");
   let [ errorDialogDisplayed, setErrorDialogDisplayed ] = useState(false);
   let [ pages, setPages ] = useState(null);
-  let [ paginationEnabled, setPaginationEnabled ] = useState(false);
+  // Avoid rendering everything at once before we get all of the questionnaire details
+  let [ paginationEnabled, setPaginationEnabled ] = useState(true);
   let [ removeWindowHandlers, setRemoveWindowHandlers ] = useState();
   let [ actionsMenu, setActionsMenu ] = useState(null);
   let [ formContentOffsetTop, setFormContentOffsetTop ] = useState(contentOffset);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -114,6 +114,7 @@ let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, o
         questionName={key}
         onChange={onChange}
         onAddedAnswerPath={onAddedAnswerPath}
+        pageActive={pageActive}
         sectionAnswersState={sectionAnswersState}
         isEdit={isEdit}
         instanceId={instanceId || ''}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -51,9 +51,9 @@ const GHOST_SENTINEL = "custom-input";
   * @param {bool} error indicates if the current selection is in a state of error
   */
 function MultipleChoice(props) {
-  let { classes, customInput, customInputProps, existingAnswer, input, textbox, onUpdate, onChange, additionalInputProps, muiInputProps, naValue, noneOfTheAboveValue, error, pageActive, questionName, ...rest } = props;
+  let { classes, customInput, customInputProps, existingAnswer, input, textbox, onUpdate, onChange, additionalInputProps, muiInputProps, naValue, noneOfTheAboveValue, error, questionName, ...rest } = props;
   let { maxAnswers, minAnswers, displayMode, enableSeparatorDetection } = {...props.questionDefinition, ...props};
-  let { instanceId } = props;
+  let { instanceId, pageActive } = props;
 
   let defaults = props.defaults || Object.values(props.questionDefinition)
     // Keep only answer options

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -53,7 +53,8 @@ const GHOST_SENTINEL = "custom-input";
 function MultipleChoice(props) {
   let { classes, customInput, customInputProps, existingAnswer, input, textbox, onUpdate, onChange, additionalInputProps, muiInputProps, naValue, noneOfTheAboveValue, error, questionName, ...rest } = props;
   let { maxAnswers, minAnswers, displayMode, enableSeparatorDetection } = {...props.questionDefinition, ...props};
-  let { instanceId, pageActive } = props; // pageActive should be passed to the Answer component, so we make sure to include it in the `rest` variable above
+  // pageActive should be passed to the Answer component, so we make sure to include it in the `rest` variable above
+  let { instanceId, pageActive } = props;
 
   let defaults = props.defaults || Object.values(props.questionDefinition)
     // Keep only answer options

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -53,7 +53,7 @@ const GHOST_SENTINEL = "custom-input";
 function MultipleChoice(props) {
   let { classes, customInput, customInputProps, existingAnswer, input, textbox, onUpdate, onChange, additionalInputProps, muiInputProps, naValue, noneOfTheAboveValue, error, questionName, ...rest } = props;
   let { maxAnswers, minAnswers, displayMode, enableSeparatorDetection } = {...props.questionDefinition, ...props};
-  let { instanceId, pageActive } = props;
+  let { instanceId, pageActive } = props; // pageActive should be passed to the Answer component, so we make sure to include it in the `rest` variable above
 
   let defaults = props.defaults || Object.values(props.questionDefinition)
     // Keep only answer options

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -47,10 +47,11 @@ const GHOST_SENTINEL = "custom-input";
   * @param {Object} muiInputProps additional props to be forwarded to the MUI input element
   * @param {Object} naValue if provided, any answer with this value will de-select all other selected options, and will be unselected if any other option is selected
   * @param {Object} noneOfTheAboveValue if provided, any answer with this value will de-select all other pre-defined options, and will be unselected if any other option is selected
+  * @param {bool} pageActive if true, this page will render graphical components. Otherwise, it will skip rendering (to save on performance)
   * @param {bool} error indicates if the current selection is in a state of error
   */
 function MultipleChoice(props) {
-  let { classes, customInput, customInputProps, existingAnswer, input, textbox, onUpdate, onChange, additionalInputProps, muiInputProps, naValue, noneOfTheAboveValue, error, questionName, ...rest } = props;
+  let { classes, customInput, customInputProps, existingAnswer, input, textbox, onUpdate, onChange, additionalInputProps, muiInputProps, naValue, noneOfTheAboveValue, error, pageActive, questionName, ...rest } = props;
   let { maxAnswers, minAnswers, displayMode, enableSeparatorDetection } = {...props.questionDefinition, ...props};
   let { instanceId } = props;
 
@@ -416,18 +417,22 @@ function MultipleChoice(props) {
   if (isSelect) {
     return (
       <React.Fragment>
-        {instructions}
-        <Select
-          value={selection?.[0]?.[0] || ''}
-          className={classes.textField + ' ' + classes.answerField}
-          onChange={(event) => {
-            setSelection([[event.target.value, event.target.value]]);
-          }
-        }>
-        {defaults.map(function([name, key], index) {
-            return <MenuItem value={key} key={key}>{name}</MenuItem>;
-        })}
-        </Select>
+        {
+          pageActive && <>
+            {instructions}
+            <Select
+              value={selection?.[0]?.[0] || ''}
+              className={classes.textField + ' ' + classes.answerField}
+              onChange={(event) => {
+                setSelection([[event.target.value, event.target.value]]);
+              }
+            }>
+            {defaults.map(function([name, key], index) {
+                return <MenuItem value={key} key={key}>{name}</MenuItem>;
+            })}
+            </Select>
+          </>
+        }
         <Answer
           answers={answers}
           existingAnswer={existingAnswer}
@@ -440,8 +445,12 @@ function MultipleChoice(props) {
   } else if (isBare) {
     return(
       <React.Fragment>
-        {instructions}
-        {ghostInput}
+        {
+          pageActive && <>
+            {instructions}
+            {ghostInput}
+          </>
+        }
         <Answer
           answers={answers}
           existingAnswer={existingAnswer}
@@ -454,44 +463,48 @@ function MultipleChoice(props) {
   } else if (isRadio) {
     return (
       <React.Fragment>
-        {instructions}
-        <RadioGroup
-          aria-label="selection"
-          name={props.questionDefinition['jcr:uuid'] + (instanceId || '')}
-          className={classes.selectionList}
-          value={selection.length > 0 && String(selection[0][VALUE_POS])}
-        >
-          <List className={classes.optionsList}>
-          {generateDefaultOptions(options, selection, disabled, isRadio, selectNonGhostOption, removeOption)}
-          {/* Ghost radio for the text input */}
-          {
-          ghostInput && <ListItem className={classes.ghostListItem}>
-            <FormControlLabel
-              control={
-              <Radio
-                checked={ghostSelected}
-                onChange={() => {
-                  selectOption(ghostValue, ghostName);
-                  onUpdate && onUpdate(ghostSelected ? undefined : ghostName);
-                }}
-                onClick={() => {inputEl && inputEl.select();}}
-                disabled={!ghostSelected && disabled}
-                className={classes.ghostRadiobox}
-              />
+        {
+          pageActive && <>
+            {instructions}
+            <RadioGroup
+              aria-label="selection"
+              name={props.questionDefinition['jcr:uuid'] + (instanceId || '')}
+              className={classes.selectionList}
+              value={selection.length > 0 && String(selection[0][VALUE_POS])}
+            >
+              <List className={classes.optionsList}>
+              {generateDefaultOptions(options, selection, disabled, isRadio, selectNonGhostOption, removeOption)}
+              {/* Ghost radio for the text input */}
+              {
+              ghostInput && <ListItem className={classes.ghostListItem}>
+                <FormControlLabel
+                  control={
+                  <Radio
+                    checked={ghostSelected}
+                    onChange={() => {
+                      selectOption(ghostValue, ghostName);
+                      onUpdate && onUpdate(ghostSelected ? undefined : ghostName);
+                    }}
+                    onClick={() => {inputEl && inputEl.select();}}
+                    disabled={!ghostSelected && disabled}
+                    className={classes.ghostRadiobox}
+                  />
+                  }
+                  label="&nbsp;"
+                  value={ghostValue}
+                  key={ghostValue}
+                  className={classes.ghostFormControl + " " + classes.childFormControl}
+                  classes={{
+                    label: classes.inputLabel
+                  }}
+                />
+                {ghostInput}
+              </ListItem>
               }
-              label="&nbsp;"
-              value={ghostValue}
-              key={ghostValue}
-              className={classes.ghostFormControl + " " + classes.childFormControl}
-              classes={{
-                label: classes.inputLabel
-              }}
-            />
-            {ghostInput}
-          </ListItem>
-          }
-          </List>
-        </RadioGroup>
+              </List>
+            </RadioGroup>
+          </>
+        }
         <Answer
           answers={answers}
           existingAnswer={existingAnswer}
@@ -504,11 +517,15 @@ function MultipleChoice(props) {
   } else {
     return (
       <React.Fragment>
-        {instructions}
-        <List className={classes.optionsList}>
-          {generateDefaultOptions(options, selection, disabled, isRadio, selectNonGhostOption, removeOption)}
-          {ghostInput && <ListItem>{ghostInput}</ListItem>}
-        </List>
+        {
+          pageActive && <>
+            {instructions}
+            <List className={classes.optionsList}>
+              {generateDefaultOptions(options, selection, disabled, isRadio, selectNonGhostOption, removeOption)}
+              {ghostInput && <ListItem>{ghostInput}</ListItem>}
+            </List>
+          </>
+        }
         <Answer
           answers={answers}
           existingAnswer={existingAnswer}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Note.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Note.jsx
@@ -28,7 +28,7 @@ import UnfoldLess from "@material-ui/icons/UnfoldLess";
 import QuestionnaireStyle from "./QuestionnaireStyle";
 
 function Note (props) {
-  const { answerPath, children, existingAnswer, classes, onAddSuggestion, onChangeNote, ...rest } = {...props};
+  const { answerPath, children, existingAnswer, classes, onAddSuggestion, onChangeNote, pageActive, ...rest } = {...props};
   let [ note, setNote ] = useState((existingAnswer?.[1]?.note));
   let [ visible, setVisible ] = useState(Boolean(note));
   let inputRef = useRef();
@@ -43,6 +43,11 @@ function Note (props) {
   }
 
   const noteIsEmpty = note == null || note == "";
+
+  // Render nothing but keep state if this page is inactive
+  if (!pageActive) {
+    return <></>;
+  }
 
   return (<React.Fragment>
     <div className = {classes.notesContainer}>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
@@ -127,7 +127,7 @@ const useSliderStyles = makeStyles(theme => ({
 //    errorText="Please enter an age above 18, or select the <18 option"
 //    />
 function NumberQuestion(props) {
-  const { existingAnswer, errorText, classes, ...rest} = props;
+  const { existingAnswer, errorText, classes, pageActive, ...rest} = props;
   const { dataType,displayMode, minAnswers, minValue, maxValue, isRange,
     sliderStep, sliderMarkStep, sliderOrientation, minValueLabel, maxValueLabel }
     = {sliderOrientation: "horizontal", ...props.questionDefinition, ...props};
@@ -326,7 +326,7 @@ function NumberQuestion(props) {
       disableInstructions
       {...props}
       >
-      { (minMaxError || rangeError) && errorText &&
+      { pageActive && (minMaxError || rangeError) && errorText &&
         <Typography
           component="p"
           color="error"
@@ -336,7 +336,7 @@ function NumberQuestion(props) {
           { errorText }
         </Typography>
       }
-      { minMaxMessage &&
+      { pageActive && minMaxMessage &&
         <Typography
           component="p"
           color={minMaxError ? 'error' : 'textSecondary'}
@@ -347,7 +347,7 @@ function NumberQuestion(props) {
         </Typography>
       }
       { isRange ?
-        <>
+        pageActive && <>
         <AnswerInstructions
           minAnswers={Math.min(1, minAnswers)}
           maxAnswers={0}
@@ -363,7 +363,7 @@ function NumberQuestion(props) {
           { rangeErrorMessage }
           </Typography>
         }
-        { isSlider ?
+        { pageActive && (isSlider ?
             makeSlider({
               valueLabelDisplay: (isRangeSelected ? "on" : "off"),
               value: sliderValues,
@@ -388,7 +388,7 @@ function NumberQuestion(props) {
               inputProps={textFieldProps}
               InputProps={Object.assign({shrink: "true"}, muiInputProps)}
               />
-          </div>
+          </div>)
         }
         <Answer
           answers={answers}
@@ -401,7 +401,7 @@ function NumberQuestion(props) {
         :
         <>
         { isSlider ?
-          <>
+          (pageActive && <>
           <AnswerInstructions
             minAnswers={Math.min(1, minAnswers)}
             maxAnswers={0}
@@ -420,7 +420,7 @@ function NumberQuestion(props) {
             valueType={valueType}
             {...rest}
             />
-          </>
+          </>)
           :
           <MultipleChoice
             answerNodeType={answerNodeType}
@@ -432,6 +432,7 @@ function NumberQuestion(props) {
             muiInputProps={muiInputProps}
             error={minMaxError}
             existingAnswer={existingAnswer}
+            pageActive={pageActive}
             {...rest}
             />
         }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
@@ -395,6 +395,7 @@ function NumberQuestion(props) {
           existingAnswer={existingAnswer}
           answerNodeType={answerNodeType}
           valueType={valueType}
+          pageActive={pageActive}
           {...rest}
           />
         </>
@@ -418,6 +419,7 @@ function NumberQuestion(props) {
             existingAnswer={existingAnswer}
             answerNodeType={answerNodeType}
             valueType={valueType}
+            pageActive={pageActive}
             {...rest}
             />
           </>)

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
@@ -162,6 +162,7 @@ function PedigreeQuestion(props) {
         existingAnswer={existingAnswer}
         answerNodeType="cards:PedigreeAnswer"
         valueType="String"
+        pageActive={pageActive}
         {...rest}
       />
     </Question>);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
@@ -47,7 +47,7 @@ import PedigreeEditor from "../pedigree/pedigree";
 //      }}
 //    />
 function PedigreeQuestion(props) {
-  const { existingAnswer, classes, ...rest } = props;
+  const { existingAnswer, classes, pageActive, ...rest } = props;
   const [ expanded, setExpanded ] = useState(false);
   // default pedigreeData state variable to the pedigree saved in CARDS:
   const [ pedigreeData, setPedigree ] = useState(existingAnswer && existingAnswer.length > 1 && existingAnswer[1].value
@@ -120,37 +120,41 @@ function PedigreeQuestion(props) {
       currentAnswers={outputAnswers.length}
       {...props}
       >
-      <div className={classes.answerField}>
-      { pedigreeData.image ?
-        <Grid container direction="row" justify="flex-start" alignItems="flex-start" spacing={0}>
-          <Grid item>
-            <Tooltip title="Edit Pedigree">
-              <Link className={classes.thumbnailLink} onClick={() => {setExpanded(true);}}>
-                {image_div}
-              </Link>
-            </Tooltip>
-          </Grid>
-          <Grid item>
-            <DeleteButton
-              entryName={"pedigree"}
-              entryType={"Pedigree"}
-              shouldGoBack={false}
-              onComplete={() => {setPedigree({});}}
-            />
-          </Grid>
-        </Grid>
-        :
-        <Button variant="outlined" onClick={() => {setExpanded(true);}}>Draw</Button>
+      {
+        pageActive && <>
+          <div className={classes.answerField}>
+          { pedigreeData.image ?
+            <Grid container direction="row" justify="flex-start" alignItems="flex-start" spacing={0}>
+              <Grid item>
+                <Tooltip title="Edit Pedigree">
+                  <Link className={classes.thumbnailLink} onClick={() => {setExpanded(true);}}>
+                    {image_div}
+                  </Link>
+                </Tooltip>
+              </Grid>
+              <Grid item>
+                <DeleteButton
+                  entryName={"pedigree"}
+                  entryType={"Pedigree"}
+                  shouldGoBack={false}
+                  onComplete={() => {setPedigree({});}}
+                />
+              </Grid>
+            </Grid>
+            :
+            <Button variant="outlined" onClick={() => {setExpanded(true);}}>Draw</Button>
+          }
+          </div>
+          <Dialog fullScreen open={expanded}
+            onEntering={() => { openPedigree(); }}
+            onExit={() => { closePedigree(); }}
+            onClose={() => { setExpanded(false); }}>
+            <DialogContent>
+              <div id="pedigreeEditor"></div>
+            </DialogContent>
+          </Dialog>
+        </>
       }
-      </div>
-      <Dialog fullScreen open={expanded}
-        onEntering={() => { openPedigree(); }}
-        onExit={() => { closePedigree(); }}
-        onClose={() => { setExpanded(false); }}>
-        <DialogContent>
-          <div id="pedigreeEditor"></div>
-        </DialogContent>
-      </Dialog>
       <Answer
         answers={outputAnswers}
         answerMetadata={answerMetadata}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Question.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Question.jsx
@@ -28,7 +28,7 @@ import FormattedText from "../components/FormattedText.jsx";
 
 // GUI for displaying answers
 function Question (props) {
-  let { classes, children, questionDefinition, existingAnswer, isEdit, preventDefaultView, defaultDisplayFormatter } = props;
+  let { classes, children, questionDefinition, existingAnswer, isEdit, pageActive, preventDefaultView, defaultDisplayFormatter } = props;
   let { text, compact, description, disableInstructions } = { ...questionDefinition, ...props }
 
   return (
@@ -36,45 +36,53 @@ function Question (props) {
       variant="outlined"
       className={classes.questionCard}
       >
-      <CardHeader
-        title={text}
-        titleTypographyProps={{ variant: 'h6' }}
-        subheader={<FormattedText variant="caption">{description}</FormattedText>}
-        subheaderTypographyProps={{ component: "div" }}
-        />
+      {
+        // Note that we need to preserve the hierarchy in which we place children
+        // so that pageActive changing does not cause children to lose state
+        pageActive && <CardHeader
+          title={text}
+          titleTypographyProps={{ variant: 'h6' }}
+          subheader={<FormattedText variant="caption">{description}</FormattedText>}
+          subheaderTypographyProps={{ component: "div" }}
+          />
+      }
       <CardContent className={isEdit ? classes.editModeAnswers : classes.viewModeAnswers}>
         <div className={compact ? classes.compactLayout : null}>
-        { !(isEdit && disableInstructions) &&
-          <AnswerInstructions
-             {...questionDefinition}
-             {...props}
-          />
-        }
-        { !isEdit && !preventDefaultView ?
-          ( existingAnswer?.[1]["displayedValue"] ?
-            <List>
-              { Array.of(existingAnswer?.[1]["displayedValue"]).flat().map( (item, idx) => {
-                return(
-                  <ListItem key={item}> {defaultDisplayFormatter ? defaultDisplayFormatter(item, idx) : item} </ListItem>
-                )})
+          {
+            pageActive && <>
+              { !(isEdit && disableInstructions) &&
+                <AnswerInstructions
+                  {...questionDefinition}
+                  {...props}
+                />
               }
-            </List>
+            </>
+          }
+          { !isEdit && !preventDefaultView ?
+            ( existingAnswer?.[1]["displayedValue"] ?
+              <List>
+                { Array.of(existingAnswer?.[1]["displayedValue"]).flat().map( (item, idx) => {
+                  return(
+                    <ListItem key={item}> {defaultDisplayFormatter ? defaultDisplayFormatter(item, idx) : item} </ListItem>
+                  )})
+                }
+              </List>
+              :
+              ""
+            )
             :
-            ""
-          )
-          :
-          children
-        }
-        { !isEdit && existingAnswer?.[1]?.note &&
-          <div className={classes.notesContainer}>
-            <Typography variant="subtitle1">Notes</Typography>
-            {existingAnswer[1].note}
-          </div>
-        }
+            children
+          }
+          { !isEdit && existingAnswer?.[1]?.note && pageActive &&
+            <div className={classes.notesContainer}>
+              <Typography variant="subtitle1">Notes</Typography>
+              {existingAnswer[1].note}
+            </div>
+          }
         </div>
       </CardContent>
     </Card>
-    );
+    )
 }
 
 Question.propTypes = {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Question.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Question.jsx
@@ -73,7 +73,7 @@ function Question (props) {
             :
             children
           }
-          { !isEdit && existingAnswer?.[1]?.note && pageActive &&
+          { pageActive && !isEdit && existingAnswer?.[1]?.note &&
             <div className={classes.notesContainer}>
               <Typography variant="subtitle1">Notes</Typography>
               {existingAnswer[1].note}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
@@ -89,7 +89,7 @@ export class Time {
 //  upperLimit={"23:59"}
 //  />
 function TimeQuestion(props) {
-  let {existingAnswer, classes, ...rest} = props;
+  let {existingAnswer, classes, pageActive, ...rest} = props;
   let {text, lowerLimit, upperLimit, errorText, minAnswers, dateFormat} = {...props.questionDefinition, ...props};
   let currentStartValue = (existingAnswer && existingAnswer[1].value && new Time(existingAnswer[1].value).isValid)
     ? existingAnswer[1].value : "";
@@ -126,28 +126,32 @@ function TimeQuestion(props) {
       currentAnswers={!!selectedTime ? 1 : 0}
       {...props}
       >
-      {error && <Typography color='error'>{errorMessage}</Typography>}
-      <TextField
-        /* time input is hh:mm or hh:mm:ss only */
-        type={Time.timeQuestionFieldType(dateFormat)}
-        className={classes.textField + " " + classes.answerField}
-        InputLabelProps={{
-          shrink: true,
-        }}
-        InputProps={{
-          className: classes.textField
-        }}
-        inputProps={{
-          max: upperLimit,
-          min: lowerLimit
-        }}
-        onChange={(event) => {
-          checkError(event.target.value);
-          changeTime(event.target.value);
-        }}
+      {
+        pageActive && <>
+          {error && <Typography color='error'>{errorMessage}</Typography>}
+          <TextField
+            /* time input is hh:mm or hh:mm:ss only */
+            type={Time.timeQuestionFieldType(dateFormat)}
+            className={classes.textField + " " + classes.answerField}
+            InputLabelProps={{
+              shrink: true,
+            }}
+            InputProps={{
+              className: classes.textField
+            }}
+            inputProps={{
+              max: upperLimit,
+              min: lowerLimit
+            }}
+            onChange={(event) => {
+              checkError(event.target.value);
+              changeTime(event.target.value);
+            }}
 
-        value={selectedTime}
-      />
+            value={selectedTime}
+          />
+        </>
+      }
       <Answer
         answers={outputAnswers}
         questionDefinition={props.questionDefinition}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
@@ -158,6 +158,7 @@ function TimeQuestion(props) {
         existingAnswer={existingAnswer}
         answerNodeType="cards:TimeAnswer"
         valueType="Time"
+        pageActive={pageActive}
         {...rest}
         />
     </Question>);


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/CARDS-1459)

As with its previous PR #933 , this PR aims to reduce the amount of time it takes to load a questionnaire by skipping rendering steps on other pages. Unlike the previous PR, this does not prevent rendering the entire section from the DOM, and instead alters each individual question to do so.

As viewed through Chrome's Inspector, a question on an inactive page will now look like this:
![image](https://user-images.githubusercontent.com/4656440/155413424-ff7b51fe-bc1c-46f3-bc8f-969b92d728e6.png)

Compare that to a question on an active page, which is far more complex:
![image](https://user-images.githubusercontent.com/4656440/155405273-a0f52050-f1be-4d8f-9078-212b019b2fb8.png)

Unfortunately, due to an issue where altering the DOM tree can cause child elements to lose state, I couldn't completely remove all elements of the `<Question>` object.

**To test**: In paginated forms, all types of questions that are not on the current page should have the truncated structure that I demonstrate above (divs and hidden inputs only). All other functionality regarding form pagination should be the same, and unpaginated forms should be completely unaffected. I've tested all of Sergiu's findings in the `#testing` and `#cards-dev` channel, but a second pass wouldn't hurt.