### PR TITLE
CARDS-1606: As a patient, I receive rich text notification emails to fill out my pre-appointment surveys in DATA-PRO

### DIFF
--- a/distribution/Dockerfile
+++ b/distribution/Dockerfile
@@ -57,6 +57,7 @@ COPY target/dependency/org.apache.sling.feature.launcher.jar .
 COPY target/${project.artifactId}-${project.version}-core_mongo_far.far .
 COPY target/${project.artifactId}-${project.version}-core_tar_far.far .
 COPY logback.xml ./.cards-data/
+COPY mailcap /root/.mailcap
 
 # This is where Sling stores its data
 # Make this a volume which can be persisted between different container versions

--- a/distribution/mailcap
+++ b/distribution/mailcap
@@ -1,0 +1,3 @@
+text/html;; x-java-content-handler=com.sun.mail.handlers.text_html
+text/plain;; x-java-content-handler=com.sun.mail.handlers.text_plain
+multipart/*;; x-java-content-handler=com.sun.mail.handlers.multipart_mixed

--- a/modules/email-notifications/src/main/java/io/uhndata/cards/emailnotifications/EmailTestEndpoint.java
+++ b/modules/email-notifications/src/main/java/io/uhndata/cards/emailnotifications/EmailTestEndpoint.java
@@ -61,6 +61,7 @@ public final class EmailTestEndpoint extends SlingSafeMethodsServlet
         final String fromName = request.getParameter("fromName");
         final String toEmail = request.getParameter("toEmail");
         final String toName = request.getParameter("toName");
+        final boolean isHtml = "true".equals(request.getParameter("isHtml"));
         if (fromEmail == null || fromName == null || toEmail == null || toName == null) {
             //Missing parameters
             response.setStatus(400);
@@ -69,13 +70,25 @@ public final class EmailTestEndpoint extends SlingSafeMethodsServlet
         }
 
         try {
-            MimeMessage message = this.mailService.getMessageBuilder()
-                .from(fromEmail, fromName)
-                .to(toEmail, toName)
-                .replyTo(fromEmail)
-                .subject(subject)
-                .text(text)
-                .build();
+            MimeMessage message;
+            if (isHtml) {
+                message = this.mailService.getMessageBuilder()
+                    .from(fromEmail, fromName)
+                    .to(toEmail, toName)
+                    .replyTo(fromEmail)
+                    .subject(subject)
+                    .text(text)
+                    .html("<html><head><title>Rich Text</title></head><body><p>" + text + "</p></body></html>")
+                    .build();
+            } else {
+                message = this.mailService.getMessageBuilder()
+                    .from(fromEmail, fromName)
+                    .to(toEmail, toName)
+                    .replyTo(fromEmail)
+                    .subject(subject)
+                    .text(text)
+                    .build();
+            }
 
             this.mailService.sendMessage(message);
             response.setStatus(200);

--- a/modules/email-notifications/src/main/java/io/uhndata/cards/emailnotifications/EmailUtils.java
+++ b/modules/email-notifications/src/main/java/io/uhndata/cards/emailnotifications/EmailUtils.java
@@ -51,7 +51,7 @@ public final class EmailUtils
     }
 
     /**
-     * Sends an email.
+     * Sends a simple plaintext email.
      *
      * @param mailService the MailService object which sends the email
      * @param toAddress the destination email address
@@ -68,6 +68,31 @@ public final class EmailUtils
             .replyTo(FROM_ADDRESS)
             .subject(emailSubject)
             .text(emailTextBody)
+            .build();
+
+        mailService.sendMessage(message);
+    }
+
+    /**
+     * Sends a rich-text HTML email with fallback to plaintext for legacy mail clients.
+     *
+     * @param mailService the MailService object which sends the email
+     * @param toAddress the destination email address
+     * @param toName the name of the email recipient
+     * @param emailSubject the subject line of the email
+     * @param emailTextBody the plaintext body of the email
+     * @param emailHtmlBody the rich-text HTML body of the email
+     */
+    public static void sendNotificationHtmlEmail(MailService mailService, String toAddress,
+        String toName, String emailSubject, String emailTextBody, String emailHtmlBody) throws MessagingException
+    {
+        MimeMessage message = mailService.getMessageBuilder()
+            .from(FROM_ADDRESS, FROM_NAME)
+            .to(toAddress, toName)
+            .replyTo(FROM_ADDRESS)
+            .subject(emailSubject)
+            .text(emailTextBody)
+            .html(emailHtmlBody)
             .build();
 
         mailService.sendMessage(message);

--- a/pom.xml
+++ b/pom.xml
@@ -528,6 +528,8 @@
             <exclude>Utilities/Development/ExtensionPointResources/**</exclude>
             <!-- Ignore email template files since we do not send a license in notification emails -->
             <exclude>**/mailTemplates/**</exclude>
+            <!-- No license in mailcap file -->
+            <exclude>mailcap</exclude>
           </excludes>
         </configuration>
         <executions>

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AbstractPromsNotification.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AbstractPromsNotification.java
@@ -63,8 +63,8 @@ abstract class AbstractPromsNotification
     }
 
     @SuppressWarnings("checkstyle:ExecutableStatementCount")
-    public long sendNotification(final int daysInTheFuture, final String emailTemplateName,
-        final String emailSubject)
+    public long sendNotification(final int daysInTheFuture, final String emailTextTemplateName,
+        final String emailHtmlTemplateName, final String emailSubject)
     {
         final Calendar dateToQuery = Calendar.getInstance();
         dateToQuery.add(Calendar.DATE, daysInTheFuture);
@@ -95,8 +95,13 @@ abstract class AbstractPromsNotification
                     continue;
                 }
                 String emailTextTemplate =
-                    AppointmentUtils.getVisitEmailTemplate(resolver, visitSubject, emailTemplateName);
+                    AppointmentUtils.getVisitEmailTemplate(resolver, visitSubject, emailTextTemplateName);
                 if (emailTextTemplate == null) {
+                    continue;
+                }
+                String emailHtmlTemplate =
+                    AppointmentUtils.getVisitEmailTemplate(resolver, visitSubject, emailHtmlTemplateName);
+                if (emailHtmlTemplate == null) {
                     continue;
                 }
                 String patientFullName = AppointmentUtils.getPatientFullName(resolver, patientSubject);
@@ -115,9 +120,10 @@ abstract class AbstractPromsNotification
                     "unsubscribeLink",
                     "https://" + CARDS_HOST_AND_PORT + "/Proms.unsubscribe.html?auth_token=" + token);
                 String emailTextBody = EmailUtils.renderEmailTemplate(emailTextTemplate, valuesMap);
+                String emailHtmlBody = EmailUtils.renderEmailTemplate(emailHtmlTemplate, valuesMap);
                 try {
-                    EmailUtils.sendNotificationEmail(this.mailService, patientEmailAddress,
-                        patientFullName, emailSubject, emailTextBody);
+                    EmailUtils.sendNotificationHtmlEmail(this.mailService, patientEmailAddress,
+                        patientFullName, emailSubject, emailTextBody, emailHtmlBody);
                     emailsSent += 1;
                 } catch (MessagingException e) {
                     LOGGER.warn("Failed to send Initial Notification Email");

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/InitialNotificationsTask.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/InitialNotificationsTask.java
@@ -39,7 +39,7 @@ public class InitialNotificationsTask extends AbstractPromsNotification implemen
     @Override
     public void run()
     {
-        long emailsSent = sendNotification(3, "72h.txt", PATIENT_NOTIFICATION_SUBJECT);
+        long emailsSent = sendNotification(3, "72h.txt", "72h.html", PATIENT_NOTIFICATION_SUBJECT);
         Metrics.increment(this.resolverFactory, "InitialEmailsSent", emailsSent);
     }
 }

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/ReminderNotificationsTask.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/ReminderNotificationsTask.java
@@ -39,7 +39,7 @@ public class ReminderNotificationsTask extends AbstractPromsNotification impleme
     @Override
     public void run()
     {
-        long emailsSent = sendNotification(1, "24h.txt", PATIENT_NOTIFICATION_SUBJECT);
+        long emailsSent = sendNotification(1, "24h.txt", "24h.html", PATIENT_NOTIFICATION_SUBJECT);
         Metrics.increment(this.resolverFactory, "ReminderEmailsSent", emailsSent);
     }
 }

--- a/start_cards.sh
+++ b/start_cards.sh
@@ -60,6 +60,25 @@ function handle_missing_sling_commons_crypto_fail() {
   exit -1
 }
 
+function handle_missing_mailcap_fail() {
+  echo -e "${TERMINAL_RED}********************************************************************************${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_RED}*                                                                              *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_RED}*   The file ~/.mailcap is missing. Exiting.                                   *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_RED}*   You can create ~/.mailcap by running: cp distribution/mailcap ~/.mailcap   *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_RED}*                                                                              *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_RED}********************************************************************************${TERMINAL_NOCOLOR}"
+  exit -1
+}
+
+function warn_different_mailcap() {
+  echo -e "${TERMINAL_YELLOW}********************************************************************${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*                                                                  *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*    Warning: The file ~/.mailcap differs from what is expected.   *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*    Sending emails may not work properly!                         *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*                                                                  *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}********************************************************************${TERMINAL_NOCOLOR}"
+}
+
 function handle_cards_java_fail() {
   echo -e "${TERMINAL_RED}**********************************************$(print_length_of $BIND_PORT '*' 4)${TERMINAL_NOCOLOR}"
   echo -e "${TERMINAL_RED}*                                             $(print_length_of $BIND_PORT ' ' 3)*${TERMINAL_NOCOLOR}"
@@ -276,6 +295,11 @@ then
   then
     handle_missing_sling_commons_crypto_fail
   fi
+  if [ ! -e ~/.mailcap ]
+  then
+    handle_missing_mailcap_fail
+  fi
+  diff -q ~/.mailcap distribution/mailcap || warn_different_mailcap
 fi
 
 #Start CARDS in the background


### PR DESCRIPTION
This PR implements CARDS-1606 by ensuring that the appropriate `~/.mailcap` file is available in order for rich-text HTML emails to be sent.

**Please note that this PR is still in draft mode as code for sending the 24 hour and 72 hour templates as well as testing instruction for these scenarios need to be added.**

Testing with `start_cards.sh` (Development Environment)
--------------------------------------------------------------------------------

1. Follow instructions 1-5 (inclusive) in https://github.com/data-team-uhn/cards/pull/822#issue-1063852994 to setup a local SMTPS debugging server.
2. Build this branch with `mvn clean install`.
3. Ensure that the file `~/.mailcap` does not exist.
5. Start CARDS with `SLING_COMMONS_CRYPTO_PASSWORD=password ./start_cards.sh --project cards4proms --dev`.
5. CARDS should fail to start with the error `The file ~/.mailcap is missing. Exiting.`.
6. Follow the instructions presented by the error message and create the `~/.mailcap` file with the command `cp distribution/mailcap ~/.mailcap`.
7. Start CARDS again with the same command as before - `SLING_COMMONS_CRYPTO_PASSWORD=password ./start_cards.sh --project cards4proms --dev`.
8. Once CARDS starts, visit `http://localhost:8080` and login as `admin`:`admin`.
9. Visit `http://localhost:8080/content.emailtest?fromEmail=alice@mail.com&fromName=Alice&toEmail=bob@mail.com&toName=Bob`. In the SMTPS debugging console, a plaintext email message from Alice (`alice@mail.com`) to Bob (`bob@mail.com`) should be displayed.
10. Visit `http://localhost:8080/content.emailtest?fromEmail=alice@mail.com&fromName=Alice&toEmail=bob@mail.com&toName=Bob&isHtml=true`. In the SMTPS debugging console, a _multipart_ plaintext and HTML email from (`alice@mail.com`) to Bob (`bob@mail.com`) should be displayed.
11. Stop CARDS with _CTRL+C_.
12. `rm -rf .cards-data`
13. Replace `~/.mailcap` with a blank file with the command `echo "" > ~/.mailcap`.
14. Start CARDS again with the same command as before - `SLING_COMMONS_CRYPTO_PASSWORD=password ./start_cards.sh --project cards4proms --dev`.
15. The warning `The file ~/.mailcap differs from what is expected.` should be displayed in the console upon startup.
16. Once CARDS starts, visit `http://localhost:8080` and login as `admin`:`admin`.
17. Sending plaintext emails with `http://localhost:8080/content.emailtest?fromEmail=alice@mail.com&fromName=Alice&toEmail=bob@mail.com&toName=Bob` should work while sending HTML emails with `http://localhost:8080/content.emailtest?fromEmail=alice@mail.com&fromName=Alice&toEmail=bob@mail.com&toName=Bob&isHtml=true` should not.
18. Stop CARDS, `rm -rf .cards-data`, `cp distribution/mailcap ~/.mailcap`, and restart CARDS with `PATIENT_NOTIFICATION_FROM_ADDRESS='datapro@uhn.ca' PATIENT_NOTIFICATION_FROM_NAME='UHN DATAPRO' NIGHTLY_NOTIFICATIONS_SCHEDULE='0 * * * * ? *' SLING_COMMONS_CRYPTO_PASSWORD=password CARDS_HOST_AND_PORT='localhost:8080' ./start_cards.sh --project cards4proms --dev`.
19. Follow the instructions in https://github.com/data-team-uhn/cards/pull/947#issue-1154651141 to import an appointment that is in _72_ hours from now. Every minute, you should see the initial appointment notification HTML email being displayed in the console.
20. Follow the instructions in https://github.com/data-team-uhn/cards/pull/947#issue-1154651141 to import an appointment that is in _24_ hours from now. Every minute, you should see the reminder appointment notification HTML email being displayed in the console.

Testing with Docker Compose (Production Environment)
-----------------------------------------------------------------------------

1. Build a simple Docker Compose environment by entering the `compose-cluster` directory and running the command `./cleanup.sh`, then `python3 generate_compose_yaml.py --oak_filesystem --cards_project cards4proms --dev`.
2. Edit the `docker-compose.yml` file and add the following changes:
  - Under `services`/`cardsinitial`/`environment` add the lines `- SLING_COMMONS_CRYPTO_PASSWORD=password`, `NIGHTLY_NOTIFICATIONS_SCHEDULE=0 * * * * ? *`, `PATIENT_NOTIFICATION_FROM_ADDRESS=datapro@uhn.ca`, `PATIENT_NOTIFICATION_FROM_NAME=UHN DATAPRO`, `CARDS_HOST_AND_POST=localhost:8080`, and `- ADDITIONAL_SLING_FEATURES=mvn:io.uhndata.cards/cards-email-notifications/0.9-SNAPSHOT/slingosgifeature`
  - Under `services`/`cardsinitial`/`volumes` add the lines `- ./load_email_cert.sh:/volume_mounted_init.sh:ro`, `- ./EmailCertificate.pem:/EmailCertificate.pem:ro`, and `- ./CompleteEmailCertificate.key:/CompleteEmailCertificate.key:ro`
3. Copy the `completecert.key` file that was created when following the instructions at https://github.com/data-team-uhn/cards/pull/822#issue-1063852994 into the `compose-cluster` directory as `CompleteEmailCertificate.key`.
4. Copy the `cert.pem` file that was created when following the instructions at https://github.com/data-team-uhn/cards/pull/822#issue-1063852994 into the `compose-cluster` directory as `EmailCertificate.pem`.
5. Create the `load_email_cert.sh` file in the `compose-cluster` directory, make it executable (`chmod +x load_email_cert.sh`), and populate it as follows:
```bash
keytool -import -trustcacerts -file /EmailCertificate.pem \
  -keystore /etc/ssl/certs/java/cacerts \
  -keypass changeit -storepass changeit -noprompt
```
6. `docker-compose build`
7. `docker-compose up -d`
8. `docker-compose exec cardsinitial /bin/sh`
9. `apk add socat python3`
10. `socat -d -d -v OPENSSL-LISTEN:8465,verify=0,cert=/CompleteEmailCertificate.key,reuseaddr,fork TCP-CONNECT:127.0.0.1:8025`
11. Open a new terminal to the `compose-cluster` directory.
12. `docker-compose exec cardsinitial /bin/sh`
13. `python3 -m smtpd -c DebuggingServer -n 127.0.0.1:8025`
14. Visit `http://localhost:8080` and login as `admin`:`admin`.
15. You should be able to send:
  - Plaintext emails to the SMTP debugging server by visiting `http://localhost:8080/content.emailtest?fromEmail=alice@mail.com&fromName=Alice&toEmail=bob@mail.com&toName=Bob`.
  - Multipart HTML and plaintext emails to the SMTP debugging server by visiting `http://localhost:8080/content.emailtest?fromEmail=alice@mail.com&fromName=Alice&toEmail=bob@mail.com&toName=Bob&isHtml=true`.
16. Open a new terminal to the `compose-cluster` directory.
17. `docker cp ../Utilities/Development/mock_torch.js compose-cluster_cardsinitial_1:/opt/cards`
18. `docker-compose exec cardsinitial /bin/sh`
19. `apk add nodejs npm`
20. `npm install express --save`
21. `node mock_torch.js --appointment-time-hours-from-now=72`
22.  Import the data into CARDS using the same steps and the _Development Environment_ section.
23. You should be seeing (72 hour) initial appointment HTML emails every one minute.
24. Redo the data import with `node mock_torch.js --appointment-time-hours-from-now=24`.
25. You should be seeing (24 hour) reminder appointment HTML emails every one minute.