### PR TITLE
CARDS-1640: Proms mode: start_cards.sh should do all necessary initialization without requiring any additional manual settings

### DIFF
--- a/start_cards.sh
+++ b/start_cards.sh
@@ -51,13 +51,13 @@ function print_length_of() {
   done
 }
 
-function handle_missing_sling_commons_crypto_fail() {
-  echo -e "${TERMINAL_RED}**********************************************************************************${TERMINAL_NOCOLOR}"
-  echo -e "${TERMINAL_RED}*                                                                                *${TERMINAL_NOCOLOR}"
-  echo -e "${TERMINAL_RED}*   The SLING_COMMONS_CRYPTO_PASSWORD enviroment variable is missing. Exiting.   *${TERMINAL_NOCOLOR}"
-  echo -e "${TERMINAL_RED}*                                                                                *${TERMINAL_NOCOLOR}"
-  echo -e "${TERMINAL_RED}**********************************************************************************${TERMINAL_NOCOLOR}"
-  exit -1
+function handle_missing_sling_commons_crypto_warning() {
+  echo -e "${TERMINAL_YELLOW}*************************************************************************${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*                                                                       *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*   The SLING_COMMONS_CRYPTO_PASSWORD enviroment variable is missing.   *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*   Using the default value of 'password'.                              *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*                                                                       *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*************************************************************************${TERMINAL_NOCOLOR}"
 }
 
 function handle_missing_mailcap_fail() {
@@ -293,7 +293,8 @@ if [ $SMTPS_ENABLED = true ]
 then
   if [ -z $SLING_COMMONS_CRYPTO_PASSWORD ]
   then
-    handle_missing_sling_commons_crypto_fail
+    handle_missing_sling_commons_crypto_warning
+    export SLING_COMMONS_CRYPTO_PASSWORD=password
   fi
   if [ ! -e ~/.mailcap ]
   then


### PR DESCRIPTION
If SMTPS is enabled and the `SLING_COMMONS_CRYPTO_PASSWORD` environment variable is not specified, the default value of `password` will be used instead of `start_cards.sh` terminating with a non-zero exit code.

To test:

1. Build this `CARDS-1640` branch with `mvn clean install`.
2. Ensure that the `SLING_COMMONS_CRYPTO_PASSWORD` environment variable is empty. Running `echo $SLING_COMMONS_CRYPTO_PASSWORD` should return a blank line.
3. Follow the _Testing Instructions_ 1 to 5 (inclusive) in https://github.com/data-team-uhn/cards/pull/822 to start a local instance of Python's SMTP debugging server and a _socat_ SMTPS-to-SMTP relay.
4. Start CARDS with the command `./start_cards.sh -P cards4proms --dev`.
5. Visit `http://localhost:8080` and login as `admin`:`admin`.
6. Send a test email by visiting `http://localhost:8080/content.emailtest?fromEmail=alice@mail.com&fromName=Alice&toEmail=bob@mail.com&toName=Bob`.
7. The test email should appear in the terminal window running Python's SMTP debugging server.