### PR TITLE
CARDS-1798: Sending SMTPS emails from CARDS is broken

### DIFF
--- a/modules/email-notifications/src/main/features/feature.json
+++ b/modules/email-notifications/src/main/features/feature.json
@@ -33,7 +33,7 @@
       "start-order":"25"
     },
     {
-      "id":"jakarta.activation:jakarta.activation-api:2.1.0",
+      "id":"jakarta.activation:jakarta.activation-api:2.0.1",
       "start-order":"25"
     },
     {


### PR DESCRIPTION
This PR changes the version of `jakarta.activation:jakarta.activation-api` back to `2.0.1` as it was before https://github.com/data-team-uhn/cards/pull/976.

Version 2.0.1 is the last version of Jakarta Activation to contain an implementation of the Jakarta Activation API. Implementation of the Jakarta Activation API is now part of Eclipse Angus - see https://github.com/eclipse-ee4j/jaf/blob/master/README.md. Switching to Eclipse Angus will take place in a separate task.

To test this PR, build this branch (`CARDS-1798`) with `mvn clean install` and follow the instructions in https://github.com/data-team-uhn/cards/blob/dev/Utilities/Development/EmailServer/README.md. Verify that emails are sent as expected.