### PR TITLE
CARDS-1724: Add support for coloured DICOM images and MONO other than knee and head

### DIFF
--- a/modules/data-entry/src/main/frontend/package.json
+++ b/modules/data-entry/src/main/frontend/package.json
@@ -40,7 +40,7 @@
     "@material-ui/lab": "4.0.0-alpha.57",
     "classnames": "2.2.6",
     "cornerstone-core": "2.6.1",
-    "cornerstone-wado-image-loader": "4.1.2",
+    "cornerstone-wado-image-loader": "4.1.3",
     "dicom-parser": "1.8.13",
     "react": "16.14.0",
     "react-beautiful-dnd": "13.1.0",

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DicomQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DicomQuestion.jsx
@@ -129,16 +129,23 @@ function DicomQuestion(props) {
     let dicomCtx = dicomCanvas.getContext('2d');
     let canvasImageData = dicomCtx.getImageData(0, 0, dicomCanvas.width, dicomCanvas.height);
 
-    // Normalize the data so that all pixels are between 0 and 255
-    for (let i = 0; i < canvasImageData.data.length; i+=4) {
-      let thisPixVal = 0;
-      if ((dicomMaxPix - dicomMinPix) !== 0) {
-        thisPixVal = Math.floor(255 * ((dicomImagePixels[i/4] - dicomMinPix) / (dicomMaxPix - dicomMinPix)));
+    if (dicomImage.color) {
+      // If the DICOM image is colored, simply copy the RGBA pixel values
+      for (let i = 0; i < canvasImageData.data.length; i++) {
+        canvasImageData.data[i] = dicomImagePixels[i];
       }
-      canvasImageData.data[i] = thisPixVal;
-      canvasImageData.data[i+1] = thisPixVal;
-      canvasImageData.data[i+2] = thisPixVal;
-      canvasImageData.data[i+3] = 255;
+    } else {
+      // Normalize the data so that all pixels are between 0 and 255
+      for (let i = 0; i < canvasImageData.data.length; i+=4) {
+        let thisPixVal = 0;
+        if ((dicomMaxPix - dicomMinPix) !== 0) {
+          thisPixVal = Math.floor(255 * ((dicomImagePixels[i/4] - dicomMinPix) / (dicomMaxPix - dicomMinPix)));
+        }
+        canvasImageData.data[i] = thisPixVal;
+        canvasImageData.data[i+1] = thisPixVal;
+        canvasImageData.data[i+2] = thisPixVal;
+        canvasImageData.data[i+3] = 255;
+      }
     }
     dicomCtx.putImageData(canvasImageData, 0, 0);
     return dicomCanvas.toDataURL();

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DicomQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DicomQuestion.jsx
@@ -217,6 +217,7 @@ function DicomQuestion(props) {
         onClose={() => {
           setErrorDialogText();
           setAdvancedErrorDialogText();
+          setShowAdvancedErrorHelp();
         }}
       >
         <DialogTitle disableTypography>


### PR DESCRIPTION
This PR addresses some of the concerns documented in CARDS-1724, specifically;
- `OT-PAL-8-face.dcm` now shows an error upon loading. Using the `gdcmconv` command listed in the error message's _Advanced Help_ provides a working DICOM file that can be properly uploaded and displayed.
- `US-RGB-8-epicard.dcm` now works properly.
- `US-RGB-8-esopecho.dcm` now works properly.
- `CR-MONO1-10-chest.dcm` now shows an error upon loading. Using the `gdcmconv` command listed in the error message's _Advanced Help_ provides a working DICOM file that can be properly uploaded and displayed.
- `MR-MONO2-12-shoulder.dcm` is still not working. This could be made to work by using the _dynamic-import_ version of Cornerstone.js - see Line 39 in `DicomQuestion.jsx`. This however requires certain WebWorker Javascript files from NPM to be placed the JCR and thus requires additional work that is outside the scope of this PR.
- `CT-MONO2-16-chest.dcm` is still not working. This could be made to work by using the _dynamic-import_ version of Cornerstone.js - see Line 39 in `DicomQuestion.jsx`. This however requires certain WebWorker Javascript files from NPM to be placed the JCR and thus requires additional work that is outside the scope of this PR.
- `MR-MONO2-16-head.dcm` now works properly.
- `OT-MONO2-8-a7.dcm` now shows an error upon loading. Using the `gdcmconv` command listed in the error message's _Advanced Help_ provides a working DICOM file that can be properly uploaded and displayed.
- `CT-MONO2-12-lomb-an2.dcm` could not be converted with `gdcmconv`

To test:

- Build this `clindig_demo` branch with `mvn clean install`
- Start with `SLING_COMMONS_CRYPTO_PASSWORD=password ./start_cards.sh --project cards4clindig --dev`
- Test that the above described addressed concerns work as expected.