### PR TITLE
[bugfix] Incomplete refactoring of formatString->camelCaseToWords leads to WSORD in clinic administration

### DIFF
--- a/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
@@ -29,7 +29,7 @@ import {
   Typography
 } from "@mui/material";
 
-import Fields, { formatString } from "../questionnaireEditor/Fields.jsx";
+import Fields from "../questionnaireEditor/Fields.jsx";
 import LiveTable from "../dataHomepage/LiveTable.jsx";
 import NewItemButton from "../components/NewItemButton.jsx";
 import ResponsiveDialog from "../components/ResponsiveDialog.jsx";
@@ -55,7 +55,7 @@ function Clinics(props) {
     .map((stat) => {
       return {
         key: stat,
-        label: (stat in formattedNames) ? formattedNames[stat] : formatString(stat),
+        label: (stat in formattedNames) ? formattedNames[stat] : camelCaseToWords(stat),
         format: clinicsSpecs[stat]
       };
     });


### PR DESCRIPTION
To test:
- start in proms mode
- log in as admin
- go to Administration -> Clinics
- there should be no crashing blank page