### PR TITLE
CARDS-1612: Automatically generate side bar entries, dashboard extensions, and user groups for onboarded clinics

### DIFF
--- a/modules/commons/pom.xml
+++ b/modules/commons/pom.xml
@@ -46,6 +46,7 @@
             <!-- Initial content to be loaded on bundle installation -->
             <Sling-Initial-Content>
               SLING-INF/content/libs/cards/Resource/;path:=/libs/cards/Resource/;overwrite:=true,
+              SLING-INF/content/libs/cards/ResourceHomepage/;path:=/libs/cards/ResourceHomepage/;overwrite:=true,
               SLING-INF/content/libs/sling/servlet/errorhandler/;path:=/libs/sling/servlet/errorhandler/;overwrite:=true,
               SLING-INF/content/ROOT/;path:=/;overwrite:=true
             </Sling-Initial-Content>

--- a/modules/commons/src/main/resources/SLING-INF/content/libs/cards/ResourceHomepage/ROOT.json
+++ b/modules/commons/src/main/resources/SLING-INF/content/libs/cards/ResourceHomepage/ROOT.json
@@ -1,0 +1,4 @@
+{
+  "jcr:primaryType": "sling:Folder",
+  "sling:resourceSuperType": "cards/Resource"
+}

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Fields.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Fields.jsx
@@ -35,6 +35,10 @@ import FormattedText from "../components/FormattedText.jsx";
 import ReferenceInput from "./ReferenceInput";
 import { FieldsProvider } from "./FieldsContext.jsx";
 
+export function formatString(str) {
+  return str.charAt(0).toUpperCase() + str.slice(1).replace( /([A-Z])/g, " $1" ).toLowerCase();
+}
+
 let Fields = (props) => {
   let { data, JSON, edit, classes, ...rest } = props;
 
@@ -58,10 +62,6 @@ let Fields = (props) => {
           />
     );
   };
-
-  let formatString = (str) => {
-    return str.charAt(0).toUpperCase() + str.slice(1).replace( /([A-Z])/g, " $1" ).toLowerCase();
-  }
 
   let displayStaticField = (key, value) => {
     return (<React.Fragment key={key}>

--- a/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
@@ -75,8 +75,7 @@ import org.slf4j.LoggerFactory;
  */
 @Component(service = { Servlet.class })
 @SlingServletResourceTypes(
-    resourceTypes = { "cards/QuestionnairesHomepage", "cards/FormsHomepage", "cards/SubjectsHomepage",
-        "cards/SubjectTypesHomepage", "cards/StatisticsHomepage", "cards/ResourceHomepage" },
+    resourceTypes = { "cards/ResourceHomepage" },
     selectors = { "paginate" })
 public class PaginationServlet extends SlingSafeMethodsServlet
 {

--- a/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
@@ -76,7 +76,7 @@ import org.slf4j.LoggerFactory;
 @Component(service = { Servlet.class })
 @SlingServletResourceTypes(
     resourceTypes = { "cards/QuestionnairesHomepage", "cards/FormsHomepage", "cards/SubjectsHomepage",
-        "cards/SubjectTypesHomepage", "cards/StatisticsHomepage", "cards/ClinicMappingFolder" },
+        "cards/SubjectTypesHomepage", "cards/StatisticsHomepage", "cards/ResourceHomepage" },
     selectors = { "paginate" })
 public class PaginationServlet extends SlingSafeMethodsServlet
 {

--- a/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
@@ -76,7 +76,7 @@ import org.slf4j.LoggerFactory;
 @Component(service = { Servlet.class })
 @SlingServletResourceTypes(
     resourceTypes = { "cards/QuestionnairesHomepage", "cards/FormsHomepage", "cards/SubjectsHomepage",
-        "cards/SubjectTypesHomepage", "cards/StatisticsHomepage" },
+        "cards/SubjectTypesHomepage", "cards/StatisticsHomepage", "cards/ClinicMappingFolder" },
     selectors = { "paginate" })
 public class PaginationServlet extends SlingSafeMethodsServlet
 {

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -462,8 +462,8 @@
   // Hardcode the resource type.
   - sling:resourceType (STRING) = "cards/QuestionnairesHomepage" mandatory autocreated protected
 
-  // Hardcode the resource supertype: the QuestionnairesHomepage is a resource.
-  - sling:resourceSuperType (STRING) = "cards/Resource" mandatory autocreated protected
+  // Hardcode the resource supertype: the QuestionnairesHomepage is a resource homepage.
+  - sling:resourceSuperType (STRING) = "cards/ResourceHomepage" mandatory autocreated protected
 
   // Set a default title.
   - title (String) = "Questionnaires" mandatory autocreated
@@ -755,8 +755,8 @@
   // Hardcode the resource type.
   - sling:resourceType (STRING) = "cards/FormsHomepage" mandatory autocreated protected
 
-  // Hardcode the resource supertype: the FormsHomepage is a resource.
-  - sling:resourceSuperType (STRING) = "cards/Resource" mandatory autocreated protected
+  // Hardcode the resource supertype: the FormsHomepage is a resource homepage.
+  - sling:resourceSuperType (STRING) = "cards/ResourceHomepage" mandatory autocreated protected
 
   // Set a default title.
   - title (String) = "Data" mandatory autocreated
@@ -818,8 +818,8 @@
   // Hardcode the resource type.
   - sling:resourceType (STRING) = "cards/SubjectsHomepage" mandatory autocreated protected
 
-  // Hardcode the resource supertype: the SubjectsHomepage is a resource.
-  - sling:resourceSuperType (STRING) = "cards/Resource" mandatory autocreated protected
+  // Hardcode the resource supertype: the SubjectsHomepage is a resource homepage.
+  - sling:resourceSuperType (STRING) = "cards/ResourceHomepage" mandatory autocreated protected
 
   // Set a default title.
   - title (String) = "Subjects" mandatory autocreated
@@ -868,8 +868,8 @@
   // Hardcode the resource type.
   - sling:resourceType (STRING) = "cards/SubjectTypesHomepage" mandatory autocreated protected
 
-  // Hardcode the resource supertype: the SubjectTypesHomepage is a resource.
-  - sling:resourceSuperType (STRING) = "cards/Resource" mandatory autocreated protected
+  // Hardcode the resource supertype: the SubjectTypesHomepage is a resource homepage.
+  - sling:resourceSuperType (STRING) = "cards/ResourceHomepage" mandatory autocreated protected
 
   // Set a default title.
   - title (String) = "Subject Types" mandatory autocreated

--- a/modules/statistics/src/main/resources/SLING-INF/nodetypes/statistics.cnd
+++ b/modules/statistics/src/main/resources/SLING-INF/nodetypes/statistics.cnd
@@ -74,8 +74,8 @@
   // Hardcode the resource type.
   - sling:resourceType (STRING) = "cards/StatisticsHomepage" mandatory autocreated protected
 
-  // Hardcode the resource supertype: the StatisticsHomepage is a resource.
-  - sling:resourceSuperType (STRING) = "cards/Resource" mandatory autocreated protected
+  // Hardcode the resource supertype: the StatisticsHomepage is a resource homepage.
+  - sling:resourceSuperType (STRING) = "cards/ResourceHomepage" mandatory autocreated protected
 
   // Set a default title.
   - title (String) = "Statistics" mandatory autocreated

--- a/proms-resources/backend/pom.xml
+++ b/proms-resources/backend/pom.xml
@@ -163,6 +163,6 @@
     <groupId>org.osgi</groupId>
       <artifactId>org.osgi.framework</artifactId>
       <version>1.9.0</version>
-  </dependency>
+    </dependency>
   </dependencies>
 </project>

--- a/proms-resources/backend/pom.xml
+++ b/proms-resources/backend/pom.xml
@@ -154,5 +154,15 @@
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.metatype.annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
+      <version>1.6.1</version>
+    </dependency>
+    <dependency>
+    <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.framework</artifactId>
+      <version>1.9.0</version>
+  </dependency>
   </dependencies>
 </project>

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ClinicsServlet.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ClinicsServlet.java
@@ -69,8 +69,11 @@ public class ClinicsServlet extends SlingAllMethodsServlet
         try {
             Configuration[] configs = this.configAdmin.listConfigurations(
                 "(service.factoryPid=" + IMPORT_FACTORY_PID + ")");
-            for (Configuration config : configs) {
-                this.insertNewClinic(config, newClinics);
+
+            if (configs != null) {
+                for (Configuration config : configs) {
+                    this.insertNewClinic(config, newClinics);
+                }
             }
         } catch (InvalidSyntaxException e) {
             // This can happen when the filter given to the listConfigurations call above is wrong

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ClinicsServlet.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ClinicsServlet.java
@@ -104,7 +104,6 @@ public class ClinicsServlet extends SlingAllMethodsServlet
             this.displayName.set(getUniqueDisplayName(resolver, this.displayName.get()));
             this.createClinicMapping(resolver);
             this.createSidebar(resolver);
-            this.createDashboardView(resolver);
             this.createDashboardExtension(resolver);
             this.createDashboardViews(resolver);
             session.save();
@@ -258,24 +257,6 @@ public class ClinicsServlet extends SlingAllMethodsServlet
             "cards:targetURL", "/content.html/Dashboard/" + this.idHash.get(),
             "cards:icon", "asset:proms-homepage.clinicIcon.js",
             "cards:defaultOrder", 10,
-            ClinicsServlet.PRIMARY_TYPE_FIELD, "cards:Extension"));
-    }
-
-    /**
-     * Create a dashboard view for the new clinic.
-     *
-     * @param resolver Resource resolver to use
-     */
-    private void createDashboardView(final ResourceResolver resolver)
-        throws RepositoryException, PersistenceException
-    {
-        final Resource parentResource = resolver.getResource("/Extensions/Views");
-        resolver.create(parentResource, this.idHash.get() + "Dashboard", Map.of(
-            "cards:extensionPointId", "cards/coreUI/view",
-            "cards:extensionName", "Dashboard",
-            "cards:extensionRenderURL", "asset:proms-homepage.PromsDashboard.js",
-            "cards:targetURL", "/content.html/Dashboard",
-            "cards:exactURLMatch", false,
             ClinicsServlet.PRIMARY_TYPE_FIELD, "cards:Extension"));
     }
 

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ClinicsServlet.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ClinicsServlet.java
@@ -113,6 +113,8 @@ public class ClinicsServlet extends SlingAllMethodsServlet
             this.returnError(response, e.getMessage());
         } catch (NoSuchSurveyException e) {
             this.returnError(response, e.getMessage());
+        } catch (NullPointerException e) {
+            this.returnError(response, e.getMessage());
         }
 
         // Grab the configuration to edit
@@ -210,7 +212,7 @@ public class ClinicsServlet extends SlingAllMethodsServlet
     {
         LOGGER.error(reason);
         try {
-            response.setStatus(SlingHttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            response.setStatus(SlingHttpServletResponse.SC_BAD_REQUEST);
             Writer out = response.getWriter();
             JsonGenerator generator = Json.createGenerator(out);
             generator.writeStartObject();

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ClinicsServlet.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ClinicsServlet.java
@@ -275,7 +275,7 @@ public class ClinicsServlet extends SlingAllMethodsServlet
             "cards:extensionPointName", this.displayName.get() + " questionnaires dashboard",
             "title", this.displayName.get(),
             ClinicsServlet.DESCRIPTION_FIELD, this.description.get(),
-            "surveys", this.idHash.get()
+            "surveys", this.surveyID.get()
             ));
     }
 

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ClinicsServlet.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ClinicsServlet.java
@@ -22,14 +22,26 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.Arrays;
 import java.util.Dictionary;
+import java.util.HashSet;
 import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 import javax.json.Json;
 import javax.json.stream.JsonGenerator;
 import javax.servlet.Servlet;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
 import org.osgi.framework.InvalidSyntaxException;
@@ -51,6 +63,24 @@ public class ClinicsServlet extends SlingAllMethodsServlet
 
     private static final String IMPORT_FACTORY_PID = "io.uhndata.cards.proms.internal.importer.ImportConfig";
 
+    private static final String DESCRIPTION_FIELD = "description";
+
+    private static final String PRIMARY_TYPE_FIELD = "jcr:primaryType";
+
+    private final ThreadLocal<String> clinicName = new ThreadLocal<>();
+
+    private final ThreadLocal<String> displayName = new ThreadLocal<>();
+
+    private final ThreadLocal<String> sidebarLabel = new ThreadLocal<>();
+
+    private final ThreadLocal<String> surveyID = new ThreadLocal<>();
+
+    private final ThreadLocal<String> emergencyContact = new ThreadLocal<>();
+
+    private final ThreadLocal<String> description = new ThreadLocal<>();
+
+    private final ThreadLocal<String> idHash = new ThreadLocal<>();
+
     @Reference
     private ConfigurationAdmin configAdmin;
 
@@ -58,11 +88,20 @@ public class ClinicsServlet extends SlingAllMethodsServlet
     public void doPost(final SlingHttpServletRequest request, final SlingHttpServletResponse response)
         throws IOException
     {
-        // Determine what new clinic we're adding
-        String[] newClinics = request.getParameterValues(":newClinic");
-        if (newClinics == null || newClinics.length <= 0) {
-            // Nothing to do
-            return;
+        // Create all of the necessary nodes
+        final ResourceResolver resolver = request.getResourceResolver();
+        this.getArguments(request);
+        try {
+            final Session session = resolver.adaptTo(Session.class);
+            this.displayName.set(getUniqueDisplayName(resolver, this.displayName.get()));
+            this.createClinicMapping(resolver);
+            this.createSidebar(resolver);
+            this.createDashboardView(resolver);
+            this.createDashboardExtension(resolver);
+            this.createDashboardViews(resolver);
+            session.save();
+        } catch (RepositoryException e) {
+            this.returnError(response, e.getMessage());
         }
 
         // Grab the configuration to edit
@@ -72,7 +111,7 @@ public class ClinicsServlet extends SlingAllMethodsServlet
 
             if (configs != null) {
                 for (Configuration config : configs) {
-                    this.insertNewClinic(config, newClinics);
+                    this.insertNewClinic(config, this.clinicName.get());
                 }
             }
         } catch (InvalidSyntaxException e) {
@@ -84,6 +123,74 @@ public class ClinicsServlet extends SlingAllMethodsServlet
             // Unknown how to handle this
             this.returnError(response, "Updating clinic configurations failed.");
         }
+    }
+
+    /**
+     * Parse out the arguments from the SlingHttpServletRequest into threadlocal variables for parsing.
+     *
+     * @param request servlet request whose arguments we need to parse
+     */
+    private boolean getArguments(final SlingHttpServletRequest request)
+    {
+        this.clinicName.set(request.getParameter("clinicName"));
+        this.displayName.set(request.getParameter("displayName"));
+        this.sidebarLabel.set(request.getParameter("sidebarLabel"));
+        this.surveyID.set(request.getParameter("surveyId"));
+        this.emergencyContact.set(request.getParameter("emergencyContact"));
+        this.description.set(request.getParameter("description"));
+        this.idHash.set(Integer.toString(this.clinicName.get().hashCode()));
+        return true;
+    }
+
+    /**
+     * Get a unique display name for a cards:ClinicMapping node, appending numbers to the end if one already exists.
+     *
+     * @param resolver Resource resolver to use
+     * @param displayName Given display name to check for duplicates for
+     * @return Unique display name
+     */
+    public String getUniqueDisplayName(final ResourceResolver resolver, String displayName)
+        throws RepositoryException
+    {
+        // Pre-sanitize the name
+        String sanitizedName = displayName.replaceAll("[\"'\\[\\]\\(\\)\\\\]", "");
+        LOGGER.error(displayName + " becomes " + sanitizedName);
+
+        // Query for similar names
+        String query = "SELECT * FROM [cards:ClinicMapping] as c WHERE c.'displayName' LIKE '"
+            + sanitizedName + "%'";
+        Iterator<Resource> results = resolver.findResources(query, "JCR-SQL2");
+
+        // Determine what names currently exist
+        Set<Integer> foundNames = new HashSet<>();
+        boolean noNumberValid = true;
+        Pattern numberRegex = Pattern.compile(sanitizedName + " ([\\d]+)");
+        while (results.hasNext()) {
+            String name = results.next().adaptTo(Node.class).getProperty("displayName").getString();
+            LOGGER.error("Found: " + name);
+
+            Matcher match = numberRegex.matcher(name);
+            if (match.find()) {
+                LOGGER.error("Adding int");
+                foundNames.add(Integer.parseInt(match.group(1)));
+            } else if (sanitizedName.equals(name)) {
+                LOGGER.error("No number is no longer valid");
+                noNumberValid = false;
+            }
+        }
+
+        // Determine if we can use the display name as-is
+        if (noNumberValid) {
+            return sanitizedName;
+        }
+
+        // Find the first number i that works if we stick it after the display name
+        for (int i = 1; i < foundNames.size(); i++) {
+            if (!foundNames.contains(i)) {
+                return sanitizedName + " " + String.valueOf(i);
+            }
+        }
+        return sanitizedName + " " + String.valueOf(foundNames.size() + 1);
     }
 
     /**
@@ -109,16 +216,124 @@ public class ClinicsServlet extends SlingAllMethodsServlet
     }
 
     /**
+     * Create a cards:ClinicMapping node.
+     *
+     * @param resolver Resource resolver to use
+     */
+    private void createClinicMapping(final ResourceResolver resolver)
+        throws RepositoryException, PersistenceException
+    {
+        final Resource parentResource = resolver.getResource("/Proms/ClinicMapping");
+
+        resolver.create(parentResource, this.idHash.get(), Map.of(
+            "clinicName", this.clinicName.get(),
+            "displayName", this.displayName.get(),
+            "sidebarLabel", this.sidebarLabel.get(),
+            "surveyID", this.surveyID.get(),
+            "emergencyContact", this.emergencyContact.get(),
+            ClinicsServlet.DESCRIPTION_FIELD, this.description.get(),
+            ClinicsServlet.PRIMARY_TYPE_FIELD, "cards:ClinicMapping"));
+    }
+
+    /**
+     * Create a cards:Extension node for the sidebar.
+     *
+     * @param resolver Resource resolver to use
+     */
+    private void createSidebar(final ResourceResolver resolver)
+        throws RepositoryException, PersistenceException
+    {
+        final Resource parentResource = resolver.getResource("/Extensions/Sidebar");
+        resolver.create(parentResource, this.idHash.get(), Map.of(
+            "cards:extensionPointId", "cards/coreUI/sidebar/entry",
+            "cards:extensionName", this.sidebarLabel.get(),
+            "cards:targetURL", "/content.html/Dashboard/" + this.idHash.get(),
+            "cards:icon", "asset:proms-homepage.pmccIcon.js",
+            "cards:defaultOrder", 10,
+            ClinicsServlet.PRIMARY_TYPE_FIELD, "cards:Extension"));
+    }
+
+    /**
+     * Create a dashboard view for the new clinic.
+     *
+     * @param resolver Resource resolver to use
+     */
+    private void createDashboardView(final ResourceResolver resolver)
+        throws RepositoryException, PersistenceException
+    {
+        final Resource parentResource = resolver.getResource("/Extensions/Views");
+        resolver.create(parentResource, this.idHash.get() + "Dashboard", Map.of(
+            "cards:extensionPointId", "cards/coreUI/view",
+            "cards:extensionName", "Dashboard",
+            "cards:extensionRenderURL", "asset:proms-homepage.PromsDashboard.js",
+            "cards:targetURL", "/content.html/Dashboard",
+            "cards:exactURLMatch", false,
+            ClinicsServlet.PRIMARY_TYPE_FIELD, "cards:Extension"));
+    }
+
+    /**
+     * Create a dashboard extension for the new clinic.
+     *
+     * @param resolver Resource resolver to use
+     */
+    private void createDashboardExtension(final ResourceResolver resolver)
+        throws RepositoryException, PersistenceException
+    {
+        final Resource parentResource = resolver.getResource("/apps/cards/ExtensionPoints");
+        resolver.create(parentResource, "DashboardViews" + this.idHash.get(), Map.of(
+            ClinicsServlet.PRIMARY_TYPE_FIELD, "cards:ExtensionPoint",
+            "cards:extensionPointId", "proms/dashboard/" + this.idHash.get(),
+            "cards:extensionPointName", this.displayName.get() + " questionnaires dashboard",
+            "title", this.displayName.get(),
+            ClinicsServlet.DESCRIPTION_FIELD, this.description.get(),
+            "surveys", this.idHash.get()
+            ));
+    }
+
+    /**
+     * Create a dashboard view for each questionnaire in the survey set specified by the user.
+     *
+     * @param resolver Resource resolver to use
+     */
+    private void createDashboardViews(final ResourceResolver resolver)
+        throws RepositoryException, PersistenceException
+    {
+        // First, create the folder to hold the dashboard views
+        final Resource dashboardViewFolder = resolver.getResource("/Extensions/DashboardViews/");
+        Resource folder = resolver.create(dashboardViewFolder, this.idHash.get() + "View", Map.of(
+            ClinicsServlet.PRIMARY_TYPE_FIELD, "sling:Folder"));
+
+        // Create a bunch of survey views, one per clinic ID given
+        final Resource surveys = resolver.getResource("/Proms/" + this.surveyID.get());
+        int i = 0;
+        for (final Resource questionnaireRef : surveys.getChildren()) {
+            // First, we need to grab the surveys under that resource
+            final Node questionnaireNode = questionnaireRef.adaptTo(Node.class)
+                .getProperty("questionnaire").getNode();
+
+            // Then, we need to grab the revelant details and make a new View
+            resolver.create(folder, questionnaireNode.getProperty("title").getString(), Map.of(
+                ClinicsServlet.PRIMARY_TYPE_FIELD, "cards:Extension",
+                "cards:extensionPointId", "proms/dashboard/" + this.idHash.get(),
+                "cards:extensionName", questionnaireNode.getProperty("title").getString() + " View",
+                "cards:extensionRenderURL", "asset:proms-homepage.PromsView.js",
+                "cards:defaultOrder", i++,
+                "cards:data", questionnaireRef.getPath()
+                ));
+        }
+    }
+
+    /**
      * Update the clinic.names field of the given configuration with a new clinic name.
      *
      * @param config An OSGI config object for an instance of a proms ImportConfig
-     * @param newClinicNames An array of new clinic names to add
+     * @param newClinicName An new clinic's name to add
      */
-    public void insertNewClinic(Configuration config, String[] newClinicNames) throws IOException
+    public void insertNewClinic(Configuration config, String newClinicName) throws IOException
     {
         String[] clinicNames = (String[]) config.getProperties().get("clinic.names");
-        String[] updatedClinicNames = Arrays.copyOf(clinicNames, clinicNames.length + newClinicNames.length);
-        System.arraycopy(newClinicNames, 0, updatedClinicNames, clinicNames.length, newClinicNames.length);
+        String[] updatedClinicNames = Arrays.copyOf(clinicNames, clinicNames.length + 1);
+        updatedClinicNames[clinicNames.length] = newClinicName;
 
         // Create a dictionary to contain the update request
         Dictionary<String, Object> updateDictionary = new Hashtable<String, Object>();

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ClinicsServlet.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ClinicsServlet.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.uhndata.cards.proms;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import javax.json.Json;
+import javax.json.stream.JsonGenerator;
+import javax.servlet.Servlet;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.servlets.SlingAllMethodsServlet;
+import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Component(service = { Servlet.class })
+@SlingServletResourceTypes(resourceTypes = { "cards/ClinicMappingFolder" }, extensions = {
+    "addNew" }, methods = { "POST" })
+public class ClinicsServlet extends SlingAllMethodsServlet
+{
+    private static final long serialVersionUID = -5555906093850253193L;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClinicsServlet.class);
+
+    private static final String IMPORT_FACTORY_PID = "io.uhndata.cards.proms.internal.importer.ImportConfig";
+
+    @Reference
+    private ConfigurationAdmin configAdmin;
+
+    @Override
+    public void doPost(final SlingHttpServletRequest request, final SlingHttpServletResponse response)
+        throws IOException
+    {
+        // Determine what new clinic we're adding
+        String[] newClinics = request.getParameterValues(":newClinic");
+        if (newClinics == null || newClinics.length <= 0) {
+            // Nothing to do
+            return;
+        }
+
+        // Grab the configuration to edit
+        try {
+            Configuration[] configs = this.configAdmin.listConfigurations(
+                "(service.factoryPid=" + IMPORT_FACTORY_PID + ")");
+            for (Configuration config : configs) {
+                this.insertNewClinic(config, newClinics);
+            }
+        } catch (InvalidSyntaxException e) {
+            // This can happen when the filter given to the listConfigurations call above is wrong
+            // This shouldn't happen unless a typo was made in the value of IMPORT_FACTORY_PID
+            this.returnError(response, "Invalid syntax in config search.");
+        } catch (IOException e) {
+            // This can happen while updating the properties of a configuration
+            // Unknown how to handle this
+            this.returnError(response, "Updating clinic configurations failed.");
+        }
+    }
+
+    /**
+     * Return an error code to the POST request, letting the user know that something is wrong.
+     *
+     * @param response object to send response through
+     * @param reason reason to give to user
+     */
+    private void returnError(final SlingHttpServletResponse response, String reason)
+    {
+        LOGGER.error(reason);
+        try {
+            response.setStatus(SlingHttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            Writer out = response.getWriter();
+            JsonGenerator generator = Json.createGenerator(out);
+            generator.writeStartObject();
+            generator.write("error", reason);
+            generator.writeEnd();
+            generator.flush();
+        } catch (IOException e) {
+            LOGGER.error("Furthermore, IOException occurred while returning response to user: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Update the clinic.names field of the given configuration with a new clinic name.
+     *
+     * @param config An OSGI config object for an instance of a proms ImportConfig
+     * @param newClinicNames An array of new clinic names to add
+     */
+    public void insertNewClinic(Configuration config, String[] newClinicNames) throws IOException
+    {
+        String[] clinicNames = (String[]) config.getProperties().get("clinic.names");
+        String[] updatedClinicNames = Arrays.copyOf(clinicNames, clinicNames.length + newClinicNames.length);
+        System.arraycopy(newClinicNames, 0, updatedClinicNames, clinicNames.length, newClinicNames.length);
+
+        // Create a dictionary to contain the update request
+        Dictionary<String, Object> updateDictionary = new Hashtable<String, Object>();
+        updateDictionary.put("clinic.names", updatedClinicNames);
+        config.update(updateDictionary);
+    }
+}

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ClinicsServlet.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ClinicsServlet.java
@@ -53,8 +53,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Component(service = { Servlet.class })
-@SlingServletResourceTypes(resourceTypes = { "cards/ClinicMappingFolder" }, extensions = {
-    "addNew" }, methods = { "POST" })
+@SlingServletResourceTypes(resourceTypes = { "cards/ClinicMappingFolder" }, methods = { "POST" })
 public class ClinicsServlet extends SlingAllMethodsServlet
 {
     private static final long serialVersionUID = -5555906093850253193L;
@@ -257,7 +256,7 @@ public class ClinicsServlet extends SlingAllMethodsServlet
             "cards:extensionPointId", "cards/coreUI/sidebar/entry",
             "cards:extensionName", this.sidebarLabel.get(),
             "cards:targetURL", "/content.html/Dashboard/" + this.idHash.get(),
-            "cards:icon", "asset:proms-homepage.pmccIcon.js",
+            "cards:icon", "asset:proms-homepage.clinicIcon.js",
             "cards:defaultOrder", 10,
             ClinicsServlet.PRIMARY_TYPE_FIELD, "cards:Extension"));
     }

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ClinicsServlet.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ClinicsServlet.java
@@ -146,7 +146,7 @@ public class ClinicsServlet extends SlingAllMethodsServlet
         this.clinicName.set(request.getParameter("clinicName"));
         this.displayName.set(request.getParameter("displayName"));
         this.sidebarLabel.set(request.getParameter("sidebarLabel"));
-        this.surveyID.set(request.getParameter("surveyId"));
+        this.surveyID.set(request.getParameter("survey"));
         this.emergencyContact.set(request.getParameter("emergencyContact"));
         this.description.set(request.getParameter("description"));
         this.idHash.set(Integer.toString(this.clinicName.get().hashCode()));
@@ -236,7 +236,7 @@ public class ClinicsServlet extends SlingAllMethodsServlet
             "clinicName", this.clinicName.get(),
             "displayName", this.displayName.get(),
             "sidebarLabel", this.sidebarLabel.get(),
-            "surveyID", this.surveyID.get(),
+            "survey", this.surveyID.get(),
             "emergencyContact", this.emergencyContact.get(),
             ClinicsServlet.DESCRIPTION_FIELD, this.description.get(),
             ClinicsServlet.PRIMARY_TYPE_FIELD, "cards:ClinicMapping"));

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ClinicsServlet.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ClinicsServlet.java
@@ -166,7 +166,7 @@ public class ClinicsServlet extends SlingAllMethodsServlet
         throws RepositoryException
     {
         // Pre-sanitize the name
-        String sanitizedName = displayName.replaceAll("[\"'\\[\\]\\(\\)\\\\]", "");
+        String sanitizedName = displayName.replaceAll("'", "''");
 
         // Query for similar names
         String query = "SELECT * FROM [cards:ClinicMapping] as c WHERE c.'displayName' LIKE '"
@@ -176,30 +176,30 @@ public class ClinicsServlet extends SlingAllMethodsServlet
         // Determine what names currently exist
         Set<Integer> foundNames = new HashSet<>();
         boolean noNumberValid = true;
-        Pattern numberRegex = Pattern.compile(sanitizedName + " ([\\d]+)");
+        Pattern numberRegex = Pattern.compile(displayName + " ([\\d]+)");
         while (results.hasNext()) {
             String name = results.next().adaptTo(Node.class).getProperty("displayName").getString();
 
             Matcher match = numberRegex.matcher(name);
             if (match.find()) {
                 foundNames.add(Integer.parseInt(match.group(1)));
-            } else if (sanitizedName.equals(name)) {
+            } else if (displayName.equals(name)) {
                 noNumberValid = false;
             }
         }
 
         // Determine if we can use the display name as-is
         if (noNumberValid) {
-            return sanitizedName;
+            return displayName;
         }
 
         // Find the first number i that works if we stick it after the display name
         for (int i = 1; i < foundNames.size(); i++) {
             if (!foundNames.contains(i)) {
-                return sanitizedName + " " + String.valueOf(i);
+                return displayName + " " + String.valueOf(i);
             }
         }
-        return sanitizedName + " " + String.valueOf(foundNames.size() + 1);
+        return displayName + " " + String.valueOf(foundNames.size() + 1);
     }
 
     /**

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/PatientLocalStorage.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/PatientLocalStorage.java
@@ -662,7 +662,7 @@ public class PatientLocalStorage
                 try {
                     final SurveyInfo thisSurvey = new SurveyInfo();
                     final Node thisNode = mapping.adaptTo(Node.class);
-                    thisSurvey.setSurveyID(thisNode.getProperty("surveyID").getString());
+                    thisSurvey.setSurveyID(thisNode.getProperty("survey").getString());
                     thisSurvey.setDisplayName(thisNode.getProperty("displayName").getString());
                     results.add(thisSurvey);
                 } catch (final RepositoryException e) {

--- a/proms-resources/clinical-data/pom.xml
+++ b/proms-resources/clinical-data/pom.xml
@@ -42,6 +42,7 @@
             <Sling-Nodetypes>SLING-INF/nodetypes/proms.cnd</Sling-Nodetypes>
             <Include-Resource>{maven-resources},src/main/media</Include-Resource>
             <Sling-Initial-Content>
+              SLING-INF/content/Extensions/;path:=/Extensions;overwrite:=false,
               SLING-INF/content/Homepage/;path:=/;overwrite:=true,
               SLING-INF/content/Questionnaires/;path:=/Questionnaires/;overwrite:=true;checkin:=true,
               SLING-INF/content/libs/cards/resources/;path:=/libs/cards/resources/;overwrite:=true,

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Extensions/AdminDashboard/Clinics.json
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Extensions/AdminDashboard/Clinics.json
@@ -1,0 +1,9 @@
+{
+  "jcr:primaryType": "cards:Extension",
+  "cards:extensionPointId": "cards/coreUI/admindashboard/entry",
+  "cards:extensionName": "Clinics",
+  "cards:targetURL": "/content.html/admin/Clinics",
+  "cards:icon": "asset:proms-homepage.clinicIcon.js",
+  "cards:hint": "Configure clinics to be queried.",
+  "cards:defaultOrder": 30
+}

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Extensions/Views/Clinics.json
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Extensions/Views/Clinics.json
@@ -1,0 +1,7 @@
+{
+  "jcr:primaryType": "cards:Extension",
+  "cards:extensionPointId": "cards/coreUI/view",
+  "cards:extensionName": "Clinics",
+  "cards:targetURL": "/content.html/admin/Clinics",
+  "cards:extensionRenderURL": "asset:proms-homepage.Clinics.js"
+}

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms/ClinicMapping.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms/ClinicMapping.xml
@@ -19,6 +19,12 @@
 
 <node>
     <name>ClinicMapping</name>
+    <primaryNodeType>cards:ClinicMappingFolder</primaryNodeType>
+    <property>
+        <name>childNodeType</name>
+        <value>cards:ClinicMapping</value>
+        <type>String</type>
+    </property>
     <node>
         <name>481110456</name>
         <primaryNodeType>cards:ClinicMapping</primaryNodeType>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms/ClinicMapping.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms/ClinicMapping.xml
@@ -67,5 +67,15 @@
             <value>True</value>
             <type>Boolean</type>
         </property>
+        <property>
+            <name>description</name>
+            <value>Peter Munk Cardiac Centre</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>sidebarLabel</name>
+            <value>PMCC - ACHD</value>
+            <type>String</type>
+        </property>
     </node>
 </node>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms/ClinicMapping.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms/ClinicMapping.xml
@@ -34,7 +34,7 @@
             <type>String</type>
         </property>
         <property>
-            <name>surveyID</name>
+            <name>survey</name>
             <value>Mood</value>
             <type>String</type>
         </property>
@@ -53,7 +53,7 @@
             <type>String</type>
         </property>
         <property>
-            <name>surveyID</name>
+            <name>survey</name>
             <value>Cardio</value>
             <type>String</type>
         </property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/nodetypes/proms.cnd
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/nodetypes/proms.cnd
@@ -150,6 +150,7 @@
   // Hardcode the resource type.
   - sling:resourceType (STRING) = "cards/ClinicMappingFolder" mandatory autocreated protected
 
-  // Hardcode the resource supertype.
-  - sling:resourceSuperType (STRING) = "cards/Resource" mandatory autocreated protected
+  // Hardcode the resource supertype. ResourceHomepage is used to allow the children to be queried
+  // with the pagination servlet.
+  - sling:resourceSuperType (STRING) = "cards/ResourceHomepage" mandatory autocreated protected
 

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/nodetypes/proms.cnd
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/nodetypes/proms.cnd
@@ -128,7 +128,7 @@
   - clinicName (String) mandatory
 
   // The internal survey ID to use for this clinic
-  - surveyID (String) mandatory
+  - survey (String) mandatory
 
   // The display name to return to the user
   - displayName (String) mandatory

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/nodetypes/proms.cnd
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/nodetypes/proms.cnd
@@ -119,7 +119,7 @@
   // Properties
 
   // Hardcode the resource type.
-  - sling:resourceType (STRING) = "cards/PromsHomepage" mandatory autocreated protected
+  - sling:resourceType (STRING) = "cards/ClinicMapping" mandatory autocreated protected
 
   // Hardcode the resource supertype.
   - sling:resourceSuperType (STRING) = "cards/Resource" mandatory autocreated protected
@@ -135,3 +135,21 @@
 
   // If TRUE, the email_ok question in Patient Information is ignored
   - ignoreEmailConsent (boolean)
+
+//-----------------------------------------------------------------------------
+// The holder for all clinic mappings. This is mostly empty, but used so the
+// pagination servlet can understand it
+[cards:ClinicMappingFolder] > sling:Folder
+  // Attributes:
+
+  // We can use this homepage in a query.
+  query
+
+  // Properties
+
+  // Hardcode the resource type.
+  - sling:resourceType (STRING) = "cards/ClinicMappingFolder" mandatory autocreated protected
+
+  // Hardcode the resource supertype.
+  - sling:resourceSuperType (STRING) = "cards/Resource" mandatory autocreated protected
+

--- a/proms-resources/frontend/src/main/frontend/src/proms/ClinicStyle.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/ClinicStyle.jsx
@@ -1,0 +1,35 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+import { blackColor, grayColor } from "../themeStyle.jsx"
+
+const clinicStyle = theme => ({
+  listButton: {
+    color: grayColor[3]
+  },
+  listItem: {
+    textDecoration: "none",
+  },
+  listText: {
+    "&:hover,&:focus,&:visited,&": {
+      color: blackColor
+    }
+  }
+})
+
+export default clinicStyle;

--- a/proms-resources/frontend/src/main/frontend/src/proms/Clinics.json
+++ b/proms-resources/frontend/src/main/frontend/src/proms/Clinics.json
@@ -2,8 +2,8 @@
   "clinicName": "string",
   "displayName": "string",
   "sidebarLabel": "string",
-  "surveyId": "string",
+  "survey": "string",
   "emergencyContact": "string",
   "description": "string",
-  "//REQUIRED": ["clinicName", "displayName", "sidebarLabel", "surveyId"]
+  "//REQUIRED": ["clinicName", "displayName", "sidebarLabel", "survey"]
 }

--- a/proms-resources/frontend/src/main/frontend/src/proms/Clinics.json
+++ b/proms-resources/frontend/src/main/frontend/src/proms/Clinics.json
@@ -1,0 +1,8 @@
+{
+  "clinicName": "string",
+  "displayName": "string",
+  "sidebarLabel": "string",
+  "surveyID": "string",
+  "emergencyContactEmail": "string",
+  "//REQUIRED": ["clinicName", "displayName"]
+}

--- a/proms-resources/frontend/src/main/frontend/src/proms/Clinics.json
+++ b/proms-resources/frontend/src/main/frontend/src/proms/Clinics.json
@@ -3,6 +3,6 @@
   "displayName": "string",
   "sidebarLabel": "string",
   "surveyID": "string",
-  "emergencyContactEmail": "string",
+  "emergencyContact": "string",
   "//REQUIRED": ["clinicName", "displayName"]
 }

--- a/proms-resources/frontend/src/main/frontend/src/proms/Clinics.json
+++ b/proms-resources/frontend/src/main/frontend/src/proms/Clinics.json
@@ -2,7 +2,8 @@
   "clinicName": "string",
   "displayName": "string",
   "sidebarLabel": "string",
-  "surveyID": "string",
+  "surveyId": "string",
   "emergencyContact": "string",
-  "//REQUIRED": ["clinicName", "displayName"]
+  "description": "string",
+  "//REQUIRED": ["clinicName", "displayName", "sidebarLabel", "surveyId"]
 }

--- a/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
@@ -51,10 +51,15 @@ function Clinics(props) {
     "emergencyContact": "Emergency Contact"
   }
 
+  // SurveyID is capitalized SurveyId in the frontend Fields component, but we need to remap it for here
+  let formattedKeys = {
+    "surveyId": "surveyID"
+  }
+
   let columns = Object.keys(clinicsSpecs).filter((stat) => !Array.isArray(clinicsSpecs[stat]))
     .map((stat) => {
       return {
-        key: stat,
+        key: (stat in formattedKeys) ? formattedKeys[stat] : stat,
         label: (stat in formattedNames) ? formattedNames[stat] : formatString(stat),
         format: clinicsSpecs[stat]
       };

--- a/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
@@ -29,7 +29,7 @@ import {
   Typography
 } from "@material-ui/core";
 
-import Fields from "../questionnaireEditor/Fields.jsx";
+import Fields, { formatString } from "../questionnaireEditor/Fields.jsx";
 import LiveTable from "../dataHomepage/LiveTable.jsx";
 import NewItemButton from "../components/NewItemButton.jsx";
 import ResponsiveDialog from "../components/ResponsiveDialog.jsx";
@@ -41,38 +41,24 @@ function Clinics(props) {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [isNewClinic, setIsNewClinic] = useState(false);
 
-  let columns = [
-    {
-      "key": "clinicName",
-      "label": "ID",
-      "format": "string",
-    },
-    {
-      "key": "displayName",
-      "label": "Name",
-      "format": "string",
-    },
-    {
-      "key": "sidebarLabel",
-      "label": "Sidebar Entry",
-      "format": "string",
-    },
-    {
-      "key": "surveyID",
-      "label": "Surveys",
-      "format": "string",
-    },
-    {
-      "key": "description",
-      "label": "Description",
-      "format": "string",
-    },
-    {
-      "key": "emergencyContact",
-      "label": "Emergency Contact",
-      "format": "string",
-    },
-  ]
+  let clinicsSpecs = require('./Clinics.json');
+
+  let formattedNames = {
+    "clinicName": "ID",
+    "displayName": "Name",
+    "sidebarLabel": "Sidebar Entry",
+    "surveyId": "Surveys",
+    "emergencyContact": "Emergency Contact"
+  }
+
+  let columns = Object.keys(clinicsSpecs).filter((stat) => !Array.isArray(clinicsSpecs[stat]))
+    .map((stat) => {
+      return {
+        key: stat,
+        label: (stat in formattedNames) ? formattedNames[stat] : formatString(stat),
+        format: clinicsSpecs[stat]
+      };
+    });
 
   let dialogSuccess = () => {
     // Since a dialog success changes the sidebar, we should reload everything

--- a/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
@@ -192,10 +192,14 @@ function OnboardNewClinicDialog(props) {
         method: 'POST',
         body: requestData
       })
-      .then(() => {
-        onSuccess && onSuccess();
+      .then((response) => {
+        if (response.ok) {
+          onSuccess && onSuccess();
+        } else {
+          return response.json().then((result) => {throw result.error});
+        }
       })
-      .catch((response) => {setError(response.status + " " + response.statusText);})
+      .catch((errorText) => {setError("Error: " + errorText);})
       .finally(() => {
         setSaveInProgress(false);
       });

--- a/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
@@ -86,7 +86,7 @@ function Clinics(props) {
         <CardHeader
           title={
             <Button>
-              Statistics
+              Clinics
           </Button>
           }
           action={
@@ -185,9 +185,10 @@ function OnboardNewClinicDialog(props) {
 
     // If this clinic does not exist, we need to create a new path for it
     let newClinicName = requestData.get("clinicName");
-    let surveyID = requestData.get("surveyID");
+    let surveyID = requestData.get("surveyId");
     let displayName = requestData.get("displayName");
     let sidebarName = requestData.get("sidebarLabel");
+    let description = requestData.get("description");
     let idHash = hashCode(newClinicName);
 
     let sanitizedName = displayName.replaceAll(/[\"']/g, "");
@@ -256,7 +257,7 @@ function OnboardNewClinicDialog(props) {
           dashboardExtension.append("cards:extensionPointId", `proms/dashboard/${idHash}`);
           dashboardExtension.append("cards:extensionPointName", `${uniqueDisplayName} questionnaires dashboard`);
           dashboardExtension.append("title", uniqueDisplayName);
-          dashboardExtension.append("description", uniqueDisplayName);
+          dashboardExtension.append("description", description);
           dashboardExtension.append("surveys", surveyID);
 
           let dashboardHomepage = new FormData();

--- a/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
@@ -1,0 +1,316 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+import React, { useContext, useEffect, useState } from 'react';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Grid,
+  Typography
+} from "@material-ui/core";
+
+import Fields from "../questionnaireEditor/Fields.jsx";
+import LiveTable from "../dataHomepage/LiveTable.jsx";
+import NewItemButton from "../components/NewItemButton.jsx";
+import ResponsiveDialog from "../components/ResponsiveDialog.jsx";
+import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
+import { formatIdentifier } from "../questionnaireEditor/EditorInput.jsx";
+
+function Clinics(props) {
+  const [currentClinicName, setCurrentClinicName] = useState("");
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [isNewClinic, setIsNewClinic] = useState(false);
+  // Keep track of how many entries we add, to force refresh of LiveTable
+  const [numNewEntries, setNumNewEntries] = useState(0);
+
+  let columns = [
+    {
+      "key": "clinicName",
+      "label": "ID",
+      "format": "string",
+    },
+    {
+      "key": "displayName",
+      "label": "Name",
+      "format": "string",
+    },
+    {
+      "key": "surveyID",
+      "label": "Menu Entry",
+      "format": "string",
+    },
+    {
+      "key": "@name", // TODO: Needs to be the @name of the actual QuestionnaireSet
+      "label": "Surveys",
+      "format": "string",
+    },
+    {
+      "key": "contact",
+      "label": "Emergency Contact",
+      "format": "string",
+    },
+  ]
+
+  let dialogSuccess = () => {
+    setNumNewEntries((old) => old + 1);
+  }
+
+  let dialogClose = () => {
+    setDialogOpen(false);
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader
+          title={
+            <Button>
+              Statistics
+          </Button>
+          }
+          action={
+            <NewItemButton
+              title="On-board a new clinic"
+              onClick={() => { setDialogOpen(true); setIsNewClinic(true); }}
+              inProgress={dialogOpen}
+            />
+          }
+        />
+        <CardContent>
+          <LiveTable
+            columns={columns}
+            entryType={"Proms/ClinicMapping"}
+            customUrl={"Proms/ClinicMapping.paginate"}
+            admin={true}
+            updateData={numNewEntries}
+          />
+        </CardContent>
+      </Card>
+      <OnboardNewClinicDialog currentClinicName={currentClinicName} open={dialogOpen} onClose={dialogClose} onSuccess={dialogSuccess} isNewClinic={isNewClinic} />
+    </>
+  );
+}
+
+function OnboardNewClinicDialog(props) {
+  let { currentClinicName, isNewClinic, open, onClose, onSuccess } = props;
+  let [error, setError] = useState("");
+  let [existingData, setExistingData] = useState(false);
+  let [saveInProgress, setSaveInProgress] = useState(false);
+  let [initialized, setInitialized] = useState(false);
+
+  const globalLoginDisplay = useContext(GlobalLoginContext);
+
+  let clinicsSpecs = require('./Clinics.json');
+
+  let reset = () => {
+    // reset all fields
+    setError();
+    setExistingData(false);
+    setInitialized(false);
+  }
+
+  // Implementation of the Java hashcode function
+  // Code taken from https://werxltd.com/wp/2010/05/13/javascript-implementation-of-javas-string-hashcode-method/
+  // This is used to determine the proper node name of a clinic mapping
+  let hashCode = (toConvert) => {
+    var hash = 0;
+    if (toConvert.length == 0) return hash;
+    for (let i = 0; i < toConvert.length; i++) {
+      let char = toConvert.charCodeAt(i);
+      hash = ((hash << 5) - hash) + char;
+      hash = hash & hash; // Convert to 32bit integer
+    }
+    return hash;
+  }
+
+  useEffect(() => {
+    if (!open) {
+      reset();
+      return;
+    }
+    if (!isNewClinic && currentClinicName) {
+      let fetchExistingData = () => {
+        // We want to keep references the way they are, since reference inputs will expect their UUIDs
+        fetchWithReLogin(globalLoginDisplay, `/Proms/ClinicData/${hashCode(currentClinicName)}.-dereference.json`)
+          .then((response) => response.ok ? response.json() : Promise.reject(response))
+          .then(setExistingData)
+          .then(() => setInitialized(true))
+          .catch(handleError);
+      };
+      if (!existingData) {
+        fetchExistingData();
+      }
+    } else {
+      setInitialized(true);
+    }
+  }, [open]);
+
+  let saveData = (event) => {
+    console.log("Testing saving data3");
+    event.preventDefault();
+
+    // Unlike normal submissions, we need to extract out fields that don't exist in a ClinicMapping node, and are
+    // meant to be processed separately
+    let requestData = new FormData(event.currentTarget);
+
+    // Verify that mandatory variables have been filled out
+    let mandatoryFields = clinicsSpecs["//REQUIRED"];
+    for (const fieldName of mandatoryFields) {
+      if ((!requestData.has(fieldName)) || requestData.get(fieldName) == "") {
+        setError(`The ${formatIdentifier(fieldName)} field is mandatory`);
+        return;
+      }
+    }
+
+    // If this clinic does not exist, we need to create a new path for it
+    let newClinicName = requestData.get("clinicName");
+    let surveyID = requestData.get("surveyID");
+    let displayName = requestData.get("displayName");
+    let idHash = hashCode(newClinicName);
+
+    // TODO: If the idHash changes (i.e. clinicName changes) and we are editing a clinic, we need to delete the old one
+    // and create a new one
+    let newFetch = fetchWithReLogin(globalLoginDisplay, "/Proms/ClinicMapping/" + idHash,
+      {
+        method: 'POST',
+        body: requestData
+      });
+
+    let testSubmission =
+
+      console.log(isNewClinic);
+    // There are a series of new things that need to eb added when creating a new clinic
+    if (isNewClinic) {
+      // Since I'm using a lot of JSON.stringify() here, I'm going to cache our headers
+      let headers = {
+        Accept: "application/json",
+        "Content-type": "application/json"
+      }
+
+      let sidebarBody = new FormData();
+      sidebarBody.append("jcr:primaryType", "cards:Extension");
+      sidebarBody.append("cards:extensionPointId", "cards/coreUI/sidebar/entry");
+      sidebarBody.append("cards:extensionName", idHash);
+      sidebarBody.append("cards:targetURL", "/content.html/Dashboard/" + idHash);
+      sidebarBody.append("cards:icon", "asset:proms-homepage.pmccIcon.js");
+      sidebarBody.append("cards:defaultOrder", 10);
+
+      let dashboardView = new FormData();
+      dashboardView.append("jcr:primaryType", "cards:Extension");
+      dashboardView.append("cards:extensionPointId", "cards/coreUI/view");
+      dashboardView.append("cards:extensionName", "Dashboard");
+      dashboardView.append("cards:extensionRenderURL", "asset:proms-homepage.PromsDashboard.js");
+      dashboardView.append("cards:targetURL", "/content.html/Dashboard");
+      dashboardView.append("cards:exactURLMatch", false);
+
+      let dashboardExtension = new FormData();
+      dashboardExtension.append("jcr:primaryType", "cards:ExtensionPoint");
+      dashboardExtension.append("cards:extensionPointId", "proms /dashboard/pmcc");
+      dashboardExtension.append("cards:extensionPointName", `${displayName} questionnaires dashboard`);
+      dashboardExtension.append("title", displayName);
+      dashboardExtension.append("description", displayName);
+      dashboardExtension.append("surveys", "Cardio"); // TODO: Is this correct?
+
+      let dashboardHomepage = new FormData();
+      dashboardHomepage.append("jcr:primaryType", "cards:Extension");
+      dashboardHomepage.append("cards:extensionPointId", "proms/dashboard/pmcc");
+      dashboardHomepage.append("cards:extensionName", `${idHash} View`);
+      dashboardHomepage.append("cards:extensionRenderURL", "asset:proms-homepage.PromsView.js");
+      dashboardHomepage.append("cards:defaultOrder", 5);
+      dashboardHomepage.append("cards:data", `/Proms/${surveyID}`); // TODO: Double check this, not sure it's right
+
+      newFetch
+        // After updating the clinicMapping, we also need to update all running configurations with the new data
+        .then(() => fetchWithReLogin(globalLoginDisplay, "/Proms/ClinicMapping.addNew",
+          {
+            method: 'POST',
+            headers: headers,
+            body: JSON.stringify({ ":newClinic": newClinicName })
+          }))
+        // After updating the configurations, we need to create the sidebar entry
+        .then(() => fetchWithReLogin(globalLoginDisplay, `/Extensions/Sidebar/${idHash}`,
+          {
+            method: 'POST',
+            body: sidebarBody
+          }))
+        // And the new dashboard view
+        .then(() => fetchWithReLogin(globalLoginDisplay, `/Extensions/Views/${idHash}Dashboard`,
+          {
+            method: 'POST',
+            headers: headers,
+            body: dashboardView
+          }))
+        // And the new extension point for the dashboard view
+        .then(() => fetchWithReLogin(globalLoginDisplay, `/apps/cards/ExtensionPoints/DashboardViews${idHash}`,
+          {
+            method: 'POST',
+            headers: headers,
+            body: dashboardExtension
+          }))
+        // And the new extension point for appointments of this clinic
+        .then(() => fetchWithReLogin(globalLoginDisplay, `/Extensions/DashboardViews/${idHash}View`,
+          {
+            method: 'POST',
+            headers: headers,
+            body: dashboardHomepage
+          }));
+    }
+  }
+
+  return (
+    <form action='/Proms/ClinicMapping' method='POST' onSubmit={saveData}>
+      <ResponsiveDialog disablePortal open={open} onClose={onClose}>
+        <DialogTitle>{isNewClinic ? "Create New Clinic Mapping" : "Edit Clinic Mapping"}</DialogTitle>
+        <DialogContent>
+          {error && <Typography color="error">{error}</Typography>}
+          <Grid container direction="column" spacing={2}>
+            {
+              // We don't want to load the Fields component until we are fully initialized
+              // since otherwise the default values will be empty and cannot be assigned
+              initialized && <Fields data={existingData || {}} JSON={clinicsSpecs} edit />
+            }
+          </Grid>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={onClose}
+            variant="contained"
+            color="default"
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="contained"
+            color="primary"
+            disabled={saveInProgress}
+          >
+            {isNewClinic ? "Create" : "Save"}
+          </Button>
+        </DialogActions>
+      </ResponsiveDialog>
+    </form>
+  );
+}
+
+export default Clinics;

--- a/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
@@ -210,7 +210,7 @@ function OnboardNewClinicDialog(props) {
             }
           }
           console.log(sanitizedName + " " + json["returnedrows"] + 1);
-          return sanitizedName + " " + json["returnedrows"] + 1;
+          return sanitizedName + " " + (json["returnedrows"] + 1);
         }
       })
       .then((uniqueDisplayName) => {
@@ -261,7 +261,7 @@ function OnboardNewClinicDialog(props) {
 
           let dashboardHomepage = new FormData();
           dashboardHomepage.append("jcr:primaryType", "cards:Extension");
-          dashboardHomepage.append("cards:extensionPointId", `proms/dashboard/${idHash}`);
+          dashboardHomepage.append("cards:extensionPointId", `proms/dashboard/${surveyID}`);
           dashboardHomepage.append("cards:extensionName", `${uniqueDisplayName} View`);
           dashboardHomepage.append("cards:extensionRenderURL", "asset:proms-homepage.PromsView.js");
           dashboardHomepage.append("cards:defaultOrder", 5);

--- a/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
@@ -186,7 +186,7 @@ function OnboardNewClinicDialog(props) {
     }
 
     // Add this new clinic mapping
-    let url = new URL("/Proms/ClinicMapping.addNew", window.location.origin);
+    let url = new URL("/Proms/ClinicMapping", window.location.origin);
     fetchWithReLogin(globalLoginDisplay, url,
       {
         method: 'POST',

--- a/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
@@ -47,19 +47,14 @@ function Clinics(props) {
     "clinicName": "ID",
     "displayName": "Name",
     "sidebarLabel": "Sidebar Entry",
-    "surveyId": "Surveys",
+    "survey": "Surveys",
     "emergencyContact": "Emergency Contact"
-  }
-
-  // SurveyID is capitalized SurveyId in the frontend Fields component, but we need to remap it for here
-  let formattedKeys = {
-    "surveyId": "surveyID"
   }
 
   let columns = Object.keys(clinicsSpecs).filter((stat) => !Array.isArray(clinicsSpecs[stat]))
     .map((stat) => {
       return {
-        key: (stat in formattedKeys) ? formattedKeys[stat] : stat,
+        key: stat,
         label: (stat in formattedNames) ? formattedNames[stat] : formatString(stat),
         format: clinicsSpecs[stat]
       };

--- a/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
@@ -156,7 +156,6 @@ function OnboardNewClinicDialog(props) {
 
   let saveData = (event) => {
     event.preventDefault();
-    setSaveInProgress(true);
 
     // Unlike normal submissions, we need to extract out fields that don't exist in a ClinicMapping node, and are
     // meant to be processed separately
@@ -173,6 +172,7 @@ function OnboardNewClinicDialog(props) {
 
     // Add this new clinic mapping
     let url = new URL("/Proms/ClinicMapping", window.location.origin);
+    setSaveInProgress(true);
     fetchWithReLogin(globalLoginDisplay, url,
       {
         method: 'POST',

--- a/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
@@ -55,13 +55,18 @@ function Clinics(props) {
       "format": "string",
     },
     {
-      "key": "surveyID",
-      "label": "Menu Entry",
+      "key": "sidebarLabel",
+      "label": "Sidebar Entry",
       "format": "string",
     },
     {
-      "key": "@name", // TODO: Needs to be the @name of the actual QuestionnaireSet
+      "key": "surveyID",
       "label": "Surveys",
+      "format": "string",
+    },
+    {
+      "key": "description",
+      "label": "Description",
       "format": "string",
     },
     {
@@ -224,6 +229,7 @@ function OnboardNewClinicDialog(props) {
         newMappingData.append("displayName", uniqueDisplayName);
         newMappingData.append("surveyID", surveyID);
         newMappingData.append("emergencyContact", requestData.get("emergencyContact"));
+        newMappingData.append("sidebarLabel", sidebarName);
         newMappingData.append("jcr:primaryType", "cards:ClinicMapping");
         let newFetch = fetchWithReLogin(globalLoginDisplay, "/Proms/ClinicMapping/" + idHash,
           {

--- a/proms-resources/frontend/src/main/frontend/webpack.config.js
+++ b/proms-resources/frontend/src/main/frontend/webpack.config.js
@@ -12,7 +12,9 @@ module.exports = {
     [module_name + 'PromsDashboard']: './src/proms/PromsDashboard.jsx',
     [module_name + 'PromsView']: './src/proms/PromsView.jsx',
     [module_name + 'VisitView']: './src/proms/VisitView.jsx',
-    [module_name + 'pmccIcon']: '@material-ui/icons/Favorite.js'
+    [module_name + 'pmccIcon']: '@material-ui/icons/Favorite.js',
+    [module_name + 'clinicIcon']: '@material-ui/icons/Event.js',
+    [module_name + 'Clinics']: './src/proms/Clinics.jsx'
   },
   plugins: [
     new CleanWebpackPlugin(),

--- a/proms-resources/frontend/src/main/frontend/webpack.config.js
+++ b/proms-resources/frontend/src/main/frontend/webpack.config.js
@@ -12,7 +12,6 @@ module.exports = {
     [module_name + 'PromsDashboard']: './src/proms/PromsDashboard.jsx',
     [module_name + 'PromsView']: './src/proms/PromsView.jsx',
     [module_name + 'VisitView']: './src/proms/VisitView.jsx',
-    [module_name + 'pmccIcon']: '@material-ui/icons/Event.js',
     [module_name + 'clinicIcon']: '@material-ui/icons/Event.js',
     [module_name + 'Clinics']: './src/proms/Clinics.jsx'
   },

--- a/proms-resources/frontend/src/main/frontend/webpack.config.js
+++ b/proms-resources/frontend/src/main/frontend/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = {
     [module_name + 'PromsDashboard']: './src/proms/PromsDashboard.jsx',
     [module_name + 'PromsView']: './src/proms/PromsView.jsx',
     [module_name + 'VisitView']: './src/proms/VisitView.jsx',
-    [module_name + 'pmccIcon']: '@material-ui/icons/Favorite.js',
+    [module_name + 'pmccIcon']: '@material-ui/icons/Event.js',
     [module_name + 'clinicIcon']: '@material-ui/icons/Event.js',
     [module_name + 'Clinics']: './src/proms/Clinics.jsx'
   },

--- a/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/Sidebar/PMCC-ACHD.json
+++ b/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/Sidebar/PMCC-ACHD.json
@@ -3,6 +3,6 @@
   "cards:extensionPointId": "cards/coreUI/sidebar/entry",
   "cards:extensionName": "PMCC - ACHD",
   "cards:targetURL": "/content.html/Dashboard/PMCC-ACHD",
-  "cards:icon": "asset:proms-homepage.pmccIcon.js",
+  "cards:icon": "asset:proms-homepage.clinicIcon.js",
   "cards:defaultOrder": 10
 }


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/CARDS-1612)

![image](https://user-images.githubusercontent.com/4656440/160674417-537693af-5d1c-4e46-8e5f-efde48ab4b9c.png)

![image](https://user-images.githubusercontent.com/4656440/160674326-5a92df92-ac2d-45a7-aa98-68b440cdcf2f.png)

This PR adds a new item to the administration page: Clinics, which allows you to automatically create a new ClinicMapping. This clinic mapping will automatically be added to the query for any existing Proms importer configs, and will generate a new Sidebar entry to look at the clinic you specify in the SurveyID.