### PR TITLE
CARDS-1670: As a user, I need to be able to unsubscribe from emails sent by the DATA-PRO application

### DIFF
--- a/distribution/src/main/features/core/base-configuration.json
+++ b/distribution/src/main/features/core/base-configuration.json
@@ -41,7 +41,7 @@
                 "-/favicon.ico",
                 "-/libs",
                 "-/apps",
-                "-/system"
+                "-/system/sling/info"
             ]
         }
     }

--- a/modules/commons/src/main/frontend/src/components/ErrorPage.jsx
+++ b/modules/commons/src/main/frontend/src/components/ErrorPage.jsx
@@ -57,7 +57,7 @@ export default function ErrorPage(props) {
           alignContent="center"
         >
           <Grid item>
-            <img src="/libs/cards/resources/logo_light_bg.png" alt="this.state.title" className={classes.logo}/>
+            <img src="/libs/cards/resources/logo_light_bg.png" alt="" className={classes.logo}/>
           </Grid>
           <Grid item>
             {errorCode && <Typography variant="h1" color={errorCodeColor || "primary"}>

--- a/modules/login/src/main/frontend/src/login/loginMainComponent.js
+++ b/modules/login/src/main/frontend/src/login/loginMainComponent.js
@@ -53,7 +53,7 @@ class MainLoginContainer extends React.Component {
       <Paper className={`${classes.paper}  ${selfContained ? classes.selfContained : ''}`} elevation={0}>
         <Grid container direction="column" spacing={3} alignItems="center" alignContent="center">
           <Grid item>
-            <img src="/libs/cards/resources/logo_light_bg.png" alt="this.state.title" className={classes.logo}/>
+            <img src="/libs/cards/resources/logo_light_bg.png" alt="" className={classes.logo}/>
           </Grid>
           <Grid item>
           { this.state.signInShown ? <SignIn handleLogin={this.props.handleLogin} redirectOnLogin={this.props.redirectOnLogin}/> : <SignUpForm loginOnSuccess={true} handleLogin={this.props.handleLogin} /> }

--- a/modules/token-authentication/src/main/frontend/src/tokenAuthentication/TokenExpired.jsx
+++ b/modules/token-authentication/src/main/frontend/src/tokenAuthentication/TokenExpired.jsx
@@ -59,7 +59,7 @@ export default function TokenExpired() {
           className={classes.notFoundContainer}
         >
           <Grid item>
-            <img src="/libs/cards/resources/logo_light_bg.png" alt="this.state.title" className={classes.logo}/>
+            <img src="/libs/cards/resources/logo_light_bg.png" alt="" className={classes.logo}/>
           </Grid>
           <Grid item>
             <Typography variant="h1" color="primary" gutterBottom>

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/UnsubscribeServlet.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/UnsubscribeServlet.java
@@ -32,6 +32,7 @@ import javax.json.Json;
 import javax.json.JsonObjectBuilder;
 import javax.servlet.Servlet;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.LoginException;
@@ -139,12 +140,13 @@ public class UnsubscribeServlet extends SlingAllMethodsServlet
                 unsubscribeAnswer = patientInformationForm.addNode(UUID.randomUUID().toString(), "cards:BooleanAnswer");
                 unsubscribeAnswer.setProperty("question", unsubscribeQuestion);
             }
-            unsubscribeAnswer.setProperty(FormUtils.VALUE_PROPERTY, 1L);
+            final long value = Long.valueOf(StringUtils.defaultString(request.getParameter("unsubscribe"), "1"));
+            unsubscribeAnswer.setProperty(FormUtils.VALUE_PROPERTY, value);
             session.save();
             if (checkin) {
                 versionManager.checkin(patientInformationForm.getPath());
             }
-            writeSuccess(response, true);
+            writeSuccess(response, value == 1);
         } catch (final LoginException e) {
             LOGGER.error("Service authorization not granted: {}", e.getMessage());
         } catch (final RepositoryException e) {

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/UnsubscribeServlet.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/UnsubscribeServlet.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.uhndata.cards.proms;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.jcr.Node;
+import javax.jcr.PropertyIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.version.VersionManager;
+import javax.json.Json;
+import javax.json.JsonObjectBuilder;
+import javax.servlet.Servlet;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.api.servlets.SlingAllMethodsServlet;
+import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.uhndata.cards.dataentry.api.FormUtils;
+import io.uhndata.cards.dataentry.api.QuestionnaireUtils;
+
+@Component(service = { Servlet.class })
+@SlingServletResourceTypes(resourceTypes = { "cards/PromsHomepage" }, extensions = {
+    "unsubscribe" }, methods = { "POST" })
+public class UnsubscribeServlet extends SlingAllMethodsServlet
+{
+    private static final long serialVersionUID = 552901093350213103L;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UnsubscribeServlet.class);
+
+    private static final String UNSUBSCRIBE = "email_unsubscribed";
+
+    @Reference
+    private ResourceResolverFactory resolverFactory;
+
+    @Reference
+    private FormUtils formUtils;
+
+    @Reference
+    private QuestionnaireUtils questionnaireUtils;
+
+    @Override
+    public void doPost(final SlingHttpServletRequest request, final SlingHttpServletResponse response)
+        throws IOException
+    {
+        // This only works for a token-authenticated session; refuse requests if this is not the case
+        final String sessionSubjectIdentifier =
+            (String) this.resolverFactory.getThreadResourceResolver().getAttribute("cards:sessionSubject");
+        if (sessionSubjectIdentifier == null) {
+            writeError(response, SlingHttpServletResponse.SC_BAD_REQUEST, "Not a valid patient session");
+            return;
+        }
+
+        try (ResourceResolver rr = this.resolverFactory.getServiceResourceResolver(
+            Map.of(ResourceResolverFactory.SUBSERVICE, "unsubscribe"))) {
+            final Session session = rr.adaptTo(Session.class);
+            final Node visitSubject = session.getNodeByIdentifier(sessionSubjectIdentifier);
+            final Node patientInformationQuestionnaire = getPatientInformationQuestionnaire(session);
+            final Node patientInformationForm =
+                getPatientInformationForm(visitSubject, patientInformationQuestionnaire, session);
+            if (patientInformationForm == null) {
+                writeError(response, SlingHttpServletResponse.SC_CONFLICT, "Sorry, cannot record your answer");
+                return;
+            }
+
+            final VersionManager versionManager = session.getWorkspace().getVersionManager();
+            final boolean checkin = !versionManager.isCheckedOut(patientInformationForm.getPath());
+            versionManager.checkout(patientInformationForm.getPath());
+
+            final Node unsubscribeQuestion =
+                this.questionnaireUtils.getQuestion(patientInformationQuestionnaire, UNSUBSCRIBE);
+            Node unsubscribeAnswer = this.formUtils.getAnswer(patientInformationForm, unsubscribeQuestion);
+            if (unsubscribeAnswer == null && patientInformationForm != null) {
+                unsubscribeAnswer = patientInformationForm.addNode(UUID.randomUUID().toString(), "cards:BooleanAnswer");
+                unsubscribeAnswer.setProperty("question", unsubscribeQuestion);
+            }
+            unsubscribeAnswer.setProperty(FormUtils.VALUE_PROPERTY, 1L);
+            session.save();
+            if (checkin) {
+                versionManager.checkin(patientInformationForm.getPath());
+            }
+            writeSuccess(response);
+        } catch (final LoginException e) {
+            LOGGER.error("Service authorization not granted: {}", e.getMessage());
+        } catch (final RepositoryException e) {
+            LOGGER.warn("Exception validating patient authentication: {}", e.getMessage(), e);
+        }
+    }
+
+    private Node getPatientInformationQuestionnaire(final Session session) throws RepositoryException
+    {
+        return session.getNode("/Questionnaires/Patient information");
+    }
+
+    private Node getPatientInformationForm(final Node visitSubject, final Node patientInformationQuestionnaire,
+        final Session session) throws RepositoryException
+    {
+        // Look for the patient's information in the repository
+        final Node patientSubject = visitSubject.getParent();
+        final PropertyIterator properties = patientSubject.getReferences("subject");
+        while (properties.hasNext()) {
+            final Node form = properties.nextProperty().getParent();
+            if (patientInformationQuestionnaire.getIdentifier()
+                .equals(this.formUtils.getQuestionnaireIdentifier(form))) {
+                return form;
+            }
+        }
+        return null;
+    }
+
+    private void writeSuccess(final SlingHttpServletResponse response)
+        throws IOException, RepositoryException
+    {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(SlingHttpServletResponse.SC_OK);
+        try (Writer out = response.getWriter()) {
+            final JsonObjectBuilder result = Json.createObjectBuilder();
+            result.add("status", "success");
+            out.append(result.build().toString());
+        }
+    }
+
+    private void writeError(final SlingHttpServletResponse response, final int statusCode, final String errorMessage)
+        throws IOException
+    {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(statusCode);
+        try (Writer out = response.getWriter()) {
+            out.append("{\"status\":\"error\",\"error\": \"" + errorMessage + "\"}");
+        }
+    }
+}

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ValidateCredentialsServlet.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ValidateCredentialsServlet.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
 import io.uhndata.cards.dataentry.api.FormUtils;
 import io.uhndata.cards.dataentry.api.QuestionnaireUtils;
 
-@Component(service = { Servlet.class })
+@Component(service = { Servlet.class }, property = { "sling.auth.requirements=-/Proms" })
 @SlingServletResourceTypes(resourceTypes = { "cards/PromsHomepage" }, extensions = {
     "validateCredentials" }, methods = { "POST" })
 public class ValidateCredentialsServlet extends SlingAllMethodsServlet

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AbstractPromsNotification.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AbstractPromsNotification.java
@@ -21,7 +21,6 @@ package io.uhndata.cards.proms.emailnotifications;
 
 import java.util.Calendar;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -107,13 +106,11 @@ abstract class AbstractPromsNotification
                         "cards:sessionSubject",
                         visitSubject.getPath()))
                     .getToken();
-                String surveysLink = "https://" + CARDS_HOST_AND_PORT + CLINIC_SLING_PATH + "?auth_token=" + token;
-                String unsubscribeLink =
-                    "https://" + CARDS_HOST_AND_PORT + "/Proms.unsubscribe.html?auth_token=" + token;
                 // Send the Notification Email
-                Map<String, String> valuesMap = new HashMap<>();
-                valuesMap.put("surveysLink", surveysLink);
-                valuesMap.put("unsubscribeLink", unsubscribeLink);
+                Map<String, String> valuesMap = Map.of(
+                    "surveysLink", "https://" + CARDS_HOST_AND_PORT + CLINIC_SLING_PATH + "?auth_token=" + token,
+                    "unsubscribeLink",
+                    "https://" + CARDS_HOST_AND_PORT + "/Proms.unsubscribe.html?auth_token=" + token);
                 String emailTextBody = EmailUtils.renderEmailTemplate(emailTextTemplate, valuesMap);
                 try {
                     EmailUtils.sendNotificationEmail(this.mailService, patientEmailAddress,

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AbstractPromsNotification.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AbstractPromsNotification.java
@@ -87,7 +87,8 @@ abstract class AbstractPromsNotification
                 if (patientSurveysComplete) {
                     continue;
                 }
-                String patientEmailAddress = AppointmentUtils.getPatientConsentedEmail(resolver, patientSubject);
+                String patientEmailAddress =
+                    AppointmentUtils.getPatientConsentedEmail(resolver, patientSubject, visitSubject);
                 if (patientEmailAddress == null) {
                     continue;
                 }

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AbstractPromsNotification.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AbstractPromsNotification.java
@@ -100,17 +100,20 @@ abstract class AbstractPromsNotification
                 String patientFullName = AppointmentUtils.getPatientFullName(resolver, patientSubject);
                 Calendar tokenExpiryDate = AppointmentUtils.parseDate(appointmentDate.getValueMap().get("value", ""));
                 atMidnight(tokenExpiryDate);
-                String surveysLink = "https://" + CARDS_HOST_AND_PORT + CLINIC_SLING_PATH + "?auth_token="
-                    + this.tokenManager.create(
-                        "patient",
-                        tokenExpiryDate,
-                        Collections.singletonMap(
-                            "cards:sessionSubject",
-                            visitSubject.getPath()))
-                        .getToken();
+                final String token = this.tokenManager.create(
+                    "patient",
+                    tokenExpiryDate,
+                    Collections.singletonMap(
+                        "cards:sessionSubject",
+                        visitSubject.getPath()))
+                    .getToken();
+                String surveysLink = "https://" + CARDS_HOST_AND_PORT + CLINIC_SLING_PATH + "?auth_token=" + token;
+                String unsubscribeLink =
+                    "https://" + CARDS_HOST_AND_PORT + "/Proms.unsubscribe.html?auth_token=" + token;
                 // Send the Notification Email
                 Map<String, String> valuesMap = new HashMap<>();
                 valuesMap.put("surveysLink", surveysLink);
+                valuesMap.put("unsubscribeLink", unsubscribeLink);
                 String emailTextBody = EmailUtils.renderEmailTemplate(emailTextTemplate, valuesMap);
                 try {
                     EmailUtils.sendNotificationEmail(this.mailService, patientEmailAddress,

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AppointmentUtils.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AppointmentUtils.java
@@ -131,9 +131,11 @@ public final class AppointmentUtils
      *
      * @param resolver a ResourceResolver that can be used to query the JCR
      * @param patientSubject the JCR Resource for the patient whose email we wish to obtain
+     * @param visitSubject the visit that we're sending emails for
      * @return the patient's email address or null
      */
-    public static String getPatientConsentedEmail(ResourceResolver resolver, Resource patientSubject)
+    public static String getPatientConsentedEmail(ResourceResolver resolver, Resource patientSubject,
+        Resource visitSubject)
     {
         long patientEmailUnsubscribed = getQuestionAnswerForSubject(
             resolver,
@@ -141,6 +143,17 @@ public final class AppointmentUtils
             "/Questionnaires/Patient information/email_unsubscribed",
             "cards:BooleanAnswer",
             0);
+        String visitLocation = getQuestionAnswerForSubject(resolver, visitSubject,
+            "/Questionnaires/Visit information/location", TEXT_ANSWER, "");
+
+        boolean ignoreEmailConsent = false;
+        Iterator<Resource> results = resolver.findResources(
+            "SELECT t.* FROM [cards:ClinicMapping] as t WHERE t.'displayName'='" + visitLocation + "'",
+            "JCR-SQL2");
+        if (results.hasNext()) {
+            ignoreEmailConsent = results.next().getValueMap().get("ignoreEmailConsent", Boolean.FALSE);
+        }
+
         long patientEmailOk = getQuestionAnswerForSubject(
             resolver,
             patientSubject,
@@ -153,7 +166,7 @@ public final class AppointmentUtils
             "/Questionnaires/Patient information/email",
             TEXT_ANSWER,
             "");
-        if (patientEmailUnsubscribed != 1 && patientEmailOk == 1) {
+        if (patientEmailUnsubscribed != 1 && (ignoreEmailConsent || patientEmailOk == 1)) {
             if (EmailValidator.getInstance().isValid(patientEmailAddress)) {
                 return patientEmailAddress;
             }

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AppointmentUtils.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AppointmentUtils.java
@@ -135,21 +135,25 @@ public final class AppointmentUtils
      */
     public static String getPatientConsentedEmail(ResourceResolver resolver, Resource patientSubject)
     {
+        long patientEmailUnsubscribed = getQuestionAnswerForSubject(
+            resolver,
+            patientSubject,
+            "/Questionnaires/Patient information/email_unsubscribed",
+            "cards:BooleanAnswer",
+            0);
         long patientEmailOk = getQuestionAnswerForSubject(
             resolver,
             patientSubject,
             "/Questionnaires/Patient information/email_ok",
             "cards:BooleanAnswer",
-            0
-        );
+            0);
         String patientEmailAddress = getQuestionAnswerForSubject(
             resolver,
             patientSubject,
             "/Questionnaires/Patient information/email",
             TEXT_ANSWER,
-            ""
-        );
-        if (patientEmailOk == 1) {
+            "");
+        if (patientEmailUnsubscribed != 1 && patientEmailOk == 1) {
             if (EmailValidator.getInstance().isValid(patientEmailAddress)) {
                 return patientEmailAddress;
             }

--- a/proms-resources/backend/src/main/resources/SLING-INF/content/apps/cards/proms/clinics/Cardio/mailTemplates/24h.html
+++ b/proms-resources/backend/src/main/resources/SLING-INF/content/apps/cards/proms/clinics/Cardio/mailTemplates/24h.html
@@ -117,5 +117,8 @@
     <p style="text-align: center" class="smallfont">
       Peter Munk Cardiac Centre
     </p>
+    <p class="smallfont">
+      <a href="${unsubscribeLink}">Unsubscribe from further emails from DATAPRO</a>
+    </p>
   </body>
 </html>

--- a/proms-resources/backend/src/main/resources/SLING-INF/content/apps/cards/proms/clinics/Cardio/mailTemplates/24h.txt
+++ b/proms-resources/backend/src/main/resources/SLING-INF/content/apps/cards/proms/clinics/Cardio/mailTemplates/24h.txt
@@ -41,3 +41,5 @@ DATAPRO
 University Health Network
 
 Peter Munk Cardiac Centre
+
+Unsubscribe from further emails from DATAPRO: ${unsubscribeLink}

--- a/proms-resources/backend/src/main/resources/SLING-INF/content/apps/cards/proms/clinics/Cardio/mailTemplates/72h.html
+++ b/proms-resources/backend/src/main/resources/SLING-INF/content/apps/cards/proms/clinics/Cardio/mailTemplates/72h.html
@@ -117,5 +117,8 @@
     <p style="text-align: center" class="smallfont">
       Peter Munk Cardiac Centre
     </p>
+    <p class="smallfont">
+      <a href="${unsubscribeLink}">Unsubscribe from further emails from DATAPRO</a>
+    </p>
   </body>
 </html>

--- a/proms-resources/backend/src/main/resources/SLING-INF/content/apps/cards/proms/clinics/Cardio/mailTemplates/72h.txt
+++ b/proms-resources/backend/src/main/resources/SLING-INF/content/apps/cards/proms/clinics/Cardio/mailTemplates/72h.txt
@@ -41,3 +41,5 @@ DATAPRO
 University Health Network
 
 Peter Munk Cardiac Centre
+
+Unsubscribe from further emails from DATAPRO: ${unsubscribeLink}

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms/ClinicMapping.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms/ClinicMapping.xml
@@ -56,5 +56,10 @@
             <value>Adult Congenital Heart Disease clinic</value>
             <type>String</type>
         </property>
+        <property>
+            <name>ignoreEmailConsent</name>
+            <value>True</value>
+            <type>Boolean</type>
+        </property>
     </node>
 </node>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Patient information.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Patient information.xml
@@ -146,6 +146,25 @@
 		</property>
 	</node>
 	<node>
+		<name>email_unsubscribed</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>The patient unsubscribed from all email notifications</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>boolean</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
 		<name>email_ok</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/config/CopyAnswers/Visit information.json
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/config/CopyAnswers/Visit information.json
@@ -3,6 +3,7 @@
   "jcr:reference:time": "/Questionnaires/Visit information/time",
   "jcr:reference:surveys_complete": "/Questionnaires/Visit information/surveys_complete",
   "jcr:reference:surveys_submitted": "/Questionnaires/Visit information/surveys_submitted",
+  "jcr:reference:email_unsubscribed": "/Questionnaires/Patient information/email_unsubscribed",
   "jcr:reference:mrn": "/Questionnaires/Patient information/mrn",
   "jcr:reference:first_name": "/Questionnaires/Patient information/first_name",
   "jcr:reference:last_name": "/Questionnaires/Patient information/last_name"

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/nodetypes/proms.cnd
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/nodetypes/proms.cnd
@@ -132,3 +132,6 @@
 
   // The display name to return to the user
   - displayName (String) mandatory
+
+  // If TRUE, the email_ok question in Patient Information is ignored
+  - ignoreEmailConsent (boolean)

--- a/proms-resources/feature/src/main/features/feature.json
+++ b/proms-resources/feature/src/main/features/feature.json
@@ -68,6 +68,8 @@
         "create service user proms-patient-validation \n set ACL for proms-patient-validation \n   allow jcr:read on /Questionnaires,/Subjects,/SubjectTypes,/Forms \n end",
         // Enforcing Terms Of Use acceptance
         "create service user proms-patient-tou \n set ACL for proms-patient-tou \n   allow jcr:read,rep:write,jcr:versionManagement on /Forms \n   allow jcr:read on /Questionnaires,/Subjects \n end",
+        // Unsubscribe from email notifications
+        "create service user proms-patient-unsubscribe \n set ACL for proms-patient-unsubscribe \n   allow jcr:read,rep:write,jcr:versionManagement on /Forms \n   allow jcr:read on /Questionnaires,/Subjects \n end",
         // Trusted users can only access forms submitted by their patients, and delete forms that they created
         "create group TrustedUsers \n\n set ACL for TrustedUsers \n   deny rep:write on /Subjects \n   allow jcr:removeChildNodes on /Forms \n     deny jcr:removeNode on /Forms restriction(rep:ntNames,cards:Form,cards:Subject) \n     allow jcr:removeNode on /Forms restriction(cards:createdBy) \n    deny jcr:all on /Forms restriction(cards:unsubmittedForms) \n end ",
         // Special handling of the 404 page button: patients go to the PROMS UI, all other users go to the dashboard
@@ -79,6 +81,7 @@
         "io.uhndata.cards.proms-backend:VisitFormsPreparation=[proms-visit-backend]",
         "io.uhndata.cards.proms-backend:validateCredentials=[proms-patient-validation]",
         "io.uhndata.cards.proms-backend:tou=[proms-patient-tou]",
+        "io.uhndata.cards.proms-backend:unsubscribe=[proms-patient-unsubscribe]",
         "io.uhndata.cards.proms-backend:EmailNotifications=[sling-readall]",
         "io.uhndata.cards.proms-backend:UnsubmittedFormsRestriction=[sling-readall]",
         "io.uhndata.cards.proms-backend:TorchImporter=[proms-import-backend]"

--- a/proms-resources/frontend/src/main/frontend/src/proms/VisitView.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/VisitView.jsx
@@ -90,7 +90,7 @@ function VisitView(props) {
          <Link
            className={classes["status" + (!row.surveys_complete ? "Incomplete" : (!row.surveys_submitted ? "Unreviewed" : "Completed"))]}
            to={`/content.html${row.subject['@path']}`}>
-           { !row.surveys_complete ? "Incomplete" : (!row.surveys_submitted ? "Pending submission" : "Completed") }
+           { row.email_unsubscribed ? "Unsubscribed" : !row.surveys_complete ? "Incomplete" : (!row.surveys_submitted ? "Pending submission" : "Completed") }
          </Link>
       )
     }

--- a/proms-resources/frontend/src/main/frontend/src/proms/unsubscribe.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/unsubscribe.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import ReactDOM from "react-dom";
 import { Router, Route, Redirect, Switch } from "react-router-dom";
 import { Paper, Grid, Button, Typography, makeStyles } from '@material-ui/core';
@@ -47,9 +47,10 @@ function Unsubscribe (props) {
   // Current user and associated subject
   const [ confirmed, setConfirmed ] = useState(false);
   const [ error, setError ] = useState();
+  const [ alreadyUnsubscribed, setAlreadyUnsubscribed ] = useState(false);
   const classes = useStyles();
   let unsubscribe = () => {
-    fetch("/Proms.unsubscribe.html", {method: 'POST'})
+    fetch("/Proms.unsubscribe", {method: 'POST'})
       .then( (response) => response.ok ? response.json() : Promise.reject(response) )
       .then( json => json.status == "success" ? setConfirmed(true) : Promise.reject(json.error))
       .catch((response) => {
@@ -69,6 +70,16 @@ function Unsubscribe (props) {
     );
   }
 
+  useEffect(() => {
+    fetch("/Proms.unsubscribe", {method: 'GET'})
+      .then( (response) => response.ok ? response.json() : Promise.reject(response) )
+      .then( json => json.status == "success" ? setAlreadyUnsubscribed(json.unsubscribed) : Promise.reject(json.error))
+      .catch((response) => {
+        let errMsg = "Cannot unsubscribe: ";
+        setError(errMsg + (response.status ? response.statusText : response));
+      });
+  }, []);
+
   return <MuiThemeProvider theme={appTheme}>
       <Paper className={classes.paper} elevation={0}>
         <Grid
@@ -87,7 +98,9 @@ function Unsubscribe (props) {
                {error}
               </Alert>
             }
-            { confirmed ?
+            { alreadyUnsubscribed ?
+              <Alert icon={false} severity="info">You are already unsubscribed.</Alert>
+              : confirmed ?
               <Alert icon={false} severity="info">
                 You have been unsubscribed.
               </Alert>

--- a/proms-resources/frontend/src/main/frontend/src/proms/unsubscribe.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/unsubscribe.jsx
@@ -79,7 +79,7 @@ function Unsubscribe (props) {
           alignContent="center"
         >
           <Grid item>
-            <img src="/libs/cards/resources/logo_light_bg.png" alt="this.state.title" className={classes.logo}/>
+            <img src="/libs/cards/resources/logo_light_bg.png" alt="" className={classes.logo}/>
           </Grid>
           <Grid item>
             { error && <Alert severity="error">

--- a/proms-resources/frontend/src/main/frontend/src/proms/unsubscribe.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/unsubscribe.jsx
@@ -1,0 +1,118 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+import React, { useState } from "react";
+import ReactDOM from "react-dom";
+import { Router, Route, Redirect, Switch } from "react-router-dom";
+import { Paper, Grid, Button, Typography, makeStyles } from '@material-ui/core';
+import { Alert, AlertTitle } from "@material-ui/lab";
+import { createBrowserHistory } from "history";
+import { MuiThemeProvider } from '@material-ui/core/styles';
+import { appTheme } from "../themePalette.jsx";
+import PromsFooter from "./Footer.jsx";
+import ErrorPage from "../components/ErrorPage.jsx";
+
+const useStyles = makeStyles(theme => ({
+  paper: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    padding: theme.spacing(12, 3, 3),
+    textAlign: "center",
+    "& .MuiGrid-item" : {
+      textAlign: "center",
+    },
+  },
+  logo: {
+    maxWidth: "240px",
+  },
+}));
+
+function Unsubscribe (props) {
+  // Current user and associated subject
+  const [ confirmed, setConfirmed ] = useState(false);
+  const [ error, setError ] = useState();
+  const classes = useStyles();
+  let unsubscribe = () => {
+    fetch("/Proms.unsubscribe.html", {method: 'POST'})
+      .then( (response) => response.ok ? response.json() : Promise.reject(response) )
+      .then( json => json.status == "success" ? setConfirmed(true) : Promise.reject(json.error))
+      .catch((response) => {
+        let errMsg = "Unsubscribing failed";
+        setError(errMsg + (response.status ? ` with error code ${response.status}: ${response.statusText}` : response));
+      });
+  }
+
+  if (!("hasSessionSubject" in document.getElementById("proms-unsubscribe-container").dataset)) {
+    return (
+      <ErrorPage
+        title="Invalid access"
+        message="This page can only be accessed by opening an invitation to fill in a survey"
+        buttonLink="/content.html/Questionnaires/User"
+        buttonLabel="Go to the dashboard"
+      />
+    );
+  }
+
+  return <MuiThemeProvider theme={appTheme}>
+      <Paper className={classes.paper} elevation={0}>
+        <Grid
+          container
+          direction="column"
+          spacing={7}
+          alignItems="center"
+          alignContent="center"
+        >
+          <Grid item>
+            <img src="/libs/cards/resources/logo_light_bg.png" alt="this.state.title" className={classes.logo}/>
+          </Grid>
+          <Grid item>
+            { error && <Alert severity="error">
+              <AlertTitle>An error occurred</AlertTitle>
+               {error}
+              </Alert>
+            }
+            { confirmed ?
+              <Alert icon={false} severity="info">
+                You have been unsubscribed.
+              </Alert>
+              :
+              <><Typography>This will unsubscribe you from receiving all emails via DATA-PRO. If you wish to unsubscribe from all UHN communication, please contact your care team.</Typography>
+              <Button
+                type="submit"
+                variant="contained"
+                color="primary"
+                className={classes.submit}
+                onClick={unsubscribe}
+                >
+                Unsubscribe
+              </Button>
+              </>
+            }
+          </Grid>
+        </Grid>
+      </Paper>
+    </MuiThemeProvider>
+}
+
+ReactDOM.render(
+  <Unsubscribe />,
+  document.querySelector('#proms-unsubscribe-container')
+);
+
+export default Unsubscribe;

--- a/proms-resources/frontend/src/main/frontend/src/proms/unsubscribe.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/unsubscribe.jsx
@@ -45,14 +45,17 @@ const useStyles = makeStyles(theme => ({
 
 function Unsubscribe (props) {
   // Current user and associated subject
-  const [ confirmed, setConfirmed ] = useState(false);
+  const [ confirmed, setConfirmed ] = useState(null);
   const [ error, setError ] = useState();
   const [ alreadyUnsubscribed, setAlreadyUnsubscribed ] = useState(false);
   const classes = useStyles();
-  let unsubscribe = () => {
-    fetch("/Proms.unsubscribe", {method: 'POST'})
+
+  let unsubscribe = (value) => {
+    let request_data = new FormData();
+    request_data.append("unsubscribe", value);
+    fetch("/Proms.unsubscribe", { method: 'POST', body: request_data })
       .then( (response) => response.ok ? response.json() : Promise.reject(response) )
-      .then( json => json.status == "success" ? setConfirmed(true) : Promise.reject(json.error))
+      .then( json => json.status == "success" ? (setConfirmed(json.unsubscribed), setAlreadyUnsubscribed(null)) : Promise.reject(json.error))
       .catch((response) => {
         let errMsg = "Unsubscribing failed";
         setError(errMsg + (response.status ? ` with error code ${response.status}: ${response.statusText}` : response));
@@ -99,10 +102,21 @@ function Unsubscribe (props) {
               </Alert>
             }
             { alreadyUnsubscribed ?
-              <Alert icon={false} severity="info">You are already unsubscribed.</Alert>
-              : confirmed ?
+              <>
+                <Alert icon={false} severity="info">You are already unsubscribed.</Alert>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  color="primary"
+                  className={classes.submit}
+                  onClick={() => unsubscribe(0)}
+                  >
+                  Resubscribe
+                </Button>
+              </>
+              : confirmed !== null ?
               <Alert icon={false} severity="info">
-                You have been unsubscribed.
+                You have been {confirmed ? "unsubscribed" : "resubscribed"}.
               </Alert>
               :
               <><Typography>This will unsubscribe you from receiving all emails via DATA-PRO. If you wish to unsubscribe from all UHN communication, please contact your care team.</Typography>
@@ -111,7 +125,7 @@ function Unsubscribe (props) {
                 variant="contained"
                 color="primary"
                 className={classes.submit}
-                onClick={unsubscribe}
+                onClick={() => unsubscribe(1)}
                 >
                 Unsubscribe
               </Button>

--- a/proms-resources/frontend/src/main/frontend/webpack.config.js
+++ b/proms-resources/frontend/src/main/frontend/webpack.config.js
@@ -7,6 +7,7 @@ module.exports = {
   mode: 'development',
   entry: {
     [module_name + 'index']: './src/proms/index.jsx',
+    [module_name + 'unsubscribe']: './src/proms/unsubscribe.jsx',
     [module_name + 'ToULink']: './src/proms/ToULink.jsx'
     [module_name + 'PromsDashboard']: './src/proms/PromsDashboard.jsx',
     [module_name + 'PromsView']: './src/proms/PromsView.jsx',

--- a/proms-resources/frontend/src/main/resources/SLING-INF/content/libs/cards/PromsHomepage/html.GET.html
+++ b/proms-resources/frontend/src/main/resources/SLING-INF/content/libs/cards/PromsHomepage/html.GET.html
@@ -18,29 +18,6 @@
   under the License.
 */-->
 <sly data-sly-resource="${@selectors='header'}"/>
-    <script>
-      // Redirect to /login if the user is not logged in
-      // Since the default window.Sling.getSessionInfo() throws an async warning, we fetch it ourselves
-      var url = window.Sling.baseurl + "/system/sling/info.sessionInfo.json";
-      fetch(url)
-      .then(function(response) {
-        if (response.ok) {
-          return response.json();
-        } else {
-          throw new Error();
-        }
-      })
-      .then(function(json) {
-        if (json.userID === 'anonymous') {
-          throw new Error();
-        }
-      })
-      .catch(function() {
-        // Provide the `resource` to redirect to after successful login
-        var relativeLocation = window.location.toString().substring(window.location.origin.length);
-        window.location = window.Sling.baseurl + "/login.html" + ((relativeLocation.length > 1) ? ("?resource=" + encodeURIComponent(relativeLocation)) : "");
-      });
-    </script>
     <div id="proms-container" data-sly-use.sessionAttributes="sessionAttributes.js" data-sly-attribute.data-has-session-subject="${sessionAttributes.hasSessionSubject}" style="min-height: calc(100vh - 16px);display: flex;flex-direction: column;justify-content: space-between;"></div>
     <sly data-sly-use.assets="/libs/cards/resources/assets">
       <script src="/libs/cards/resources/${assets['proms-homepage.index.js']}"></script>

--- a/proms-resources/frontend/src/main/resources/SLING-INF/content/libs/cards/PromsHomepage/unsubscribe.html.GET.html
+++ b/proms-resources/frontend/src/main/resources/SLING-INF/content/libs/cards/PromsHomepage/unsubscribe.html.GET.html
@@ -1,0 +1,48 @@
+<sly data-sly-use.contentType="io.uhndata.cards.scripting.ContentTypeSetter">${contentType.html}</sly>
+<!--/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+*/-->
+<sly data-sly-resource="${@selectors='header'}"/>
+    <script>
+      // Redirect to /login if the user is not logged in
+      // Since the default window.Sling.getSessionInfo() throws an async warning, we fetch it ourselves
+      var url = window.Sling.baseurl + "/system/sling/info.sessionInfo.json";
+      fetch(url)
+      .then(function(response) {
+        if (response.ok) {
+          return response.json();
+        } else {
+          throw new Error();
+        }
+      })
+      .then(function(json) {
+        if (json.userID === 'anonymous') {
+          throw new Error();
+        }
+      })
+      .catch(function() {
+        // Provide the `resource` to redirect to after successful login
+        var relativeLocation = window.location.toString().substring(window.location.origin.length);
+        window.location = window.Sling.baseurl + "/login.html" + ((relativeLocation.length > 1) ? ("?resource=" + encodeURIComponent(relativeLocation)) : "");
+      });
+    </script>
+    <div id="proms-unsubscribe-container" data-sly-use.sessionAttributes="sessionAttributes.js" data-sly-attribute.data-has-session-subject="${sessionAttributes.hasSessionSubject}" style="min-height: calc(100vh - 16px);display: flex;flex-direction: column;justify-content: space-between;"></div>
+    <sly data-sly-use.assets="/libs/cards/resources/assets">
+      <script src="/libs/cards/resources/${assets['proms-homepage.unsubscribe.js']}"></script>
+    </sly>
+<sly data-sly-resource="${@selectors='footer'}"/>

--- a/proms-resources/frontend/src/main/resources/SLING-INF/content/libs/cards/PromsHomepage/unsubscribe.html.GET.html
+++ b/proms-resources/frontend/src/main/resources/SLING-INF/content/libs/cards/PromsHomepage/unsubscribe.html.GET.html
@@ -18,29 +18,6 @@
   under the License.
 */-->
 <sly data-sly-resource="${@selectors='header'}"/>
-    <script>
-      // Redirect to /login if the user is not logged in
-      // Since the default window.Sling.getSessionInfo() throws an async warning, we fetch it ourselves
-      var url = window.Sling.baseurl + "/system/sling/info.sessionInfo.json";
-      fetch(url)
-      .then(function(response) {
-        if (response.ok) {
-          return response.json();
-        } else {
-          throw new Error();
-        }
-      })
-      .then(function(json) {
-        if (json.userID === 'anonymous') {
-          throw new Error();
-        }
-      })
-      .catch(function() {
-        // Provide the `resource` to redirect to after successful login
-        var relativeLocation = window.location.toString().substring(window.location.origin.length);
-        window.location = window.Sling.baseurl + "/login.html" + ((relativeLocation.length > 1) ? ("?resource=" + encodeURIComponent(relativeLocation)) : "");
-      });
-    </script>
     <div id="proms-unsubscribe-container" data-sly-use.sessionAttributes="sessionAttributes.js" data-sly-attribute.data-has-session-subject="${sessionAttributes.hasSessionSubject}" style="min-height: calc(100vh - 16px);display: flex;flex-direction: column;justify-content: space-between;"></div>
     <sly data-sly-use.assets="/libs/cards/resources/assets">
       <script src="/libs/cards/resources/${assets['proms-homepage.unsubscribe.js']}"></script>


### PR DESCRIPTION
**To test [CARDS-1670](https://phenotips.atlassian.net/browse/CARDS-1670): (_As a user, I need to be able to unsubscribe from emails sent by the DATA-PRO application_)**
- start in proms mode
- create a new Patient Information form, set "The patient consents to being contacted by email" to Yes
- create a new Visit set 4 days in the futue
- trigger the 72h notification job
- [ ] does the email notification contain the right link?
- [ ] does the link lead to a working Unsubscribe page?
- [ ] does unsubscribing change the "Patient Information form / The patient unsubscribed from all email notifications" answer to Yes?
- trigger the 24h notifications job
- [ ] is the notification not sent to the patient?
- [ ] in composum, remove the answer for the Unsubscribe question
- [ ] open the Unsubscribe link again, unsubscribe -> is a new answer created and set to Yes?
- [ ] delete the Patient Information form
- [ ] open the Unsubscribe link again, unsubscribe -> is an error "Sorry, cannot record your answer" displayed?
- [ ] create the Patient Information form again, open the Unsubscribe page, unsubscribe
- [ ] open the Unsubscribe page, does it say "You are already unsubscribed" and shows a Resubscribe button?
- [ ] click the Resubscribe button, does it say "You have been resubscribed", and does the Answer switch to No?

**To test [CARDS-1681](https://phenotips.atlassian.net/browse/CARDS-1681) (_PROMs: Accessing the Proms homepage should not display the login dialog_):**
- start in proms mode
- [ ] while not authenticated, open `/Proms.html` -> is the log in dialog displayed (wrong) or the "Invalid access" error page (correct)?
- [ ] while not authenticated, open `/Proms.unsubscribe.html` -> is the log in dialog displayed (wrong) or the "Invalid access" error page (correct)?
- [ ] while not authenticated, open `/Proms.html?auth_token=invalid` -> is the "Expired" error page displayed?