### PR TITLE
CARDS-1674: As and admin, I can enable the entry of Notes associated with answers to any type of question using the questionnaire wizard

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -204,7 +204,6 @@
           "user": {
             "minAnswers": "long",
             "maxAnswers": "long",
-            "enableNotes": "boolean",
             "displayMode": {
               "input": {},
               "list": {
@@ -250,6 +249,7 @@
       "pedigree" : {
         "minAnswers": {"0":{}, "1":{}}
       }
-    }
+    },
+    "enableNotes": "boolean"
   }
 ]


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/CARDS-1674)

**Before**:
* Only questions with "Data type: vocabulary" have the "Enable notes" switch

**After**:
* All types of questions have the "Enable notes" switch