### PR TITLE
CARDS-1731: Refactor the PROMs dashboard to display appointments and surveys by default

### DIFF
--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms/ClinicMapping.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms/ClinicMapping.xml
@@ -59,7 +59,7 @@
         </property>
         <property>
             <name>displayName</name>
-            <value>Adult Congenital Heart Disease clinic</value>
+            <value>Adult Congenital Heart Disease Clinic</value>
             <type>String</type>
         </property>
         <property>

--- a/proms-resources/frontend/src/main/frontend/src/proms/PromsDashboard.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PromsDashboard.jsx
@@ -35,6 +35,9 @@ import {
 
 import { useTheme } from '@material-ui/core/styles';
 
+import PromsView from "./PromsView";
+import VisitView from "./VisitView";
+
 async function getDashboardExtensions(name) {
   return loadExtensions("DashboardViews" + name)
     .then(extensions => extensions.slice()
@@ -85,12 +88,14 @@ const useStyles = makeStyles(theme => ({
 // Component that renders the proms dashboard, with one LiveTable per questionnaire.
 // Each LiveTable contains all forms that use the given questionnaire.
 function PromsDashboard(props) {
-  let [ name, setName ] = useState();
+  let [ clinicId, setClinicId ] = useState();
   let [ title, setTitle ] = useState();
   let [ description, setDescription ] = useState();
   let [ surveysId, setSurveysId ] = useState("");
+  let [ surveys, setSurveys ] = useState();
   let [ dashboardExtensions, setDashboardExtensions ] = useState([]);
-  let [ loading, setLoading ] = useState(true);
+  let [ defaultsLoading, setDefaultsLoading ] = useState(true);
+  let [ extensionsLoading, setExtensionsLoading ] = useState(true);
   let [ visitInfo, setVisitInfo ] = useState();
 
   const globalLoginDisplay = useContext(GlobalLoginContext);
@@ -98,7 +103,7 @@ function PromsDashboard(props) {
 
   // If there's an extra path segment, we use it to obtain the extension point
   // Otherwise default to "DashboardViews" (main dashboard)
-  useEffect(() => setName(location.pathname.split("/Dashboard/")?.[1] || ""), [location]);
+  useEffect(() => setClinicId(location.pathname.split("/Dashboard/")?.[1] || ""), [location]);
 
   // At startup, load the visit information questionnaire to pass it to all extensions
   useEffect(() => {
@@ -107,26 +112,43 @@ function PromsDashboard(props) {
       .then((json) => setVisitInfo(json));
   }, []);
 
-  // Also load all extensions
+  // Load the extensions, if any
   useEffect(() => {
-    if (!name) return;
-    getDashboardExtensions(name)
+    if (!clinicId) return;
+    getDashboardExtensions(clinicId)
       .then(extensions => setDashboardExtensions(extensions))
       .catch(err => console.log("Something went wrong loading the proms dashboard", err))
-      .finally(() => setLoading(false));
-  }, [name])
+      .finally(() => setExtensionsLoading(false));
+  }, [clinicId])
 
-  // And the extension point definition to obtain its name
+  // Also load the clinic configuration...
   useEffect(() => {
-    if (!name) return;
-    fetchWithReLogin(globalLoginDisplay, `/apps/cards/ExtensionPoints/DashboardViews${name}.json`)
+    if (!clinicId) return;
+    fetchWithReLogin(globalLoginDisplay, `/Proms/ClinicMapping/${clinicId}.deep.json`)
       .then((response) => response.ok ? response.json() : Promise.reject(response))
       .then((json) => {
-        setTitle(json?.title || json?.["cards:extensionPointName"] || name);
-        setDescription(json?.description || "")
-        setSurveysId(json?.surveys || "");
-      });
-  }, [name]);
+        setTitle(json.displayName || json.clinicName || clinicId);
+        setDescription(json.description || "");
+        setSurveysId(json.surveyID);
+      })
+  }, [clinicId])
+
+  // ... and the surveys configured for the clinic
+  useEffect(() => {
+    if (!surveysId) {
+      // if we have a clinic but no surveys, nothing more to load
+      setDefaultsLoading(!!!clinicId);
+      return;
+    }
+    fetchWithReLogin(globalLoginDisplay, `/Proms/${surveysId}.deep.json`)
+      .then((response) => response.ok ? response.json() : Promise.reject(response))
+      .then((json) => setSurveys(
+        Object.values(json || {})
+          .filter(e => e["jcr:primaryType"] == "cards:QuestionnaireRef")
+          .sort((a, b) => a.order - b.order)
+      ))
+      .finally(() => setDefaultsLoading(false));
+  }, [surveysId]);
 
   const classes = useStyles();
 
@@ -148,7 +170,7 @@ function PromsDashboard(props) {
   const theme = useTheme();
   const appbarExpanded = useMediaQuery(theme.breakpoints.up('md'));
 
-  if (loading || !visitInfo) {
+  if (defaultsLoading || extensionsLoading || !visitInfo) {
     return (
       <Grid container justify="center"><Grid item><CircularProgress/></Grid></Grid>
     );
@@ -159,6 +181,18 @@ function PromsDashboard(props) {
       <Typography variant="h4" className={classes.dashboardTitle + (appbarExpanded ? ' ' + classes.withMargin : '')}>{title}</Typography>
       { description && <Typography variant="overline">{description}</Typography>}
       <Grid container spacing={4} className={classes.dashboardContainer}>
+        {/* Appointments view */}
+        <Grid item lg={12} xl={6} key="view-appointments" className={classes.dashboardEntry}>
+          <VisitView color={getColor(0)} visitInfo={visitInfo} surveysId={surveysId} />
+        </Grid>
+        {/* Survey views */}
+        { surveys?.map((s, index) => (
+            <Grid item lg={12} xl={6} key={`view-survey-${index}`} className={classes.dashboardEntry}>
+              <PromsView data={s["@path"]} color={getColor(index + 1)} visitInfo={visitInfo} surveysId={surveysId} />
+            </Grid>
+          ))
+        }
+        {/* Extensions */}
         {
           dashboardExtensions.map((extension, index) => {
             let Extension = extension["cards:extensionRender"];

--- a/proms-resources/frontend/src/main/frontend/src/proms/PromsDashboard.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PromsDashboard.jsx
@@ -129,7 +129,7 @@ function PromsDashboard(props) {
       .then((json) => {
         setTitle(json.displayName || json.clinicName || clinicId);
         setDescription(json.description || "");
-        setSurveysId(json.surveyID);
+        setSurveysId(json.survey);
       })
   }, [clinicId])
 

--- a/proms-resources/frontend/src/main/frontend/src/proms/PromsDashboard.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PromsDashboard.jsx
@@ -182,12 +182,12 @@ function PromsDashboard(props) {
       { description && <Typography variant="overline">{description}</Typography>}
       <Grid container spacing={4} className={classes.dashboardContainer}>
         {/* Appointments view */}
-        <Grid item lg={12} xl={6} key="view-appointments" className={classes.dashboardEntry}>
+        <Grid item lg={12} xl={6} key={`view-appointments-${clinicId}`} className={classes.dashboardEntry}>
           <VisitView color={getColor(0)} visitInfo={visitInfo} surveysId={surveysId} />
         </Grid>
         {/* Survey views */}
         { surveys?.map((s, index) => (
-            <Grid item lg={12} xl={6} key={`view-survey-${index}`} className={classes.dashboardEntry}>
+            <Grid item lg={12} xl={6} key={`view-survey-${clinicId}-${s["@name"]}`} className={classes.dashboardEntry}>
               <PromsView data={s["@path"]} color={getColor(index + 1)} visitInfo={visitInfo} surveysId={surveysId} />
             </Grid>
           ))

--- a/proms-resources/frontend/src/main/frontend/src/proms/PromsDashboard.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PromsDashboard.jsx
@@ -188,7 +188,7 @@ function PromsDashboard(props) {
         {/* Survey views */}
         { surveys?.map((s, index) => (
             <Grid item lg={12} xl={6} key={`view-survey-${clinicId}-${s["@name"]}`} className={classes.dashboardEntry}>
-              <PromsView data={s["@path"]} color={getColor(index + 1)} visitInfo={visitInfo} surveysId={surveysId} />
+              <PromsView data={s} color={getColor(index + 1)} visitInfo={visitInfo} surveysId={surveysId} />
             </Grid>
           ))
         }
@@ -196,7 +196,7 @@ function PromsDashboard(props) {
         {
           dashboardExtensions.map((extension, index) => {
             let Extension = extension["cards:extensionRender"];
-            return <Grid item lg={12} xl={6} key={"extension-" + index} className={classes.dashboardEntry}>
+            return <Grid item lg={12} xl={6} key={`extension-${clinicId}-${index}`} className={classes.dashboardEntry}>
               <Extension data={extension["cards:data"]} color={getColor(index)} visitInfo={visitInfo} surveysId={surveysId} />
             </Grid>
           })

--- a/proms-resources/frontend/src/main/frontend/src/proms/PromsView.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PromsView.jsx
@@ -39,17 +39,13 @@ function PromsView(props) {
 
   // At startup, load questionnaire
   useEffect(() => {
-    if (data && !columns) {
-      fetchWithReLogin(globalLoginDisplay, data + ".deep.json")
-      .then((response) => response.ok ? response.json() : Promise.reject(response))
-      .then((json) => {
-        setColumns(JSON.parse(json["view"] || "[]"));
-        setQuestionnaireId(json.questionnaire?.["jcr:uuid"] || "");
-        setTitle(json.questionnaire?.["title"]);
-        setAcronym(json.questionnaire?.["@name"]);
-      });
+    if (data) {
+        setColumns(JSON.parse(data["view"] || "[]"));
+        setQuestionnaireId(data.questionnaire?.["jcr:uuid"] || "");
+        setTitle(data.questionnaire?.["title"]);
+        setAcronym(data.questionnaire?.["@name"]);
     }
-  }, [data]);
+  }, [data["@path"]]);
 
   if (!questionnaireId || !visitInfo) {
     return <CircularProgress/>;
@@ -84,6 +80,7 @@ function PromsView(props) {
       query={query}
       dateField="visitDate"
       questionnaireId={questionnaireId}
+      key={data?.["@path"]}
     />
   );
 }

--- a/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/DashboardViews/AUDITCView.json
+++ b/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/DashboardViews/AUDITCView.json
@@ -1,8 +1,0 @@
-{
-  "jcr:primaryType": "cards:Extension",
-  "cards:extensionPointId": "proms/dashboard/pmcc",
-  "cards:extensionName": "AUDITC View",
-  "cards:extensionRenderURL": "asset:proms-homepage.PromsView.js",
-  "cards:defaultOrder": 4,
-  "cards:data": "/Proms/Cardio/Step4"
-}

--- a/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/DashboardViews/EQ5DView.json
+++ b/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/DashboardViews/EQ5DView.json
@@ -1,8 +1,0 @@
-{
-  "jcr:primaryType": "cards:Extension",
-  "cards:extensionPointId": "proms/dashboard/pmcc",
-  "cards:extensionName": "EQ5D View",
-  "cards:extensionRenderURL": "asset:proms-homepage.PromsView.js",
-  "cards:defaultOrder": 1,
-  "cards:data": "/Proms/Cardio/Step1"
-}

--- a/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/DashboardViews/GAD7View.json
+++ b/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/DashboardViews/GAD7View.json
@@ -1,8 +1,0 @@
-{
-  "jcr:primaryType": "cards:Extension",
-  "cards:extensionPointId": "proms/dashboard/pmcc",
-  "cards:extensionName": "GAD7 View",
-  "cards:extensionRenderURL": "asset:proms-homepage.PromsView.js",
-  "cards:defaultOrder": 3,
-  "cards:data": "/Proms/Cardio/Step3"
-}

--- a/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/DashboardViews/PHQ9View.json
+++ b/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/DashboardViews/PHQ9View.json
@@ -1,8 +1,0 @@
-{
-  "jcr:primaryType": "cards:Extension",
-  "cards:extensionPointId": "proms/dashboard/pmcc",
-  "cards:extensionName": "PHQ9 View",
-  "cards:extensionRenderURL": "asset:proms-homepage.PromsView.js",
-  "cards:defaultOrder": 2,
-  "cards:data": "/Proms/Cardio/Step2"
-}

--- a/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/DashboardViews/SCView.json
+++ b/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/DashboardViews/SCView.json
@@ -1,8 +1,0 @@
-{
-  "jcr:primaryType": "cards:Extension",
-  "cards:extensionPointId": "proms/dashboard/pmcc",
-  "cards:extensionName": "SC View",
-  "cards:extensionRenderURL": "asset:proms-homepage.PromsView.js",
-  "cards:defaultOrder": 5,
-  "cards:data": "/Proms/Cardio/Step5"
-}

--- a/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/DashboardViews/VisitView.json
+++ b/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/DashboardViews/VisitView.json
@@ -1,7 +1,0 @@
-{
-  "jcr:primaryType": "cards:Extension",
-  "cards:extensionPointId": "proms/dashboard/pmcc",
-  "cards:extensionName": "Visit View",
-  "cards:extensionRenderURL": "asset:proms-homepage.VisitView.js",
-  "cards:defaultOrder": -1
-}

--- a/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/Sidebar/PMCC-ACHD.json
+++ b/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/Sidebar/PMCC-ACHD.json
@@ -2,7 +2,7 @@
   "jcr:primaryType": "cards:Extension",
   "cards:extensionPointId": "cards/coreUI/sidebar/entry",
   "cards:extensionName": "PMCC - ACHD",
-  "cards:targetURL": "/content.html/Dashboard/PMCC-ACHD",
+  "cards:targetURL": "/content.html/Dashboard/853703519",
   "cards:icon": "asset:proms-homepage.clinicIcon.js",
   "cards:defaultOrder": 10
 }

--- a/proms-resources/frontend/src/main/resources/SLING-INF/content/apps/cards/ExtensionPoints/DashboardViews853703519.json
+++ b/proms-resources/frontend/src/main/resources/SLING-INF/content/apps/cards/ExtensionPoints/DashboardViews853703519.json
@@ -1,0 +1,5 @@
+{
+  "jcr:primaryType": "cards:ExtensionPoint",
+  "cards:extensionPointId": "proms/dashboard/pmcc-achd",
+  "cards:extensionPointName": "PMCC-ACHD pre-appointment questionnaires dashboard"
+}

--- a/proms-resources/frontend/src/main/resources/SLING-INF/content/apps/cards/ExtensionPoints/DashboardViewsPMCC-ACHD.json
+++ b/proms-resources/frontend/src/main/resources/SLING-INF/content/apps/cards/ExtensionPoints/DashboardViewsPMCC-ACHD.json
@@ -1,8 +1,0 @@
-{
-  "jcr:primaryType": "cards:ExtensionPoint",
-  "cards:extensionPointId": "proms/dashboard/pmcc",
-  "cards:extensionPointName": "PMCC-ACHD pre-appointment questionnaires dashboard",
-  "title" : "Adult Congenital Heart Disease Clinic",
-  "description" : "Peter Munk Cardiac Centre",
-  "surveys" : "Cardio"
-}


### PR DESCRIPTION
**What changed:**
* Proms dashboard widgets for appointments and surveys no longer need to be specified via extensions, they are displayed by default
* An extension point is still available for adding more widgets to the dashboards
* The url of the clinic dashboard is now specified using the node name for the clinic configuration

**Testing:**
* Everything on the proms dashboard should work as before. The correct display of existing appointments and Survey responses (in the right time tabs) must be tested.

**Implications:**
* The code in PR #983 for configuring the dashboard would have to be modified as follows:
  * Proms dashboard extensions no longer need to be generated
  * Proms dashboard extension point for a specific clinic now has a different node name (`DashboardViews<hash of clinic id>`)
  * Sidebar label link now points to a different URL (`/Dashboard/<hash of clinic id>`)