### PR TITLE
Misc: Fix mock_torch.js so that it works with the version of Express.js available in Debian 11

### DIFF
--- a/Utilities/Development/mock_torch.js
+++ b/Utilities/Development/mock_torch.js
@@ -175,7 +175,7 @@ const graphQlResponse = {
   }
 };
 
-webApp.post('*', (req, res) => {
+webApp.post('(.*)', (req, res) => {
   console.log("GraphQL QUERY => " + req.body);
   console.log("");
   console.log("RESPONSE <= " + JSON.stringify(graphQlResponse));

--- a/Utilities/Development/mock_torch.js
+++ b/Utilities/Development/mock_torch.js
@@ -175,7 +175,7 @@ const graphQlResponse = {
   }
 };
 
-webApp.post('(.*)', (req, res) => {
+webApp.post(/.*/, (req, res) => {
   console.log("GraphQL QUERY => " + req.body);
   console.log("");
   console.log("RESPONSE <= " + JSON.stringify(graphQlResponse));


### PR DESCRIPTION
Newer versions of Express.js no longer allow for wildcard (`*`) paths but instead require the use of regular expressions (`(.*)`).

To test this PR, follow the instructions at https://github.com/data-team-uhn/cards/pull/979#issue-1174062988 and ensure that you are able to import (from the Mock Torch server) an upcoming appointment.