### PR TITLE
CARDS-1708: The Patient chart shows only 10 out of 10+ child subjects

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -56,6 +56,7 @@ import SubjectTimeline from "./SubjectTimeline.jsx";
 let createQueryURL = (query, type) => {
   let url = new URL("/query", window.location.origin);
   url.searchParams.set("query", `SELECT * FROM [${type}] as n` + query);
+  url.searchParams.set("limit", 1000);
   return url;
 }
 


### PR DESCRIPTION
Quick fix: Increased the `limit` of the query to 1000, the same upper bound we have when showing forms on the patient chart.