### PR TITLE
CARDS-1726: Create a simple placeholder html page template to be displayed when CARDS is down

### DIFF
--- a/compose-cluster/cleanup.sh
+++ b/compose-cluster/cleanup.sh
@@ -32,6 +32,9 @@ rm mongos/mongo-router.conf
 echo "Removing proxy/000-default.conf"
 rm proxy/000-default.conf
 
+echo "Removing proxy/proxyerror/logo.png"
+rm proxy/proxyerror/logo.png
+
 echo "Removing smtps_localhost_proxy/nginx.conf"
 rm smtps_localhost_proxy/nginx.conf
 

--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -111,6 +111,21 @@ def generateSelfSignedCert():
   pem_cert = crypto.dump_certificate(crypto.FILETYPE_PEM, cert).decode('utf-8')
   return pem_key, pem_cert
 
+def getCardsProjectLogoPath(project_name):
+  logoPathMap = {}
+  logoPathMap['cards4care'] = "cardiac-rehab-resources/clinical-data/src/main/media/SLING-INF/content/libs/cards/resources/logo_light_bg.png"
+  logoPathMap['cards4kids'] = "kids-resources/clinical-data/src/main/media/SLING-INF/content/libs/cards/resources/logo_light_bg.png"
+  logoPathMap['cards4lfs'] = "lfs-resources/clinical-data/src/main/media/SLING-INF/content/libs/cards/resources/logo_light_bg.png"
+  logoPathMap['cards4proms'] = "proms-resources/clinical-data/src/main/media/SLING-INF/content/libs/cards/resources/logo_light_bg.png"
+
+  #Default logo if CARDS project is not specified
+  projectLogoPath = "modules/homepage/src/main/media/SLING-INF/content/libs/cards/resources/logo_light_bg.png"
+
+  if project_name in logoPathMap:
+    projectLogoPath = logoPathMap[project_name]
+
+  return "../" + projectLogoPath
+
 OUTPUT_FILENAME = "docker-compose.yml"
 
 yaml_obj = {}
@@ -388,6 +403,9 @@ yaml_obj['services']['proxy']['networks']['internalnetwork']['aliases'] = ['prox
 yaml_obj['services']['proxy']['depends_on'] = ['cardsinitial']
 if ENABLE_NCR:
   yaml_obj['services']['proxy']['depends_on'].append('neuralcr')
+
+#Add the appropriate CARDS logo (eg. DATAPRO, Cards4CaRe, etc...) for the selected project
+shutil.copyfile(getCardsProjectLogoPath(args.cards_project), "./proxy/proxyerror/logo.png")
 
 if SSL_PROXY:
   if args.saml:

--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -113,6 +113,13 @@ def generateSelfSignedCert():
 
 def getPathToProjectResourcesDirectory(project_name):
   CARDS4_PREFIX = "cards4"
+  resourcesPathMap = {}
+  resourcesPathMap['cards4care'] = "../cardiac-rehab-resources/"
+
+  # If an entry for this project_name exists in resourcesPathMap use it instead of anything else
+  if project_name in resourcesPathMap:
+    return resourcesPathMap[project_name]
+
   if not project_name.startswith(CARDS4_PREFIX):
     return None
 
@@ -162,14 +169,6 @@ def getLogoByResourcesDirectory(project_name):
   return logo_light_path
 
 def getCardsProjectLogoPath(project_name):
-  logoPathMap = {}
-  logoPathMap['cards4care'] = "cardiac-rehab-resources/clinical-data/src/main/media/SLING-INF/content/libs/cards/resources/media/care/logo_light_bg.png"
-
-  # If an entry for this project_name exists in logoPathMap use it instead of anything else
-  if project_name in logoPathMap:
-    projectLogoPath = "../" + logoPathMap[project_name]
-    return projectLogoPath
-
   # Try to see if a {project_id}-resources directory exists that can be used for obtaining the logo
   projectLogoPath = getLogoByResourcesDirectory(project_name)
   if projectLogoPath is not None:
@@ -203,13 +202,6 @@ def getApplicationNameByResourcesDirectory(project_name):
   return appname_config['AppName']
 
 def getCardsApplicationName(project_name):
-  projectApplicationNameMap = {}
-  projectApplicationNameMap['cards4care'] = "Cards 4 CaRe"
-
-  # If an entry for this project_name exists in projectApplicationNameMap use it instead of anything else
-  if project_name in projectApplicationNameMap:
-    return projectApplicationNameMap[project_name]
-
   # Try to see if a {project_id}-resources directory exists that can be used for obtaining the logo
   projectAppName = getApplicationNameByResourcesDirectory(project_name)
   if projectAppName is not None:

--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -169,10 +169,11 @@ def getLogoByResourcesDirectory(project_name):
   return logo_light_path
 
 def getCardsProjectLogoPath(project_name):
-  # Try to see if a {project_id}-resources directory exists that can be used for obtaining the logo
-  projectLogoPath = getLogoByResourcesDirectory(project_name)
-  if projectLogoPath is not None:
-    return projectLogoPath
+  if project_name is not None:
+    # Try to see if a {project_id}-resources directory exists that can be used for obtaining the logo
+    projectLogoPath = getLogoByResourcesDirectory(project_name)
+    if projectLogoPath is not None:
+      return projectLogoPath
 
   # If all else fails, use the default CARDS logo
   projectLogoPath = "../modules/homepage/src/main/media/SLING-INF/content/libs/cards/resources/media/default/logo_light_bg.png"
@@ -202,10 +203,11 @@ def getApplicationNameByResourcesDirectory(project_name):
   return appname_config['AppName']
 
 def getCardsApplicationName(project_name):
-  # Try to see if a {project_id}-resources directory exists that can be used for obtaining the logo
-  projectAppName = getApplicationNameByResourcesDirectory(project_name)
-  if projectAppName is not None:
-    return projectAppName
+  if project_name is not None:
+    # Try to see if a {project_id}-resources directory exists that can be used for obtaining the logo
+    projectAppName = getApplicationNameByResourcesDirectory(project_name)
+    if projectAppName is not None:
+      return projectAppName
 
   # If all else fails, use the generic CARDS name
   return "CARDS"

--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -119,7 +119,7 @@ def getCardsProjectLogoPath(project_name):
   logoPathMap['cards4proms'] = "proms-resources/clinical-data/src/main/media/SLING-INF/content/libs/cards/resources/media/proms/logo_light_bg.png"
 
   #Default logo if CARDS project is not specified
-  projectLogoPath = "modules/homepage/src/main/media/SLING-INF/content/libs/cards/resources/logo_light_bg.png"
+  projectLogoPath = "modules/homepage/src/main/media/SLING-INF/content/libs/cards/resources/media/default/logo_light_bg.png"
 
   if project_name in logoPathMap:
     projectLogoPath = logoPathMap[project_name]

--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -111,21 +111,27 @@ def generateSelfSignedCert():
   pem_cert = crypto.dump_certificate(crypto.FILETYPE_PEM, cert).decode('utf-8')
   return pem_key, pem_cert
 
-def getPathToConfDirectory(project_name):
+def getPathToProjectResourcesDirectory(project_name):
   CARDS4_PREFIX = "cards4"
   if not project_name.startswith(CARDS4_PREFIX):
     return None
 
   project_id = project_name[len(CARDS4_PREFIX):]
-  return "../{}-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/conf/".format(project_id)
+  return "../{}-resources/".format(project_id)
+
+def getPathToConfDirectory(project_name):
+  project_resources_dir = getPathToProjectResourcesDirectory(project_name)
+  if project_resources_dir is not None:
+    return os.path.join(project_resources_dir, "clinical-data/src/main/resources/SLING-INF/content/libs/cards/conf/")
+
+  return None
 
 def getPathToMediaContentDirectory(project_name):
-  CARDS4_PREFIX = "cards4"
-  if not project_name.startswith(CARDS4_PREFIX):
-    return None
+  project_resources_dir = getPathToProjectResourcesDirectory(project_name)
+  if project_resources_dir is not None:
+    return os.path.join(project_resources_dir, "clinical-data/src/main/media/SLING-INF/content")
 
-  project_id = project_name[len(CARDS4_PREFIX):]
-  return "../{}-resources/clinical-data/src/main/media/SLING-INF/content".format(project_id)
+  return None
 
 def getLogoByResourcesDirectory(project_name):
   path_to_media_json = os.path.join(getPathToConfDirectory(project_name), "Media.json")

--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -113,10 +113,10 @@ def generateSelfSignedCert():
 
 def getCardsProjectLogoPath(project_name):
   logoPathMap = {}
-  logoPathMap['cards4care'] = "cardiac-rehab-resources/clinical-data/src/main/media/SLING-INF/content/libs/cards/resources/logo_light_bg.png"
-  logoPathMap['cards4kids'] = "kids-resources/clinical-data/src/main/media/SLING-INF/content/libs/cards/resources/logo_light_bg.png"
-  logoPathMap['cards4lfs'] = "lfs-resources/clinical-data/src/main/media/SLING-INF/content/libs/cards/resources/logo_light_bg.png"
-  logoPathMap['cards4proms'] = "proms-resources/clinical-data/src/main/media/SLING-INF/content/libs/cards/resources/logo_light_bg.png"
+  logoPathMap['cards4care'] = "cardiac-rehab-resources/clinical-data/src/main/media/SLING-INF/content/libs/cards/resources/media/care/logo_light_bg.png"
+  logoPathMap['cards4kids'] = "kids-resources/clinical-data/src/main/media/SLING-INF/content/libs/cards/resources/media/kids/logo_light_bg.png"
+  logoPathMap['cards4lfs'] = "lfs-resources/clinical-data/src/main/media/SLING-INF/content/libs/cards/resources/media/lfs/logo_light_bg.png"
+  logoPathMap['cards4proms'] = "proms-resources/clinical-data/src/main/media/SLING-INF/content/libs/cards/resources/media/proms/logo_light_bg.png"
 
   #Default logo if CARDS project is not specified
   projectLogoPath = "modules/homepage/src/main/media/SLING-INF/content/libs/cards/resources/logo_light_bg.png"

--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -126,6 +126,18 @@ def getCardsProjectLogoPath(project_name):
 
   return "../" + projectLogoPath
 
+def getCardsApplicationName(project_name):
+  projectApplicationNameMap = {}
+  projectApplicationNameMap['cards4care'] = "Cards 4 CaRe"
+  projectApplicationNameMap['cards4kids'] = "WilliamsDB"
+  projectApplicationNameMap['cards4lfs'] = "LFS Data Core"
+  projectApplicationNameMap['cards4proms'] = "DATA-PRO"
+
+  if project_name in projectApplicationNameMap:
+    return projectApplicationNameMap[project_name]
+  else:
+    return "CARDS"
+
 OUTPUT_FILENAME = "docker-compose.yml"
 
 yaml_obj = {}
@@ -407,6 +419,10 @@ if ENABLE_NCR:
 #Add the appropriate CARDS logo (eg. DATAPRO, Cards4CaRe, etc...) for the selected project
 shutil.copyfile(getCardsProjectLogoPath(args.cards_project), "./proxy/proxyerror/logo.png")
 
+#Specify the Application Name of the CARDS project to the proxy
+yaml_obj['services']['proxy']['environment'] = []
+yaml_obj['services']['proxy']['environment'].append("CARDS_APP_NAME={}".format(getCardsApplicationName(args.cards_project)))
+
 if SSL_PROXY:
   if args.saml:
     shutil.copyfile("proxy/https_saml_000-default.conf", "proxy/000-default.conf")
@@ -424,8 +440,6 @@ else:
     shutil.copyfile("proxy/http_000-default.conf", "proxy/000-default.conf")
 
 if args.saml:
-  yaml_obj['services']['proxy']['environment'] = []
-
   if args.saml_idp_destination:
     idp_url = args.saml_idp_destination
   else:

--- a/compose-cluster/proxy/Dockerfile
+++ b/compose-cluster/proxy/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update
 RUN apt-get -y install \
 	apache2 \
 	nodejs \
-	node-fetch
+	node-fetch \
+	node-mustache
 
 RUN a2enmod proxy
 RUN a2enmod proxy_http
@@ -31,6 +32,7 @@ RUN a2enmod ssl
 COPY 000-default.conf /etc/apache2/sites-enabled/000-default.conf
 COPY proxyerror /var/www/html/proxyerror
 COPY http_proxy.js /http_proxy.js
+COPY render_503_page.js /render_503_page.js
 
 COPY startup.sh /startup.sh
 RUN chmod +x /startup.sh

--- a/compose-cluster/proxy/Dockerfile
+++ b/compose-cluster/proxy/Dockerfile
@@ -29,7 +29,7 @@ RUN a2enmod headers
 RUN a2enmod ssl
 
 COPY 000-default.conf /etc/apache2/sites-enabled/000-default.conf
-
+COPY proxyerror /var/www/html/proxyerror
 COPY http_proxy.js /http_proxy.js
 
 COPY startup.sh /startup.sh

--- a/compose-cluster/proxy/http_000-default.conf
+++ b/compose-cluster/proxy/http_000-default.conf
@@ -18,11 +18,15 @@
 <VirtualHost *:80>
 	Header unset WWW-Authenticate
 	ProxyPreserveHost On
-	
+
+	DocumentRoot "/var/www/html"
+	ProxyPass /proxyerror/ !
+	ErrorDocument 503 /proxyerror/503.html
+
 	ProxyPass /ncr/ http://127.0.0.1:8600/
 	ProxyPassReverse /ncr/ http://127.0.0.1:8600/
-	
+
 	ProxyPass / http://cardsinitial:8080/
 	ProxyPassReverse / http://cardsinitial:8080/
-	
+
 </VirtualHost>

--- a/compose-cluster/proxy/http_saml_000-default.conf
+++ b/compose-cluster/proxy/http_saml_000-default.conf
@@ -20,6 +20,10 @@
 	Header unset WWW-Authenticate
 	ProxyPreserveHost On
 
+	DocumentRoot "/var/www/html"
+	ProxyPass /proxyerror/ !
+	ErrorDocument 503 /proxyerror/503.html
+
 	<Location "/">
 		Header edit Location ${SAML_IDP_DESTINATION}.* http://${CARDS_HOST_AND_PORT}/login "expr=(%{REQUEST_STATUS} == 302) && (%{REQUEST_URI} != '/fetch_requires_saml_login.html') && (%{REQUEST_URI} != '/goto_saml_login')"
 		ProxyPass http://cardsinitial:8080/

--- a/compose-cluster/proxy/http_saml_000-default.conf
+++ b/compose-cluster/proxy/http_saml_000-default.conf
@@ -21,13 +21,16 @@
 	ProxyPreserveHost On
 
 	DocumentRoot "/var/www/html"
-	ProxyPass /proxyerror/ !
 	ErrorDocument 503 /proxyerror/503.html
 
 	<Location "/">
 		Header edit Location ${SAML_IDP_DESTINATION}.* http://${CARDS_HOST_AND_PORT}/login "expr=(%{REQUEST_STATUS} == 302) && (%{REQUEST_URI} != '/fetch_requires_saml_login.html') && (%{REQUEST_URI} != '/goto_saml_login')"
 		ProxyPass http://cardsinitial:8080/
 		ProxyPassReverse http://cardsinitial:8080/
+	</Location>
+
+	<Location "/proxyerror">
+		ProxyPass !
 	</Location>
 
 	<Location "/goto_saml_login">

--- a/compose-cluster/proxy/https_000-default.conf
+++ b/compose-cluster/proxy/https_000-default.conf
@@ -29,11 +29,15 @@
 	Header edit location ^http://(.*)$ https://$1
 	Header edit Set-Cookie ^(.*)$ $1;Secure
 	ProxyPreserveHost On
-	
+
+	DocumentRoot "/var/www/html"
+	ProxyPass /proxyerror/ !
+	ErrorDocument 503 /proxyerror/503.html
+
 	ProxyPass /ncr/ http://127.0.0.1:8600/
 	ProxyPassReverse /ncr/ http://127.0.0.1:8600/
-	
+
 	ProxyPass / http://cardsinitial:8080/
 	ProxyPassReverse / http://cardsinitial:8080/
-	
+
 </VirtualHost>

--- a/compose-cluster/proxy/https_saml_000-default.conf
+++ b/compose-cluster/proxy/https_saml_000-default.conf
@@ -31,13 +31,16 @@
 	ProxyPreserveHost On
 
 	DocumentRoot "/var/www/html"
-	ProxyPass /proxyerror/ !
 	ErrorDocument 503 /proxyerror/503.html
 
 	<Location "/">
 		Header edit Location ${SAML_IDP_DESTINATION}.* https://${CARDS_HOST_AND_PORT}/login "expr=(%{REQUEST_STATUS} == 302) && (%{REQUEST_URI} != '/fetch_requires_saml_login.html') && (%{REQUEST_URI} != '/goto_saml_login')"
 		ProxyPass http://cardsinitial:8080/
 		ProxyPassReverse http://cardsinitial:8080/
+	</Location>
+
+	<Location "/proxyerror">
+		ProxyPass !
 	</Location>
 
 	<Location "/goto_saml_login">

--- a/compose-cluster/proxy/https_saml_000-default.conf
+++ b/compose-cluster/proxy/https_saml_000-default.conf
@@ -30,6 +30,10 @@
 	Header edit Set-Cookie ^(.*)$ $1;Secure
 	ProxyPreserveHost On
 
+	DocumentRoot "/var/www/html"
+	ProxyPass /proxyerror/ !
+	ErrorDocument 503 /proxyerror/503.html
+
 	<Location "/">
 		Header edit Location ${SAML_IDP_DESTINATION}.* https://${CARDS_HOST_AND_PORT}/login "expr=(%{REQUEST_STATUS} == 302) && (%{REQUEST_URI} != '/fetch_requires_saml_login.html') && (%{REQUEST_URI} != '/goto_saml_login')"
 		ProxyPass http://cardsinitial:8080/

--- a/compose-cluster/proxy/proxyerror/503.html
+++ b/compose-cluster/proxy/proxyerror/503.html
@@ -1,0 +1,26 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<html>
+  <head>
+    <title>CARDS is down</title>
+  </head>
+  <body>
+    <h1>CARDS is down</h1>
+  </body>
+</html>

--- a/compose-cluster/proxy/proxyerror/503.html
+++ b/compose-cluster/proxy/proxyerror/503.html
@@ -22,5 +22,6 @@
   </head>
   <body>
     <h1>CARDS is down</h1>
+    <img src="/proxyerror/logo.png"/>
   </body>
 </html>

--- a/compose-cluster/proxy/proxyerror/503.html.template
+++ b/compose-cluster/proxy/proxyerror/503.html.template
@@ -22,10 +22,10 @@
   </head>
   <body>
     <div style="display: flex; align-items: center; justify-content: center; height: 100%">
-      <div style="text-align: center">
-        <img style="width: 75%" src="/proxyerror/logo.png"/>
-        <p style="font-family: sans">{{CARDS_APP_NAME}} is down for maintenance.</p>
-        <p style="font-family: sans">We apoligize for any inconvenience this may cause.</p>
+      <div style="color: #024; font-family: sans; font-size: large; text-align: center">
+        <img style="margin-bottom: 40px; max-width: 500px; width: 100%" src="/proxyerror/logo.png"/>
+        <h1>{{CARDS_APP_NAME}} is down for maintenance</h1>
+        <p>We apologize for any inconvenience this may cause.</p>
       </div>
     </div>
   </body>

--- a/compose-cluster/proxy/proxyerror/503.html.template
+++ b/compose-cluster/proxy/proxyerror/503.html.template
@@ -20,9 +20,13 @@
   <head>
     <title>{{CARDS_APP_NAME}} is down</title>
   </head>
-  <body style="text-align: center">
-    <img style="width: 25%" src="/proxyerror/logo.png"/>
-    <p style="font-family: sans">{{CARDS_APP_NAME}} is down for maintenance.</p>
-    <p style="font-family: sans">We apoligize for any inconvenience this may cause.</p>
+  <body>
+    <div style="display: flex; align-items: center; justify-content: center; height: 100%">
+      <div style="text-align: center">
+        <img style="width: 25%" src="/proxyerror/logo.png"/>
+        <p style="font-family: sans">{{CARDS_APP_NAME}} is down for maintenance.</p>
+        <p style="font-family: sans">We apoligize for any inconvenience this may cause.</p>
+      </div>
+    </div>
   </body>
 </html>

--- a/compose-cluster/proxy/proxyerror/503.html.template
+++ b/compose-cluster/proxy/proxyerror/503.html.template
@@ -23,7 +23,7 @@
   <body>
     <div style="display: flex; align-items: center; justify-content: center; height: 100%">
       <div style="text-align: center">
-        <img style="width: 25%" src="/proxyerror/logo.png"/>
+        <img style="width: 75%" src="/proxyerror/logo.png"/>
         <p style="font-family: sans">{{CARDS_APP_NAME}} is down for maintenance.</p>
         <p style="font-family: sans">We apoligize for any inconvenience this may cause.</p>
       </div>

--- a/compose-cluster/proxy/proxyerror/503.html.template
+++ b/compose-cluster/proxy/proxyerror/503.html.template
@@ -20,9 +20,9 @@
   <head>
     <title>{{CARDS_APP_NAME}} is down</title>
   </head>
-  <body>
-    <img src="/proxyerror/logo.png"/>
-    <p>{{CARDS_APP_NAME}} is down for maintenance.</p>
-    <p>We apoligize for any inconvenience this may cause.</p>
+  <body style="text-align: center">
+    <img style="width: 25%" src="/proxyerror/logo.png"/>
+    <p style="font-family: sans">{{CARDS_APP_NAME}} is down for maintenance.</p>
+    <p style="font-family: sans">We apoligize for any inconvenience this may cause.</p>
   </body>
 </html>

--- a/compose-cluster/proxy/proxyerror/503.html.template
+++ b/compose-cluster/proxy/proxyerror/503.html.template
@@ -18,10 +18,11 @@
 -->
 <html>
   <head>
-    <title>CARDS is down</title>
+    <title>{{CARDS_APP_NAME}} is down</title>
   </head>
   <body>
-    <h1>CARDS is down</h1>
     <img src="/proxyerror/logo.png"/>
+    <p>{{CARDS_APP_NAME}} is down for maintenance.</p>
+    <p>We apoligize for any inconvenience this may cause.</p>
   </body>
 </html>

--- a/compose-cluster/proxy/proxyerror/503.html.template
+++ b/compose-cluster/proxy/proxyerror/503.html.template
@@ -22,7 +22,7 @@
   </head>
   <body>
     <div style="display: flex; align-items: center; justify-content: center; height: 100%">
-      <div style="color: #024; font-family: sans; font-size: large; text-align: center">
+      <div style="color: #024; font-family: sans-serif; font-size: large; text-align: center">
         <img style="margin-bottom: 40px; max-width: 500px; width: 100%" src="/proxyerror/logo.png"/>
         <h1>{{CARDS_APP_NAME}} is down for maintenance</h1>
         <p>We apologize for any inconvenience this may cause.</p>

--- a/compose-cluster/proxy/render_503_page.js
+++ b/compose-cluster/proxy/render_503_page.js
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+const fs = require('fs');
+const process = require('process');
+const mustache = require('mustache');
+
+fs.writeFileSync(
+  "/var/www/html/proxyerror/503.html",
+  mustache.render(
+    fs.readFileSync("/var/www/html/proxyerror/503.html.template", "utf-8"),
+    process.env
+  )
+);

--- a/compose-cluster/proxy/startup.sh
+++ b/compose-cluster/proxy/startup.sh
@@ -17,5 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
+nodejs /render_503_page.js
 nodejs /http_proxy.js &
 apachectl -D FOREGROUND


### PR DESCRIPTION
This PR adds a project-specific _CARDS is down_ page that is returned to the client by the reverse proxy whenever the CARDS Docker container is unavailable.

To test:

- Build this branch with `mvn clean install`.
- `cd compose-cluster`
- For each project in `cards4care`, `cards4kids`, `cards4lfs`, `cards4proms`:
  - `python3 generate_compose_yaml.py --dev_docker_image --oak_filesystem --cards_project <PROJECT NAME> && docker-compose build && docker-compose up -d`, replacing `<PROJECT NAME>` with the actual project name (eg. `cards4care`).
  - Wait for CARDS to become available at `http://localhost:8080`
  - `docker-compose stop cardsinitial`
  - Visiting `http://localhost:8080` should now show the project-specific _down for maintenance_ page.
  - `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`
- Also, attempt the above with a generic CARDS deployment (ie. don't specify the `--cards_project` parameter)
- Verify that this works in all 4 proxy modes: HTTP, HTTP+SAML, HTTPS, HTTPS+SAML.