### PR TITLE
CARDS-1631: Mark visits with no surveys as "No surveys assigned"

### DIFF
--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/VisitChangeListener.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/VisitChangeListener.java
@@ -192,12 +192,12 @@ public class VisitChangeListener implements ResourceChangeListener
 
             // If case 1, record that this visit has no forms
             if (prunedQuestionnaireSetSize == baseQuestionnaireSetSize) {
-                changeVisitInformation(form, false, session, "has_surveys");
+                changeVisitInformation(form, "has_surveys", false, session);
             }
             return;
         } else {
             // Record that this visit has forms
-            changeVisitInformation(form, true, session, "has_surveys");
+            changeVisitInformation(form, "has_surveys", true, session);
 
             final List<String> createdForms = createForms(visit, questionnaireSetInfo, session);
             commitForms(createdForms, session);
@@ -241,7 +241,7 @@ public class VisitChangeListener implements ResourceChangeListener
         // The actual number of forms does not matter, since all the needed forms have been pre-created, and any still
         // incomplete form will cause the method to return early from the check above
         if (visitInformationForm != null) {
-            changeVisitInformation(visitInformationForm, true, session, "surveys_complete");
+            changeVisitInformation(visitInformationForm, "surveys_complete", true, session);
         }
     }
 
@@ -558,12 +558,12 @@ public class VisitChangeListener implements ResourceChangeListener
      * Will not update the visit information form if the question already has the desired answer.
      *
      * @param visitInformationForm the Visit Information form to save the value to, if needed
+     * @param questionPath the relative path from the visit information questionnaire to the question to be answered
      * @param value the value that answer should be set to
      * @param session a service session providing access to the repository
-     * @param questionPath the relative path from the visit information questionnaire to the question to be answered
      */
-    private void changeVisitInformation(final Node visitInformationForm, final boolean value, final Session session,
-        final String questionPath)
+    private void changeVisitInformation(final Node visitInformationForm, final String questionPath,
+        final boolean value, final Session session)
     {
         try {
             final Long newValue = value ? 1L : 0L;

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/VisitChangeListener.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/VisitChangeListener.java
@@ -180,6 +180,13 @@ public class VisitChangeListener implements ResourceChangeListener
 
         if (prunedQuestionnaireSetSize < 1) {
             // Visit already has all needed forms: end early
+
+            // Ideally, has_surveys would already be set to true so this should not be needed.
+            // However, if the visit information form is edited via the browser editor and saved twice,
+            // `has_surveys` can be incorrectly deleted and may need to be set back to true.
+            if (baseQuestionnaireSetSize > 0) {
+                changeVisitInformation(form, "has_surveys", true, session);
+            }
             return;
         }
 

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/VisitChangeListener.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/VisitChangeListener.java
@@ -179,7 +179,7 @@ public class VisitChangeListener implements ResourceChangeListener
         final int prunedQuestionnaireSetSize = questionnaireSetInfo.size();
 
         if (prunedQuestionnaireSetSize < 1) {
-            // Visit already has all needed forms: end early
+            // Visit already has all forms in the questionnaire set: end early
 
             // Ideally, has_surveys would already be set to true so this should not be needed.
             // However, if the visit information form is edited via the browser editor and saved twice,
@@ -193,13 +193,22 @@ public class VisitChangeListener implements ResourceChangeListener
         pruneQuestionnaireSet(visit, visitInformation, questionnaireSetInfo);
 
         if (questionnaireSetInfo.size() < 1) {
-            // No questionnaires were created. This can be due to 2 situations:
-            // 1. There are no questionnaires that need to be filled out for this visit
-            // 2. All the questionnaires that need to be filled out already exist
+            // No questionnaires were created as all missing questionnaires from the questionnaire set
+            // have their frequencies met by other visits.
 
-            // If case 1, record that this visit has no forms
+            // This visit can either have:
+            // 1. No questionnaires
+            // 2. A subset of the questionnaires from the questionnaire set which were previously created
             if (prunedQuestionnaireSetSize == baseQuestionnaireSetSize) {
+                // If case 1, record that this visit has no forms
                 changeVisitInformation(form, "has_surveys", false, session);
+            } else {
+                // If case 2, record that this visit has forms
+
+                // Ideally, has_surveys would already be set to true so this should not be needed.
+                // However, if the visit information form is edited via the browser editor and saved twice,
+                // `has_surveys` can be incorrectly deleted and may need to be set back to true.
+                changeVisitInformation(form, "has_surveys", true, session);
             }
             return;
         } else {

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Visit information.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Visit information.xml
@@ -95,6 +95,30 @@
 		</property>
 	</node>
 	<node>
+		<name>has_surveys</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Answered when generating surveys for the visit.</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>hidden</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>boolean</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+	</node>
+	<node>
 		<name>time</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/config/CopyAnswers/Visit information.json
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/config/CopyAnswers/Visit information.json
@@ -3,6 +3,7 @@
   "jcr:reference:time": "/Questionnaires/Visit information/time",
   "jcr:reference:surveys_complete": "/Questionnaires/Visit information/surveys_complete",
   "jcr:reference:surveys_submitted": "/Questionnaires/Visit information/surveys_submitted",
+  "jcr:reference:has_surveys": "/Questionnaires/Visit information/has_surveys",
   "jcr:reference:email_unsubscribed": "/Questionnaires/Patient information/email_unsubscribed",
   "jcr:reference:mrn": "/Questionnaires/Patient information/mrn",
   "jcr:reference:first_name": "/Questionnaires/Patient information/first_name",

--- a/proms-resources/frontend/src/main/frontend/src/proms/VisitView.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/VisitView.jsx
@@ -32,6 +32,9 @@ const useStyles = color => makeStyles(theme => ({
        border: "2px solid " + color,
     },
   },
+  statusUnassigned : {
+    color: theme.palette.text.secondary,
+  },
   statusIncomplete : {
     color: theme.palette.error.main,
   },
@@ -88,9 +91,9 @@ function VisitView(props) {
       "label" : "Survey completion",
       "format" : (row) => (
          <Link
-           className={classes["status" + (!row.surveys_complete ? "Incomplete" : (!row.surveys_submitted ? "Unreviewed" : "Completed"))]}
+           className={classes["status" + (!row.has_surveys ? "Unassigned" : (!row.surveys_complete ? "Incomplete" : (!row.surveys_submitted ? "Unreviewed" : "Completed")))]}
            to={`/content.html${row.subject['@path']}`}>
-           { row.email_unsubscribed ? "Unsubscribed" : !row.surveys_complete ? "Incomplete" : (!row.surveys_submitted ? "Pending submission" : "Completed") }
+           { row.email_unsubscribed ? "Unsubscribed" : (!row.has_surveys ? "No surveys assigned" : (!row.surveys_complete ? "Incomplete" : (!row.surveys_submitted ? "Pending submission" : "Completed"))) }
          </Link>
       )
     }


### PR DESCRIPTION
- Add `has_surveys` question to visit information form
- Mark visits with no surveys by setting `has_surveys` to false, rather than setting `surveys_complete` to true
- Update VisitView component with `No surveys assigned` text

![image](https://user-images.githubusercontent.com/20056751/157334171-a2b898a4-d209-450b-9009-199c7f924023.png)