### PR TITLE
CARDS-1758: Proms import: Add the ability to specify a list of physician roles used for filtering appointments

### DIFF
--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportConfigDefinition.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportConfigDefinition.java
@@ -45,6 +45,9 @@ public @interface ImportConfigDefinition
     /** Vault role to login to. */
     String VAULT_ROLE = "prom_role";
 
+    /** Allowed provider roles. */
+    String PROVIDER_ROLE = "ATND";
+
     @AttributeDefinition(name = "Name", description = "Configuration name")
     String name();
 
@@ -71,6 +74,12 @@ public @interface ImportConfigDefinition
     @AttributeDefinition(name = "Provider names",
         description = "List of names of providers to query. If empty, all providers will be fetched.", required = false)
     String[] provider_names();
+
+    @AttributeDefinition(name = "Allowed provider roles",
+        description = "If set along with the provider names attribute, only take appointments if the provider is"
+            + " one of the given roles. The most useful role to filter by is ATND for an attending physician.",
+        required = false)
+    String[] allowed_roles() default PROVIDER_ROLE;
 
     @AttributeDefinition(name = "Vault role name",
         description = "Name of the role to login to Vault with. If not given, skip the Vault login process.",

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportEndpoint.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportEndpoint.java
@@ -82,7 +82,7 @@ public class ImportEndpoint extends SlingSafeMethodsServlet
         final Runnable importJob =
             new ImportTask(this.resolverFactory, this.rrp, config.auth_url(), config.endpoint_url(),
                 config.days_to_query(), config.vault_token(), config.clinic_names(), config.provider_names(),
-                config.vault_role(), config.dates_to_query());
+                config.allowed_roles(), config.vault_role(), config.dates_to_query());
         final Thread thread = new Thread(importJob);
         thread.start();
         writeSuccess(response);

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportTask.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportTask.java
@@ -75,6 +75,9 @@ public class ImportTask implements Runnable
     /** List of providers to query. If empty, all providers' appointments are used. */
     private final String[] providerIDs;
 
+    /** List of allowed provider roles, such that providerIDs must be the given role. Optionally set. */
+    private final String[] providerRoles;
+
     /** URL for the Torch server endpoint. */
     private final String endpointURL;
 
@@ -106,7 +109,7 @@ public class ImportTask implements Runnable
     ImportTask(final ResourceResolverFactory resolverFactory, final ThreadResourceResolverProvider rrp,
         final String authURL, final String endpointURL,
         final int daysToQuery, final String vaultToken, final String[] clinicNames, final String[] providerIDs,
-        final String vaultRole, final String[] queryDates)
+        final String[] providerRoles, final String vaultRole, final String[] queryDates)
     {
         this.resolverFactory = resolverFactory;
         this.rrp = rrp;
@@ -125,11 +128,11 @@ public class ImportTask implements Runnable
                 this.queryDates.add(date);
             } catch (ParseException e) {
                 LOGGER.error("Query date invalid: {}", e.getMessage(), e);
-                this.queryDates.set(i, null);
             }
         }
-        // If we have no provider IDs, we want an empty list instead of a list of length 1 with an empty string
+        // If we have no provider IDs/roles, we want an empty list instead of a list of length 1 with an empty string
         this.providerIDs = StringUtils.isAllBlank(providerIDs) ? new String[0] : providerIDs;
+        this.providerRoles = StringUtils.isAllBlank(providerRoles) ? new String[0] : providerRoles;
         this.vaultRole = vaultRole;
     }
 
@@ -215,7 +218,7 @@ public class ImportTask implements Runnable
                 Map.of(ResourceResolverFactory.SUBSERVICE, "TorchImporter"))) {
                 this.rrp.push(resolver);
                 final PatientLocalStorage storage = new PatientLocalStorage(resolver, startDate, endDate,
-                    this.providerIDs, this.queryDates);
+                    this.providerIDs, this.providerRoles, this.queryDates);
 
                 data.forEach(storage::store);
                 importedAppointmentsCount += storage.getCountAppointmentsCreated();

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/NightlyImport.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/NightlyImport.java
@@ -79,6 +79,7 @@ public class NightlyImport
                 newConfig.getConfig().vault_token(),
                 newConfig.getConfig().clinic_names(),
                 newConfig.getConfig().provider_names(),
+                newConfig.getConfig().allowed_roles(),
                 newConfig.getConfig().vault_role(),
                 newConfig.getConfig().dates_to_query());
         try {


### PR DESCRIPTION
This PR allows for the role of the attendee to be configured. As long as at least one of the roles given matches with the providers for an appointment (and both are set), we accept the given provider.

![image](https://user-images.githubusercontent.com/4656440/166325727-caf4b024-cee5-4da4-ab93-8dc744b4de8f.png)


