### PR TITLE
CARDS-1682: Setting and resetting completed and submitted values in the Visit information Form is causing re-import from Torch to fail

### DIFF
--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Visit information.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Visit information.xml
@@ -135,6 +135,11 @@
 			<value>Location</value>
 			<type>String</type>
 		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
 	</node>
 	<node>
 		<name>status</name>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Visit information.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Visit information.xml
@@ -169,13 +169,4 @@
 			<type>Long</type>
 		</property>
 	</node>
-	<node>
-		<name>location</name>
-		<primaryNodeType>cards:Question</primaryNodeType>
-		<property>
-			<name>text</name>
-			<value>Location</value>
-			<type>String</type>
-		</property>
-	</node>
 </node>


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/CARDS-1682)

Made Location single-valued