### PR TITLE
CARDS-1722: .data JSON processor uses slow and lightly wrong query when filtering by status

### DIFF
--- a/cardiac-rehab-resources/backend/src/main/java/io/uhndata/cards/cardiacrehab/internal/export/ExportTask.java
+++ b/cardiac-rehab-resources/backend/src/main/java/io/uhndata/cards/cardiacrehab/internal/export/ExportTask.java
@@ -216,7 +216,7 @@ public class ExportTask implements Runnable
             String query = String.format(
                 "SELECT subject.* FROM [cards:Form] AS form INNER JOIN [cards:Subject] AS subject"
                     + " ON form.'subject'=subject.[jcr:uuid]"
-                    + " WHERE form.[jcr:lastModified] >= '%s' AND NOT CONTAINS(form.[statusFlags], 'INCOMPLETE')",
+                    + " WHERE form.[jcr:lastModified] >= '%s' AND NOT form.[statusFlags] = 'INCOMPLETE'",
                 requestDateString
             );
 
@@ -244,7 +244,7 @@ public class ExportTask implements Runnable
                     + " ON form.'subject'=subject.[jcr:uuid]"
                     + " WHERE form.[jcr:lastModified] >= '%s'"
                     + " AND form.[jcr:lastModified] < '%s'"
-                    + " AND NOT CONTAINS(form.[statusFlags], 'INCOMPLETE')",
+                    + " AND NOT form.[statusFlags] = 'INCOMPLETE'",
                 requestDateStringLower, requestDateStringUpper
             );
 

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/DataSubjectProcessor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/DataSubjectProcessor.java
@@ -158,10 +158,10 @@ public class DataSubjectProcessor implements ResourceJsonProcessor
                     result.append(" and n.[jcr:createdBy] = '").append(value).append('\'');
                     break;
                 case "status":
-                    result.append(" and contains(n.[statusFlags], '").append(value).append("')");
+                    result.append(" and n.[statusFlags] = '").append(value).append('\'');
                     break;
                 case "statusNot":
-                    result.append(" and not contains(n.[statusFlags], '").append(value).append("')");
+                    result.append(" and not n.[statusFlags] = '").append(value).append('\'');
                     break;
                 case "modifiedAfter":
                     result.append(" and n.[jcr:lastModified] >= '").append(value).append('\'');

--- a/modules/vocabularies/src/main/frontend/src/vocabularyAction.jsx
+++ b/modules/vocabularies/src/main/frontend/src/vocabularyAction.jsx
@@ -97,7 +97,7 @@ export default function VocabularyAction(props) {
   let fetchQuestionnaires = () => {
     if (questionnaires.length === 0) {
       // Send a fetch request to determine the questionnaires available
-      const query = `select n.* from [cards:Questionnaire] as n inner join [cards:Question] as q on isdescendantnode(q, n) where contains(q.sourceVocabularies, '${vocabulary.acronym}')`;
+      const query = `select n.* from [cards:Questionnaire] as n inner join [cards:Question] as q on isdescendantnode(q, n) where q.sourceVocabularies = '${vocabulary.acronym}'`;
       fetchWithReLogin(globalLoginDisplay, `/query?query=${encodeURIComponent(query)}&limit=100`)
         .then((response) => response.ok ? response.json() : Promise.reject(response))
         .then((json) => {


### PR DESCRIPTION
To test:
- start in lfs mode
- create one Patient subject and 3 chemotherapy forms
- form 1 COMPLETE
- form 2 INCOMPLETE
- form 3 first complete, then re-edit and make it INCOMPLETE and INVALID, for example by removing the Treatment Protocol answer
- open the subject's .data.json with the following filters in the URL:
    - `/Subjects/UUID.data.dataFilter:statusNot=INCOMPLETE.json` -> should only contain the complete form 1
    - `/Subjects/UUID.data.dataFilter:statusNot=INVALID.json` -> should contain forms 1 and 2
    - `/Subjects/UUID.data.dataFilter:status=INCOMPLETE.json` -> should contain forms 2 and 3
    - `/Subjects/UUID.data.dataFilter:status=INVALID.json` -> should only contain the invalid form 3
    - `/Subjects/UUID.data.json` -> should contain all 3 forms

Another thing to test:
- install ORDO and HP
- reload the vocabularies admin page
- try to uninstall ORDO and HP -> does it warn that the Tumors/Symptoms question is using this vocabulary?