### PR TITLE
CARDS-1801: The dashboard widgets don't take out the full screen width on narrow screens

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -98,7 +98,7 @@ function UserDashboard(props) {
         {
           dashboardExtensions.map((extension, index) => {
             let Extension = extension["cards:extensionRender"];
-            return <Grid item lg={12} xl={6} key={"extension-" + index} className={classes.dashboardEntry}>
+            return <Grid item xs={12} xl={6} key={"extension-" + index} className={classes.dashboardEntry}>
               <Extension />
             </Grid>
           })

--- a/modules/statistics/src/main/frontend/src/Statistics/Statistic.jsx
+++ b/modules/statistics/src/main/frontend/src/Statistics/Statistic.jsx
@@ -199,7 +199,7 @@ function Statistic(props) {
 
   let customStyle = disableClick ? {} : {cursor: "pointer"};
 
-  return <Grid item md={12} lg={6}>
+  return <Grid item xs={12} lg={6}>
     <Card className={classes.statsCard}>
       <CardHeader
         disableTypography

--- a/proms-resources/frontend/src/main/frontend/src/proms/PromsDashboard.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PromsDashboard.jsx
@@ -183,12 +183,12 @@ function PromsDashboard(props) {
       { description && <Typography variant="overline">{description}</Typography>}
       <Grid container spacing={4} className={classes.dashboardContainer}>
         {/* Appointments view */}
-        <Grid item lg={12} xl={6} key={`view-appointments-${clinicId}`} className={classes.dashboardEntry}>
+        <Grid item xs={12} xl={6} key={`view-appointments-${clinicId}`} className={classes.dashboardEntry}>
           <VisitView color={getColor(0)} visitInfo={visitInfo} clinicId={clinicId} />
         </Grid>
         {/* Survey views */}
         { surveys?.map((s, index) => (
-            <Grid item lg={12} xl={6} key={`view-survey-${clinicId}-${s["@name"]}`} className={classes.dashboardEntry}>
+            <Grid item xs={12} xl={6} key={`view-survey-${clinicId}-${s["@name"]}`} className={classes.dashboardEntry}>
               <PromsView data={s} color={getColor(index + 1)} visitInfo={visitInfo} clinicId={clinicId} />
             </Grid>
           ))
@@ -197,7 +197,7 @@ function PromsDashboard(props) {
         {
           dashboardExtensions.map((extension, index) => {
             let Extension = extension["cards:extensionRender"];
-            return <Grid item lg={12} xl={6} key={`extension-${clinicId}-${index}`} className={classes.dashboardEntry}>
+            return <Grid item xs={12} xl={6} key={`extension-${clinicId}-${index}`} className={classes.dashboardEntry}>
               <Extension data={extension["cards:data"]} color={getColor(index)} visitInfo={visitInfo} clinicId={clinicId} />
             </Grid>
           })


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/CARDS-1801).

**To test**:
* User Dashboard and PROMs Clinic dashboard **without any data in the widgets** (so that the widget doesn't expand to its content and mask the bug) on screen sizes under 1200px.
* Statistics Dashboard **without any data in the widgets** (so that the widget doesn't expand to its content and mask the bug) on screen sizes under 900px.