### PR TITLE
Torch Mock Server

### DIFF
--- a/Utilities/Development/mock_torch.js
+++ b/Utilities/Development/mock_torch.js
@@ -84,20 +84,22 @@ const graphQlResponse = {
             location: ['6012-HC-Congenital Cardiac'],
             status: 'planned',
             fhirID: 'AppointmentFhirID',
-            attending: {
-              name: {
-                prefix: [
-                  'Dr.'
-                ],
-                given: [
-                  'Robert'
-                ],
-                family: 'Smith',
-                suffix: [
-                  'M.D.'
-                ]
+            participants: [
+              {
+                name: {
+                  prefix: [
+                    'Dr.'
+                  ],
+                  given: [
+                    'Robert'
+                  ],
+                  family: 'Smith',
+                  suffix: [
+                    'M.D.'
+                  ]
+                }
               }
-            },
+            ],
             time: {toJSON: getMockAppointmentTime}
           }
         ]

--- a/Utilities/Development/mock_torch.js
+++ b/Utilities/Development/mock_torch.js
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/*
+ * This program provides a mock Torch GraphQL server for testing
+ * Torch data import into CARDS.
+ */
+
+const LISTEN_HOST = '0.0.0.0';
+const LISTEN_PORT = 8011;
+
+const bodyParser = require('body-parser');
+const express = require('express');
+const webApp = express();
+webApp.use(bodyParser.text({type: '*/*'}));
+const webServer = require('http').createServer(webApp);
+
+const graphQlResponse = {
+  data: {
+    patientsByDateAndClinic: [
+      {
+        mrn: '12345',
+        ohip: '980173',
+        fhirID: 'Fh1R1D',
+        dob: '1970-01-01',
+        sex: 'F',
+        name: {
+          given: [
+            'Alice'
+          ],
+          family: 'Robertson'
+        },
+        emailOk: true,
+        com: {
+          email: {
+            personal: 'alice.bob@mail.com'
+          }
+        },
+        appointments: [
+          {
+            location: ['6012-HC-Congenital Cardiac'],
+            status: 'upcoming',
+            fhirID: 'AppointmentFhirID',
+            attending: {
+              name: {
+                prefix: [
+                  'Dr.'
+                ],
+                given: [
+                  'Robert'
+                ],
+                family: 'Smith',
+                suffix: [
+                  'M.D.'
+                ]
+              }
+            },
+            time: '2022-02-20T10:00:00'
+          }
+        ]
+      }
+    ]
+  }
+};
+
+webApp.post('*', (req, res) => {
+  console.log("GraphQL QUERY => " + req.body);
+  console.log("");
+  console.log("RESPONSE <= " + JSON.stringify(graphQlResponse));
+  console.log("");
+  console.log("");
+  res.json(graphQlResponse);
+});
+
+webServer.listen(LISTEN_PORT, LISTEN_HOST, (err) => {
+  if (err) {
+    console.log("Mock Torch GraphQL server failed to start");
+  } else {
+    console.log("Mock Torch GraphQL server listening on port " + LISTEN_PORT);
+    console.log("====================================================");
+    console.log("");
+  }
+});

--- a/Utilities/Development/mock_torch.js
+++ b/Utilities/Development/mock_torch.js
@@ -29,6 +29,13 @@ const webApp = express();
 webApp.use(bodyParser.text({type: '*/*'}));
 const webServer = require('http').createServer(webApp);
 
+const tomorrowAsIsoString = function() {
+  const date = new Date();
+  date.setHours(date.getHours() + 24);
+  return date.toISOString();
+}
+
+
 const graphQlResponse = {
   data: {
     patientsByDateAndClinic: [
@@ -69,7 +76,7 @@ const graphQlResponse = {
                 ]
               }
             },
-            time: '2022-02-20T10:00:00'
+            time: {toJSON: tomorrowAsIsoString}
           }
         ]
       }

--- a/Utilities/Development/mock_torch.js
+++ b/Utilities/Development/mock_torch.js
@@ -82,7 +82,7 @@ const graphQlResponse = {
         appointments: [
           {
             location: ['6012-HC-Congenital Cardiac'],
-            status: 'upcoming',
+            status: 'planned',
             fhirID: 'AppointmentFhirID',
             attending: {
               name: {

--- a/Utilities/Development/mock_torch.js
+++ b/Utilities/Development/mock_torch.js
@@ -58,6 +58,15 @@ const getMockAppointmentTime = () => {
   return "2022-02-20T10:00:00";
 };
 
+const getMockAppointmentStatus = () => {
+  for (let i = 0; i < process.argv.length; i++) {
+    if (process.argv[i].startsWith("--appointment-status=")) {
+      return process.argv[i].split("=")[1];
+    }
+  }
+  return "planned";
+};
+
 const graphQlResponse = {
   data: {
     patientsByDateAndClinic: [
@@ -82,7 +91,7 @@ const graphQlResponse = {
         appointments: [
           {
             location: ['6012-HC-Congenital Cardiac'],
-            status: 'planned',
+            status: {toJSON: getMockAppointmentStatus},
             fhirID: 'AppointmentFhirID',
             participants: [
               {

--- a/Utilities/Development/mock_torch.js
+++ b/Utilities/Development/mock_torch.js
@@ -23,18 +23,40 @@
 const LISTEN_HOST = '0.0.0.0';
 const LISTEN_PORT = 8011;
 
+const process = require('process');
 const bodyParser = require('body-parser');
 const express = require('express');
 const webApp = express();
 webApp.use(bodyParser.text({type: '*/*'}));
 const webServer = require('http').createServer(webApp);
 
-const tomorrowAsIsoString = function() {
-  const date = new Date();
-  date.setHours(date.getHours() + 24);
-  return date.toISOString();
-}
+const dateToTorchString = (date) => {
+  let dateStr = "";
+  dateStr += date.getFullYear().toString().padStart(4, '0');
+  dateStr += '-';
+  dateStr += (date.getMonth()+1).toString().padStart(2, '0');
+  dateStr += '-';
+  dateStr += date.getDate().toString().padStart(2, '0');
+  dateStr += 'T';
+  dateStr += date.getHours().toString().padStart(2, '0');
+  dateStr += ':';
+  dateStr += date.getMinutes().toString().padStart(2, '0');
+  dateStr += ':';
+  dateStr += date.getSeconds().toString().padStart(2, '0');
+  return dateStr;
+};
 
+const getMockAppointmentTime = () => {
+  for (let i = 0; i < process.argv.length; i++) {
+    if (process.argv[i].startsWith("--appointment-time-hours-from-now=")) {
+      let timeOffset = parseInt(process.argv[i].split("=")[1]);
+      let nowTime = new Date();
+      let apptTime = new Date(nowTime.getTime() + (1000*60*60*timeOffset));
+      return dateToTorchString(apptTime);
+    }
+  }
+  return "2022-02-20T10:00:00";
+};
 
 const graphQlResponse = {
   data: {
@@ -76,7 +98,7 @@ const graphQlResponse = {
                 ]
               }
             },
-            time: {toJSON: tomorrowAsIsoString}
+            time: {toJSON: getMockAppointmentTime}
           }
         ]
       }


### PR DESCRIPTION
This Pull Request adds the `mock_torch.js` server to the set of CARDS development utilities. This server simulates data being served from Data Lake's Torch server and therefore facilitates the testing of any code that relies on the importing of data from Torch.

To test, NodeJS must be installed along with the `express` and `body-parser` Node.js packages. These packages may be installed from npm or via `apt install node-express node-body-parser`.

Once these packages are installed:
- Start the `mock_torch.js` server with the command `nodejs mock_torch.js  --appointment-time-hours-from-now=24`
- Start CARDS with `-P cards4proms --dev`
- Visit `http://localhost:8080/system/console/configMgr`
- Look for the `PROMs import` configuration, click on it to add a new config, set the _Name_ to `mock`, _Endpoint URL_ to `http://localhost:8011/`, and _Clinic_ to `6012-HC-Congenital Cardiac`. Save the configuration.
- Point your browser to `http://localhost:8080/Subjects.importTorch.json?config=mock`
- Visit `http://localhost:8080` once again. You should see newly imported data from the mock Torch server.