### PR TITLE
CARDS-1790: Concept Recognition Test Form is not highlighting potential terms

### DIFF
--- a/test-resources/src/main/java/io/uhndata/cards/test/MockNCREndpoint.java
+++ b/test-resources/src/main/java/io/uhndata/cards/test/MockNCREndpoint.java
@@ -69,11 +69,11 @@ public class MockNCREndpoint extends SlingSafeMethodsServlet
     {
         if (text == null) {
             return "{\"matches\": []}";
-        } else if (MOCK_NCR_INPUT_1.equals(text)) {
+        } else if (MOCK_NCR_INPUT_1.equals(text.stripTrailing())) {
             return MOCK_NCR_OUTPUT_1;
-        } else if (MOCK_NCR_INPUT_2.equals(text)) {
+        } else if (MOCK_NCR_INPUT_2.equals(text.stripTrailing())) {
             return MOCK_NCR_OUTPUT_2;
-        } else if (MOCK_NCR_INPUT_3.equals(text)) {
+        } else if (MOCK_NCR_INPUT_3.equals(text.stripTrailing())) {
             return MOCK_NCR_OUTPUT_3;
         }
         return "{\"matches\": []}";


### PR DESCRIPTION
This PR fixes the CARDS-1790 issue by removing trailing whitespace from the input text when matching it to a pre-defined mock-NCR response.

To test:

- Build this branch (`mvn clean install`)
- Start CARDS with the `test` Forms enabled (`./start_cards.sh --test`)
- Create a new _Concept Recognition Test_ Form for the _Sample_ Patient
- Try the test sentences in the _Notes_ field of the _Co-morbidities_ question. Append spaces and/or blank lines to the end of the sentence. The text should be annotated as expected.