### PR TITLE
Misc: Cards4Proms docker_entry.sh fix - automatically enable the cards-email-notifications module in cards4proms mode

### DIFF
--- a/distribution/docker_entry.sh
+++ b/distribution/docker_entry.sh
@@ -55,6 +55,7 @@ then
 elif [[ "${CARDS_PROJECT}" == 'cards4proms' ]]
 then
   featureFlagString="$featureFlagString -f mvn:io.uhndata.cards/cards4proms/${PROJECT_VERSION}/slingosgifeature"
+  SMTPS_ENABLED="true"
 fi
 
 if [ ! -z $DEV ]
@@ -105,6 +106,7 @@ do
   elif [[ ${legacyRunMode} == 'proms' ]]
   then
     featureFlagString="$featureFlagString -f mvn:io.uhndata.cards/cards4proms/${PROJECT_VERSION}/slingosgifeature"
+    SMTPS_ENABLED="true"
   elif [[ ${legacyRunMode} == 'test' ]]
   then
     featureFlagString="$featureFlagString -f mvn:io.uhndata.cards/cards-modules-test-forms/${PROJECT_VERSION}/slingosgifeature"


### PR DESCRIPTION
This PR causes the `cards-email-notifiations` module to be automatically enabled whenever a CARDS Docker container is started in `cards4proms` mode.

To test:

- Build the latest **`dev`** branch. (`git checkout dev && mvn clean install`)
- Attempt to start a simple Cards4Proms Docker container:
  - `cd compose-cluster`
  - `./cleanup.sh`
  - `python3 generate_compose_yaml.py --dev_docker_image --oak_filesystem --cards_project cards4proms && docker-compose build && docker-compose up -d`
- Visiting `http://localhost:8080` will perpetually show _CARDS is starting up, please wait_ but never actually start.
- If you run `docker-compose logs cardsinitial`, you will see an error message `org.osgi.framework.BundleException: Unable to resolve io.uhndata.cards.proms-backend` ... `osgi.wiring.package=io.uhndata.cards.emailnotifications`...
- Bring the Docker Compose environment down (`docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`)
- Build this **`misc-cards4proms-docker_entry-fix`** branch. (`git checkout misc-cards4proms-docker_entry-fix && mvn clean install`)
- Start a simple Cards4Proms Docker container:
  - `cd compose-cluster`
  - `./cleanup.sh`
  - `python3 generate_compose_yaml.py --dev_docker_image --oak_filesystem --cards_project cards4proms && docker-compose build && docker-compose up -d`
- Cards4Proms will start on `http://localhost:8080`
- Bring the Docker Compose environment down (`docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`)