### PR TITLE
CARDS-919: Add an extension point allowing the insertion of a visual element at the top of the login page

### DIFF
--- a/modules/demo-banner/pom.xml
+++ b/modules/demo-banner/pom.xml
@@ -42,7 +42,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Sling-Initial-Content>SLING-INF/content/Extensions/PageStart/;path:=/Extensions/PageStart/;overwrite:=true</Sling-Initial-Content>
+            <Sling-Initial-Content>SLING-INF/content/Extensions/PageStart/;path:=/Extensions/PageStart/;overwrite:=true,SLING-INF/content/Extensions/LoginPageStart/;path:=/Extensions/LoginPageStart/;overwrite:=true</Sling-Initial-Content>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/demo-banner/pom.xml
+++ b/modules/demo-banner/pom.xml
@@ -42,7 +42,10 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Sling-Initial-Content>SLING-INF/content/Extensions/PageStart/;path:=/Extensions/PageStart/;overwrite:=true,SLING-INF/content/Extensions/LoginPageStart/;path:=/Extensions/LoginPageStart/;overwrite:=true</Sling-Initial-Content>
+            <Sling-Initial-Content>
+              SLING-INF/content/Extensions/PageStart/;path:=/Extensions/PageStart/;overwrite:=true,
+              SLING-INF/content/Extensions/LoginPageStart/;path:=/Extensions/LoginPageStart/;overwrite:=true
+            </Sling-Initial-Content>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/demo-banner/src/main/resources/SLING-INF/content/Extensions/LoginPageStart/WarningBanner.json
+++ b/modules/demo-banner/src/main/resources/SLING-INF/content/Extensions/LoginPageStart/WarningBanner.json
@@ -1,0 +1,6 @@
+{
+  "jcr:primaryType": "cards:Extension",
+  "cards:extensionPointId": "cards/coreUI/loginPageStart",
+  "cards:extensionName": "Demo Warning Banner",
+  "cards:extensionRenderURL": "asset:cards-demo-banner.demoBanner.js"
+}

--- a/modules/homepage/src/main/frontend/src/themePage/index.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/index.jsx
@@ -28,7 +28,7 @@ import { Redirect, Router, Route, Switch } from "react-router-dom";
 import { createBrowserHistory } from "history";
 import Navbar from "./Navbars/Navbar";
 import Page from "./Page";
-import PageStart from "./PageStart/PageStart";
+import PageStart from "../PageStart";
 import IndexStyle from "./indexStyle.jsx";
 import DialogueLoginContainer, { GlobalLoginContext } from "../login/loginDialogue.js";
 

--- a/modules/login/pom.xml
+++ b/modules/login/pom.xml
@@ -52,7 +52,10 @@
             <Include-Resource>{maven-resources}</Include-Resource>
             <Sling-Nodetypes>SLING-INF/nodetypes/login.cnd</Sling-Nodetypes>
             <!-- Initial content to be loaded on bundle installation -->
-            <Sling-Initial-Content>SLING-INF/content/libs/cards/login/;overwrite:=true;path:=/libs/cards/login/,SLING-INF/content/apps/cards/ExtensionPoints/;overwrite:=true;path:=/apps/cards/ExtensionPoints/</Sling-Initial-Content>
+            <Sling-Initial-Content>
+              SLING-INF/content/libs/cards/login/;overwrite:=true;path:=/libs/cards/login/,
+              SLING-INF/content/apps/cards/ExtensionPoints/;overwrite:=true;path:=/apps/cards/ExtensionPoints/
+            </Sling-Initial-Content>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/login/src/main/frontend/src/login/loginMain.js
+++ b/modules/login/src/main/frontend/src/login/loginMain.js
@@ -19,5 +19,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import MainLoginComponent from './loginMainComponent';
+import PageStart from '../PageStart';
 
-ReactDOM.render(<MainLoginComponent selfContained redirectOnLogin={true} />, document.getElementById('main-login-container'));
+ReactDOM.render(
+  <React.Fragment>
+    <PageStart
+      extensionsName="LoginPageStart"
+    />
+    <MainLoginComponent selfContained redirectOnLogin={true} />
+  </React.Fragment>,
+  document.getElementById('main-login-container')
+);

--- a/modules/login/src/main/resources/SLING-INF/content/apps/cards/ExtensionPoints/LoginPageStart.json
+++ b/modules/login/src/main/resources/SLING-INF/content/apps/cards/ExtensionPoints/LoginPageStart.json
@@ -1,0 +1,5 @@
+{
+    "jcr:primaryType": "cards:ExtensionPoint",
+    "cards:extensionPointId": "cards/coreUI/loginPageStart",
+    "cards:extensionPointName": "Content to be displayed on the top of the login page"
+}

--- a/modules/page-start-header/pom.xml
+++ b/modules/page-start-header/pom.xml
@@ -7,9 +7,7 @@
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
-
   http://www.apache.org/licenses/LICENSE-2.0
-
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -26,23 +24,18 @@
     <version>0.9-SNAPSHOT</version>
   </parent>
 
-  <artifactId>cards-login</artifactId>
+  <artifactId>cards-modules-page-start-header</artifactId>
   <packaging>bundle</packaging>
-  <name>CARDS - Signup and Login</name>
+  <name>CARDS - Page Start Header</name>
 
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.sling</groupId>
         <artifactId>slingfeature-maven-plugin</artifactId>
       </plugin>
 
+      <!-- This is an OSGi bundle -->
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
@@ -50,9 +43,6 @@
         <configuration>
           <instructions>
             <Include-Resource>{maven-resources}</Include-Resource>
-            <Sling-Nodetypes>SLING-INF/nodetypes/login.cnd</Sling-Nodetypes>
-            <!-- Initial content to be loaded on bundle installation -->
-            <Sling-Initial-Content>SLING-INF/content/libs/cards/login/;overwrite:=true;path:=/libs/cards/login/,SLING-INF/content/apps/cards/ExtensionPoints/;overwrite:=true;path:=/apps/cards/ExtensionPoints/</Sling-Initial-Content>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/page-start-header/src/main/features/feature.json
+++ b/modules/page-start-header/src/main/features/feature.json
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+{
+  "bundles":[
+    {
+      "id":"${project.groupId}:${project.artifactId}:${project.version}",
+      "start-order":"25"
+    }
+  ]
+}

--- a/modules/page-start-header/src/main/frontend/package.json
+++ b/modules/page-start-header/src/main/frontend/package.json
@@ -1,0 +1,43 @@
+{
+    "name": "cards-page-start-header",
+    "version": "0.1.0",
+    "description": "React component that loads and displays page headers from a UI ExtensionPoint",
+    "author": "UHN DATA",
+    "license": "Apache-2.0",
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/data-team-uhn/cards.git",
+      "directory": "modules/page-start-header/src/main/frontend"
+    },
+    "babel": {
+      "presets": [
+        "@babel/preset-env",
+        "@babel/preset-react"
+      ],
+      "plugins": [
+        [
+          "@babel/plugin-proposal-class-properties"
+        ]
+      ]
+  },
+  "dependencies": {
+    "@material-ui/core": "4.11.2",
+    "@material-ui/icons": "4.11.2",
+    "react": "16.14.0",
+    "moment": "2.29.1"
+  },
+  "devDependencies": {
+    "@babel/core": "7.12.10",
+    "@babel/plugin-proposal-class-properties": "7.10.4",
+    "@babel/preset-env": "7.12.11",
+    "@babel/preset-react": "7.12.10",
+    "babel-loader": "8.2.2",
+    "clean-webpack-plugin": "3.0.0",
+    "eslint-plugin-react": "7.22.0",
+    "eslint-plugin-auto-import": "0.1.0",
+    "eslint": "7.17.0",
+    "webpack": "5.17.0",
+    "webpack-cli": "4.4.0",
+    "webpack-assets-manifest": "5.0.0"
+  }
+}

--- a/modules/page-start-header/src/main/frontend/package.json
+++ b/modules/page-start-header/src/main/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cards-page-start-header",
-    "version": "0.1.0",
+    "version": "0.9-SNAPSHOT",
     "description": "React component that loads and displays page headers from a UI ExtensionPoint",
     "author": "UHN DATA",
     "license": "Apache-2.0",
@@ -23,8 +23,7 @@
   "dependencies": {
     "@material-ui/core": "4.11.2",
     "@material-ui/icons": "4.11.2",
-    "react": "16.14.0",
-    "moment": "2.29.1"
+    "react": "16.14.0"
   },
   "devDependencies": {
     "@babel/core": "7.12.10",

--- a/modules/page-start-header/src/main/frontend/src/PageStart.jsx
+++ b/modules/page-start-header/src/main/frontend/src/PageStart.jsx
@@ -18,7 +18,7 @@
 //
 
 import React, { useEffect, useState } from "react";
-import { loadExtensions } from "../../uiextension/extensionManager";
+import { loadExtensions } from "./uiextension/extensionManager";
 
 export default function PageStart(props) {
 
@@ -31,8 +31,11 @@ export default function PageStart(props) {
   const [ extensionData, setExtensionData ] = useState(null);
   const [ isInitialized, setIsInitialized ] = useState(false);
   const [ pageStartHeight, setPageStartHeight ] = useState(0);
+
+  const extensionsName = props.extensionsName || "PageStart";
+
   useEffect(() => {
-    props.setTotalHeight(pageStartHeight);
+    props.setTotalHeight && props.setTotalHeight(pageStartHeight);
   });
 
   useEffect(() => {
@@ -57,7 +60,7 @@ export default function PageStart(props) {
   };
 
   if (!isInitialized) {
-    loadExtensions("PageStart")
+    loadExtensions(extensionsName)
       .then((resp) => {
         if (resp.length > 0) {
           setExtensionData(resp);

--- a/modules/page-start-header/src/main/frontend/webpack.config.js
+++ b/modules/page-start-header/src/main/frontend/webpack.config.js
@@ -1,0 +1,34 @@
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const WebpackAssetsManifest = require('webpack-assets-manifest');
+
+module_name = require("./package.json").name + ".";
+
+module.exports = {
+  mode: 'development',
+  entry: {
+    [module_name + 'demoBanner']: './src/demoBanner.jsx'
+  },
+  plugins: [
+    new CleanWebpackPlugin(),
+    new WebpackAssetsManifest({
+      output: "assets.json"
+    })
+  ],
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+        use: ['babel-loader']
+      }
+    ]
+  },
+  resolve: {
+    extensions: ['*', '.js', '.jsx']
+  },
+  output: {
+    path: __dirname + '/dist/SLING-INF/content/libs/cards/resources/',
+    publicPath: '/',
+    filename: '[name].[contenthash].js',
+  }
+};

--- a/modules/page-start-header/src/main/resources/SLING-INF/.keep
+++ b/modules/page-start-header/src/main/resources/SLING-INF/.keep
@@ -1,0 +1,3 @@
+This folder is required for the build process, but so far
+page-start-header does not need to place any files here, while git
+can not add empty folders to a repository

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -62,5 +62,6 @@
     <module>fetch-requires-saml-login</module>
     <module>metrics</module>
     <module>http-requests</module>
+    <module>page-start-header</module>
   </modules>
 </project>


### PR DESCRIPTION
This PR implements CARDS-919 by providing the `loginPageStart` UI extension point which displays associated UI components on the top of the CARDS login page.

This PR also moves the definition of the `<PageStart>` component out of the `homepage` module and into it's own `page-start-header` module.

To test:

1. Build this (`CARDS-919`) branch with `mvn clean install`.
2. Start CARDS in `demo` mode and with Composum enabled (`./start_cards.sh --demo --dev`).
3. Visit `http://localhost:8080`.
4. You should see the CARDS login page with a warning banner at the top of the page.
5. Login as `admin`:`admin`.
6. You should see a generic CARDS dashboard with a warning banner at the top of the page.
7. Visit `http://localhost:8080/bin/browser.html`
8. Delete the `WarningBanner` JCR node at `/Extensions/LoginPageStart/WarningBanner`.
9. Visit `http://localhost:8080` once again.
10. You should still see a generic CARDS dashboard with a warning banner at the top of the page.
11. Logout of CARDS.
12. You should see the CARDS login page, but this time, without any warning banner at the top of the page.