### PR TITLE
CARDS-558: Replace moment.js with luxon

### DIFF
--- a/Utilities/Development/ExtensionPointResources/package.json
+++ b/Utilities/Development/ExtensionPointResources/package.json
@@ -17,7 +17,7 @@
     "@material-ui/core": "4.11.2",
     "@material-ui/icons": "4.11.2",
     "react": "16.14.0",
-    "luxon": "2.3.2"
+    "luxon": "2.4.0"
   },
   "devDependencies": {
     "@babel/core": "7.12.10",

--- a/Utilities/Development/ExtensionPointResources/package.json
+++ b/Utilities/Development/ExtensionPointResources/package.json
@@ -17,7 +17,7 @@
     "@material-ui/core": "4.11.2",
     "@material-ui/icons": "4.11.2",
     "react": "16.14.0",
-    "moment": "2.29.1"
+    "luxon": "2.3.2"
   },
   "devDependencies": {
     "@babel/core": "7.12.10",

--- a/lfs-resources/variants/src/main/frontend/package.json
+++ b/lfs-resources/variants/src/main/frontend/package.json
@@ -24,7 +24,7 @@
     "@material-ui/core": "4.11.2",
     "@material-ui/icons": "4.11.2",
     "react": "16.14.0",
-    "moment": "2.29.1"
+    "luxon": "2.3.2"
   },
   "devDependencies": {
     "@babel/core": "7.12.10",

--- a/lfs-resources/variants/src/main/frontend/package.json
+++ b/lfs-resources/variants/src/main/frontend/package.json
@@ -24,7 +24,7 @@
     "@material-ui/core": "4.11.2",
     "@material-ui/icons": "4.11.2",
     "react": "16.14.0",
-    "luxon": "2.3.2"
+    "luxon": "2.4.0"
   },
   "devDependencies": {
     "@babel/core": "7.12.10",

--- a/lfs-resources/variants/src/main/frontend/src/variantFilesContainer.jsx
+++ b/lfs-resources/variants/src/main/frontend/src/variantFilesContainer.jsx
@@ -42,7 +42,7 @@ import CloseIcon from '@material-ui/icons/Close';
 import GetApp from '@material-ui/icons/GetApp';
 import MaterialTable from "material-table";
 import { v4 as uuidv4 } from 'uuid';
-import moment from "moment";
+import { DateTime } from "luxon";
 import DragAndDrop from "./components/dragAndDrop.jsx";
 import { escapeJQL } from "./escape.jsx";
 import { fetchWithReLogin, GlobalLoginContext } from "./login/loginDialogue.js";
@@ -934,7 +934,7 @@ export default function VariantFilesContainer() {
                 whiteSpace: 'nowrap',
               },
               render: rowData => <Link href={rowData["@path"]}>
-                                  {moment(rowData['jcr:created']).format("YYYY-MM-DD")}
+                                  {DateTime.fromISO(rowData['jcr:created']).toFormat("yyyy-MM-dd")}
                                 </Link> },
             { title: 'Uploaded By',
               cellStyle: {

--- a/modules/commons/src/main/frontend/package.json
+++ b/modules/commons/src/main/frontend/package.json
@@ -26,7 +26,7 @@
     "react": "16.14.0",
     "classnames": "2.2.6",
     "prop-types": "15.7.2",
-    "luxon": "2.3.2"
+    "luxon": "2.4.0"
   },
   "devDependencies": {
     "@babel/core": "7.12.10",

--- a/modules/commons/src/main/frontend/package.json
+++ b/modules/commons/src/main/frontend/package.json
@@ -25,7 +25,8 @@
     "@material-ui/icons": "4.11.2",
     "react": "16.14.0",
     "classnames": "2.2.6",
-    "prop-types": "15.7.2"
+    "prop-types": "15.7.2",
+    "luxon": "2.3.2"
   },
   "devDependencies": {
     "@babel/core": "7.12.10",

--- a/modules/commons/src/main/frontend/src/components/DropdownsDatePicker.jsx
+++ b/modules/commons/src/main/frontend/src/components/DropdownsDatePicker.jsx
@@ -25,7 +25,7 @@
 import React, { useState } from "react";
 import { Select, MenuItem,  makeStyles } from "@material-ui/core";
 import PropTypes from "prop-types";
-import moment from "moment";
+import { Info } from "luxon";
 
 const DropdownDate = {
   year: 'year',
@@ -78,9 +78,9 @@ const useStyles = makeStyles(theme => ({
  * React-based date picker. Select date from Day, Month and Year dropdowns.
  * Code adapted & optimized from https://github.com/ssxv/react-dropdown-date
  *
- * @param {string} startDate optional, if not provided 1900-01-01 is startDate, 'yyyy-mm-dd' format only
- * @param {string} endDate optional, if not provided current date is endDate, 'yyyy-mm-dd' format only
- * @param {string} selectedDate optional, if not provided default values will be displayed, 'yyyy-mm-dd' format only
+ * @param {string} startDate optional, if not provided 1900-01-01 is startDate, 'yyyy-MM-dd' format only
+ * @param {string} endDate optional, if not provided current date is endDate, 'yyyy-MM-dd' format only
+ * @param {string} selectedDate optional, if not provided default values will be displayed, 'yyyy-MM-dd' format only
  * @param {array} order optional, Order of the dropdowns
  * @param {func} onDateChange optional, Callback on day, month or year change
  * @param {bool} yearReverse optional, If true, the year dropdown is ordered in time reverse order
@@ -135,7 +135,7 @@ function DropdownsDatePicker(props) {
     for (let i = start; i <= end; i++) {
       monthOptions.push(
         <MenuItem key={i} value={i}>
-          {monthShort ? moment().month(i).format("MMM") : moment().month(i).format("MMMM")}
+          {monthShort ? Info.months('short')[i] : Info.months()[i]}
         </MenuItem>
       );
     }
@@ -241,7 +241,7 @@ function DropdownsDatePicker(props) {
             if (selected < 0 ) {
               return <div className={classes.placeholder}>Month</div>;
             }
-            return monthShort ? moment().month(selected).format("MMM") : moment().month(selected).format("MMMM");
+            return monthShort ? Info.months('short')[selected] : Info.months()[selected];
         }}
       >
         {generateMonthOptions()}

--- a/modules/commons/src/main/frontend/src/components/DropdownsDatePicker.jsx
+++ b/modules/commons/src/main/frontend/src/components/DropdownsDatePicker.jsx
@@ -262,9 +262,6 @@ function DropdownsDatePicker(props) {
             if (selected < 0 ) {
               return <div className={classes.placeholder}>Day</div>;
             }
-            if (selected < 10 ) {
-              return "0" + selected;
-            }
             return selected;
         }}
       >

--- a/modules/data-entry/src/main/frontend/package.json
+++ b/modules/data-entry/src/main/frontend/package.json
@@ -47,8 +47,7 @@
     "react-to-print": "2.14.4",
     "material-table": "1.69.2",
     "material-ui-dropzone": "3.5.0",
-    "moment-jdateformatparser": "1.2.1",
-    "moment": "2.29.1",
+    "luxon": "2.3.2",
     "prop-types": "15.7.2",
     "uuid": "8.3.1",
     "@uiw/react-md-editor": "3.4.7"

--- a/modules/data-entry/src/main/frontend/package.json
+++ b/modules/data-entry/src/main/frontend/package.json
@@ -47,7 +47,7 @@
     "react-to-print": "2.14.4",
     "material-table": "1.69.2",
     "material-ui-dropzone": "3.5.0",
-    "luxon": "2.3.2",
+    "luxon": "2.4.0",
     "prop-types": "15.7.2",
     "uuid": "8.3.1",
     "@uiw/react-md-editor": "3.4.7"

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -62,7 +62,7 @@ function FormView(props) {
     {
       "key": "jcr:created",
       "label": "Created on",
-      "format": "date:YYYY-MM-DD HH:mm",
+      "format": "date:yyyy-MM-dd HH:mm",
     },
     {
       "key": "jcr:createdBy",

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -64,7 +64,7 @@ function Forms(props) {
     {
       "key": "jcr:created",
       "label": "Created on",
-      "format": "date:YYYY-MM-DD HH:mm",
+      "format": "date:yyyy-MM-dd HH:mm",
     },
     {
       "key": "jcr:createdBy",

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -21,7 +21,7 @@ import React, { useState, useEffect, useContext } from "react";
 import { Paper, Table, TableHead, TableBody, TableRow, TableCell, TablePagination } from "@material-ui/core";
 import { Card, CardHeader, CardContent, CardActions, Chip, IconButton, Typography, Button, LinearProgress, withStyles } from "@material-ui/core";
 import { Link } from 'react-router-dom';
-import moment from "moment";
+import { DateTime } from "luxon";
 
 import Filters from "./Filters.jsx";
 import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
@@ -32,9 +32,9 @@ import LiveTableStyle from "./tableStyle.jsx";
 // Convert a date into the given format string
 // If the date is invalid (usually because it is missing), return ""
 let _formatDate = (date, formatString) => {
-  let dateObj = moment(date);
-  if (dateObj.isValid()) {
-    return dateObj.format(formatString)
+  let dateObj = DateTime.fromISO(date);
+  if (dateObj.isValid) {
+    return dateObj.toFormat(formatString);
   }
   return "";
 };
@@ -192,7 +192,7 @@ function LiveTable(props) {
       // The format can be either just "date", in which case a default date format is used, or "date:FORMAT".
       // Cutting after the fifth char means that either we skip "date:" and read the format,
       // or we just get the empty string and use the default format.
-      let format = column.format.substring(5) || 'YYYY-MM-dd';
+      let format = column.format.substring(5) || 'yyyy-MM-dd';
       content = _formatDate(content, format);
     }
 

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/PrintButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/PrintButton.jsx
@@ -23,7 +23,7 @@ import PropTypes from "prop-types";
 import { Button, IconButton, Tooltip, withStyles } from "@material-ui/core";
 import PrintIcon from "@material-ui/icons/Print";
 import PrintPreview from "../questionnaire/PrintPreview.jsx";
-import moment from "moment";
+
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 
 /**

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
@@ -44,7 +44,7 @@ function Questionnaires(props) {
     {
       "key": "jcr:created",
       "label": "Created on",
-      "format": "date:YYYY-MM-DD HH:mm",
+      "format": "date:yyyy-MM-dd HH:mm",
     },
     {
       "key": "jcr:createdBy",

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
@@ -71,7 +71,7 @@ function SubjectView(props) {
     {
       "key": "jcr:created",
       "label": "Created on",
-      "format": "date:YYYY-MM-DD HH:mm",
+      "format": "date:yyyy-MM-dd HH:mm",
     },
     {
       "key": "jcr:createdBy",

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
@@ -62,7 +62,7 @@ function Subjects(props) {
     {
       "key": "jcr:created",
       "label": "Created on",
-      "format": "date:YYYY-MM-DD HH:mm",
+      "format": "date:yyyy-MM-dd HH:mm",
     },
     {
       "key": "jcr:createdBy",

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -104,7 +104,7 @@ let ComputedQuestion = (props) => {
         newDisplayedValue = DateQuestionUtilities.formatDateAnswer(dateFormat, DateQuestionUtilities.stripTimeZone(newDisplayedValue));
       } else if (dateType === DateQuestionUtilities.DATETIME_TYPE || dateType === DateQuestionUtilities.FULL_DATE_TYPE) {
         newDisplayedValue = typeof(newDisplayedValue) === "string" && newDisplayedValue.length > 0
-          ? DateQuestionUtilities.momentToString(DateQuestionUtilities.amendMoment(DateQuestionUtilities.stripTimeZone(newDisplayedValue || ""), dateFormat), dateType)
+          ? DateQuestionUtilities.ToString(DateQuestionUtilities.toPrecision(DateQuestionUtilities.stripTimeZone(newDisplayedValue || ""), dateFormat), dateType)
           : "";
       }
     } else if (dataType === "vocabulary") {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -284,7 +284,6 @@ let ComputedQuestion = (props) => {
           :
           <TextField
             type={fieldType}
-            dateFormat={(fieldType === "date" || fieldType === "time" && dateFormat) || null}
             disabled={true}
             className={classes.textField + " " + classes.answerField}
             value={displayValue}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -104,7 +104,7 @@ let ComputedQuestion = (props) => {
         newDisplayedValue = DateQuestionUtilities.formatDateAnswer(dateFormat, DateQuestionUtilities.stripTimeZone(newDisplayedValue));
       } else if (dateType === DateQuestionUtilities.DATETIME_TYPE || dateType === DateQuestionUtilities.FULL_DATE_TYPE) {
         newDisplayedValue = typeof(newDisplayedValue) === "string" && newDisplayedValue.length > 0
-          ? DateQuestionUtilities.ToString(DateQuestionUtilities.toPrecision(DateQuestionUtilities.stripTimeZone(newDisplayedValue || ""), dateFormat), dateType)
+          ? DateQuestionUtilities.dateToFormattedString(DateQuestionUtilities.toPrecision(DateQuestionUtilities.stripTimeZone(newDisplayedValue || ""), dateFormat), dateType)
           : "";
       }
     } else if (dataType === "vocabulary") {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionFull.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionFull.jsx
@@ -21,8 +21,7 @@ import React, { useState } from "react";
 
 import { TextField, Typography, withStyles } from "@material-ui/core";
 
-import moment from "moment";
-import * as jdfp from "moment-jdateformatparser";
+import { DateTime } from "luxon";
 
 import Answer from "./Answer";
 import Question from "./Question";
@@ -39,14 +38,14 @@ import DateQuestionUtilities from "./DateQuestionUtilities";
 // text: the question to be displayed
 // type: "timestamp" for a single date or "interval" for two dates
 // dateFormat: A string specifying a date format including date, as detected by DateQuestionUtilities
-// lowerLimit: lower date limit (inclusive) given as an object or string parsable by moment()
-// upperLimit: upper date limit (inclusive) given as an object or string parsable by moment()
+// lowerLimit: lower date limit (inclusive) given as an object or string parsable by luxon
+// upperLimit: upper date limit (inclusive) given as an object or string parsable by luxon
 // Other options are passed to the <question> widget
 //
 // Sample usage:
 //<DateQuestion
 //  text="Please enter a date-time in 2019"
-//  dateFormat="yyyy-MM-dd hh:mm:ss"
+//  dateFormat="yyyy-MM-dd HH:mm:ss"
 //  lowerLimit={new Date("01-01-2019")}
 //  upperLimit={new Date("12-31-2019")}
 //  type="timestamp"
@@ -111,7 +110,7 @@ function DateQuestionFull(props) {
 
   let getSlingDate = (isEnd) => {
     let date = isEnd ? endDate : startDate;
-    return date ? date.formatWithJDF(DateQuestionUtilities.slingDateFormat) : "";
+    return date ? date.toFormat(DateQuestionUtilities.slingDateFormat) : "";
   }
 
   // Determine the granularity of the input textfield

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionFull.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionFull.jsx
@@ -156,12 +156,12 @@ function DateQuestionFull(props) {
       {
         pageActive && <>
           {error && <Typography color='error'>{errorMessage}</Typography>}
-          {getTextField(false, DateQuestionUtilities.ToString(startDate, textFieldType))}
+          {getTextField(false, DateQuestionUtilities.dateToFormattedString(startDate, textFieldType))}
           { /* If this is an interval, allow the user to select a second date */
           type === DateQuestionUtilities.INTERVAL_TYPE &&
           <React.Fragment>
             <span className={classes.mdash}>&mdash;</span>
-            {getTextField(true, DateQuestionUtilities.ToString(endDate, textFieldType))}
+            {getTextField(true, DateQuestionUtilities.dateToFormattedString(endDate, textFieldType))}
           </React.Fragment>
           }
         </>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionFull.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionFull.jsx
@@ -56,14 +56,14 @@ function DateQuestionFull(props) {
 
   let startValues = existingAnswer && existingAnswer[1].value || "";
 
-  const [ startDate, setStartDate ] = useState(DateQuestionUtilities.amendMoment(
+  const [ startDate, setStartDate ] = useState(DateQuestionUtilities.toPrecision(
     DateQuestionUtilities.stripTimeZone(typeof(startValues) === "object" ? startValues[0] : startValues)
   ));
   const [ endDate, setEndDate ] = useState(
-    typeof(startValues) === "object" ? DateQuestionUtilities.amendMoment(DateQuestionUtilities.stripTimeZone(startValues[1])) : null
+    typeof(startValues) === "object" ? DateQuestionUtilities.toPrecision(DateQuestionUtilities.stripTimeZone(startValues[1])) : null
   );
-  const upperLimitMoment = DateQuestionUtilities.amendMoment(upperLimit);
-  const lowerLimitMoment = DateQuestionUtilities.amendMoment(lowerLimit);
+  const upperLimitMoment = DateQuestionUtilities.toPrecision(upperLimit);
+  const lowerLimitMoment = DateQuestionUtilities.toPrecision(lowerLimit);
 
   const [error, setError] = useState(false);
   const [errorMessage, setErrorMessage] = useState("Invalid date");
@@ -77,7 +77,7 @@ function DateQuestionFull(props) {
   }
 
   let processChange = (value, isEnd) => {
-    setDate(DateQuestionUtilities.amendMoment(value, dateFormat), isEnd);
+    setDate(DateQuestionUtilities.toPrecision(value, dateFormat), isEnd);
   }
 
   let processBlur = (value, isEnd) => {
@@ -93,7 +93,7 @@ function DateQuestionFull(props) {
   // Check that the given date is within the upper/lower limit (if specified),
   // and also after an optional startDate
   let boundDate = (date, startDate = null) => {
-    date = DateQuestionUtilities.amendMoment(date, dateFormat);
+    date = DateQuestionUtilities.toPrecision(date, dateFormat);
     if (upperLimitMoment && upperLimitMoment < date) {
       date = upperLimitMoment;
     }
@@ -156,12 +156,12 @@ function DateQuestionFull(props) {
       {
         pageActive && <>
           {error && <Typography color='error'>{errorMessage}</Typography>}
-          {getTextField(false, DateQuestionUtilities.momentToString(startDate, textFieldType))}
+          {getTextField(false, DateQuestionUtilities.ToString(startDate, textFieldType))}
           { /* If this is an interval, allow the user to select a second date */
           type === DateQuestionUtilities.INTERVAL_TYPE &&
           <React.Fragment>
             <span className={classes.mdash}>&mdash;</span>
-            {getTextField(true, DateQuestionUtilities.momentToString(endDate, textFieldType))}
+            {getTextField(true, DateQuestionUtilities.ToString(endDate, textFieldType))}
           </React.Fragment>
           }
         </>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionMonth.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionMonth.jsx
@@ -71,7 +71,9 @@ function DateQuestionMonth(props) {
   const yearRegExp = "\\d{4}";
   // Create a RegExp to test for the display format
   let regExpString = `^${dateFormat.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`;
+  // tests for month being in the format `1x` or `0x` or just `x`
   inputRegExp = new RegExp(regExpString.replace("yyyy", `(${yearRegExp})`).replace("MM", `(1[0-2]|0?[1-9])`));
+  // tests for month being strictly in the format `1x` or `0x`
   strictInputRegExp = new RegExp(regExpString.replace("yyyy", `(${yearRegExp})`).replace("MM", `(1[0-2]|0[1-9])`));
 
   let onBlur = (value, isEnd) => {
@@ -136,16 +138,10 @@ function DateQuestionMonth(props) {
   let displayMonthToString = (value) => {
     let monthIndex = dateFormat.indexOf('MM');
     if (!strictInputRegExp.test(value)) {
-      // Input has a single digit month. Prepend month with 0 to ensure Moment can handle the date
+      // Input has a single digit month. Prepend month with 0 to ensure Luxon can handle the date
       value = [value.slice(0, monthIndex), "0", value.slice(monthIndex)].join('');
     }
 
-    // Make sure month and year are ordered correctly for parsing via Moment
-    if (monthIndex === 0) {
-      // Moment requires year before month.
-      let yearIndex = dateFormat.indexOf('y');
-      value = [value.slice(yearIndex, yearIndex + 4), '-', value.slice(0, 2)].join('');
-    }
     return value.replace('/', '-') + '-01'
   }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionMonth.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionMonth.jsx
@@ -60,8 +60,8 @@ function DateQuestionMonth(props) {
   const [ displayedEndDate, setDisplayedEndDate ] = useState(DateQuestionUtilities.formatDateAnswer(
     dateFormat,
     DateQuestionUtilities.stripTimeZone(typeof(startValues) === "object" ? startValues[1] : "")));
-  const upperLimitMoment = DateQuestionUtilities.amendMoment(upperLimit);
-  const lowerLimitMoment = DateQuestionUtilities.amendMoment(lowerLimit);
+  const upperLimitMoment = DateQuestionUtilities.toPrecision(upperLimit);
+  const lowerLimitMoment = DateQuestionUtilities.toPrecision(lowerLimit);
 
   const [error, setError] = useState(false);
   const [errorMessage, setErrorMessage] = useState("Invalid date");
@@ -76,7 +76,7 @@ function DateQuestionMonth(props) {
 
   let onBlur = (value, isEnd) => {
     if (validateMonthString(value)) {
-      let startDate = isEnd ? amendMomentFromString(displayedDate, dateFormat) : null;
+      let startDate = isEnd ? toPrecisionFromString(displayedDate, dateFormat) : null;
       let parsedDate = DateQuestionUtilities.formatDateAnswer(dateFormat, boundDate(value, startDate));
       setDate(value.length === 0 ? value : parsedDate, isEnd);
       if (!isEnd) {
@@ -114,7 +114,7 @@ function DateQuestionMonth(props) {
   // Check that the given date is within the upper/lower limit (if specified),
   // and also after an optional startDate
   let boundDate = (date, startDate = null) => {
-    date = amendMomentFromString(date, dateFormat);
+    date = toPrecisionFromString(date, dateFormat);
     if (upperLimitMoment && upperLimitMoment < date) {
       date = upperLimitMoment;
     }
@@ -129,8 +129,8 @@ function DateQuestionMonth(props) {
     return(date);
   }
 
-  let amendMomentFromString = (value, dateFormat) => {
-    return DateQuestionUtilities.amendMoment(value, dateFormat, dateFormat);
+  let toPrecisionFromString = (value, dateFormat) => {
+    return DateQuestionUtilities.toPrecision(value, dateFormat, dateFormat);
   }
 
   let getSlingDate = (isEnd) => {
@@ -139,7 +139,7 @@ function DateQuestionMonth(props) {
       dateString = "";
     }
     if (dateString.length > 0) {
-      dateString = amendMomentFromString(dateString, dateFormat).toFormat(DateQuestionUtilities.slingDateFormat);
+      dateString = toPrecisionFromString(dateString, dateFormat).toFormat(DateQuestionUtilities.slingDateFormat);
     }
     return dateString;
   }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionMonth.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionMonth.jsx
@@ -21,8 +21,6 @@ import React, { useState } from "react";
 
 import { TextField, Typography, withStyles } from "@material-ui/core";
 
-import * as jdfp from "moment-jdateformatparser";
-
 import Answer from "./Answer";
 import Question from "./Question";
 import QuestionnaireStyle from "./QuestionnaireStyle";
@@ -38,8 +36,8 @@ import DateQuestionUtilities from "./DateQuestionUtilities";
 // text: the question to be displayed
 // type: "timestamp" for a single date or "interval" for two dates
 // dateFormat: A string specifying a date format, including month but not date, as detected by DateQuestionUtilities
-// lowerLimit: lower date limit (inclusive) given as an object or string parsable by moment()
-// upperLimit: upper date limit (inclusive) given as an object or string parsable by moment()
+// lowerLimit: lower date limit (inclusive) given as an object or string parsable by luxon
+// upperLimit: upper date limit (inclusive) given as an object or string parsable by luxon
 // Other options are passed to the <question> widget
 //
 // Sample usage:
@@ -132,23 +130,7 @@ function DateQuestionMonth(props) {
   }
 
   let amendMomentFromString = (value, dateFormat) => {
-    return DateQuestionUtilities.amendMoment(typeof value === "string" ? displayMonthToMomentString(value) : value, dateFormat);
-  }
-
-  let displayMonthToMomentString = (value) => {
-    let monthIndex = dateFormat.indexOf('MM');
-    if (!strictInputRegExp.test(value)) {
-      // Input has a single digit month. Prepend month with 0 to ensure Moment can handle the date
-      value = [value.slice(0, monthIndex), "0", value.slice(monthIndex)].join('');
-    }
-
-    // Make sure month and year are ordered correctly for parsing via Moment
-    if (monthIndex === 0) {
-      // Moment requires year before month.
-      let yearIndex = dateFormat.indexOf('y');
-      value = [value.slice(yearIndex, yearIndex + 4), '-', value.slice(0, 2)].join('');
-    }
-    return value.replace('/', '-') + '-01'
+    return DateQuestionUtilities.amendMoment(value, dateFormat, dateFormat);
   }
 
   let getSlingDate = (isEnd) => {
@@ -157,7 +139,7 @@ function DateQuestionMonth(props) {
       dateString = "";
     }
     if (dateString.length > 0) {
-      dateString = amendMomentFromString(dateString, dateFormat).formatWithJDF(DateQuestionUtilities.slingDateFormat);
+      dateString = amendMomentFromString(dateString, dateFormat).toFormat(DateQuestionUtilities.slingDateFormat);
     }
     return dateString;
   }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionMonth.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionMonth.jsx
@@ -130,7 +130,23 @@ function DateQuestionMonth(props) {
   }
 
   let toPrecisionFromString = (value, dateFormat) => {
-    return DateQuestionUtilities.toPrecision(value, dateFormat, dateFormat);
+    return DateQuestionUtilities.toPrecision(typeof value === "string" ? displayMonthToString(value) : value, dateFormat);
+  }
+
+  let displayMonthToString = (value) => {
+    let monthIndex = dateFormat.indexOf('MM');
+    if (!strictInputRegExp.test(value)) {
+      // Input has a single digit month. Prepend month with 0 to ensure Moment can handle the date
+      value = [value.slice(0, monthIndex), "0", value.slice(monthIndex)].join('');
+    }
+
+    // Make sure month and year are ordered correctly for parsing via Moment
+    if (monthIndex === 0) {
+      // Moment requires year before month.
+      let yearIndex = dateFormat.indexOf('y');
+      value = [value.slice(yearIndex, yearIndex + 4), '-', value.slice(0, 2)].join('');
+    }
+    return value.replace('/', '-') + '-01'
   }
 
   let getSlingDate = (isEnd) => {
@@ -139,7 +155,7 @@ function DateQuestionMonth(props) {
       dateString = "";
     }
     if (dateString.length > 0) {
-      dateString = toPrecisionFromString(dateString, dateFormat).toFormat(DateQuestionUtilities.slingDateFormat);
+      dateString = toPrecisionFromString(dateString, dateFormat)?.toFormat(DateQuestionUtilities.slingDateFormat) || "";
     }
     return dateString;
   }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
@@ -175,11 +175,8 @@ export default class DateQuestionUtilities {
   }
 
   static stripTimeZone(dateString) {
-    if (!dateString) {
-      return dateString;
-    }
     // Remove the time zone (eg. "-05:00") from the end of a sling provided date string
-    return dateString.replace(/[-+][0-9]{2}:[0-9]{2}$/gm, '');
+    return dateString?.replace(/[-+][0-9]{2}:[0-9]{2}$/gm, '');
   }
 
   static isAnswerComplete(answers, type) {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
@@ -154,8 +154,6 @@ export default class DateQuestionUtilities {
       // Year-only dates are displayed like a number
       return value;
     }
-    // Quick fix for moment using a different date specifier than Java
-    dateFormat = dateFormat.replaceAll('d', "D");
     let date = this.toPrecision(value, dateFormat);
     if (dateType === this.MONTH_DATE_TYPE) {
       return this.dateStringToDisplayMonth(

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
@@ -113,8 +113,6 @@ export default class DateQuestionUtilities {
       'M':'year'
     };
     let truncateTo;
-    // Both 'd' and 'D' should truncate to month
-    toFormat = toFormat.replaceAll("D","d");
     for (let [formatSpecifier, targetPrecision] of Object.entries(truncate)) {
       if (toFormat.indexOf(formatSpecifier) < 0) {
         truncateTo = targetPrecision;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
@@ -124,7 +124,7 @@ export default class DateQuestionUtilities {
     return(new_date.startOf(truncateTo));
   }
 
-  static ToString(date, textFieldType) {
+  static dateToFormattedString(date, textFieldType) {
     return (!date || !date.isValid) ? "" :
     textFieldType === "date" ? date.toFormat("yyyy-MM-dd") : date.toFormat("yyyy-MM-dd\'T\'HH:mm");
   }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
@@ -87,12 +87,12 @@ export default class DateQuestionUtilities {
 
   // Truncates fields in the given moment object or date string
   // according to the given format string
-  static amendMoment(date, format, fromFormat) {
+  static toPrecision(date, toFormat, fromFormat) {
     if (!date) {
       return null;
     }
-    if (!format) {
-      format = this.slingDateFormat;
+    if (!toFormat) {
+      toFormat = this.slingDateFormat;
     }
 
     let new_date = date;
@@ -114,9 +114,9 @@ export default class DateQuestionUtilities {
     };
     let truncateTo;
     // Both 'd' and 'D' should truncate to month
-    format = format.replaceAll("D","d");
+    toFormat = toFormat.replaceAll("D","d");
     for (let [formatSpecifier, targetPrecision] of Object.entries(truncate)) {
-      if (format.indexOf(formatSpecifier) < 0) {
+      if (toFormat.indexOf(formatSpecifier) < 0) {
         truncateTo = targetPrecision;
       }
     }
@@ -124,13 +124,13 @@ export default class DateQuestionUtilities {
     return(new_date.startOf(truncateTo));
   }
 
-  static momentToString(date, textFieldType) {
+  static ToString(date, textFieldType) {
     return (!date || !date.isValid) ? "" :
     textFieldType === "date" ? date.toFormat("yyyy-MM-dd") : date.toFormat("yyyy-MM-dd\'T\'HH:mm");
   }
 
   // Convert a moment string to a month display
-  static momentStringToDisplayMonth(dateFormat, value) {
+  static dateStringToDisplayMonth(dateFormat, value) {
     // Switch month and year if required as Moment returns a fixed order
     let monthIndex = dateFormat.indexOf('MM');
     if (monthIndex === 0) {
@@ -163,9 +163,9 @@ export default class DateQuestionUtilities {
     }
     // Quick fix for moment using a different date specifier than Java
     dateFormat = dateFormat.replaceAll('d', "D");
-    let date = this.amendMoment(value, dateFormat);
+    let date = this.toPrecision(value, dateFormat);
     if (dateType === this.MONTH_DATE_TYPE) {
-      return this.momentStringToDisplayMonth(
+      return this.dateStringToDisplayMonth(
         dateFormat,
         !date || !date.isValid ? "" : date.toFormat("yyyy-MM")
         );
@@ -190,8 +190,8 @@ export default class DateQuestionUtilities {
     // Compute the displayed difference
     let result = {long:""}
     if (startDateInput && endDateInput) {
-      let startDate = this.amendMoment(startDateInput, "yyyy-MM-dd");
-      let endDate = this.amendMoment(endDateInput, "yyyy-MM-dd");
+      let startDate = this.toPrecision(startDateInput, "yyyy-MM-dd");
+      let endDate = this.toPrecision(endDateInput, "yyyy-MM-dd");
 
       let diff = [];
       let longDiff = [];

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
@@ -131,13 +131,8 @@ export default class DateQuestionUtilities {
 
   // Convert a moment string to a month display
   static dateStringToDisplayMonth(dateFormat, value) {
-    // Switch month and year if required as Moment returns a fixed order
     let monthIndex = dateFormat.indexOf('MM');
-    if (monthIndex === 0) {
-      let separator = dateFormat[2];
-      // Switch back from moment supported yyyy/mm to desired mm/yyyy.
-      value = [value.slice(5, 7), separator, value.slice(0, 4)].join('');
-    } else if (monthIndex === 5) {
+    if (monthIndex === 5) {
       value = value.replaceAll("-", dateFormat[4]);
     }
     if (value.length > 7) {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
@@ -85,7 +85,7 @@ export default class DateQuestionUtilities {
     return result;
   }
 
-  // Truncates fields in the given moment object or date string
+  // Truncates fields in the given DateTime object or date string
   // according to the given format string
   static toPrecision(date, toFormat, fromFormat) {
     if (!date) {
@@ -125,7 +125,7 @@ export default class DateQuestionUtilities {
   }
 
   static dateToFormattedString(date, textFieldType) {
-    return (!date || !date.isValid) ? "" :
+    return (!date?.isValid) ? "" :
     textFieldType === "date" ? date.toFormat("yyyy-MM-dd") : date.toFormat("yyyy-MM-dd\'T\'HH:mm");
   }
 
@@ -167,7 +167,7 @@ export default class DateQuestionUtilities {
     if (dateType === this.MONTH_DATE_TYPE) {
       return this.dateStringToDisplayMonth(
         dateFormat,
-        !date || !date.isValid ? "" : date.toFormat("yyyy-MM")
+        !date?.isValid ? "" : date.toFormat("yyyy-MM")
         );
     } else {
       return date.format(dateFormat);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionYear.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionYear.jsx
@@ -35,14 +35,14 @@ import DateQuestionUtilities from "./DateQuestionUtilities";
 // text: the question to be displayed
 // type: "timestamp" for a single date or "interval" for two dates
 // dateFormat: yyyy
-// lowerLimit: lower date limit (inclusive) given as an object or string parsable by moment()
-// upperLimit: upper date limit (inclusive) given as an object or string parsable by moment()
+// lowerLimit: lower date limit (inclusive) given as an object or string parsable by luxon
+// upperLimit: upper date limit (inclusive) given as an object or string parsable by luxon
 // Other options are passed to the <question> widget
 //
 // Sample usage:
 //<DateQuestionYear
 //  text="Please enter a date-time in 2019"
-//  dateFormat="yyyy-MM-dd hh:mm:ss"
+//  dateFormat="yyyy-MM-dd HH:mm:ss"
 //  lowerLimit={new Date("01-01-2019")}
 //  upperLimit={new Date("12-31-2019")}
 //  type="timestamp"

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -47,7 +47,7 @@ import MoreIcon from '@material-ui/icons/MoreVert';
 
 import QuestionnaireStyle, { FORM_ENTRY_CONTAINER_PROPS } from "./QuestionnaireStyle";
 import FormEntry, { QUESTION_TYPES, ENTRY_TYPES } from "./FormEntry";
-import moment from "moment";
+import { DateTime } from "luxon";
 import { getHierarchy, getTextHierarchy, getHierarchyAsList } from "./Subject";
 import { SelectorDialog, parseToArray } from "./SubjectSelector";
 import { FormProvider } from "./FormContext";
@@ -369,7 +369,7 @@ function Form (props) {
                          resourcePath={formURL}
                          resourceData={data}
                          breadcrumb={getTextHierarchy(data?.subject, true)}
-                         date={moment(data['jcr:created']).format("MMM Do YYYY")}
+                         date={DateTime.fromISO(data['jcr:created']).toLocaleString(DateTime.DATE_MED)}
                          onClose={() => { setActionsMenu(null); }}
                        />
                     </ListItem>
@@ -460,7 +460,7 @@ function Form (props) {
           <Breadcrumbs separator="·">
           {
             data && data['jcr:createdBy'] && data['jcr:created'] ?
-            <Typography variant="overline">Entered by {data['jcr:createdBy']} on {moment(data['jcr:created']).format("dddd, MMMM Do YYYY")}</Typography>
+            <Typography variant="overline">Entered by {data['jcr:createdBy']} on {DateTime.fromISO(data['jcr:created']).toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)}</Typography>
             : ""
           }
           {
@@ -470,10 +470,10 @@ function Form (props) {
           }
           {
             lastSaveTimestamp ?
-            <Typography variant="overline">{saveInProgress ? "Saving ... " : "Saved " + moment(lastSaveTimestamp.toISOString()).calendar()}</Typography>
+            <Typography variant="overline">{saveInProgress ? "Saving ... " : "Saved " + DateTime.fromISO(lastSaveTimestamp.toISOString()).toRelativeCalendar()}</Typography>
             :
             data && data['jcr:lastModified'] ?
-            <Typography variant="overline">{"Last modified " + moment(data['jcr:lastModified']).calendar()}</Typography>
+            <Typography variant="overline">{"Last modified " + DateTime.fromISO(data['jcr:lastModified']).toRelativeCalendar()}</Typography>
             : ""
           }
           </Breadcrumbs>
@@ -567,7 +567,7 @@ function Form (props) {
             <Typography variant="h6">Your changes were not saved.</Typography>
             <Typography variant="body1" paragraph>Server responded with response code {errorCode}: {errorMessage}</Typography>
             {lastSaveTimestamp &&
-            <Typography variant="body1" paragraph>Time of the last successful save: {moment(lastSaveTimestamp.toISOString()).calendar()}</Typography>
+            <Typography variant="body1" paragraph>Time of the last successful save: {DateTime.fromISO(lastSaveTimestamp.toISOString()).toRelativeCalendar()}</Typography>
             }
         </DialogContent>
       </Dialog>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
@@ -34,7 +34,7 @@ import {
   withStyles
 } from "@material-ui/core";
 
-import moment from "moment";
+import { DateTime } from "luxon";
 
 import EditIcon from '@material-ui/icons/Edit';
 import PreviewIcon from '@material-ui/icons/FindInPage';
@@ -162,7 +162,7 @@ let Questionnaire = (props) => {
           >
           { data?.['jcr:createdBy'] && data?.['jcr:created'] &&
             <Typography variant="overline">
-              Created by {data['jcr:createdBy']} on {moment(data['jcr:created']).format("dddd, MMMM Do YYYY")}
+              Created by {data['jcr:createdBy']} on {DateTime.fromISO(data['jcr:created']).toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)}
             </Typography>
           }
         </ResourceHeader>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -20,7 +20,7 @@
 import React, { useState, useContext, useEffect } from "react";
 import { Link, useLocation, withRouter } from 'react-router-dom';
 import PropTypes from "prop-types";
-import moment from "moment";
+import { DateTime } from "luxon";
 
 import FormattedText from "../components/FormattedText";
 import QuestionnaireStyle from "./QuestionnaireStyle.jsx";
@@ -359,7 +359,7 @@ function SubjectHeader(props) {
                  resourcePath={path}
                  resourceData={subject?.data}
                  breadcrumb={pageTitle}
-                 date={moment(subject?.data['jcr:created']).format("MMM Do YYYY")}
+                 date={DateTime.fromISO(subject?.data['jcr:created']).toLocaleString(DateTime.DATE_MED)}
                />
                <DeleteButton
                  entryPath={path}
@@ -385,7 +385,7 @@ function SubjectHeader(props) {
         <Typography
           variant="overline"
           color="textSecondary" >
-            Entered by {subject.data['jcr:createdBy']} on {moment(subject.data['jcr:created']).format("dddd, MMMM Do YYYY")}
+            Entered by {subject.data['jcr:createdBy']} on {DateTime.fromISO(subject.data['jcr:created']).toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)}
         </Typography>
         : ""
       }
@@ -462,7 +462,7 @@ function SubjectMemberInternal (props) {
                    resourcePath={path}
                    resourceData={data}
                    breadcrumb={getTextHierarchy(data, true)}
-                   date={moment(data['jcr:created']).format("MMM Do YYYY")}
+                   date={DateTime.fromISO(data['jcr:created']).toLocaleString(DateTime.DATE_MED)}
                    buttonClass={classes.childSubjectHeaderButton}
                    disableShortcut
                  />
@@ -526,7 +526,7 @@ function SubjectMemberInternal (props) {
                       whiteSpace: 'nowrap',
                     },
                     render: rowData => <Link to={"/content.html" + rowData["@path"]}>
-                                         {moment(rowData['jcr:created']).format("YYYY-MM-DD")}
+                                         {DateTime.fromISO(rowData['jcr:created']).toFormat("yyyy-MM-dd")}
                                        </Link> },
                   { title: 'Status',
                     cellStyle: {

--- a/modules/demo-banner/src/main/frontend/package.json
+++ b/modules/demo-banner/src/main/frontend/package.json
@@ -24,7 +24,7 @@
     "@material-ui/core": "4.11.2",
     "@material-ui/icons": "4.11.2",
     "react": "16.14.0",
-    "moment": "2.29.1"
+    "luxon": "2.3.2"
   },
   "devDependencies": {
     "@babel/core": "7.12.10",

--- a/modules/demo-banner/src/main/frontend/package.json
+++ b/modules/demo-banner/src/main/frontend/package.json
@@ -23,8 +23,7 @@
   "dependencies": {
     "@material-ui/core": "4.11.2",
     "@material-ui/icons": "4.11.2",
-    "react": "16.14.0",
-    "luxon": "2.3.2"
+    "react": "16.14.0"
   },
   "devDependencies": {
     "@babel/core": "7.12.10",

--- a/modules/homepage/src/main/frontend/package.json
+++ b/modules/homepage/src/main/frontend/package.json
@@ -41,7 +41,6 @@
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-router-dom": "5.2.0",
-    "luxon": "2.3.2",
     "prop-types": "15.7.2",
     "formik": "2.2.6",
     "history": "4.10.1",

--- a/modules/homepage/src/main/frontend/package.json
+++ b/modules/homepage/src/main/frontend/package.json
@@ -41,7 +41,7 @@
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-router-dom": "5.2.0",
-    "moment": "2.29.1",
+    "luxon": "2.3.2",
     "prop-types": "15.7.2",
     "formik": "2.2.6",
     "history": "4.10.1",

--- a/modules/statistics/src/main/frontend/package.json
+++ b/modules/statistics/src/main/frontend/package.json
@@ -39,7 +39,7 @@
     "@material-ui/icons": "4.11.2",
     "google-palette": "1.1.0",
     "material-table": "1.69.2",
-    "moment": "2.29.1",
+    "luxon": "2.3.2",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-router-dom": "5.2.0",

--- a/modules/statistics/src/main/frontend/package.json
+++ b/modules/statistics/src/main/frontend/package.json
@@ -39,7 +39,7 @@
     "@material-ui/icons": "4.11.2",
     "google-palette": "1.1.0",
     "material-table": "1.69.2",
-    "luxon": "2.3.2",
+    "luxon": "2.4.0",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-router-dom": "5.2.0",

--- a/modules/statistics/src/main/frontend/src/Statistics/Statistic.jsx
+++ b/modules/statistics/src/main/frontend/src/Statistics/Statistic.jsx
@@ -32,7 +32,7 @@ import { deepPurple, indigo } from '@material-ui/core/colors';
 
 import { useHistory } from 'react-router-dom';
 
-import moment from "moment";
+import { DateTime } from "luxon";
 import palette from "google-palette";
 import {
    BarChart, Bar, CartesianGrid, Line, LineChart, Label, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis
@@ -87,7 +87,7 @@ function Statistic(props) {
     });
     // Reformat to a human readable format
     rechartsData = rechartsData.map((field) => {
-      field["x"] = DateQuestionUtilities.amendMoment(field["x"], dateFormat).format(moment.HTML5_FMT.DATE);
+      field["x"] = DateTime.fromISO(field["x"]).toFormat("yyyy-MM-dd");
       return field;
     })
   } else {

--- a/modules/statistics/src/main/frontend/src/Statistics/Statistic.jsx
+++ b/modules/statistics/src/main/frontend/src/Statistics/Statistic.jsx
@@ -83,7 +83,7 @@ function Statistic(props) {
     // Date sort -- first convert string->moment to compare
     let dateFormat = xVar["dateFormat"] || "yyyy-MM-dd";
     rechartsData.sort((a, b) => {
-        return DateQuestionUtilities.amendMoment(a["x"], dateFormat).diff(DateQuestionUtilities.amendMoment(b["x"], dateFormat))
+        return DateQuestionUtilities.toPrecision(a["x"], dateFormat).diff(DateQuestionUtilities.toPrecision(b["x"], dateFormat))
     });
     // Reformat to a human readable format
     rechartsData = rechartsData.map((field) => {

--- a/proms-resources/frontend/src/main/frontend/package.json
+++ b/proms-resources/frontend/src/main/frontend/package.json
@@ -42,7 +42,7 @@
     "react-router-dom": "5.2.0",
     "prop-types": "15.7.2",
     "history": "4.10.1",
-    "luxon": "2.3.2",
+    "luxon": "2.4.0",
     "semantic-ui-css": "2.4.1",
     "semantic-ui-react": "2.0.1"
   },

--- a/proms-resources/frontend/src/main/frontend/src/proms/QuestionnaireSet.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/QuestionnaireSet.jsx
@@ -445,7 +445,7 @@ function QuestionnaireSet(props) {
 
   const getVisitDate = () => {
     let dateAnswer = getVisitInformation("time");
-    return DateQuestionUtilities.amendMoment(DateQuestionUtilities.stripTimeZone(dateAnswer));
+    return DateQuestionUtilities.toPrecision(DateQuestionUtilities.stripTimeZone(dateAnswer));
   }
 
   const appointmentDate = () => {

--- a/proms-resources/frontend/src/main/frontend/src/proms/QuestionnaireSet.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/QuestionnaireSet.jsx
@@ -38,8 +38,7 @@ import NextStepIcon from '@material-ui/icons/ChevronRight';
 import DoneIcon from '@material-ui/icons/Done';
 import WarningIcon from '@material-ui/icons/Warning';
 
-import moment from "moment";
-import * as jdfp from "moment-jdateformatparser";
+import { DateTime } from "luxon";
 
 import Form from "../questionnaire/Form.jsx";
 import PromsHeader from "./Header.jsx";
@@ -446,13 +445,12 @@ function QuestionnaireSet(props) {
 
   const getVisitDate = () => {
     let dateAnswer = getVisitInformation("time");
-    return dateAnswer == null ? null : DateQuestionUtilities.amendMoment(DateQuestionUtilities.stripTimeZone(dateAnswer));
+    return DateQuestionUtilities.amendMoment(DateQuestionUtilities.stripTimeZone(dateAnswer));
   }
 
   const appointmentDate = () => {
     let date = getVisitDate();
-    return date == null ? ""
-      : date.formatWithJDF("EEEE, MMMM d, yyyy h:mma");
+    return !date.isValid ? "" : date.toLocaleString(DateTime.DATETIME_MED_WITH_WEEKDAY);
   }
 
   let appointmentAlert = () => {
@@ -470,11 +468,8 @@ function QuestionnaireSet(props) {
       : null
   }
 
-  const diffString = (startDate, endDate, division, result, modulus = null) => {
-    let diff = endDate.diff(startDate, division);
-    if (modulus != null) {
-      diff = diff % modulus;
-    }
+  const diffString = (division, result, diffs) => {
+    let diff = diffs[division];
     if (diff > 0) {
       result.push(diff + " " + (diff == 1 && division[division.length - 1] == "s"
         ? division.substring(0, division.length -1)
@@ -485,17 +480,17 @@ function QuestionnaireSet(props) {
   const expiryDate = () => {
     let result = "";
     const date = getVisitDate();
-    if (date != null) {
+    if (date && date.isValid) {
       // If the visit date could be retrieved, this is an emailed token and will expire 2 hours after the visit
-      date.add(2, 'hours');
+      date.plus({hours: 2});
 
       // Get the date difference in the format: X days, Y hours and Z minutes,
       // skipping any time division that has a value of 0
-      const now = moment();
-      const diffStrings = [];
-      diffString(now, date, "days", diffStrings);
-      diffString(now, date, "hours", diffStrings, 24);
-      diffString(now, date, "minutes", diffStrings, 60);
+      const diffs = date.diffNow(['days', 'hours', 'minutes']).toObject();
+      let diffStrings = [];
+      diffString("days", diffStrings, diffs);
+      diffString("hours", diffStrings, diffs);
+      diffString("minutes", diffStrings, diffs);
 
       if (diffStrings.length > 1) {
         result = " and " + diffStrings.pop();

--- a/proms-resources/frontend/src/main/frontend/src/proms/QuestionnaireSet.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/QuestionnaireSet.jsx
@@ -450,7 +450,7 @@ function QuestionnaireSet(props) {
 
   const appointmentDate = () => {
     let date = getVisitDate();
-    return !date.isValid ? "" : date.toLocaleString(DateTime.DATETIME_MED_WITH_WEEKDAY);
+    return !date?.isValid ? "" : date.toLocaleString(DateTime.DATETIME_MED_WITH_WEEKDAY);
   }
 
   let appointmentAlert = () => {
@@ -469,7 +469,7 @@ function QuestionnaireSet(props) {
   }
 
   const diffString = (division, result, diffs) => {
-    let diff = diffs[division];
+    let diff = Math.floor(diffs[division]);
     if (diff > 0) {
       result.push(diff + " " + (diff == 1 && division[division.length - 1] == "s"
         ? division.substring(0, division.length -1)
@@ -480,7 +480,7 @@ function QuestionnaireSet(props) {
   const expiryDate = () => {
     let result = "";
     const date = getVisitDate();
-    if (date && date.isValid) {
+    if (date?.isValid) {
       // If the visit date could be retrieved, this is an emailed token and will expire 2 hours after the visit
       date.plus({hours: 2});
 

--- a/proms-resources/frontend/src/main/frontend/src/proms/VisitView.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/VisitView.jsx
@@ -86,7 +86,7 @@ function VisitView(props) {
     {
       "key": "time",
       "label": "Visit time",
-      "format": "date:YYYY-MM-DD hh:mm"
+      "format": "date:yyyy-MM-dd HH:mm"
     },
     {
       "key" : "status",

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ComputedTest.xml
@@ -580,7 +580,7 @@ or
 			</property>
 			<property>
 				<name>dateFormat</name>
-				<value>yyyy-MM-DD</value>
+				<value>yyyy-MM-dd</value>
 				<type>String</type>
 			</property>
 			<property>
@@ -614,7 +614,7 @@ or
 			</property>
 			<property>
 				<name>dateFormat</name>
-				<value>yyyy-MM-DD</value>
+				<value>yyyy-MM-dd</value>
 				<type>String</type>
 			</property>
 			<property>
@@ -842,7 +842,7 @@ or
 			</property>
 			<property>
 				<name>dateFormat</name>
-				<value>yyyy-MM-DD HH:mm</value>
+				<value>yyyy-MM-dd HH:mm</value>
 				<type>String</type>
 			</property>
 			<property>
@@ -881,7 +881,7 @@ or
 			</property>
 			<property>
 				<name>dateFormat</name>
-				<value>yyyy-MM-DD HH:mm</value>
+				<value>yyyy-MM-dd HH:mm</value>
 				<type>String</type>
 			</property>
 		</node>
@@ -920,7 +920,7 @@ or
 			</property>
 			<property>
 				<name>dateFormat</name>
-				<value>yyyy-MM-DD HH:mm</value>
+				<value>yyyy-MM-dd HH:mm</value>
 				<type>String</type>
 			</property>
 		</node>
@@ -939,7 +939,7 @@ or
 			</property>
 			<property>
 				<name>dateFormat</name>
-				<value>yyyy-MM-DD HH:mm:ss</value>
+				<value>yyyy-MM-dd HH:mm:ss</value>
 				<type>String</type>
 			</property>
 			<property>
@@ -978,7 +978,7 @@ or
 			</property>
 			<property>
 				<name>dateFormat</name>
-				<value>yyyy-MM-DD HH:mm:ss</value>
+				<value>yyyy-MM-dd HH:mm:ss</value>
 				<type>String</type>
 			</property>
 		</node>
@@ -1017,7 +1017,7 @@ or
 			</property>
 			<property>
 				<name>dateFormat</name>
-				<value>yyyy-MM-DD HH:mm:ss</value>
+				<value>yyyy-MM-dd HH:mm:ss</value>
 				<type>String</type>
 			</property>
 		</node>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/DateFormatsTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/DateFormatsTest.xml
@@ -148,7 +148,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>MM-DD-yyyy</value>
+			<value>MM-dd-yyyy</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -336,7 +336,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>MM-DD-yyyy</value>
+			<value>MM-dd-yyyy</value>
 			<type>String</type>
 		</property>
 		<property>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/DateFormatsTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/DateFormatsTest.xml
@@ -124,7 +124,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>yyyy-MM-DD</value>
+			<value>yyyy-MM-dd</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -172,7 +172,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>yyyy-MM-DD HH:mm</value>
+			<value>yyyy-MM-dd HH:mm</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -196,7 +196,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>yyyy-MM-DD HH:mm:ss</value>
+			<value>yyyy-MM-dd HH:mm:ss</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -307,7 +307,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>yyyy-MM-DD</value>
+			<value>yyyy-MM-dd</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -365,7 +365,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>yyyy-MM-DD HH:mm</value>
+			<value>yyyy-MM-dd HH:mm</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -394,7 +394,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>yyyy-MM-DD HH:mm:ss</value>
+			<value>yyyy-MM-dd HH:mm:ss</value>
 			<type>String</type>
 		</property>
 		<property>


### PR DESCRIPTION
This PR replaces a deprecated javascript library for parsing and formatting dates (moment.js) with a new one (luxon).

There should be no visible changes to the user. Everything that involves dates on the frontend needs to be tested, in all projects. 