### PR TITLE
CARDS-1683: Conditionals do not support <= or >=

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
@@ -34,6 +34,8 @@ const OPERATIONS = {
   "=": (a, b) => (a == b),
   "<": (a, b) => (a < b),
   ">": (a, b) => (a > b),
+  "<=": (a, b) => (a <= b),
+  ">=": (a, b) => (a >= b),
   "<>": (a, b) => (a != b),
   "is empty": (a, b) => (EMPTY.indexOf(a) >= 0 || EMPTY.indexOf(b) >= 0),
   "is not empty": (a, b) => (EMPTY.indexOf(a) < 0 || EMPTY.indexOf(b) < 0)

--- a/modules/form-completion-status/src/main/java/io/uhndata/cards/formcompletionstatus/ConditionalSectionUtils.java
+++ b/modules/form-completion-status/src/main/java/io/uhndata/cards/formcompletionstatus/ConditionalSectionUtils.java
@@ -132,7 +132,7 @@ public final class ConditionalSectionUtils
                 put(PropertyType.DATE, (a, b) -> {
                     Calendar dateA = toDate(a);
                     Calendar dateB = toDate(b);
-                    return dateA != null && dateB != null && (dateA.before(dateB) || dateA.equals(dateB));
+                    return dateA != null && dateB != null && !dateA.after(dateB);
                 });
             }
         };
@@ -152,7 +152,7 @@ public final class ConditionalSectionUtils
                 put(PropertyType.DATE, (a, b) -> {
                     Calendar dateA = toDate(a);
                     Calendar dateB = toDate(b);
-                    return dateA != null && dateB != null && (dateA.after(dateB) || dateA.equals(dateB));
+                    return dateA != null && dateB != null && !dateA.before(dateB);
                 });
             }
         };

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/LongConditionalTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/LongConditionalTest.xml
@@ -27,7 +27,7 @@
 	</property>
 	<property>
 		<name>description</name>
-		<value>LFS-273, LFS-275, LFS-484</value>
+		<value>LFS-273, LFS-275, LFS-484, CARDS-1683</value>
 		<type>String</type>
 	</property>
 	<property>
@@ -756,6 +756,183 @@
 				<property>
 					<name>isReference</name>
 					<value>True</value>
+					<type>Boolean</type>
+				</property>
+			</node>
+		</node>
+		<node>
+			<name>test</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Confirm okay</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>text</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+		</node>
+	</node>
+
+	<node>
+		<name>string_ref_nine</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Long Value I, make it greater than or equal to 5</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>long</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>stringref_gte_stringref_details</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<node>
+			<name>condition</name>
+			<primaryNodeType>cards:Conditional</primaryNodeType>
+			<property>
+				<name>comparator</name>
+				<value><![CDATA[>=]]></value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>long</value>
+				<type>String</type>
+			</property>
+			<node>
+				<name>operandA</name>
+				<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+				<property>
+					<name>value</name>
+					<values>
+						<value>string_ref_nine</value>
+					</values>
+					<type>String</type>
+				</property>
+				<property>
+					<name>isReference</name>
+					<value>True</value>
+					<type>Boolean</type>
+				</property>
+			</node>
+			<node>
+				<name>operandB</name>
+				<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+				<property>
+					<name>value</name>
+					<values>
+						<value>5</value>
+					</values>
+					<type>Long</type>
+				</property>
+				<property>
+					<name>isReference</name>
+					<value>False</value>
+					<type>Boolean</type>
+				</property>
+			</node>
+		</node>
+		<node>
+			<name>test</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Confirm okay</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>text</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+		</node>
+	</node>
+	<node>
+		<name>string_ref_ten</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Long Value J, make it less than or equal to 5</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>long</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>stringref_lte_stringref_details</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<node>
+			<name>condition</name>
+			<primaryNodeType>cards:Conditional</primaryNodeType>
+			<property>
+				<name>comparator</name>
+				<value><![CDATA[<=]]></value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>long</value>
+				<type>String</type>
+			</property>
+			<node>
+				<name>operandA</name>
+				<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+				<property>
+					<name>value</name>
+					<values>
+						<value>string_ref_ten</value>
+					</values>
+					<type>String</type>
+				</property>
+				<property>
+					<name>isReference</name>
+					<value>True</value>
+					<type>Boolean</type>
+				</property>
+			</node>
+			<node>
+				<name>operandB</name>
+				<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+				<property>
+					<name>value</name>
+					<values>
+						<value>5</value>
+					</values>
+					<type>Long</type>
+				</property>
+				<property>
+					<name>isReference</name>
+					<value>False</value>
 					<type>Boolean</type>
 				</property>
 			</node>


### PR DESCRIPTION
- Add front end and back end support for `<=`/`>=` conditionals
- Add test case to the Long conditional test form

Testing: Need to verify that these new conditionals work in both the front end and back end. Since the incomplete tag is computed on the backend taking conditionals into account, this tag can be used to verify backend functionality.

2 questions have been added to the Long conditional test form. A conditional section is shown when `Long Value I` is >= 5 and a different conditional section is shown when `Long Value J` is <= 5.

First, enter a value into `Must be empty` question to hide it's conditional section.

Setting Long Value `I` and `J` to 5 should open a conditional section with a confirm ok question. Verify that whenever a blank confirm field is present from these question, the form is marked incomplete and that when no blank confirm fields are present, the form is complete.