### PR TITLE
CARDS-1732: Appointment utils is doing the incorrect check for invalid appointments

### DIFF
--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AppointmentUtils.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AppointmentUtils.java
@@ -460,7 +460,8 @@ public final class AppointmentUtils
                 + "  AND d.'value' >= cast('" + formatter.format(lowerBoundDate.getTime()) + "' AS date)"
                 + "  AND d.'value' < cast('" + formatter.format(upperBoundDate.getTime()) + "' AS date)"
                 + "  AND s.'question' = '" + statusUUID + "' "
-                + "  AND s.'value' = 'planned'",
+                + "  AND s.'value' <> 'cancelled'"
+                + "  AND s.'value' <> 'entered-in-error'",
             "JCR-SQL2");
         return results;
     }


### PR DESCRIPTION
- Change AppointmentUtil to check valid appointments for cancelled or entered-in-error

Testing instructions adapted from #822 and #881 (thanks for the thorough instructions):

1. Generate a self-signed SSL certificate for localhost.
```
mkdir ~/cards-1457-test
cd ~/cards-1457-test
openssl req -newkey rsa:4096 -nodes -keyout cert.key -x509 -days 365 -out cert.pem

# You may leave all fields blank except for "Common Name (e.g. server FQDN or YOUR name) []:", set that to "localhost"

cat cert.pem cert.key > completecert.key
```
2. Create a backup of Java's CA Certificates Keystore as we do not want to permanently store the self-signed localhost certificate there.
```
sudo cp /etc/ssl/certs/java/cacerts /etc/ssl/certs/java/BACKUP_cacerts
```
4. Import the self-signed localhost certificate into Java's CA Certificates Keystore.
```
sudo keytool -import -trustcacerts -file cert.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit -noprompt
```
5. Start a Socat SSL-termination relay.
```
socat -d -d -v OPENSSL-LISTEN:8465,verify=0,cert=completecert.key,reuseaddr,fork TCP6-CONNECT:localhost:8025
```
6. In a new terminal window, start the SMTP debugging server.
```
python3 -m smtpd -c DebuggingServer -n localhost:8025
```
7. In a new terminal window, build, run, and test the CARDS-1732 branch.
```
# Ensure that you have entered the directory of the CARDS git repository and have checkout out the CARDS-1732 branch

# Build
mvn clean install

# Start CARDS
CARDS_HOST_AND_PORT='datapro.uhn.ca' CLINIC_SLING_PATH='/Proms.html/Cardio' PATIENT_NOTIFICATION_FROM_ADDRESS='datapro@uhn.ca' PATIENT_NOTIFICATION_FROM_NAME='UHN DATAPRO' NIGHTLY_NOTIFICATIONS_SCHEDULE='0 * * * * ? *' SLING_COMMONS_CRYPTO_PASSWORD=password ./start_cards.sh --project cards4proms --dev -f mvn:io.uhndata.cards/cards-email-notifications/0.9-SNAPSHOT/slingosgifeature -V emailnotifications.smtps.port=8465 -V emailnotifications.smtps.host=localhost.
```
8. Login to CARDS as `admin`:`admin`.
1. Change the `Visit information` form's `survey` field from `hidden` to `input` using the administration interface
1. Create a new `Patient information` Form and, with it, a new Patient subject (P1).
1. Complete the `Patient information` and provide an email address, select `Yes` for the question `The patient consents to be contacted by email` and `No` for `The patient unsubscribed from all email notifications`.
1. Create a new `Visit information` Form and, with it, a new Visit subject (V1). Select P1 as the parent Patient for this V1 subject.
1. Set the value of the `Surveys` field in this question to Cardio.
1. Set the `Time` for this Form to be in one day from now (eg. tomorrow).
1. Select `No` for the question `The patient has completed the pre-appointment surveys` and `The patient submitted the pre-appointment surveys`.
1. Fill in the status field (`cancelled`, `entered-in-error`, or anything else)
1. Save the Form.
1. In the console with Python's SMTP debugging server, you should see email notifications being received as long as the status firled is not `canceled` or `entered-in-error`. The rate at which the notifications are received is set by the `NIGHTLY_NOTIFICATIONS_SCHEDULE` environment variable which, for testing purposes, I have provided instructions so that it runs at the start of every minute.
1. Clean up by restoring the original Java CA Certificates Keystore.
```
sudo mv /etc/ssl/certs/java/BACKUP_cacerts /etc/ssl/certs/java/cacerts
```