### PR TITLE
CARDS-1817: All frontend code should check specifically for INCOMPLETE and INVALID status flags to determine form entry completion

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/AnswerInstructions.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/AnswerInstructions.jsx
@@ -26,6 +26,11 @@ import withStyles from '@mui/styles/withStyles';
 
 import QuestionnaireStyle from "./QuestionnaireStyle";
 
+// Check if an answer has been automatically flagged as incomplete or invalid
+export function hasWarningFlags (data) {
+  return data?.[1]?.statusFlags?.includes('INCOMPLETE') || data?.[1]?.statusFlags?.includes('INVALID')
+}
+
 // Display instructions regarding how many answers must be provided to a question,
 // based on minAnswers and maxAnswers from the question definition
 
@@ -34,7 +39,7 @@ function AnswerInstructions (props) {
   let { isEdit, existingAnswer } = props;
   let [ answerIsAcceptable, setAnswerAcceptable] = useState();
 
-  const instructionsExist = (minAnswers > 0 || maxAnswers > 1) && (isEdit || existingAnswer?.[1]?.statusFlags?.length > 0);
+  const instructionsExist = (minAnswers > 0 || maxAnswers > 1) && (isEdit || hasWarningFlags(existingAnswer));
   const isMandatory = minAnswers == 1 && !(maxAnswers > minAnswers);
   const isAtLeast = !(minAnswers < maxAnswers);
   const isExactly = minAnswers == maxAnswers;
@@ -49,7 +54,7 @@ function AnswerInstructions (props) {
   }
 
   useEffect(() => {
-    setAnswerAcceptable((currentAnswers >= minAnswers) && (!(maxAnswers >= minAnswers) || currentAnswers <= maxAnswers) || !isEdit && existingAnswer?.[1]?.statusFlags?.length == 0)
+    setAnswerAcceptable((currentAnswers >= minAnswers) && (!(maxAnswers >= minAnswers) || currentAnswers <= maxAnswers) || !isEdit && !hasWarningFlags(existingAnswer))
   }, [currentAnswers]);
 
   return (instructionsExist && (

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -60,6 +60,7 @@ import FormPagination from "./FormPagination";
 import { usePageNameWriterContext } from "../themePage/Page.jsx";
 import FormattedText from "../components/FormattedText.jsx";
 import ResourceHeader from "./ResourceHeader.jsx";
+import { hasWarningFlags } from "./AnswerInstructions";
 
 // TODO Once components from the login module can be imported, open the login Dialog in-page instead of opening a popup window
 
@@ -320,15 +321,11 @@ function Form (props) {
   }, [data])
 
   let getIncompleteAnswers = (obj, results) => {
-    for (var property in obj) {
-      if (obj.hasOwnProperty(property)) {
-        if (obj[property]["jcr:primaryType"] == "cards:AnswerSection" && (obj[property].statusFlags.includes('INCOMPLETE') || obj[property].statusFlags.includes('INVALID'))) {
-          getIncompleteAnswers(obj[property], results);
-        } else {
-          if (obj[property]["sling:resourceSuperType"] == "cards/Answer" && (obj[property].statusFlags.includes('INCOMPLETE') || obj[property].statusFlags.includes('INVALID'))) {
-            results.push(obj[property]);
-          }
-        }
+    for (var entry in Object.entries(obj || {})) {
+      if (entry[1]?.["jcr:primaryType"] == "cards:AnswerSection" && hasWarningFlags(entry)) {
+        getIncompleteAnswers(entry[1], results);
+      } else if (entry[1]?.["sling:resourceSuperType"] == "cards/Answer" && hasWarningFlags(entry)) {
+        results.push(entry[1]);
       }
     }
     return results;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -43,6 +43,8 @@ import DicomQuestion from "./DicomQuestion";
 
 import FormattedText from "../components/FormattedText";
 
+import { hasWarningFlags } from "./AnswerInstructions";
+
 export const QUESTION_TYPES = ["cards:Question"];
 export const SECTION_TYPES = ["cards:Section"];
 export const INFO_TYPES = ["cards:Information"];
@@ -64,7 +66,7 @@ let displayQuestion = (questionDefinition, path, existingAnswer, key, classes, o
       && value["question"]["jcr:uuid"] === questionDefinition["jcr:uuid"]);
 
   // View mode should display all mandatory questions whether or not they have an answer
-  if (!existingQuestionAnswer?.[1].statusFlags.includes('INCOMPLETE') && (!(existingQuestionAnswer?.[1]["displayedValue"] || existingQuestionAnswer?.[1]["note"]) && !isEdit)) {
+  if (!hasWarningFlags(existingQuestionAnswer) && (!(existingQuestionAnswer?.[1]["displayedValue"] || existingQuestionAnswer?.[1]["note"]) && !isEdit)) {
     return null;
   }
 
@@ -173,8 +175,7 @@ let displayMatrix = (sectionDefinition, path, existingAnswer, key, classes, page
       && answer[1]["sling:resourceSuperType"] === "cards/Answer");
 
   // Determine if the section is flagged as incomplete/invalid
-  // Note: may be better to explicitly check <statusFlags.includes('INCOMPLETE')>, and same for INVALID
-  const isFlagged = (existingSectionAnswer?.[1]?.statusFlags?.length > 0);
+  const isFlagged = hasWarningFlags(existingSectionAnswer);
   // View mode should display all mandatory questions whether or not they have an answer
   const hasAnswers = existingAnswers?.filter(answer => answer[1]["displayedValue"]).length > 0;
   if (!isEdit && !isFlagged && !hasAnswers) {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionMatrix.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionMatrix.jsx
@@ -243,7 +243,7 @@ let QuestionMatrix = (props) => {
     return (<>
       { existingAnswers.map((answer, idx) => (answer[1].displayedValue || hasWarningFlags(answer)) && (
         <TableRow key={answer[0] + idx} className={enableVerticalLayout ? classes.questionMatrixStackedAnswer : ''}>
-          { renderQuestion(answer[1].question, answer[1].statusFlags) }
+          { renderQuestion(answer[1].question, hasWarningFlags(answer)) }
           { !enableVerticalLayout && <TableCell>—</TableCell> }
           { renderAnswer(answer[1], (enableVerticalLayout ? '-' : '')) }
         </TableRow>
@@ -251,10 +251,10 @@ let QuestionMatrix = (props) => {
     </>);
   };
 
-  let renderQuestion = (question, flags) => {
+  let renderQuestion = (question, hasWarningFlags) => {
     return (
       <TableCell component="th" >
-        <Typography color={ flags?.length > 0 ? 'error' : 'inherit'}>{question.text}</Typography>
+        <Typography color={ hasWarningFlags ? 'error' : 'inherit'}>{question.text}</Typography>
         { question.description &&
           <FormattedText variant="caption" display="block" color="textSecondary">
             { question.description }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionMatrix.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionMatrix.jsx
@@ -36,6 +36,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 
 import Answer, {LABEL_POS, VALUE_POS, DESC_POS, IS_DEFAULT_OPTION_POS, IS_DEFAULT_ANSWER_POS} from "./Answer";
 import AnswerInstructions from "./AnswerInstructions";
+import { hasWarningFlags } from "./AnswerInstructions";
 import Question from "./Question";
 import FormattedText from "../components/FormattedText.jsx";
 import QuestionnaireStyle from './QuestionnaireStyle';
@@ -185,7 +186,7 @@ let QuestionMatrix = (props) => {
 
   // Adapt the section / answerSection info to pass to the Question component
 
-  let existingAnswerMock = [sectionAnswerPath, {displayedValue: existingAnswers, statusFlags: existingSectionAnswer ? existingSectionAnswer[1].statusFlags : null}];
+  let existingAnswerMock = [sectionAnswerPath, {displayedValue: existingAnswers, statusFlags: existingSectionAnswer?.[1]?.statusFlags || null}];
   let questionMatrixDefinition = { ...sectionDefinition, text: sectionDefinition.label};
   let currentAnswers = subquestions.reduce((min, item) => {return Math.min(min, selection[item[0]]?.length || 0);}, minAnswers);
 
@@ -240,7 +241,7 @@ let QuestionMatrix = (props) => {
 
   let renderViewMode = () => {
     return (<>
-      { existingAnswers.map((answer, idx) => (answer[1].displayedValue || answer[1].statusFlags?.length > 0) && (
+      { existingAnswers.map((answer, idx) => (answer[1].displayedValue || hasWarningFlags(answer)) && (
         <TableRow key={answer[0] + idx} className={enableVerticalLayout ? classes.questionMatrixStackedAnswer : ''}>
           { renderQuestion(answer[1].question, answer[1].statusFlags) }
           { !enableVerticalLayout && <TableCell>—</TableCell> }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -30,6 +30,7 @@ import ConditionalComponentManager from "./ConditionalComponentManager";
 import FormEntry, { ENTRY_TYPES } from "./FormEntry";
 import { useFormReaderContext } from "./FormContext";
 import QuestionnaireStyle, { FORM_ENTRY_CONTAINER_PROPS } from "./QuestionnaireStyle";
+import { hasWarningFlags } from "./AnswerInstructions";
 
 // FIXME In order for the conditionals to be registered, they need to be loaded, and the only way to do that at the moment is to explicitly invoke them here. Find a way to automatically load all conditional types, possibly using self-declaration in a node, like the assets, or even by filtering through assets.
 import ConditionalGroup from "./ConditionalGroup";
@@ -125,7 +126,7 @@ function Section(props) {
   }, [conditionIsMet])
 
   // Determine if the section is flagged as incomplete
-  const isFlagged = (existingAnswer?.[0]?.[1]?.statusFlags?.length > 0);
+  const isFlagged = hasWarningFlags(existingAnswer?.[0]);
 
   // Determine if the section has any answers
   let detectAnswers = (answerSection) => {


### PR DESCRIPTION
… instead of assuming that the presence of any status flag means the answer is incomplete

**Testing:**
* Nothing should have changed from the user perspective.

**Regression testing**
* Check that Answer instructions are displayed correctly
* Check that mandatory questions without an answer are displayed in view mode
  * whether they are direct descendants of a questionnaire or inside a section
  * whether they are "regular" or `matrix`