### PR TITLE
PROMs Patient UI improvements: CARDS-1747, CARDS-1748, CARDS-1749, CARDS-1750, CARDS-1751

### DIFF
--- a/modules/commons/src/main/frontend/src/components/style.jsx
+++ b/modules/commons/src/main/frontend/src/components/style.jsx
@@ -26,11 +26,14 @@ const style = theme => ({
     zIndex: 100,
     "& .MuiCircularProgress-root" : {
       position: 'absolute',
-      top: 0,
-      left: 0,
+      top: "50%",
+      left: "50%",
+      marginTop: "-28px",
+      marginLeft: "-28px",
     },
     "& .MuiFab-extended + .MuiCircularProgress-root" : {
-      margin: theme.spacing(1, 1.5),
+      marginTop: "-16px",
+      marginLeft: "-16px",
     },
     "& .MuiFab-extended .MuiSvgIcon-root" : {
       marginRight: theme.spacing(1),

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -527,9 +527,10 @@ function Form (props) {
             }
           </FormUpdateProvider>
         </FormProvider>
-        {/* If the form is in edit mode, padding from the pagination is used to space out the save button, even with
-            pagination disabled. In view modes, there is no save button, so hide the pagination completely*/}
-        <Grid item xs={12} className={isEdit ? classes.formFooter : classes.hiddenFooter} id="cards-resource-footer">
+        {/* FormPagination must be called regardless of whether it is paginationEnabled is true or false,
+            because it is what populates the contents of the form.
+            However, it should only be displayed to the user in edit mode when paginationEnabled is true. */}
+        <Grid item xs={12} className={paginationEnabled ? classes.formFooter : classes.hiddenFooter} id="cards-resource-footer">
           <FormPagination
               saveInProgress={saveInProgress}
               lastSaveStatus={lastSaveStatus}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -527,7 +527,7 @@ function Form (props) {
             }
           </FormUpdateProvider>
         </FormProvider>
-        {/* FormPagination must be called regardless of whether it is paginationEnabled is true or false,
+        {/* FormPagination must be called regardless of whether paginationEnabled is true or false,
             because it is what populates the contents of the form.
             However, it should only be displayed to the user in edit mode when paginationEnabled is true. */}
         <Grid item xs={12} className={paginationEnabled ? classes.formFooter : classes.hiddenFooter} id="cards-resource-footer">

--- a/proms-resources/frontend/src/main/frontend/src/proms/Header.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/Header.jsx
@@ -68,6 +68,9 @@ const useStyles = makeStyles(theme => ({
       zoom: 1.2,
     }
   },
+  collapsed : {
+    display: "none",
+  },
 }));
 
 function PromsHeader (props) {
@@ -89,6 +92,7 @@ function PromsHeader (props) {
     : <></>;
 
   return (
+    <>
     <AppBar position="sticky" className={classes.appbar}>
       <Collapse in={!subtitle || !(scrollTrigger)}>
         <Toolbar variant="dense" className={classes.toolbar}>
@@ -106,8 +110,13 @@ function PromsHeader (props) {
       </Collapse>
       { subtitle && <Collapse in={scrollTrigger}>{subtitleBar}</Collapse> }
       <LinearProgress variant="determinate" value={progress} />
-      { subtitle && <Fade in={!scrollTrigger} className={classes.fullSize + ' ' + classes.toolbar}>{subtitleBar}</Fade> }
+      { subtitle && <Fade in={!scrollTrigger} className={(scrollTrigger ? classes.collapsed : '') + ' ' + classes.fullSize + ' ' + classes.toolbar}>{subtitleBar}</Fade> }
     </AppBar>
+    {/* We render another copy of the full size subtitle to maintain the same content height when the first one
+        disappears and thus prevent the subtitle from "jumping" between full size and compact when scrollTrigger
+        becomes true. */}
+    { subtitle && scrollTrigger && <div className={classes.fullSize + ' ' + classes.toolbar}>{subtitleBar}</div> }
+    </>
   );
 }
 

--- a/proms-resources/frontend/src/main/frontend/src/proms/QuestionnaireSet.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/QuestionnaireSet.jsx
@@ -562,7 +562,7 @@ function QuestionnaireSet(props) {
     <Grid container direction="column" spacing={8}>
       {(questionnaireIds || []).map((q, i) => (
       <Grid item key={q+"Review"}>
-      <Grid container spacing={4}>
+      <Grid container direction="column" spacing={4}>
         <Grid item>
           <Typography variant="h5">{questionnaires[q].title || questionnaires[q]["@name"]}</Typography>
         </Grid>

--- a/proms-resources/frontend/src/main/frontend/src/proms/QuestionnaireSet.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/QuestionnaireSet.jsx
@@ -86,13 +86,6 @@ const useStyles = makeStyles(theme => ({
     justify: "space-between",
     flexWrap: "nowrap",
   },
-  reviewFab : {
-    margin: theme.spacing(1),
-    position: "fixed",
-    bottom: theme.spacing(2),
-    right: theme.spacing(4),
-    zIndex: 100,
-  }
 }));
 
 function QuestionnaireSet(props) {
@@ -587,9 +580,7 @@ function QuestionnaireSet(props) {
       </Grid>
       ))}
     </Grid>,
-    <div className={classes.reviewFab}>
-      <Fab variant="extended" color="primary" onClick={() => {onSubmit()}}>Submit my answers</Fab>
-    </div>
+    <Fab variant="extended" color="primary" onClick={() => {onSubmit()}}>Submit my answers</Fab>
   ];
 
   // Are there any response interpretations to display to the patient?


### PR DESCRIPTION
**Included in this PR:**
* [CARDS-1747](https://phenotips.atlassian.net/browse/CARDS-1747): _In longer forms that require scrolling, the radiobuttons that are right under the header cannot be clicked_
* [CARDS-1748](https://phenotips.atlassian.net/browse/CARDS-1748): _Unnecessary gap between the form and the `[Continue to...]` button_
* [CARDS-1749](https://phenotips.atlassian.net/browse/CARDS-1749): _While waiting to load the submitted answers for review, the `[Update this survey]` button is displayed on the side of the form title, only to move under once the contents are loaded_
* [CARDS-1750](https://phenotips.atlassian.net/browse/CARDS-1750): _`[Submit my answers]` is the only main action button that is not centered and that is sticky to the bottom of the screen_
* [CARDS-1751](https://phenotips.atlassian.net/browse/CARDS-1751): _Misplaced circular progress when clicking on `[Continue to <next questionnaire>]`_

**Testing:**
* Follow the JIRA task description for details
* `CARDS-1748` **may impact forms** in admin/clinician UI; make sure there are no unwanted side effects
* `CARDS-1751` **may impact main action buttons** in admin/clinican UI (e.g. the (+) buttons on Dashboard, Subjects, Forms, admin/Questionnaires, etc, as well as the form's `Save` button); make sure there are no unwanted side effects

**Reviewing:**
* There is a separate small commit for each task. Reviewing **commit by commit** rather than file by file is recommended.