### PR TITLE
CARDS-1752: Proms import: Add the ability to specify a list of dates used for querying appointments

### DIFF
--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportConfigDefinition.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportConfigDefinition.java
@@ -45,9 +45,6 @@ public @interface ImportConfigDefinition
     /** Vault role to login to. */
     String VAULT_ROLE = "prom_role";
 
-    /** Vault role to login to. */
-    String DATES_TO_QUERY = "dates_to_query";
-
     @AttributeDefinition(name = "Name", description = "Configuration name")
     String name();
 
@@ -81,7 +78,7 @@ public @interface ImportConfigDefinition
     String vault_role();
 
     @AttributeDefinition(name = "Dates to query",
-        description = "Dates to query, which limits the dates that will be queried.",
+        description = "If set, only appointments for these dates will be imported. Must be in the format yyyy-mm-dd.",
         required = false)
     String[] dates_to_query();
 }

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportConfigDefinition.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportConfigDefinition.java
@@ -45,6 +45,9 @@ public @interface ImportConfigDefinition
     /** Vault role to login to. */
     String VAULT_ROLE = "prom_role";
 
+    /** Vault role to login to. */
+    String DATES_TO_QUERY = "dates_to_query";
+
     @AttributeDefinition(name = "Name", description = "Configuration name")
     String name();
 
@@ -76,4 +79,9 @@ public @interface ImportConfigDefinition
         description = "Name of the role to login to Vault with. If not given, skip the Vault login process.",
         required = false)
     String vault_role();
+
+    @AttributeDefinition(name = "Dates to query",
+        description = "Dates to query, which limits the dates that will be queried.",
+        required = false)
+    String[] dates_to_query();
 }

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportEndpoint.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportEndpoint.java
@@ -82,7 +82,7 @@ public class ImportEndpoint extends SlingSafeMethodsServlet
         final Runnable importJob =
             new ImportTask(this.resolverFactory, this.rrp, config.auth_url(), config.endpoint_url(),
                 config.days_to_query(), config.vault_token(), config.clinic_names(), config.provider_names(),
-                config.vault_role());
+                config.vault_role(), config.dates_to_query());
         final Thread thread = new Thread(importJob);
         thread.start();
         writeSuccess(response);

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportTask.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportTask.java
@@ -78,7 +78,7 @@ public class ImportTask implements Runnable
     /** URL for the Torch server endpoint. */
     private final String endpointURL;
 
-    /** Vault role name for use when logging in with the JWT. */
+    /** List of dates to filter appointments by. May be empty if no date filtering is applied. */
     private final List<Calendar> queryDates;
 
     /** JWT token for querying the endpoint. */
@@ -98,9 +98,9 @@ public class ImportTask implements Runnable
      * @param endpointURL The URL for the Torch server endpoint
      * @param daysToQuery Number of days to query
      * @param vaultToken JWT token for querying the endpoint
-     * @param clinicNames Pipe-delimited list of names of clinics to query
-     * @param providerIDs Pipe-delimited list of names of providers to filter queries to
-     * @param queryDates Pipe-delimited list of dates to restrict queries to, if any
+     * @param clinicNames list of names of clinics to query
+     * @param providerIDs list of names of providers to filter queries to
+     * @param queryDates list of dates to restrict queries to, if any
      */
     @SuppressWarnings({ "checkstyle:ParameterNumber" })
     ImportTask(final ResourceResolverFactory resolverFactory, final ThreadResourceResolverProvider rrp,
@@ -115,16 +115,15 @@ public class ImportTask implements Runnable
         this.daysToQuery = daysToQuery;
         this.vaultToken = vaultToken;
         this.clinicNames = clinicNames;
-        // Fixate the query dates
+        // Parse the query dates
         this.queryDates = new LinkedList<Calendar>();
         final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
         for (int i = 0; i < queryDates.length; i++) {
-            this.queryDates.add(Calendar.getInstance());
-            try
-            {
-                this.queryDates.get(i).setTime(formatter.parse(queryDates[i]));
-            } catch (ParseException e)
-            {
+            try {
+                final Calendar date = Calendar.getInstance();
+                date.setTime(formatter.parse(queryDates[i]));
+                this.queryDates.add(date);
+            } catch (ParseException e) {
                 LOGGER.error("Query date invalid: {}", e.getMessage(), e);
                 this.queryDates.set(i, null);
             }

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportTask.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportTask.java
@@ -28,9 +28,12 @@ import java.io.StringReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 import javax.json.Json;
@@ -75,6 +78,9 @@ public class ImportTask implements Runnable
     /** URL for the Torch server endpoint. */
     private final String endpointURL;
 
+    /** Vault role name for use when logging in with the JWT. */
+    private final List<Calendar> queryDates;
+
     /** JWT token for querying the endpoint. */
     private final String vaultToken;
 
@@ -94,12 +100,13 @@ public class ImportTask implements Runnable
      * @param vaultToken JWT token for querying the endpoint
      * @param clinicNames Pipe-delimited list of names of clinics to query
      * @param providerIDs Pipe-delimited list of names of providers to filter queries to
+     * @param queryDates Pipe-delimited list of dates to restrict queries to, if any
      */
     @SuppressWarnings({ "checkstyle:ParameterNumber" })
     ImportTask(final ResourceResolverFactory resolverFactory, final ThreadResourceResolverProvider rrp,
         final String authURL, final String endpointURL,
         final int daysToQuery, final String vaultToken, final String[] clinicNames, final String[] providerIDs,
-        final String vaultRole)
+        final String vaultRole, final String[] queryDates)
     {
         this.resolverFactory = resolverFactory;
         this.rrp = rrp;
@@ -108,6 +115,20 @@ public class ImportTask implements Runnable
         this.daysToQuery = daysToQuery;
         this.vaultToken = vaultToken;
         this.clinicNames = clinicNames;
+        // Fixate the query dates
+        this.queryDates = new LinkedList<Calendar>();
+        final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+        for (int i = 0; i < queryDates.length; i++) {
+            this.queryDates.add(Calendar.getInstance());
+            try
+            {
+                this.queryDates.get(i).setTime(formatter.parse(queryDates[i]));
+            } catch (ParseException e)
+            {
+                LOGGER.error("Query date invalid: {}", e.getMessage(), e);
+                this.queryDates.set(i, null);
+            }
+        }
         // If we have no provider IDs, we want an empty list instead of a list of length 1 with an empty string
         this.providerIDs = StringUtils.isAllBlank(providerIDs) ? new String[0] : providerIDs;
         this.vaultRole = vaultRole;
@@ -194,7 +215,7 @@ public class ImportTask implements Runnable
                 Map.of(ResourceResolverFactory.SUBSERVICE, "TorchImporter"))) {
                 this.rrp.push(resolver);
                 final PatientLocalStorage storage = new PatientLocalStorage(resolver, startDate, endDate,
-                    this.providerIDs);
+                    this.providerIDs, this.queryDates);
 
                 data.forEach(storage::store);
                 importedAppointmentsCount += storage.getCountAppointmentsCreated();

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/NightlyImport.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/NightlyImport.java
@@ -79,7 +79,8 @@ public class NightlyImport
                 newConfig.getConfig().vault_token(),
                 newConfig.getConfig().clinic_names(),
                 newConfig.getConfig().provider_names(),
-                newConfig.getConfig().vault_role());
+                newConfig.getConfig().vault_role(),
+                newConfig.getConfig().dates_to_query());
         try {
             if (importJob != null) {
                 this.scheduler.schedule(importJob, options);

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/PatientLocalStorage.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/PatientLocalStorage.java
@@ -292,7 +292,7 @@ public class PatientLocalStorage
      * @param appointment JsonObject of a provider from the "providers" object within an appointment
      * @return True if the provider is approved and is an attendee.
      */
-    Boolean isAllowedProvider(final JsonObject provider)
+    private boolean isAllowedProvider(final JsonObject provider)
     {
         // Check that the provider is an attendee
         if (provider.containsKey("role") && !"ATND".equals(provider.getString("role"))) {


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/CARDS-1752).

Adds a new date list to the OSGi config that allows you to filter import results to a specific set of dates.

![image](https://user-images.githubusercontent.com/4656440/165834814-5d895fad-75bd-4a9b-b486-b409a0296b81.png)