### PR TITLE
CARDS-1740: Appointments with the status 'entered-in-error' should not appear on the PROMs dashboard

### DIFF
--- a/proms-resources/frontend/src/main/frontend/src/proms/PromsView.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PromsView.jsx
@@ -65,7 +65,7 @@ function PromsView(props) {
     `visitInformation.questionnaire = '${visitInfo?.["jcr:uuid"]}' ` +
       `and visitDate.question = '${visitInfo?.time?.["jcr:uuid"]}' and __DATE_FILTER_PLACEHOLDER__ ` +
       `and visitSurveys.question = '${visitInfo?.surveys?.["jcr:uuid"]}' and visitSurveys.value = '${surveysId}' ` +
-      `and visitStatus.question = '${visitInfo?.status?.["jcr:uuid"]}' and visitStatus.value <> 'cancelled' ` +
+      `and visitStatus.question = '${visitInfo?.status?.["jcr:uuid"]}' and visitStatus.value <> 'cancelled' and visitStatus.value <> 'entered-in-error' ` +
       `and patientSubmitted.question = '${visitInfo?.surveys_submitted?.["jcr:uuid"]}' and patientSubmitted.value = 1 ` +
     `and dataForm.questionnaire = '${questionnaireId}' ` +
   "order by visitDate.value __SORT_ORDER_PLACEHOLDER__"

--- a/proms-resources/frontend/src/main/frontend/src/proms/VisitView.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/VisitView.jsx
@@ -63,7 +63,7 @@ function VisitView(props) {
     `visitInformation.questionnaire = '${visitInfo?.["jcr:uuid"]}' ` +
       `and visitDate.question = '${visitInfo?.time?.["jcr:uuid"]}' and __DATE_FILTER_PLACEHOLDER__ ` +
       `and visitSurveys.question = '${visitInfo?.surveys?.["jcr:uuid"]}' and visitSurveys.value = '${surveysId}' ` +
-      `and visitStatus.question = '${visitInfo?.status?.["jcr:uuid"]}' and visitStatus.value <> 'cancelled' ` +
+      `and visitStatus.question = '${visitInfo?.status?.["jcr:uuid"]}' and visitStatus.value <> 'cancelled' and visitStatus.value <> 'entered-in-error' ` +
   "order by visitDate.value __SORT_ORDER_PLACEHOLDER__"
 )
 


### PR DESCRIPTION
To test, create some appointments with different statuses, including `entered-in-error`. Appointments entered in error should not show up in the Appointments box on the proms clinic dashboard, and any surveys they may have should not show up in the dashboard survey boxes.