### PR TITLE
CARDS-1693: Sometimes starting CARDS fails with "setting ACL" errors

### DIFF
--- a/modules/data-entry/src/main/features/feature.json
+++ b/modules/data-entry/src/main/features/feature.json
@@ -27,7 +27,7 @@
     },
     {
       "id":"io.uhndata.cards:cards-permissions:${cards.version}",
-      "start-order":"25"
+      "start-order":"15"
     },
     {
       "id":"org.apache.commons:commons-compress:1.21",

--- a/modules/data-entry/src/main/features/permissions_ownership.json
+++ b/modules/data-entry/src/main/features/permissions_ownership.json
@@ -21,7 +21,7 @@
   "bundles":[
     {
       "id":"io.uhndata.cards:cards-permissions-ownership:${cards.version}",
-      "start-order":"25"
+      "start-order":"15"
     }
   ],
   "configurations":{

--- a/modules/data-entry/src/main/features/permissions_trusted.json
+++ b/modules/data-entry/src/main/features/permissions_trusted.json
@@ -21,7 +21,7 @@
   "bundles":[
     {
       "id":"io.uhndata.cards:cards-permissions-trusted:${cards.version}",
-      "start-order":"25"
+      "start-order":"15"
     }
   ],
   "configurations":{

--- a/proms-resources/backend/pom.xml
+++ b/proms-resources/backend/pom.xml
@@ -98,10 +98,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
-      <artifactId>oak-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.jackrabbit</groupId>
       <artifactId>oak-security-spi</artifactId>
     </dependency>
     <dependency>

--- a/proms-resources/feature/src/main/features/feature.json
+++ b/proms-resources/feature/src/main/features/feature.json
@@ -30,6 +30,10 @@
       "start-order":"26"
     },
     {
+      "id":"${project.groupId}:proms-permissions:${project.version}",
+      "start-order":"15"
+    },
+    {
       "id":"${project.groupId}:proms-frontend:${project.version}",
       "start-order":"26"
     },

--- a/proms-resources/permissions/pom.xml
+++ b/proms-resources/permissions/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.uhndata.cards</groupId>
+    <artifactId>proms-resources</artifactId>
+    <version>0.9-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>proms-permissions</artifactId>
+  <packaging>bundle</packaging>
+  <name>Proms Resources - Custom permissions</name>
+
+  <build>
+    <plugins>
+      <!-- This is an OSGi bundle -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.jcr</groupId>
+      <artifactId>jcr</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jackrabbit</groupId>
+      <artifactId>oak-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jackrabbit</groupId>
+      <artifactId>oak-security-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.uhndata.cards</groupId>
+      <artifactId>cards-data-model-forms-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.uhndata.cards</groupId>
+      <artifactId>cards-permissions</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/proms-resources/permissions/src/main/java/io/uhndata/cards/proms/permissions/UnsubmittedFormsRestrictionFactory.java
+++ b/proms-resources/permissions/src/main/java/io/uhndata/cards/proms/permissions/UnsubmittedFormsRestrictionFactory.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package io.uhndata.cards.proms.internal;
+package io.uhndata.cards.proms.permissions;
 
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;

--- a/proms-resources/permissions/src/main/java/io/uhndata/cards/proms/permissions/UnsubmittedFormsRestrictionPattern.java
+++ b/proms-resources/permissions/src/main/java/io/uhndata/cards/proms/permissions/UnsubmittedFormsRestrictionPattern.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package io.uhndata.cards.proms.internal;
+package io.uhndata.cards.proms.permissions;
 
 import java.util.Map;
 

--- a/proms-resources/pom.xml
+++ b/proms-resources/pom.xml
@@ -35,6 +35,7 @@
     <module>clinical-data</module>
     <module>frontend</module>
     <module>backend</module>
+    <module>permissions</module>
     <module>feature</module>
   </modules>
 </project>


### PR DESCRIPTION
Start permissions modules earlier, before repoinit statements are executed