### PR TITLE
Misc: Fix mock_slack.js so that it works with the version of Express.js available in Debian 11

### DIFF
--- a/Utilities/Development/mock_slack.js
+++ b/Utilities/Development/mock_slack.js
@@ -29,7 +29,7 @@ const webApp = express();
 webApp.use(bodyParser.text({type: '*/*'}));
 const webServer = require('http').createServer(webApp);
 
-webApp.post('*', (req, res) => {
+webApp.post(/.*/, (req, res) => {
   console.log("Slack API Request => " + req.body);
   console.log("");
   res.json({"success": true});


### PR DESCRIPTION
To test, follow the testing instructions in the _Testing setup_ section of https://github.com/data-team-uhn/cards/pull/970#issue-1165556431 and ensure that messages are sent to the mock Slack server once every minute.