### PR TITLE
CARDS-1692: AUDIT-C form marked as complete when automatically created

### DIFF
--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/VisitChangeListener.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/VisitChangeListener.java
@@ -438,7 +438,13 @@ public class VisitChangeListener implements ResourceChangeListener
                         sexAnswer.setProperty(FormUtils.QUESTION_PROPERTY, sexQuestion);
                         sexAnswer.setProperty(FormUtils.VALUE_PROPERTY, sex);
                         // Add in a second answer node with no value so that the form is not marked as complete
-                        final Node scoreAnswer = form.addNode(UUID.randomUUID().toString(), "cards:TextAnswer");
+                        final Node scoreAnswerSection = form.addNode(UUID.randomUUID().toString(),
+                            "cards:AnswerSection");
+                        final Node scoreSection = session.getNode("/Questionnaires/AUDITC/audit_results");
+                        scoreAnswerSection.setProperty(FormUtils.SECTION_PROPERTY, scoreSection);
+
+                        final Node scoreAnswer = scoreAnswerSection.addNode(UUID.randomUUID().toString(),
+                            "cards:LongAnswer");
                         final Node scoreQuestion = session.getNode("/Questionnaires/AUDITC/audit_results/audit_score");
                         scoreAnswer.setProperty(FormUtils.QUESTION_PROPERTY, scoreQuestion);
                     } catch (final RepositoryException e) {

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/VisitChangeListener.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/VisitChangeListener.java
@@ -433,10 +433,14 @@ public class VisitChangeListener implements ResourceChangeListener
                 final String sex = getPatientSex(visit);
                 if (sex != null) {
                     try {
-                        final Node answer = form.addNode(UUID.randomUUID().toString(), "cards:TextAnswer");
+                        final Node sexAnswer = form.addNode(UUID.randomUUID().toString(), "cards:TextAnswer");
                         final Node sexQuestion = session.getNode("/Questionnaires/AUDITC/sex");
-                        answer.setProperty(FormUtils.QUESTION_PROPERTY, sexQuestion);
-                        answer.setProperty(FormUtils.VALUE_PROPERTY, sex);
+                        sexAnswer.setProperty(FormUtils.QUESTION_PROPERTY, sexQuestion);
+                        sexAnswer.setProperty(FormUtils.VALUE_PROPERTY, sex);
+                        // Add in a second answer node with no value so that the form is not marked as complete
+                        final Node scoreAnswer = form.addNode(UUID.randomUUID().toString(), "cards:TextAnswer");
+                        final Node scoreQuestion = session.getNode("/Questionnaires/AUDITC/audit_results/audit_score");
+                        scoreAnswer.setProperty(FormUtils.QUESTION_PROPERTY, scoreQuestion);
                     } catch (final RepositoryException e) {
                         LOGGER.error("Failed to set sex: {}", e.getMessage(), e);
                     }

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/VisitChangeListener.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/VisitChangeListener.java
@@ -437,16 +437,17 @@ public class VisitChangeListener implements ResourceChangeListener
                         final Node sexQuestion = session.getNode("/Questionnaires/AUDITC/sex");
                         sexAnswer.setProperty(FormUtils.QUESTION_PROPERTY, sexQuestion);
                         sexAnswer.setProperty(FormUtils.VALUE_PROPERTY, sex);
-                        // Add in a second answer node with no value so that the form is not marked as complete
-                        final Node scoreAnswerSection = form.addNode(UUID.randomUUID().toString(),
-                            "cards:AnswerSection");
-                        final Node scoreSection = session.getNode("/Questionnaires/AUDITC/audit_results");
-                        scoreAnswerSection.setProperty(FormUtils.SECTION_PROPERTY, scoreSection);
 
-                        final Node scoreAnswer = scoreAnswerSection.addNode(UUID.randomUUID().toString(),
+                        // Add in a second answer node with no value so that the form is not marked as complete
+                        final Node secondAnswerSection = form.addNode(UUID.randomUUID().toString(),
+                            "cards:AnswerSection");
+                        final Node secondSection = session.getNode("/Questionnaires/AUDITC/audit_survey");
+                        secondAnswerSection.setProperty(FormUtils.SECTION_PROPERTY, secondSection);
+
+                        final Node secondAnswer = secondAnswerSection.addNode(UUID.randomUUID().toString(),
                             "cards:LongAnswer");
-                        final Node scoreQuestion = session.getNode("/Questionnaires/AUDITC/audit_results/audit_score");
-                        scoreAnswer.setProperty(FormUtils.QUESTION_PROPERTY, scoreQuestion);
+                        final Node secondQuestion = session.getNode("/Questionnaires/AUDITC/audit_survey/audit_1");
+                        secondAnswer.setProperty(FormUtils.QUESTION_PROPERTY, secondQuestion);
                     } catch (final RepositoryException e) {
                         LOGGER.error("Failed to set sex: {}", e.getMessage(), e);
                     }

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/AUDITC.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/AUDITC.xml
@@ -96,11 +96,6 @@ disorder. AUDIT-C has been validated in mental health and primary care clinics.
 				<value>formatted</value>
 				<type>String</type>
 			</property>
-			<property>
-				<name>minAnswers</name>
-				<value>1</value>
-				<type>Long</type>
-			</property>
 		</node>
 		<node>
 			<name>audit_interpretation</name>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/AUDITC.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/AUDITC.xml
@@ -96,6 +96,11 @@ disorder. AUDIT-C has been validated in mental health and primary care clinics.
 				<value>formatted</value>
 				<type>String</type>
 			</property>
+			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
 		</node>
 		<node>
 			<name>audit_interpretation</name>


### PR DESCRIPTION
- Create a blank score answer whenever automatically copying the sex into AUDIT-C so that the form will not get incorrectly marked as complete

![image](https://user-images.githubusercontent.com/20056751/157735181-7718a609-4076-481c-bd25-35d6899e95ed.png)
![image](https://user-images.githubusercontent.com/20056751/157735268-cfcf1995-7794-4e79-908b-50f89bb1073e.png)
