### PR TITLE
[misc] Improve the correctness and performance of PROMs dashboard queries

### DIFF
--- a/proms-resources/frontend/src/main/frontend/src/proms/PromsView.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PromsView.jsx
@@ -60,10 +60,10 @@ function PromsView(props) {
   "from " +
     "[cards:Subject] as visitSubject " +
     "inner join [cards:Form] as visitInformation on visitSubject.[jcr:uuid] = visitInformation.subject " +
-      "inner join [cards:Answer] as visitDate on isdescendantnode(visitDate, visitInformation) " +
-      "inner join [cards:Answer] as visitSurveys on isdescendantnode(visitSurveys, visitInformation) " +
-      "inner join [cards:Answer] as visitStatus on isdescendantnode(visitStatus, visitInformation) " +
-      "inner join [cards:Answer] as patientSubmitted on isdescendantnode(patientSubmitted, visitInformation) " +
+      "inner join [cards:DateAnswer] as visitDate on isdescendantnode(visitDate, visitInformation) " +
+      "inner join [cards:TextAnswer] as visitSurveys on isdescendantnode(visitSurveys, visitInformation) " +
+      "inner join [cards:TextAnswer] as visitStatus on isdescendantnode(visitStatus, visitInformation) " +
+      "inner join [cards:BooleanAnswer] as patientSubmitted on isdescendantnode(patientSubmitted, visitInformation) " +
     "inner join [cards:Form] as dataForm on visitSubject.[jcr:uuid] = dataForm.subject " +
   "where " +
     `visitInformation.questionnaire = '${visitInfo?.["jcr:uuid"]}' ` +

--- a/proms-resources/frontend/src/main/frontend/src/proms/VisitView.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/VisitView.jsx
@@ -56,9 +56,9 @@ function VisitView(props) {
 "select distinct visitInformation.* " +
   "from " +
     "[cards:Form] as visitInformation " +
-      "inner join [cards:Answer] as visitSurveys on isdescendantnode(visitSurveys, visitInformation) " +
-      "inner join [cards:Answer] as visitDate on isdescendantnode(visitDate, visitInformation) " +
-      "inner join [cards:Answer] as visitStatus on isdescendantnode(visitStatus, visitInformation) " +
+      "inner join [cards:TextAnswer] as visitSurveys on isdescendantnode(visitSurveys, visitInformation) " +
+      "inner join [cards:DateAnswer] as visitDate on isdescendantnode(visitDate, visitInformation) " +
+      "inner join [cards:TextAnswer] as visitStatus on isdescendantnode(visitStatus, visitInformation) " +
   "where " +
     `visitInformation.questionnaire = '${visitInfo?.["jcr:uuid"]}' ` +
       `and visitDate.question = '${visitInfo?.time?.["jcr:uuid"]}' and __DATE_FILTER_PLACEHOLDER__ ` +


### PR DESCRIPTION
Specifying the precise answer type (e.g. `cards:TextAnswer`) instead of the supertype `cards:Answer` should make the queries faster.

Co-authored by: @sdumitriu

**Testing**:
* The changes in this PR only affect the PROMs dashboard.
* There should be no visible functionality change to a dashboard displaying a relatively small dataset.
* On very large datasets, the dashboard should be faster to load after these changes.