### PR TITLE
CARDS-1797: provider.names parameter in OSGi configuration for PROMs Import is broken

### DIFF
--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/PatientLocalStorage.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/PatientLocalStorage.java
@@ -304,7 +304,7 @@ public class PatientLocalStorage
             if (provider.containsKey("role")) {
                 Boolean isAllowedRole = false;
                 for (final String allowedRole : this.providerRoles) {
-                    if (provider.getString("role") == allowedRole) {
+                    if (allowedRole.equals(provider.getString("role"))) {
                         isAllowedRole = true;
                         break;
                     }


### PR DESCRIPTION
This PR fixes the CARDS-1797 bug by replacing the incorrect `==` string comparison with the correct `.equals()` string comparison.

To test:
- Build this (`CARDS-1797`) branch with `mvn clean install`.
- Start CARDS in _Cards4Proms_ mode with `./start_cards.sh --dev --project cards4proms`.
- Start the mock Torch server by entering `Utilities/Development` and running `nodejs mock_torch.js --appointment-time-hours-from-now=24`.
- Visit `http://localhost:8080` and login as `admin`:`admin`.
- Visit `http://localhost:8080/system/console/configMgr` and create a new _PROMs Import` configuration with the following arguments:
  - `Name`: `LocalNodeJS`
  - `Import schedule`: `0 0 0 * * ? *`
  - `days to query`: `3`
  - `Endpoint URL`: `http://localhost:8011/`
  - `Authentication URL`: (leave blank)
  - `Vault token`: (leave blank)
  - `Clinic names`: `6012-HC-Congenital Cardiac`
  - `Provider names`: `SomeParticipantEID`
  - `Allowed provider roles`: `ATND`
  - `Vault role name`: (leave blank)
  - `Dates to query`: (leave blank)
- Trigger the import by visiting `http://localhost:8080/Subjects.importTorch?config=LocalNodeJS`
- Only the `12345 / AppointmentOneFhirID-Cardio` appointment should be created. No other _Patients_ or _Visits_ should be created.
- Following these steps on a build of `dev` will result in no data being imported.