### PR TITLE
[misc] Torch Mock Server Updates

### DIFF
--- a/Utilities/Development/mock_torch.js
+++ b/Utilities/Development/mock_torch.js
@@ -92,10 +92,63 @@ const graphQlResponse = {
           {
             location: ['6012-HC-Congenital Cardiac'],
             status: {toJSON: getMockAppointmentStatus},
-            fhirID: 'AppointmentFhirID',
+            fhirID: 'AppointmentOneFhirID',
             participants: [
               {
                 role: 'ATND',
+                participant: {
+                  eID: 'SomeParticipantEID',
+                  fhirID: 'SomeParticipantFhirID',
+                  name: {
+                    prefix: [
+                      'Dr.'
+                    ],
+                    given: [
+                      'Robert'
+                    ],
+                    family: 'Smith',
+                    suffix: [
+                      'M.D.'
+                    ]
+                  }
+                }
+              }
+            ],
+            time: {toJSON: getMockAppointmentTime}
+          },
+          {
+            location: ['6012-HC-Congenital Cardiac'],
+            status: {toJSON: getMockAppointmentStatus},
+            fhirID: 'AppointmentTwoFhirID',
+            participants: [
+              {
+                role: 'ABCD',
+                participant: {
+                  eID: 'SomeParticipantEID',
+                  fhirID: 'SomeParticipantFhirID',
+                  name: {
+                    prefix: [
+                      'Dr.'
+                    ],
+                    given: [
+                      'Robert'
+                    ],
+                    family: 'Smith',
+                    suffix: [
+                      'M.D.'
+                    ]
+                  }
+                }
+              }
+            ],
+            time: {toJSON: getMockAppointmentTime}
+          },
+          {
+            location: ['6012-HC-Congenital Cardiac'],
+            status: {toJSON: getMockAppointmentStatus},
+            fhirID: 'AppointmentThreeFhirID',
+            participants: [
+              {
                 participant: {
                   eID: 'SomeParticipantEID',
                   fhirID: 'SomeParticipantFhirID',

--- a/Utilities/Development/mock_torch.js
+++ b/Utilities/Development/mock_torch.js
@@ -95,17 +95,22 @@ const graphQlResponse = {
             fhirID: 'AppointmentFhirID',
             participants: [
               {
-                name: {
-                  prefix: [
-                    'Dr.'
-                  ],
-                  given: [
-                    'Robert'
-                  ],
-                  family: 'Smith',
-                  suffix: [
-                    'M.D.'
-                  ]
+                role: 'ATND',
+                participant: {
+                  eID: 'SomeParticipantEID',
+                  fhirID: 'SomeParticipantFhirID',
+                  name: {
+                    prefix: [
+                      'Dr.'
+                    ],
+                    given: [
+                      'Robert'
+                    ],
+                    family: 'Smith',
+                    suffix: [
+                      'M.D.'
+                    ]
+                  }
                 }
               }
             ],

--- a/Utilities/Development/mock_torch.js
+++ b/Utilities/Development/mock_torch.js
@@ -96,7 +96,7 @@ const graphQlResponse = {
             participants: [
               {
                 role: 'ATND',
-                participant: {
+                physician: {
                   eID: 'SomeParticipantEID',
                   fhirID: 'SomeParticipantFhirID',
                   name: {
@@ -123,7 +123,7 @@ const graphQlResponse = {
             participants: [
               {
                 role: 'ABCD',
-                participant: {
+                physician: {
                   eID: 'SomeParticipantEID',
                   fhirID: 'SomeParticipantFhirID',
                   name: {
@@ -149,7 +149,7 @@ const graphQlResponse = {
             fhirID: 'AppointmentThreeFhirID',
             participants: [
               {
-                participant: {
+                physician: {
                   eID: 'SomeParticipantEID',
                   fhirID: 'SomeParticipantFhirID',
                   name: {


### PR DESCRIPTION
This PR updates the `mock_torch.js` server so that the returned data schema matches what is being returned by the production DHP Torch server.

**This PR is currently in _draft_ mode as testing it will fail until the comment at https://github.com/data-team-uhn/cards/pull/975#discussion_r830367553 is addressed.**

To test:

1. Checkout this `torch-mock-server_update_2022-03-15` branch.
2. Merge in the changes from the `provider-filter-update` branch (`git merge provider-filter-update`) - ensure that you have pulled in the latest changes for the `provider-filter-update` branch.
3. Build this branch (`mvn clean install`)
4. Start the `mock_torch.js` server with the command `nodejs mock_torch.js  --appointment-time-hours-from-now=24`
5. Start CARDS in `cards4proms` mode (`SLING_COMMONS_CRYPTO_PASSWORD=password ./start_cards.sh --project cards4proms --dev`)
6. Visit `http://localhost:8080` and login as `admin`:`admin`
7. Visit `http://localhost:8080/system/console/configMgr`
8. Look for the `PROMs import` configuration, click on it to add a new config, set the _Name_ to `mock`, _Endpoint URL_ to `http://localhost:8011/`, _Clinic_ to `6012-HC-Congenital Cardiac`, and _Provider names_ to `SomeParticipantEID`. Save the configuration.
9. Point your browser to `http://localhost:8080/Subjects.importTorch.json?config=mock`
10. Visit `http://localhost:8080` once again. You should see that only the `AppointmentOneFhirID-Cardio` _Visit_ has been created.