### PR TITLE
[misc] Minor improvements in handling answerMetadata

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -90,7 +90,7 @@ function Answer (props) {
           })}
           {
             answerMetadata &&
-              Array.from(answerMetadata.entries()).map(([key, value], index) => {
+              Object.entries(answerMetadata).map(([key, value], index) => {
                 return (
                   <input
                     type="hidden"

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -102,7 +102,18 @@ function Answer (props) {
           }
         </React.Fragment>)
       :
+        <>
         <input type="hidden" name={`${answerPath}/value@Delete`} value="0"></input>
+        { Object.entries(answerMetadata || {}).map(([key, value], index) => (
+            <input
+              type="hidden"
+              name={`${answerPath}/${key}@Delete`}
+              key={value === undefined ? index + (answers ? answers.length : 0) : value}
+              value={0}
+            />
+          ))
+        }
+        </>
       }
       {enableNotes &&
         <NoteComponent

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
@@ -78,7 +78,7 @@ function PedigreeQuestion(props) {
   }
 
   let [ outputAnswers, setOutputAnswers ] = useState(pedigreeJSON ? [["value", pedigreeJSON]] : []);
-  let answerMetadata = pedigreeSVG ? new Map().set("image", pedigreeSVG) : null;
+  let answerMetadata = pedigreeSVG ? {image:  pedigreeSVG} : undefined;
 
   useEffect(() => {
     setOutputAnswers(pedigreeJSON ? [["value", pedigreeJSON]] : []);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
@@ -78,7 +78,7 @@ function PedigreeQuestion(props) {
   }
 
   let [ outputAnswers, setOutputAnswers ] = useState(pedigreeJSON ? [["value", pedigreeJSON]] : []);
-  let answerMetadata = pedigreeSVG ? {image:  pedigreeSVG} : undefined;
+  let answerMetadata = {image:  pedigreeSVG};
 
   useEffect(() => {
     setOutputAnswers(pedigreeJSON ? [["value", pedigreeJSON]] : []);


### PR DESCRIPTION
**Background:**
The `answerMetadata` property of the `Answer` component is used to specify properties of the answer node to be set, in addition to the standard `value`. For example, it is used by `PedigreeQuestion` to store the svg image of the pedigree in the `image` property of its answer node.

**In this PR:**
* Refactoring: switched the proptype of `answerMetadata` to Object instead of Map
* Data cleanup: when the value is deleted, also delete the metadata

**Testing:**
Currently only `PedigreeQuestion` uses `answerMetadata`.
* Make sure pedigrees still work as it did before from the user perspective (creating, viewing, editing, deleting).
* Check that the `image` property of the answer node is no longer present after deleting a pedigree. 