### PR TITLE
CARDS-1672: PROMs: Wrong answer for the "patient submitted" question in imported visits

### DIFF
--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/PatientLocalStorage.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/PatientLocalStorage.java
@@ -478,8 +478,8 @@ public class PatientLocalStorage
         updateForm(form, info, "/Questionnaires/Visit information", formMapping);
 
         // Also create some questions that need to be present for the VisitChangeListener, if they don't exist
-        ensureAnswerExists(form, "/Questionnaires/Visit information/surveys_complete", "cards:BooleanAnswer", false);
-        ensureAnswerExists(form, "/Questionnaires/Visit information/surveys_submitted", "cards:BooleanAnswer", false);
+        ensureAnswerExists(form, "/Questionnaires/Visit information/surveys_complete", "cards:BooleanAnswer", 0L);
+        ensureAnswerExists(form, "/Questionnaires/Visit information/surveys_submitted", "cards:BooleanAnswer", 0L);
     }
 
     /**


### PR DESCRIPTION
To test:
- start the mock torch server from #947 
- start in cards4proms mode, configure the mock torch server, start the import (instructions in #947)
- open the Visit Information form, check that the first two questions have `No` as the answer instead of `false`
- edit the form, make sure the correct radio button is preselected