### PR TITLE
CARDS-1694: Logs are filled with Access Denied errors when using the PROMS UI

### DIFF
--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AnswerCopyProcessor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/AnswerCopyProcessor.java
@@ -23,6 +23,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.function.Function;
 
+import javax.jcr.AccessDeniedException;
 import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.PropertyIterator;
@@ -200,7 +201,9 @@ public class AnswerCopyProcessor implements ResourceJsonProcessor
                 // Not found among the subject's forms, next look in the parent subject's forms
                 nextSubject = nextSubject.getParent();
             }
-        } catch (RepositoryException e) {
+        } catch (final AccessDeniedException e) {
+            // This is an "expected" exception, access to specific forms or questions may be denied to users
+        } catch (final RepositoryException e) {
             LOGGER.warn("Failed to look for the right answer to copy: {}", e.getMessage(), e);
         }
         return null;

--- a/modules/data-entry/src/main/java/io/uhndata/cards/internal/FormRelatedSubjectsEditor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/internal/FormRelatedSubjectsEditor.java
@@ -19,6 +19,8 @@ package io.uhndata.cards.internal;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.jcr.AccessDeniedException;
+import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
@@ -93,12 +95,14 @@ public class FormRelatedSubjectsEditor extends DefaultEditor
     }
 
     @Override
-    public void leave(NodeState before, NodeState after) throws CommitFailedException
+    public void leave(final NodeState before, final NodeState after) throws CommitFailedException
     {
         if (isForm(this.currentNodeBuilder)) {
             try {
                 setRelatedSubjects();
-            } catch (RepositoryException e) {
+            } catch (final AccessDeniedException | ItemNotFoundException e) {
+                // This is an "expected" exception, access to specific subjects may be denied to users
+            } catch (final RepositoryException e) {
                 // This is not a fatal error, the related subjects is not required for a functional application
                 LOGGER.warn("Unexpected exception while computing the related subjects of form {}",
                     this.currentNodeBuilder.getString("jcr:uuid"));


### PR DESCRIPTION
- start in proms mode
- create Patient Information, Visit Information, and other data forms for the visit
- generate a token for the visit
- log in as a patient
- fill in the forms
- are there many "access denied" errors in `.cards-data/logs/error.log`?