### PR TITLE
CARDS-1791: The terms are not visible enough when using text recognition

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/NCRNote.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/NCRNote.jsx
@@ -20,7 +20,7 @@
 import React, { useState, useRef } from "react";
 import PropTypes from "prop-types";
 
-import { CircularProgress, Link, Tooltip, Typography } from "@mui/material";
+import { CircularProgress, Chip, Tooltip, Typography } from "@mui/material";
 
 import withStyles from '@mui/styles/withStyles';
 
@@ -59,7 +59,7 @@ function ParsedNoteSection (props) {
     var endMatter = text.substring(lastMatch-offset);
   }
 
-  // Handle the user clicking on a link which corresponds to a suggestion
+  // Handle the user clicking on a chip which corresponds to a suggestion
   let addSuggestion = (event) => {
     event.preventDefault();
     onAddSuggestion(firstMatch[ONTOLOGY_KEY].replace(/:/g, ""), firstMatch["names"][0])
@@ -70,13 +70,11 @@ function ParsedNoteSection (props) {
     {hasMatch &&
       <React.Fragment>
         <Tooltip title={`Add ${matchName} (${matchID}) to selection`}>
-          <Link
+          <Chip
+            size="small"
             onClick={addSuggestion}
-            component="button"
-            underline="hover"
-            >
-            {/* Create a div purely to hold a ref for the above Tooltip */}
-            <span className={classes.NCRTooltip}>
+            color="info"
+            label={
               <ParsedNoteSection
                 tooltips={containedMatches}
                 text={containedMatter}
@@ -84,8 +82,8 @@ function ParsedNoteSection (props) {
                 classes={classes}
                 onAddSuggestion={onAddSuggestion}
                 />
-            </span>
-          </Link>
+            }
+          />
         </Tooltip>
         <ParsedNoteSection
           tooltips={uncontainedMatches}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -524,9 +524,6 @@ const questionnaireStyle = theme => ({
     invalidSubjectText: {
         fontStyle: "italic"
     },
-    NCRTooltip: {
-        color: theme.palette.primary.main
-    },
     NCRLoadingIndicator: {
         disable: "flex"
     },


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/CARDS-1791)

Displayed the terms as mui `Chip`s of `info` color. **Feedback on the best color to use is welcome.**

**Preview:**

![image](https://user-images.githubusercontent.com/651980/173076708-f4a7d677-ce52-41f9-85cb-8bb7299c7d7a.png)


**Known issue:**
On very narrow screens, a long text inside a Chip is not broken on multiple lines. Instead, the excess is hidden and marked with `...` at the right end.