### PR TITLE
CARDS-1800: Computed questions fail to evaluate with invalid question names

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -183,6 +183,11 @@ let ComputedQuestion = (props) => {
             "value": getQuestionValue(questionName, form, defaultValue)});
       }
 
+      if (missingValue) {
+        // Exit early as the expression cannot be evaluated without all inputs
+        return null;
+      }
+
       // Remove the start and end tags and replace the question name with the argument name for this question
       expr = [expr.substring(0, start), questions.get(questionName)["argument"],
         expr.substring(end + endTag.length)].join('');
@@ -197,18 +202,22 @@ let ComputedQuestion = (props) => {
     let expressionError = null;
     try {
       let parseResults = parseExpressionInputs(expression, form);
-      let questions = parseResults[0];
-      let parsedExpression = parseResults[1];
+      if (missingValue) {
+        result = ""
+      } else {
+        let questions = parseResults[0];
+        let parsedExpression = parseResults[1];
 
-      let expressionArguments = ["form", "setError"];
-      let expressionValues = [form, (errorMessage) => {expressionError = errorMessage}];
-      for(const question of questions.values()) {
-        expressionArguments.push(question["argument"]);
-        expressionValues.push(question["value"]);
-      };
-      result = new Function(expressionArguments, parsedExpression)(...expressionValues);
-      if (missingValue || typeof(result) === "undefined" || (typeof(result) === "number" && isNaN(result))) {
-        result = "";
+        let expressionArguments = ["form", "setError"];
+        let expressionValues = [form, (errorMessage) => {expressionError = errorMessage}];
+        for(const question of questions.values()) {
+          expressionArguments.push(question["argument"]);
+          expressionValues.push(question["value"]);
+        };
+        result = new Function(expressionArguments, parsedExpression)(...expressionValues);
+        if (typeof(result) === "undefined" || (typeof(result) === "number" && isNaN(result))) {
+          result = "";
+        }
       }
     }
     catch(err) {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -170,8 +170,8 @@ let ComputedQuestion = (props) => {
       let questionName;
       let defaultValue = null;
       if (hasDefault) {
-        questionName = expr.substring(start + startTag.length, optionStart);
-        defaultValue = expr.substring(optionStart + defaultTag.length, end);
+        questionName = expr.substring(start + startTag.length, defaultStart);
+        defaultValue = expr.substring(defaultStart + defaultTag.length, end);
       } else {
         questionName = expr.substring(start + startTag.length, end);
       }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -179,11 +179,13 @@ let ComputedQuestion = (props) => {
       // Insert this question into the list of arguments
       if (!questions.has(questionName)) {
         questions.set(questionName,
-          {"argument": "arg" + (questions.size + 1), "value": getQuestionValue(questionName, form, defaultValue)});
+          {"argument": "arg" + (questions.size + 1),
+            "value": getQuestionValue(questionName, form, defaultValue)});
       }
 
       // Remove the start and end tags and replace the question name with the argument name for this question
-      expr = [expr.substring(0, start), questions.get(questionName)["argument"], expr.substring(end + endTag.length)].join('');
+      expr = [expr.substring(0, start), questions.get(questionName)["argument"],
+        expr.substring(end + endTag.length)].join('');
       start = expr.indexOf(startTag);
       end = expr.indexOf(endTag, start);
     }

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/ExpressionUtilsImpl.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/ExpressionUtilsImpl.java
@@ -46,13 +46,16 @@ public final class ExpressionUtilsImpl implements ExpressionUtils
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(ExpressionUtilsImpl.class);
 
+    private Boolean missingValue = false;
+
     @Reference
     private ScriptEngineManager manager;
 
     @Override
     public Set<String> getDependencies(final Node question)
     {
-        return parseExpressionInputs(getExpressionFromQuestion(question), Collections.emptyMap()).getInputs().keySet();
+        return parseExpressionInputs(
+            getExpressionFromQuestion(question), Collections.emptyMap()).getQuestions().keySet();
     }
 
     @Override
@@ -79,7 +82,7 @@ public final class ExpressionUtilsImpl implements ExpressionUtils
             ScriptEngine engine = this.manager.getEngineByName("JavaScript");
 
             Bindings env = engine.createBindings();
-            parsedExpression.getInputs().forEach((key, value) -> env.put(key, value));
+            parsedExpression.getQuestions().forEach((key, value) -> env.put(value.getArgument(), value.getValue()));
             Object result = engine.eval("(function(){" + parsedExpression.getExpression() + "})()", env);
             return ValueFormatter.formatResult(result, type);
         } catch (ScriptException e) {
@@ -89,69 +92,80 @@ public final class ExpressionUtilsImpl implements ExpressionUtils
         return null;
     }
 
-    private static ExpressionUtilsImpl.ParsedExpression parseExpressionInputs(final String expression,
+    private ExpressionUtilsImpl.ParsedExpression parseExpressionInputs(final String expression,
         final Map<String, Object> values)
     {
         String expr = expression;
-        Map<String, Object> inputs = new HashMap<>();
+
+        this.missingValue = false;
+        Map<String, ExpressionArgument> questions = new HashMap<>();
+
         int start = expr.indexOf(START_MARKER);
         int end = expr.indexOf(END_MARKER, start);
-        boolean missingValue = false;
-
+        // For each argument in the expression, parse the question name and default value if present.
+        // To prevent question names from breaking the evaluating funtion, replace them with a default
+        // argument name in the evaluated expression.
         while (start > -1 && end > -1) {
-            int optionStart = expr.indexOf(DEFAULT_MARKER, start);
-            boolean hasOption = optionStart > -1 && optionStart < end;
+            int defaultStart = expr.indexOf(DEFAULT_MARKER, start);
+            boolean hasDefault = defaultStart > -1 && defaultStart < end;
 
-            String inputName;
+            // Parse out the question name and default value if provided
+            String questionName;
             String defaultValue = null;
-
-            if (hasOption) {
-                inputName = expr.substring(start + START_MARKER.length(), optionStart);
-                defaultValue = expr.substring(optionStart + DEFAULT_MARKER.length(), end);
+            if (hasDefault) {
+                questionName = expr.substring(start + START_MARKER.length(), defaultStart);
+                defaultValue = expr.substring(defaultStart + DEFAULT_MARKER.length(), end);
             } else {
-                inputName = expr.substring(start + START_MARKER.length(), end);
+                questionName = expr.substring(start + START_MARKER.length(), end);
             }
 
-            if (!inputs.containsKey(inputName)) {
-                Object value = values.get(inputName);
-                if (value == null) {
-                    value = defaultValue;
-                }
-                if (value == null) {
-                    missingValue = true;
-                }
-                inputs.put(inputName, value);
+            // Insert this question into the list of arguments
+            if (!questions.containsKey(questionName)) {
+                questions.put(questionName,
+                    new ExpressionArgument("arg" + questions.size(),
+                        getQuestionValue(questionName, values, defaultValue)));
             }
 
-            // Remove the start and end tags as well as the default option if provided, leaving just
-            // the Javascript variable name
-            expr = expr.substring(0, start) + expr.substring(start + START_MARKER.length(), hasOption
-                ? optionStart : end) + expr.substring(end + END_MARKER.length());
+            // Remove the start and end tags and replace the question name with the argument name for this question
+            expr = expr.substring(0, start) + questions.get(questionName).getArgument()
+                + expr.substring(end + END_MARKER.length());
 
-            start = expr.indexOf(START_MARKER, (hasOption ? optionStart : end) - START_MARKER.length());
+            start = expr.indexOf(START_MARKER);
             end = expr.indexOf(END_MARKER, start);
         }
-        return new ParsedExpression(inputs, expr, missingValue);
+        return new ParsedExpression(questions, expr, this.missingValue);
+    }
+
+    private Object getQuestionValue(String questionName, final Map<String, Object> values, String defaultValue)
+    {
+        Object value = values.get(questionName);
+        if (value == null) {
+            value = defaultValue;
+        }
+        if (value == null) {
+            this.missingValue = true;
+        }
+        return value;
     }
 
     private static final class ParsedExpression
     {
-        private final Map<String, Object> inputs;
+        private final Map<String, ExpressionArgument> questions;
 
         private final String expression;
 
         private final boolean missingValue;
 
-        ParsedExpression(Map<String, Object> inputs, String expression, boolean missingValue)
+        ParsedExpression(Map<String, ExpressionArgument> questions, String expression, boolean missingValue)
         {
-            this.inputs = inputs;
+            this.questions = questions;
             this.expression = expression;
             this.missingValue = missingValue;
         }
 
-        public Map<String, Object> getInputs()
+        public Map<String, ExpressionArgument> getQuestions()
         {
-            return this.inputs;
+            return this.questions;
         }
 
         public String getExpression()
@@ -162,6 +176,29 @@ public final class ExpressionUtilsImpl implements ExpressionUtils
         public boolean hasMissingValue()
         {
             return this.missingValue;
+        }
+    }
+
+    private static final class ExpressionArgument
+    {
+        private final String argument;
+
+        private final Object value;
+
+        ExpressionArgument(String argument, Object value)
+        {
+            this.argument = argument;
+            this.value = value;
+        }
+
+        public String getArgument()
+        {
+            return this.argument;
+        }
+
+        public Object getValue()
+        {
+            return this.value;
         }
     }
 

--- a/test-resources/src/main/features/feature.json
+++ b/test-resources/src/main/features/feature.json
@@ -31,8 +31,12 @@
     }
   ],
   "configurations":{
-    "org.apache.sling.jcr.repoinit.RepositoryInitializer~test_user":{
-      "scripts":["create user testuser with password testpassword"]
+    "org.apache.sling.jcr.repoinit.RepositoryInitializer~test":{
+      "service.ranking:Integer":300,
+      "scripts":[
+        "create user testuser with password testpassword",
+        "create user computedtestuser with password testpassword \n set ACL for computedtestuser \n     deny jcr:all on /Questionnaires restriction(rep:itemNames,computedquestions) \n     deny jcr:read on /Forms restriction(cards:question,/Questionnaires/BackendComputedTest/question1computed,/Questionnaires/BackendComputedTest/question2computed,/Questionnaires/BackendComputedTest/question3computed) \n     end"
+      ]
     }
   }
 }

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/BackendComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/BackendComputedTest.xml
@@ -1,0 +1,256 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+    <name>BackendComputedTest</name>
+    <primaryNodeType>cards:Questionnaire</primaryNodeType>
+    <property>
+        <name>title</name>
+        <value>Backend Computed Test - Invalid Names</value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>description</name>
+        <value>CARDS-1800</value>
+        <type>String</type>
+    </property>
+
+    <node>
+        <name>dataquestions</name>
+        <primaryNodeType>cards:Section</primaryNodeType>
+        <property>
+            <name>label</name>
+            <value>Data Questions</value>
+            <type>String</type>
+        </property>
+        <node>
+            <name>question1</name>
+            <primaryNodeType>cards:Question</primaryNodeType>
+            <property>
+                <name>text</name>
+                <value>Question 1: Valid variable name</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>dataType</name>
+                <value>long</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>displayMode</name>
+                <value>input</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>maxAnswers</name>
+                <value>1</value>
+                <type>Long</type>
+            </property>
+            <property>
+                <name>compact</name>
+                <value>True</value>
+                <type>Boolean</type>
+            </property>
+        </node>
+        <node>
+            <name>2question</name>
+            <primaryNodeType>cards:Question</primaryNodeType>
+            <property>
+                <name>text</name>
+                <value>Question 2: Invalid variable name (Starts with number)</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>dataType</name>
+                <value>long</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>displayMode</name>
+                <value>input</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>maxAnswers</name>
+                <value>1</value>
+                <type>Long</type>
+            </property>
+            <property>
+                <name>compact</name>
+                <value>True</value>
+                <type>Boolean</type>
+            </property>
+        </node>
+        <node>
+            <name>question 3</name>
+            <primaryNodeType>cards:Question</primaryNodeType>
+            <property>
+                <name>text</name>
+                <value>Question 3: Invalid variable name (contains space)</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>dataType</name>
+                <value>long</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>displayMode</name>
+                <value>input</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>maxAnswers</name>
+                <value>1</value>
+                <type>Long</type>
+            </property>
+            <property>
+                <name>compact</name>
+                <value>True</value>
+                <type>Boolean</type>
+            </property>
+        </node>
+    </node>
+    <node>
+       <name>computedquestions</name>
+       <primaryNodeType>cards:Section</primaryNodeType>
+       <property>
+           <name>label</name>
+           <value>Polar</value>
+            <type>String</type>
+        </property>
+        <node>
+            <name>question1computed</name>
+            <primaryNodeType>cards:Question</primaryNodeType>
+            <property>
+                <name>text</name>
+                <value>Question 1 Computed. Should equal question 1</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>dataType</name>
+                <value>long</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>displayMode</name>
+                <value>input</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>maxAnswers</name>
+                <value>1</value>
+                <type>Long</type>
+            </property>
+            <property>
+                <name>compact</name>
+                <value>True</value>
+                <type>Boolean</type>
+            </property>
+            <property>
+                <name>entryMode</name>
+                <value>computed</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>expression</name>
+                <value>return @{question1}</value>
+                <type>String</type>
+            </property>
+        </node>
+        <node>
+            <name>question2computed</name>
+            <primaryNodeType>cards:Question</primaryNodeType>
+            <property>
+                <name>text</name>
+                <value>Question 2 Computed. Should equal question 2</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>dataType</name>
+                <value>long</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>displayMode</name>
+                <value>input</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>maxAnswers</name>
+                <value>1</value>
+                <type>Long</type>
+            </property>
+            <property>
+                <name>compact</name>
+                <value>True</value>
+                <type>Boolean</type>
+            </property>
+            <property>
+                <name>entryMode</name>
+                <value>computed</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>expression</name>
+                <value>return @{2question}</value>
+                <type>String</type>
+            </property>
+        </node>
+        <node>
+            <name>question3computed</name>
+            <primaryNodeType>cards:Question</primaryNodeType>
+            <property>
+                <name>text</name>
+                <value>Question 3 Computed. Should equal question 3</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>dataType</name>
+                <value>long</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>displayMode</name>
+                <value>input</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>maxAnswers</name>
+                <value>1</value>
+                <type>Long</type>
+            </property>
+            <property>
+                <name>compact</name>
+                <value>True</value>
+                <type>Boolean</type>
+            </property>
+            <property>
+                <name>entryMode</name>
+                <value>computed</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>expression</name>
+                <value>return @{question 3}</value>
+                <type>String</type>
+            </property>
+        </node>
+    </node>
+</node>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/BackendComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/BackendComputedTest.xml
@@ -30,13 +30,30 @@
         <value>CARDS-1800</value>
         <type>String</type>
     </property>
+    <node>
+        <name>testing-instructions</name>
+        <primaryNodeType>cards:Information</primaryNodeType>
+        <property>
+            <name>text</name>
+            <value>This form is designed to test both front end and back end computed questions.
+
+To test front end computed question handling, use the `admin` or `testuser` accounts to fill out this form.
+These users can complete all questions in this form, so the front end will calculate the computed questions.
+
+To test the back end computed questions, use the `computedtestuser` account (password: `testpassword`).
+This account has permission to view and edit the user questions, but not the computed questions.
+As a result, creating and completing this form with `computedtestuser` will force the backend to calculate the computed questions,
+which can then be verified for accuracy by opening the form in read mode with the `admin` or normal `testuser` accounts.</value>
+            <type>String</type>
+        </property>
+    </node>
 
     <node>
-        <name>dataquestions</name>
+        <name>userquestions</name>
         <primaryNodeType>cards:Section</primaryNodeType>
         <property>
             <name>label</name>
-            <value>Data Questions</value>
+            <value>User Questions</value>
             <type>String</type>
         </property>
         <node>
@@ -132,7 +149,7 @@
        <primaryNodeType>cards:Section</primaryNodeType>
        <property>
            <name>label</name>
-           <value>Polar</value>
+           <value>Computed Questions</value>
             <type>String</type>
         </property>
         <node>


### PR DESCRIPTION
Created a new `--test` form (Backend Computed Test) and a new test user (`computedtestuser`, password `testpassword`. This form contains 2 computed questions that would fail previously due to requiring invalid variable names (`2question` and `question 3`).

To test the frontend code, create and complete a `Backend Computed Test` form as admin or the regular `testuser` and verify that Question 2 and 3 Computed work properly. To test the backend code, sign in as `computedtestuser` and create a `Backend Computed Test`. Observe that the computed questions are not visible, as this user does not have access to these specific questions, forcing the backend to complete them. Complete the visible questions, save the form then sign in as admin to verify that the computed questions worked fine.

**Regression testing** - computed questions using default values: in `proms` mode, fill out surveys as a patient and then visualize them as clinician or admin, checking that  interpretations for patients and interpretations for clinicians are both computed as expected.