### PR TITLE
CARDS-1675: Exclude cancelled appointments form all data listings on the PROMs dashboard

### DIFF
--- a/proms-resources/frontend/src/main/frontend/src/proms/PromsView.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PromsView.jsx
@@ -62,12 +62,14 @@ function PromsView(props) {
     "inner join [cards:Form] as visitInformation on visitSubject.[jcr:uuid] = visitInformation.subject " +
       "inner join [cards:Answer] as visitDate on isdescendantnode(visitDate, visitInformation) " +
       "inner join [cards:Answer] as visitSurveys on isdescendantnode(visitSurveys, visitInformation) " +
+      "inner join [cards:Answer] as visitStatus on isdescendantnode(visitStatus, visitInformation) " +
       "inner join [cards:Answer] as patientSubmitted on isdescendantnode(patientSubmitted, visitInformation) " +
     "inner join [cards:Form] as dataForm on visitSubject.[jcr:uuid] = dataForm.subject " +
   "where " +
     `visitInformation.questionnaire = '${visitInfo?.["jcr:uuid"]}' ` +
       `and visitDate.question = '${visitInfo?.time?.["jcr:uuid"]}' and __DATE_FILTER_PLACEHOLDER__ ` +
       `and visitSurveys.question = '${visitInfo?.surveys?.["jcr:uuid"]}' and visitSurveys.value = '${surveysId}' ` +
+      `and visitStatus.question = '${visitInfo?.status?.["jcr:uuid"]}' and visitStatus.value <> 'cancelled' ` +
       `and patientSubmitted.question = '${visitInfo?.surveys_submitted?.["jcr:uuid"]}' and patientSubmitted.value = 1 ` +
     `and dataForm.questionnaire = '${questionnaireId}' ` +
   "order by visitDate.value __SORT_ORDER_PLACEHOLDER__"

--- a/proms-resources/frontend/src/main/frontend/src/proms/VisitView.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/VisitView.jsx
@@ -58,10 +58,12 @@ function VisitView(props) {
     "[cards:Form] as visitInformation " +
       "inner join [cards:Answer] as visitSurveys on isdescendantnode(visitSurveys, visitInformation) " +
       "inner join [cards:Answer] as visitDate on isdescendantnode(visitDate, visitInformation) " +
+      "inner join [cards:Answer] as visitStatus on isdescendantnode(visitStatus, visitInformation) " +
   "where " +
     `visitInformation.questionnaire = '${visitInfo?.["jcr:uuid"]}' ` +
       `and visitDate.question = '${visitInfo?.time?.["jcr:uuid"]}' and __DATE_FILTER_PLACEHOLDER__ ` +
       `and visitSurveys.question = '${visitInfo?.surveys?.["jcr:uuid"]}' and visitSurveys.value = '${surveysId}' ` +
+      `and visitStatus.question = '${visitInfo?.status?.["jcr:uuid"]}' and visitStatus.value <> 'cancelled' ` +
   "order by visitDate.value __SORT_ORDER_PLACEHOLDER__"
 )
 


### PR DESCRIPTION
Quick fix using the current `query` endpoint instead of the `Forms.paginate` endpoint which will introduced by 1610 in PR #945 . This code will have to be completely replaced with the implementation done in PR #945 when 1610 is approved and merged.