### PR TITLE
CARDS-1735: Patient authentication cookies should expire when the token expires

### DIFF
--- a/modules/token-authentication/src/main/java/io/uhndata/cards/auth/token/impl/CardsTokenImpl.java
+++ b/modules/token-authentication/src/main/java/io/uhndata/cards/auth/token/impl/CardsTokenImpl.java
@@ -130,7 +130,7 @@ public class CardsTokenImpl implements TokenInfo
         this.tokenTree = null;
         this.loginToken = token;
         this.userId = userId;
-        this.expirationTime = getExpirationTime();
+        this.expirationTime = parseExpirationTime();
         this.validationKey = getValidationKey();
 
         final Map<String, String> storedAttributes = new HashMap<>();
@@ -167,7 +167,7 @@ public class CardsTokenImpl implements TokenInfo
         this.tokenTree = tokenTree;
         this.loginToken = token;
         this.userId = userId;
-        this.expirationTime = getExpirationTime();
+        this.expirationTime = parseExpirationTime();
         this.validationKey = getValidationKey();
 
         Map<String, String> storedAttributes = new HashMap<>();
@@ -289,7 +289,7 @@ public class CardsTokenImpl implements TokenInfo
      *
      * @return the expiration date, or {@code null} if there's no expiration date set or accessing it fails
      */
-    private Calendar getExpirationTime()
+    private Calendar parseExpirationTime()
     {
         if (this.tokenNode != null) {
             try {
@@ -303,6 +303,16 @@ public class CardsTokenImpl implements TokenInfo
             return ISO8601.parse(this.tokenTree.getProperty(TOKEN_ATTRIBUTE_EXPIRY).getValue(Type.DATE));
         }
         return null;
+    }
+
+    /**
+     * Obtain the expiration time from this token.
+     *
+     * @return the expiration date, or {@code null} if there's no expiration date set
+     */
+    public Calendar getExpirationTime()
+    {
+        return this.expirationTime;
     }
 
     /**


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/CARDS-1735)

This adjusts the cookies that are sent when logging using a patient auth token so that they expire when the cards:Token node expires, instead of at the end of the browser session.

This PR does not address the tokenless authentication in #1008, which would just involve the insertion of another line right before line 150. (`cookie.setMaxAge`).

**To Test**:
- Start CARDS with `./start_cards.sh --project cards4proms --dev --permissions trusted`
- Follow the steps in #833 to generate a patient token and, in a new session, login with it.
- There should now be an expiration date associate with the cookie, as viewed from the developer tools (firefox) or chrome inspector. The expiration date on the cookie should follow the expiration date on test cases outlined on #833

![image](https://user-images.githubusercontent.com/4656440/165156958-6f8f1255-cd35-4a65-a8b3-e81206d17f65.png)
