### PR TITLE
CARDS-1688: When building self-contained Docker images, Webpack resources should be built in production mode

### DIFF
--- a/distribution/make_filled_m2.sh
+++ b/distribution/make_filled_m2.sh
@@ -20,4 +20,4 @@
 apk update || exit -1
 apk add bash openjdk11 maven python3 gcompat || exit -1
 ln -s /usr/bin/python3 /usr/bin/python || exit -1
-mvn clean install || exit -1
+mvn clean install -Prelease -Dgpg.skip -Dmaven.javadoc.skip || exit -1


### PR DESCRIPTION
This PR implements CARDS-1688 by modifying `distribution/make_filled_m2.sh` so that self-contained Docker images contain production-built Webpack resources as opposed to development built Webpack resources.

To test:

1. Make a fake release (`mvn release:prepare -DreleaseVersion=0.9.fake -DdevelopmentVersion=0.9-SNAPSHOT -Dtag=cards-0.9.fake`)
2. `git checkout cards-0.9.fake`
3. Build a self-contained Docker image with `MAVEN_OPTS="-Ddocker.buildArg.build_jars=true -Ddocker.verbose=true" mvn clean install | tee ~/cards-build.log` (:turtle: :turtle: :turtle: slow, as this downloads all dependency JARs :turtle: :turtle: :turtle:)
4. Ensure that `DOCKER> [INFO] Running 'webpack.js --mode=production'` is in the `~/cards-build.log` file.
5. Test it by building a simple Docker Compose set of services and verify that all works well.