### PR TITLE
CARDS-1815: Create a script to quickly start up a Docker Compose environment for testing SMTPS email sending from CARDS

### DIFF
--- a/compose-cluster/quick-environments/smtps-ci.sh
+++ b/compose-cluster/quick-environments/smtps-ci.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+if [[ "$#" -ne 1 ]]
+then
+  echo "Proper usage: smtps-ci.sh /path/to/mail/directory"
+  exit 1
+fi
+
+MAILDIR_PATH=$1
+
+if [[ ! -d $MAILDIR_PATH ]]
+then
+  echo "The directory $MAILDIR_PATH does not exist. Exiting."
+  exit 1
+fi
+
+python3 generate_compose_yaml.py \
+  --cards_project cards4proms \
+  --dev_docker_image \
+  --composum \
+  --oak_filesystem \
+  --server_address localhost:8080 \
+  --smtps \
+  --smtps_test_container \
+  --smtps_test_mail_path $MAILDIR_PATH
+
+docker-compose build
+docker-compose up -d
+
+while true
+do
+  curl --fail http://localhost:8080/system/sling/info.sessionInfo.json && break
+  sleep 5
+done


### PR DESCRIPTION
This PR introduces the `smtps-ci.sh` script under `compose-cluster/quick-environments/`. Calling this script calls `generate_compose_yaml.py` to generate a `docker-compose.yml` file for a _Cards4Proms_ deployment that uses a local Docker container as a SMTPS test server.

To test:

1. Build this branch with `mvn clean install`.
2. Build the `cards/postfix-docker` image by entering the `Utilities/Development/EmailServer` directory and running `docker build -t cards/postfix-docker .`
3. `cd compose-cluster`
4. `./cleanup.sh`
5. `mkdir ~/mail-test-directory`
6. `./quick-environments/smtps-ci.sh ~/mail-test-directory`
7. Wait for the script to return
8. Visit `http://localhost:8080` and login as `admin`:`admin`.
9. Send a test email by visiting `http://localhost:8080/content.emailtest?fromEmail=datapro@uhn.ca&fromName=UHN DATAPRO&toEmail=testuser@mail.com&toName=Test User&isHtml=true`.
10. Run `ls -l ~/mail-test-directory` - the MBOX file should be non-empty and increment in size each time an email is sent using the `/content.emailtest` endpoint.
11. `docker-compose down`
12. `docker-compose rm`
13. `docker volume prune -f`
14. `./cleanup.sh`
15. `rm -r ~/mail-test-directory`