### PR TITLE
Misc: Install bash in the build stage image of the Docker image build pipeline

### DIFF
--- a/distribution/make_filled_m2.sh
+++ b/distribution/make_filled_m2.sh
@@ -18,6 +18,6 @@
 # under the License.
 
 apk update || exit -1
-apk add openjdk11 maven python3 gcompat || exit -1
+apk add bash openjdk11 maven python3 gcompat || exit -1
 ln -s /usr/bin/python3 /usr/bin/python || exit -1
 mvn clean install || exit -1


### PR DESCRIPTION
Install bash in the build stage image of the Docker image build pipeline as it is required for running required build scripts.

This PR is required to be merged into `dev` and then `CARDS-1686` must be rebased on the new `dev` before it, itself, can be merged into `dev`.