### PR TITLE
Misc httprequests improvements

### DIFF
--- a/modules/http-requests/src/main/java/io/uhndata/cards/httprequests/HttpRequests.java
+++ b/modules/http-requests/src/main/java/io/uhndata/cards/httprequests/HttpRequests.java
@@ -71,14 +71,7 @@ public final class HttpRequests
     public static String getPostResponse(final String url, final String data, final String contentType)
         throws IOException
     {
-        CloseableHttpClient client = HttpClients.createDefault();
-        HttpPost httpPost = new HttpPost(url);
-        StringEntity entity = new StringEntity(data, "UTF-8");
-        httpPost.setEntity(entity);
-        httpPost.setHeader("Content-type", contentType);
-        CloseableHttpResponse response = client.execute(httpPost);
-        String responseString = readInputStream(response.getEntity().getContent());
-        client.close();
-        return responseString;
+        HttpResponse httpResponse = doHttpPost(url, data, contentType);
+        return httpResponse.getResponsePayload();
     }
 }

--- a/modules/http-requests/src/main/java/io/uhndata/cards/httprequests/HttpRequests.java
+++ b/modules/http-requests/src/main/java/io/uhndata/cards/httprequests/HttpRequests.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
+import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
@@ -48,12 +49,31 @@ public final class HttpRequests
         return retVal.toString();
     }
 
+    public static HttpResponse doHttpPost(final String url, final String data, final String contentType)
+        throws IOException
+    {
+        CloseableHttpClient client = HttpClients.createDefault();
+        HttpPost httpPost = new HttpPost(url);
+        StringEntity entity = new StringEntity(data, "UTF-8");
+        httpPost.setEntity(entity);
+        httpPost.setHeader("Content-type", contentType);
+        CloseableHttpResponse response = client.execute(httpPost);
+        String responseString = readInputStream(response.getEntity().getContent());
+        StatusLine statusLine = response.getStatusLine();
+        HttpResponse httpResponse = new HttpResponse(-1, responseString);
+        if (statusLine != null) {
+            httpResponse.setStatusCode(statusLine.getStatusCode());
+        }
+        client.close();
+        return httpResponse;
+    }
+
     public static String getPostResponse(final String url, final String data, final String contentType)
         throws IOException
     {
         CloseableHttpClient client = HttpClients.createDefault();
         HttpPost httpPost = new HttpPost(url);
-        StringEntity entity = new StringEntity(data);
+        StringEntity entity = new StringEntity(data, "UTF-8");
         httpPost.setEntity(entity);
         httpPost.setHeader("Content-type", contentType);
         CloseableHttpResponse response = client.execute(httpPost);

--- a/modules/http-requests/src/main/java/io/uhndata/cards/httprequests/HttpRequests.java
+++ b/modules/http-requests/src/main/java/io/uhndata/cards/httprequests/HttpRequests.java
@@ -49,12 +49,13 @@ public final class HttpRequests
         return retVal.toString();
     }
 
-    public static HttpResponse doHttpPost(final String url, final String data, final String contentType)
+    public static HttpResponse doHttpPost(final String url, final String data, final String contentType,
+        final String payloadEncoding)
         throws IOException
     {
         CloseableHttpClient client = HttpClients.createDefault();
         HttpPost httpPost = new HttpPost(url);
-        StringEntity entity = new StringEntity(data, "UTF-8");
+        StringEntity entity = new StringEntity(data, payloadEncoding);
         httpPost.setEntity(entity);
         httpPost.setHeader("Content-type", contentType);
         CloseableHttpResponse response = client.execute(httpPost);
@@ -68,10 +69,23 @@ public final class HttpRequests
         return httpResponse;
     }
 
+    public static HttpResponse doHttpPost(final String url, final String data, final String contentType)
+        throws IOException
+    {
+        return doHttpPost(url, data, contentType, "UTF-8");
+    }
+
     public static String getPostResponse(final String url, final String data, final String contentType)
         throws IOException
     {
         HttpResponse httpResponse = doHttpPost(url, data, contentType);
+        return httpResponse.getResponsePayload();
+    }
+
+    public static String getPostResponse(final String url, final String data, final String contentType,
+        final String payloadEncoding) throws IOException
+    {
+        HttpResponse httpResponse = doHttpPost(url, data, contentType, payloadEncoding);
         return httpResponse.getResponsePayload();
     }
 }

--- a/modules/http-requests/src/main/java/io/uhndata/cards/httprequests/HttpResponse.java
+++ b/modules/http-requests/src/main/java/io/uhndata/cards/httprequests/HttpResponse.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.httprequests;
+
+public class HttpResponse
+{
+    private int statusCode;
+    private String responsePayload;
+
+    public HttpResponse(int statusCode, String responsePayload)
+    {
+        this.statusCode = statusCode;
+        this.responsePayload = responsePayload;
+    }
+
+    public int getStatusCode()
+    {
+        return this.statusCode;
+    }
+
+    public String getResponsePayload()
+    {
+        return this.responsePayload;
+    }
+
+    public void setStatusCode(int statusCode)
+    {
+        this.statusCode = statusCode;
+    }
+
+    public void setResponsePayload(String responsePayload)
+    {
+        this.responsePayload = responsePayload;
+    }
+}


### PR DESCRIPTION
This PR adds various improvements to the `http-requests` CARDS module, namely the ability to send POST payloads encoded in UTF-8 as well as the ability to read the HTTP response code sent back by the server.

These improvements are required for implementing the JSON-based data backup (CARDS-1759).

To test, build this branch and follow the testing instructions in the _Testing setup_ section of https://github.com/data-team-uhn/cards/pull/970#issue-1165556431 and ensure that messages are sent to the mock Slack server once every minute.