### PR TITLE
CARDS-1715: As a user landing on the PROMs login page, I can choose whether I wish to authenticate as a Patient or a Healthcare Provider

### DIFF
--- a/proms-resources/frontend/pom.xml
+++ b/proms-resources/frontend/pom.xml
@@ -45,6 +45,7 @@
               SLING-INF/content/Extensions/Views/;path:=/Extensions/Views/;overwrite:=true,
               SLING-INF/content/Extensions/Sidebar/;path:=/Extensions/Sidebar/;overwrite:=true,
               SLING-INF/content/Extensions/Footer;path:=/Extensions/Footer;overwrite:=true,
+              SLING-INF/content/Extensions/LoginPageStart;path:=/Extensions/LoginPageStart;overwrite:=true,
             </Sling-Initial-Content>
           </instructions>
         </configuration>

--- a/proms-resources/frontend/src/main/frontend/src/proms/PromsLandingPage.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PromsLandingPage.jsx
@@ -38,21 +38,21 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
-    justifyContent: 'center',
     height: '100%',
   },
   logo : {
     maxWidth: "200px",
-    marginBottom: theme.spacing(6),
+    marginBottom: theme.spacing(5),
+    marginTop: theme.spacing(9.5),
   },
   button : {
     textTransform: "none",
     minWidth: "250px",
-    padding: theme.spacing(3, 1),
-    fontWeight: 400,
+    padding: theme.spacing(2, 1),
   },
   appInfo : {
-    marginTop: theme.spacing(6),
+    paddingTop: theme.spacing(.5),
+    marginTop: theme.spacing(5),
   }
 }));
 
@@ -71,15 +71,15 @@ function PromsLandingPage(props) {
     >
       <MuiThemeProvider theme={appTheme}>
         <DialogContent className={classes.paper}>
-          <Grid container direction="column" spacing={4} alignItems="center" alignContent="center">
+          <Grid container direction="column" spacing={2} alignItems="center" alignContent="center">
             <Grid item>
               <img src="/libs/cards/resources/logo_light_bg.png" alt="" className={classes.logo} />
             </Grid>
             <Grid item>
-              <Typography variant="h6">Sign in as a:</Typography>
+              <Typography variant="h6">I am a...</Typography>
             </Grid>
             <Grid item>
-              <Grid container spacing={4} direction="row" justify="center" alignItems="center">
+              <Grid container spacing={3} direction="column" justify="center" alignItems="center">
                 <Grid item>
                   <Button
                     fullWidth

--- a/proms-resources/frontend/src/main/frontend/src/proms/PromsLandingPage.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PromsLandingPage.jsx
@@ -57,7 +57,7 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
-function PromsLandingPageDialog(props) {
+function PromsLandingPage(props) {
 
   const classes = useStyles();
 
@@ -128,4 +128,4 @@ function PromsLandingPageDialog(props) {
   );
 }
 
-export default PromsLandingPageDialog;
+export default PromsLandingPage;

--- a/proms-resources/frontend/src/main/frontend/src/proms/PromsLandingPage.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PromsLandingPage.jsx
@@ -23,8 +23,8 @@ import {
   Breadcrumbs,
   Button,
   Dialog,
+  DialogContent,
   Grid,
-  Paper,
   Tooltip,
   Typography,
   makeStyles
@@ -39,7 +39,6 @@ const useStyles = makeStyles(theme => ({
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
-    padding: 0,
     height: '100%',
   },
   logo : {
@@ -71,10 +70,7 @@ function PromsLandingPage(props) {
       open={isOpen}
     >
       <MuiThemeProvider theme={appTheme}>
-        <Paper
-          className={classes.paper}
-          elevation={0}
-        >
+        <DialogContent className={classes.paper}>
           <Grid container direction="column" spacing={4} alignItems="center" alignContent="center">
             <Grid item>
               <img src="/libs/cards/resources/logo_light_bg.png" alt="" className={classes.logo} />
@@ -122,7 +118,7 @@ function PromsLandingPage(props) {
               </Breadcrumbs>
             </Grid>
           </Grid>
-        </Paper>
+        </DialogContent>
       </MuiThemeProvider>
     </Dialog>
   );

--- a/proms-resources/frontend/src/main/frontend/src/proms/PromsLandingPage.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PromsLandingPage.jsx
@@ -17,11 +17,12 @@
 //  under the License.
 //
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 import {
   Breadcrumbs,
   Button,
+  CircularProgress,
   Dialog,
   DialogContent,
   Grid,
@@ -45,6 +46,16 @@ const useStyles = makeStyles(theme => ({
     marginBottom: theme.spacing(5),
     marginTop: theme.spacing(9.5),
   },
+  buttonContainer: {
+    position: "relative",
+    "& .MuiCircularProgress-root" : {
+       position: 'absolute',
+       top: '50%',
+       left: '50%',
+       marginTop: '-12px',
+       marginLeft: '-12px',
+    },
+  },
   button : {
     textTransform: "none",
     minWidth: "250px",
@@ -61,8 +72,18 @@ function PromsLandingPage(props) {
   const classes = useStyles();
 
   const [ isOpen, setIsOpen ] = useState(true);
+  const [ loadingPatientLogin, setLoadingPatientLogin ] = useState(false);
+  const [ loadingHCPLogin, setLoadingHCPLogin ] = useState(false);
 
   const appInfo = document.querySelector('meta[name="title"]').content;
+
+  const USER_TYPE_PARAM = "usertype";
+  const USER_TYPE_HCP = "hcp";
+
+  useEffect(() => {
+    let userType = (new URLSearchParams(window.location.search || ""))?.get(USER_TYPE_PARAM);
+    setIsOpen(!(userType == USER_TYPE_HCP));
+  }, [window.location]);
 
   return (
     <Dialog
@@ -80,30 +101,39 @@ function PromsLandingPage(props) {
             </Grid>
             <Grid item>
               <Grid container spacing={3} direction="column" justify="center" alignItems="center">
-                <Grid item>
+                <Grid item className={classes.buttonContainer}>
                   <Button
                     fullWidth
                     variant="contained"
                     color="primary"
+                    disabled={loadingPatientLogin}
                     className={classes.button}
                     onClick={() => {
+                      setLoadingPatientLogin(true);
                       window.location = "/Proms";
                     }}
                    >
                     <Typography variant="h6">Patient</Typography>
                   </Button>
+                  {loadingPatientLogin && <CircularProgress size={24} />}
                 </Grid>
-                <Grid item>
+                <Grid item className={classes.buttonContainer}>
                   <Button
                     fullWidth
                     variant="contained"
+                    disabled={loadingHCPLogin}
                     className={classes.button}
                     onClick={() => {
-                      setIsOpen(false);
+                      setLoadingHCPLogin(true);
+                      let query = new URLSearchParams(window.location?.search || "");
+                      query.delete(USER_TYPE_PARAM);
+                      query.append(USER_TYPE_PARAM, USER_TYPE_HCP);
+                      window.location.search = query;
                     }}
                    >
                     <Typography variant="h6">Health Care Provider</Typography>
                   </Button>
+                  {loadingHCPLogin && <CircularProgress size={24} />}
                 </Grid>
               </Grid>
             </Grid>

--- a/proms-resources/frontend/src/main/frontend/src/proms/PromsLandingPage.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PromsLandingPage.jsx
@@ -22,7 +22,6 @@ import React, { useState, useEffect } from "react";
 import {
   Breadcrumbs,
   Button,
-  CircularProgress,
   Dialog,
   DialogContent,
   Grid,
@@ -46,16 +45,6 @@ const useStyles = makeStyles(theme => ({
     marginBottom: theme.spacing(5),
     marginTop: theme.spacing(9.5),
   },
-  buttonContainer: {
-    position: "relative",
-    "& .MuiCircularProgress-root" : {
-       position: 'absolute',
-       top: '50%',
-       left: '50%',
-       marginTop: '-12px',
-       marginLeft: '-12px',
-    },
-  },
   button : {
     textTransform: "none",
     minWidth: "250px",
@@ -72,8 +61,6 @@ function PromsLandingPage(props) {
   const classes = useStyles();
 
   const [ isOpen, setIsOpen ] = useState(true);
-  const [ loadingPatientLogin, setLoadingPatientLogin ] = useState(false);
-  const [ loadingHCPLogin, setLoadingHCPLogin ] = useState(false);
 
   const appInfo = document.querySelector('meta[name="title"]').content;
 
@@ -101,30 +88,25 @@ function PromsLandingPage(props) {
             </Grid>
             <Grid item>
               <Grid container spacing={3} direction="column" justify="center" alignItems="center">
-                <Grid item className={classes.buttonContainer}>
+                <Grid item>
                   <Button
                     fullWidth
                     variant="contained"
                     color="primary"
-                    disabled={loadingPatientLogin}
                     className={classes.button}
                     onClick={() => {
-                      setLoadingPatientLogin(true);
                       window.location = "/Proms";
                     }}
                    >
                     <Typography variant="h6">Patient</Typography>
                   </Button>
-                  {loadingPatientLogin && <CircularProgress size={24} />}
                 </Grid>
-                <Grid item className={classes.buttonContainer}>
+                <Grid item>
                   <Button
                     fullWidth
                     variant="contained"
-                    disabled={loadingHCPLogin}
                     className={classes.button}
                     onClick={() => {
-                      setLoadingHCPLogin(true);
                       let query = new URLSearchParams(window.location?.search || "");
                       query.delete(USER_TYPE_PARAM);
                       query.append(USER_TYPE_PARAM, USER_TYPE_HCP);
@@ -133,7 +115,6 @@ function PromsLandingPage(props) {
                    >
                     <Typography variant="h6">Health Care Provider</Typography>
                   </Button>
-                  {loadingHCPLogin && <CircularProgress size={24} />}
                 </Grid>
               </Grid>
             </Grid>

--- a/proms-resources/frontend/src/main/frontend/src/proms/PromsLandingPageDialog.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PromsLandingPageDialog.jsx
@@ -27,16 +27,40 @@ import {
   Paper,
   Tooltip,
   Typography,
-  withStyles
+  makeStyles
 } from '@material-ui/core';
 
 import { MuiThemeProvider } from '@material-ui/core/styles';
 import { appTheme } from "../themePalette.jsx";
-import styles from "../styling/styles";
+
+const useStyles = makeStyles(theme => ({
+  paper: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 0,
+    height: '100%',
+  },
+  logo : {
+    maxWidth: "200px",
+    marginBottom: theme.spacing(6),
+  },
+  button : {
+    textTransform: "none",
+    minWidth: "250px",
+    padding: theme.spacing(3, 1),
+    fontWeight: 400,
+  },
+  appInfo : {
+    marginTop: theme.spacing(6),
+  }
+}));
 
 function PromsLandingPageDialog(props) {
 
-  const { classes } = props;
+  const classes = useStyles();
+
   const [ isOpen, setIsOpen ] = useState(true);
 
   return (
@@ -46,46 +70,41 @@ function PromsLandingPageDialog(props) {
     >
       <MuiThemeProvider theme={appTheme}>
         <Paper
-          className={`${classes.paper}`}
+          className={classes.paper}
           elevation={0}
-          style={{
-            justifyContent: 'center',
-            alignItems: 'center',
-            height: '100%'
-          }}
         >
-          <Grid container direction="column" spacing={3} alignItems="center" alignContent="center">
+          <Grid container direction="column" spacing={4} alignItems="center" alignContent="center">
             <Grid item>
               <img src="/libs/cards/resources/logo_light_bg.png" alt="" className={classes.logo} />
             </Grid>
             <Grid item>
-              <Grid container spacing={1} direction="row" justify="center" alignItems="center" wrap="nowrap">
+              <Typography variant="h6">Sign in as a:</Typography>
+            </Grid>
+            <Grid item>
+              <Grid container spacing={4} direction="row" justify="center" alignItems="center">
                 <Grid item>
                   <Button
                     fullWidth
                     variant="contained"
                     color="primary"
-                    className={classes.main}
+                    className={classes.button}
                     onClick={() => {
                       window.location = "/Proms";
                     }}
                    >
-                    <Typography>I am a</Typography>
-                    <Typography style={{fontWeight: 'bold'}}>Patient</Typography>
+                    <Typography variant="h6">Patient</Typography>
                   </Button>
                 </Grid>
                 <Grid item>
                   <Button
                     fullWidth
                     variant="contained"
-                    color="primary"
-                    className={classes.main}
+                    className={classes.button}
                     onClick={() => {
                       setIsOpen(false);
                     }}
                    >
-                    <Typography>I am a</Typography>
-                    <Typography style={{fontWeight: 'bold'}}>Healthcare Provider</Typography>
+                    <Typography variant="h6">Health Care Provider</Typography>
                   </Button>
                 </Grid>
               </Grid>
@@ -107,6 +126,4 @@ function PromsLandingPageDialog(props) {
   );
 }
 
-const StyledPromsLandingPageDialog = withStyles(styles)(PromsLandingPageDialog);
-
-export default StyledPromsLandingPageDialog;
+export default PromsLandingPageDialog;

--- a/proms-resources/frontend/src/main/frontend/src/proms/PromsLandingPageDialog.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PromsLandingPageDialog.jsx
@@ -1,0 +1,112 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React, { useState } from "react";
+
+import {
+  Breadcrumbs,
+  Button,
+  Dialog,
+  Grid,
+  Paper,
+  Tooltip,
+  Typography,
+  withStyles
+} from '@material-ui/core';
+
+import { MuiThemeProvider } from '@material-ui/core/styles';
+import { appTheme } from "../themePalette.jsx";
+import styles from "../styling/styles";
+
+function PromsLandingPageDialog(props) {
+
+  const { classes } = props;
+  const [ isOpen, setIsOpen ] = useState(true);
+
+  return (
+    <Dialog
+      fullScreen
+      open={isOpen}
+    >
+      <MuiThemeProvider theme={appTheme}>
+        <Paper
+          className={`${classes.paper}`}
+          elevation={0}
+          style={{
+            justifyContent: 'center',
+            alignItems: 'center',
+            height: '100%'
+          }}
+        >
+          <Grid container direction="column" spacing={3} alignItems="center" alignContent="center">
+            <Grid item>
+              <img src="/libs/cards/resources/logo_light_bg.png" alt="" className={classes.logo} />
+            </Grid>
+            <Grid item>
+              <Grid container spacing={1} direction="row" justify="center" alignItems="center" wrap="nowrap">
+                <Grid item>
+                  <Button
+                    fullWidth
+                    variant="contained"
+                    color="primary"
+                    className={classes.main}
+                    onClick={() => {
+                      window.location = "/Proms";
+                    }}
+                   >
+                    <Typography>I am a</Typography>
+                    <Typography style={{fontWeight: 'bold'}}>Patient</Typography>
+                  </Button>
+                </Grid>
+                <Grid item>
+                  <Button
+                    fullWidth
+                    variant="contained"
+                    color="primary"
+                    className={classes.main}
+                    onClick={() => {
+                      setIsOpen(false);
+                    }}
+                   >
+                    <Typography>I am a</Typography>
+                    <Typography style={{fontWeight: 'bold'}}>Healthcare Provider</Typography>
+                  </Button>
+                </Grid>
+              </Grid>
+            </Grid>
+            <Grid item>
+              <Breadcrumbs separator="by" className={classes.appInfo}>
+                <Typography variant="subtitle2">DATA-PRO</Typography>
+                <Tooltip title="DATA Team @ UHN">
+                  <a href="https://uhndata.io/" target="_blank">
+                    <img src="/libs/cards/resources/data-logo_light_bg.png" width="80" alt="DATA" />
+                  </a>
+                </Tooltip>
+              </Breadcrumbs>
+            </Grid>
+          </Grid>
+        </Paper>
+      </MuiThemeProvider>
+    </Dialog>
+  );
+}
+
+const StyledPromsLandingPageDialog = withStyles(styles)(PromsLandingPageDialog);
+
+export default StyledPromsLandingPageDialog;

--- a/proms-resources/frontend/src/main/frontend/src/proms/PromsLandingPageDialog.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PromsLandingPageDialog.jsx
@@ -63,6 +63,8 @@ function PromsLandingPageDialog(props) {
 
   const [ isOpen, setIsOpen ] = useState(true);
 
+  const appInfo = document.querySelector('meta[name="title"]').content;
+
   return (
     <Dialog
       fullScreen
@@ -111,7 +113,7 @@ function PromsLandingPageDialog(props) {
             </Grid>
             <Grid item>
               <Breadcrumbs separator="by" className={classes.appInfo}>
-                <Typography variant="subtitle2">DATA-PRO</Typography>
+                <Typography variant="subtitle2">{appInfo}</Typography>
                 <Tooltip title="DATA Team @ UHN">
                   <a href="https://uhndata.io/" target="_blank">
                     <img src="/libs/cards/resources/data-logo_light_bg.png" width="80" alt="DATA" />

--- a/proms-resources/frontend/src/main/frontend/webpack.config.js
+++ b/proms-resources/frontend/src/main/frontend/webpack.config.js
@@ -6,14 +6,14 @@ module_name = require("./package.json").name + ".";
 module.exports = {
   mode: 'development',
   entry: {
+    [module_name + 'PromsLandingPage']: './src/proms/PromsLandingPage.jsx',
     [module_name + 'index']: './src/proms/index.jsx',
     [module_name + 'unsubscribe']: './src/proms/unsubscribe.jsx',
     [module_name + 'ToULink']: './src/proms/ToULink.jsx'
     [module_name + 'PromsDashboard']: './src/proms/PromsDashboard.jsx',
     [module_name + 'PromsView']: './src/proms/PromsView.jsx',
     [module_name + 'VisitView']: './src/proms/VisitView.jsx',
-    [module_name + 'pmccIcon']: '@material-ui/icons/Favorite.js',
-    [module_name + 'PromsLandingPageDialog']: './src/proms/PromsLandingPageDialog.jsx'
+    [module_name + 'pmccIcon']: '@material-ui/icons/Favorite.js'
   },
   plugins: [
     new CleanWebpackPlugin(),

--- a/proms-resources/frontend/src/main/frontend/webpack.config.js
+++ b/proms-resources/frontend/src/main/frontend/webpack.config.js
@@ -12,7 +12,8 @@ module.exports = {
     [module_name + 'PromsDashboard']: './src/proms/PromsDashboard.jsx',
     [module_name + 'PromsView']: './src/proms/PromsView.jsx',
     [module_name + 'VisitView']: './src/proms/VisitView.jsx',
-    [module_name + 'pmccIcon']: '@material-ui/icons/Favorite.js'
+    [module_name + 'pmccIcon']: '@material-ui/icons/Favorite.js',
+    [module_name + 'PromsLandingPageDialog']: './src/proms/PromsLandingPageDialog.jsx'
   },
   plugins: [
     new CleanWebpackPlugin(),

--- a/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/LoginPageStart/PromsLandingPage.json
+++ b/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/LoginPageStart/PromsLandingPage.json
@@ -1,0 +1,6 @@
+{
+  "jcr:primaryType": "cards:Extension",
+  "cards:extensionPointId": "cards/coreUI/loginPageStart",
+  "cards:extensionName": "PROMs Landing Page",
+  "cards:extensionRenderURL": "asset:proms-homepage.PromsLandingPageDialog.js"
+}

--- a/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/LoginPageStart/PromsLandingPage.json
+++ b/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/LoginPageStart/PromsLandingPage.json
@@ -2,5 +2,5 @@
   "jcr:primaryType": "cards:Extension",
   "cards:extensionPointId": "cards/coreUI/loginPageStart",
   "cards:extensionName": "PROMs Landing Page",
-  "cards:extensionRenderURL": "asset:proms-homepage.PromsLandingPageDialog.js"
+  "cards:extensionRenderURL": "asset:proms-homepage.PromsLandingPage.js"
 }


### PR DESCRIPTION
This PR implements [CARDS-1715](https://phenotips.atlassian.net/browse/CARDS-1715) by providing the `<PromsLandingPage>` component and attaching it to the `loginPageStart` UI ExtensionPoint. Therefore, when CARDS is first accessed, a landing page is presented asking the user if they are a _Patient_ or a _Healthcare Provider_. If the user selects _Patient_, they are directed to `/Proms`. If the user selects _Healthcare Provider_, they are shown the standard Cards4Proms login page.

To test:

1. Build this `CARDS-1715` branch with `mvn clean install`.
2. Start CARDS in _Cards4Proms_ mode with `./start_cards.sh -P cards4proms --dev`.
3. Visit `http://localhost:8080`.
4. You should be shown a screen asking if you are a _Patient_ or a _Healthcare Provider_.
5. Clicking _I am a Patient_ should redirect the browser to `/Proms`. At this point it is expected to see an _Invalid access_ message as [CARDS-1716](https://phenotips.atlassian.net/browse/CARDS-1716) has not yet been implemented.
6. Back at the landing page (`http://localhost:8080/`), clicking _I am a Healthcare Provider_ should reveal the normal _DATA PRO_ login page.