### PR TITLE
[misc] Skipping Vault authentication for PROMS import is not possible

### DIFF
--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportTask.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportTask.java
@@ -163,7 +163,7 @@ public class ImportTask implements Runnable
         String token = "Bearer " + this.vaultToken;
 
         // If we have no role to login to, we can skip the rest of the Vault auth process
-        if ("".equals(this.vaultRole)) {
+        if (StringUtils.isBlank(this.vaultRole)) {
             return token;
         }
 


### PR DESCRIPTION
Skipping the login to Vault step should in theory be possible by not providing any role name in the configuration, but in practice this does not work because an empty role is stored not as an empty string, but as a null, and the code only expects an empty string in this scenario.

To test:
- start in proms mode
- start the mock torch server with `node ./mock_torch.js --nRandomPatients=3 --appointment-time-hours-from-now=24`
- configure the proms import at `http://localhost:8080/system/console/configMgr` by adding a new `PROMs import` configuration with
    - Name=mock
    - Endpoint URL=http://localhost:8011/graphql
    - Clinic names=asd
    - leave Vault role name empty
- trigger an import at `http://localhost:8080/Subjects.importTorch.json?config=mock`
- check that the 3 patients have been successfully imported