### PR TITLE
CARDS-1826: The heading size and style should be consistent across all admin screens

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -338,7 +338,7 @@ function LiveTable(props) {
   const paginationControls = tableData && (
     <TablePagination
       component="div"
-      rowsPerPageOptions={[10, 50, 100, 1000]}
+      rowsPerPageOptions={[10, 20, 50, 100, 1000]}
       count={paginationData.totalIsApproximate ? -1 : paginationData.total}
       rowsPerPage={paginationData.limit}
       page={paginationData.page}
@@ -422,7 +422,7 @@ function LiveTable(props) {
 }
 
 LiveTable.defaultProps = {
-  defaultLimit: 50
+  defaultLimit: 20
 }
 
 export default withStyles(LiveTableStyle)(LiveTable);

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
@@ -17,18 +17,14 @@
 //  under the License.
 //
 import React from "react";
-import LiveTable from "./LiveTable.jsx";
 import Questionnaire from "../questionnaire/Questionnaire.jsx";
-import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle";
+import ResourceListing from "../dataHomepage/ResourceListing.jsx";
 import NewQuestionnaireDialog from "../questionnaireEditor/NewQuestionnaireDialog.jsx";
-import { Button, Card, CardHeader, CardContent } from "@mui/material";
-import withStyles from '@mui/styles/withStyles';
 import DeleteButton from "./DeleteButton.jsx";
 import EditButton from "./EditButton.jsx";
 import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
 
 function Questionnaires(props) {
-  const { classes } = props;
   const entry = /Questionnaires\/([^.]+)/.exec(location.pathname);
 
   if (entry) {
@@ -59,32 +55,19 @@ function Questionnaires(props) {
   ]
 
   return (
-    <React.Fragment>
-      <Card>
-       <CardHeader
-        title={
-          <Button className={classes.cardHeaderButton}>
-            Questionnaires
-          </Button>
-        }
+    <>
+      <ResourceListing
+        title="Questionnaires"
         action={
           <NewQuestionnaireDialog />
         }
-        classes={{
-          action: classes.newFormButtonHeader
-        }}
-        />
-        <CardContent>
-          <LiveTable
-            columns={columns}
-            actions={actions}
-            entryType={"Questionnaire"}
-            admin={true}
-            />
-        </CardContent>
-      </Card>
-    </React.Fragment>
+        columns={columns}
+        actions={actions}
+        entryType={"Questionnaire"}
+        admin={true}
+      />
+    </>
   );
 }
 
-export default withStyles(QuestionnaireStyle)(Questionnaires);
+export default Questionnaires;

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
@@ -18,7 +18,7 @@
 //
 import React from "react";
 import Questionnaire from "../questionnaire/Questionnaire.jsx";
-import ResourceListing from "../dataHomepage/ResourceListing.jsx";
+import AdminResourceListing from "../adminDashboard/AdminResourceListing.jsx";
 import NewQuestionnaireDialog from "../questionnaireEditor/NewQuestionnaireDialog.jsx";
 import DeleteButton from "./DeleteButton.jsx";
 import EditButton from "./EditButton.jsx";
@@ -56,7 +56,7 @@ function Questionnaires(props) {
 
   return (
     <>
-      <ResourceListing
+      <AdminResourceListing
         title="Questionnaires"
         action={
           <NewQuestionnaireDialog />

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/ResourceListing.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/ResourceListing.jsx
@@ -1,0 +1,41 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+import React from "react";
+
+import AdminScreen from "../adminDashboard/AdminScreen.jsx";
+import LiveTable from "../dataHomepage/LiveTable.jsx";
+import NewItemButton from "../components/NewItemButton.jsx";
+
+function ResourceListing(props) {
+  const { title, action, buttonProps, ...rest } = props;
+
+  return (
+    <AdminScreen
+      title={title}
+      action={buttonProps ? <NewItemButton {...buttonProps}/> : action}
+    >
+      <LiveTable
+        disableTopPagination={true}
+        {...rest}
+      />
+    </AdminScreen>
+  );
+}
+
+export default ResourceListing;

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
@@ -22,7 +22,7 @@ import LiveTable from "./LiveTable.jsx";
 import { IconButton, Tooltip } from "@mui/material";
 import { Link } from 'react-router-dom';
 import SubjectTypeDialog from "../questionnaire/SubjectTypeDialog.jsx";
-import ResourceListing from "../dataHomepage/ResourceListing.jsx";
+import AdminResourceListing from "../adminDashboard/AdminResourceListing.jsx";
 import NewItemButton from "../components/NewItemButton.jsx";
 import DeleteButton from "./DeleteButton.jsx";
 import EditIcon from "@mui/icons-material/Edit";
@@ -115,7 +115,7 @@ function SubjectTypes(props) {
 
   return (
   <>
-    <ResourceListing
+    <AdminResourceListing
       title="Subject Types"
       buttonProps={{
         title: "New subject type",

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
@@ -19,11 +19,10 @@
 import React, { useState, useEffect } from "react";
 import LiveTable from "./LiveTable.jsx";
 
-import { Button, Card, CardContent, CardHeader, IconButton, Tooltip } from "@mui/material";
-import withStyles from '@mui/styles/withStyles';
+import { IconButton, Tooltip } from "@mui/material";
 import { Link } from 'react-router-dom';
-import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 import SubjectTypeDialog from "../questionnaire/SubjectTypeDialog.jsx";
+import ResourceListing from "../dataHomepage/ResourceListing.jsx";
 import NewItemButton from "../components/NewItemButton.jsx";
 import DeleteButton from "./DeleteButton.jsx";
 import EditIcon from "@mui/icons-material/Edit";
@@ -51,7 +50,6 @@ function EditSubjectTypeButton(props) {
 }
 
 function SubjectTypes(props) {
-  const { classes } = props;
   const [ dialogOpen, setDialogOpen ] = useState(false);
   const [ updateData, setUpdateData ] = useState(false);
   const [ subjectTypeData, setSubjectTypeData ] = useState([]);
@@ -117,29 +115,19 @@ function SubjectTypes(props) {
 
   return (
   <>
-    <Card>
-      <CardHeader
-        title={
-          <Button className={classes.cardHeaderButton}>
-            Subject Types
-          </Button>
-        }
-      />
-      <CardContent>
-        <LiveTable
-          columns={columns}
-          entryType={"Subject Type"}
-          admin={true}
-          disableTopPagination={true}
-          updateData={updateData}
-          onDataReceived={setSubjectTypeData}
-        />
-      </CardContent>
-    </Card>
-    <NewItemButton
-      title="New subject type"
-      onClick={() => { setDialogOpen(true); }}
-    />
+    <ResourceListing
+      title="Subject Types"
+      buttonProps={{
+        title: "New subject type",
+        onClick: () => setDialogOpen(true)
+      }}
+      columns={columns}
+      entryType={"Subject Type"}
+      admin={true}
+      disableTopPagination={true}
+      updateData={updateData}
+      onDataReceived={setSubjectTypeData}
+    />
     { dialogOpen &&
         <SubjectTypeDialog
           onClose={() => { onClose(); }}
@@ -154,4 +142,4 @@ function SubjectTypes(props) {
   );
 }
 
-export default withStyles(QuestionnaireStyle)(SubjectTypes);
+export default SubjectTypes;

--- a/modules/downtime-warning-banner/src/main/frontend/src/DowntimeWarningConfiguration.jsx
+++ b/modules/downtime-warning-banner/src/main/frontend/src/DowntimeWarningConfiguration.jsx
@@ -24,13 +24,12 @@ import {
     Tooltip,
     Typography,
     FormControlLabel,
-    Card,
-    CardContent,
-    CardHeader,
     List,
     ListItem,
 } from '@mui/material';
 import { makeStyles } from '@mui/styles';
+
+import AdminScreen from "./adminDashboard/AdminScreen.jsx";
 
 const useStyles = makeStyles(theme => ({
   textField: {
@@ -131,12 +130,7 @@ function DowntimeWarningConfiguration() {
   }
 
   return (
-    <Card>
-      <CardHeader
-        title="Downtime warning banner settings"
-        titleTypographyProps={{variant: "h6"}}
-      />
-      <CardContent>
+    <AdminScreen title="Downtime Warning Banner Settings">
         {error && <Typography color='error'>{errorText}</Typography>}
         <form onSubmit={handleSubmit}>
           <List>
@@ -194,8 +188,7 @@ function DowntimeWarningConfiguration() {
             </ListItem>
           </List>
         </form>
-      </CardContent>
-    </Card>
+    </AdminScreen>
   );
 }
 

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminDashboard.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminDashboard.jsx
@@ -20,12 +20,9 @@ import React, { useState, useEffect } from "react";
 import { loadExtensions } from "../uiextension/extensionManager";
 import { NavLink, Route } from "react-router-dom";
 import adminStyle from "./AdminDashboardStyle.jsx";
+import AdminScreen from "./AdminScreen.jsx";
 
 import {
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
   CircularProgress,
   Grid,
   List,
@@ -64,15 +61,7 @@ function AdminDashboard(props) {
   }
 
   return (
-    <Card>
-      <CardHeader
-        title={
-          <Button>
-            Administration
-          </Button>
-        }
-      />
-      <CardContent>
+    <AdminScreen disableBreadcrumb>
         <List>
           {
             adminRoutes.map((route) => {
@@ -99,8 +88,7 @@ function AdminDashboard(props) {
             })
           }
         </List>
-      </CardContent>
-    </Card>
+    </AdminScreen>
   );
 }
 

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminResourceListing.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminResourceListing.jsx
@@ -18,11 +18,11 @@
 //
 import React from "react";
 
-import AdminScreen from "../adminDashboard/AdminScreen.jsx";
+import AdminScreen from "./AdminScreen.jsx";
 import LiveTable from "../dataHomepage/LiveTable.jsx";
 import NewItemButton from "../components/NewItemButton.jsx";
 
-function ResourceListing(props) {
+function AdminResourceListing(props) {
   const { title, action, buttonProps, ...rest } = props;
 
   return (
@@ -38,4 +38,4 @@ function ResourceListing(props) {
   );
 }
 
-export default ResourceListing;
+export default AdminResourceListing;

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminScreen.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminScreen.jsx
@@ -1,0 +1,85 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+import React from "react";
+import PropTypes from "prop-types";
+
+import { Link } from 'react-router-dom';
+import { Breadcrumbs, Card, CardContent, CardHeader, Typography } from "@mui/material";
+import { makeStyles } from '@mui/styles';
+
+import LiveTable from "../dataHomepage/LiveTable.jsx";
+import NewItemButton from "../components/NewItemButton.jsx";
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    marginTop: theme.spacing(2),
+  },
+  withMainAction: {
+    marginBottom: theme.spacing(4),
+  },
+  title: {
+    fontWeight: 300,
+  },
+}));
+
+function AdminScreen(props) {
+  const { title, action, disableBreadcrumb, children } = props;
+
+  const classes = useStyles();
+  const appName = document.querySelector('meta[name="title"]')?.content;
+
+  const heading = <Typography className={classes.title} variant="h4">{title}</Typography>;
+  const breadcrumb = (
+    <Breadcrumbs separator="/">
+      <Typography variant="overline"><Link to="/">{appName}</Link></Typography>
+      <Typography variant="overline"><Link to="/content.html/admin/">Administration</Link></Typography>
+    </Breadcrumbs>
+  );
+
+  let classNames = [classes.root];
+  if (!!action) {
+    classNames.push(classes.withMainAction);
+  }
+
+  return (
+    <Card className={classNames.join(' ')}>
+      <CardHeader
+        disableTypography
+        title={disableBreadcrumb ? heading : breadcrumb}
+        subheader={disableBreadcrumb ? undefined : heading}
+        action={action}
+      />
+      <CardContent>
+	  { children }
+      </CardContent>
+    </Card>
+  );
+}
+
+AdminScreen.propTypes = {
+  title: PropTypes.string,
+  action: PropTypes.node,
+  disableBreadcrumb: PropTypes.bool,
+};
+
+AdminScreen.defaultProps = {
+  title: "Administration",
+};
+
+export default AdminScreen;

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminScreen.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminScreen.jsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles(theme => ({
     marginBottom: theme.spacing(4),
   },
   title: {
-    fontWeight: 300,
+    fontWeight: "normal",
   },
 }));
 

--- a/modules/homepage/src/main/frontend/src/themePage/QuickSearchConfiguration.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/QuickSearchConfiguration.jsx
@@ -24,12 +24,11 @@ import {
     Tooltip,
     Typography,
     FormControlLabel,
-    Card,
-    CardContent,
-    CardHeader,
     List,
     ListItem,
 } from '@mui/material';
+
+import AdminScreen from "../adminDashboard/AdminScreen.jsx";
 
 function QuickSearchConfiguration(props) {
   const { match, location, classes } = props;
@@ -114,13 +113,7 @@ function QuickSearchConfiguration(props) {
   }
 
   return (
-    <Card>
-      <CardHeader
-        title={
-          <Typography variant="h6" gutterBottom>Quick search settings</Typography>
-        }
-      />
-      <CardContent>
+    <AdminScreen title="Quick Search Settings">
         <form onSubmit={handleSubmit}>
           <List>
             <ListItem key="h1">
@@ -135,9 +128,9 @@ function QuickSearchConfiguration(props) {
                 label="Limit"
                 value={limit}
                 onChange={(event) => { setOnSuccess(false); setLimit(event.target.value); }}
-                style={{'width' : '10%'}}
+                style={{'width' : '250px'}}
+                helperText="How many results should be displayed"
               />
-              <Typography variant="body1">How many results should be displayed</Typography>
             </ListItem>
             <ListItem key="showTotalRows">
               <FormControlLabel
@@ -181,8 +174,7 @@ function QuickSearchConfiguration(props) {
             </ListItem>
           </List>
         </form>
-      </CardContent>
-    </Card>
+    </AdminScreen>
   );
 }
 

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/groupsmanager.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/groupsmanager.jsx
@@ -26,6 +26,7 @@ import CreateGroupDialogue from "./creategroupdialogue.jsx";
 import DeletePrincipalDialogue from "../deleteprincipaldialogue.jsx";
 import AddUserToGroupDialogue from "./addusertogroupdialogue.jsx";
 import NewItemButton from "../../components/NewItemButton.jsx"
+import AdminScreen from "../../adminDashboard/AdminScreen.jsx";
 
 import MaterialTable from 'material-table';
 
@@ -151,11 +152,18 @@ class GroupsManager extends React.Component {
     const { classes } = this.props;
     const headerBackground = this.props.theme.palette.grey['200'];
     return (
-      <div>
+      <AdminScreen
+        title="Groups"
+        action={
+          <NewItemButton
+            title="Create new group"
+            onClick={(event) => this.setState({deployCreateGroup: true})}
+          />
+        }>
         <CreateGroupDialogue isOpen={this.state.deployCreateGroup} handleClose={() => {this.setState({deployCreateGroup: false});}} reload={() => this.handleReload(true)} />
         <DeletePrincipalDialogue isOpen={this.state.deployDeleteGroup} handleClose={() => {this.setState({deployDeleteGroup: false});}} name={this.state.currentGroupName} reload={() => this.handleReload(true)} url={GROUP_URL} type={"group"} />
         <AddUserToGroupDialogue isOpen={this.state.deployAddGroupUsers} handleClose={() => {this.setState({deployAddGroupUsers: false});}} name={this.state.currentGroupName} groupUsers={this.state.currentGroupUsers} allUsers={this.props.users}  reload={() => this.handleReload()} />
-        <div>
+        <div className={classes.root}>
           <MaterialTable
             tableRef={this.tableRef}
             title=""
@@ -242,11 +250,7 @@ class GroupsManager extends React.Component {
             }}
           />
         </div>
-        <NewItemButton
-          title="Create new group"
-          onClick={(event) => this.setState({deployCreateGroup: true})}
-        />
-      </div>
+      </AdminScreen>
     );
   }
 }

--- a/modules/principals/src/main/frontend/src/Userboard/Users/usersmanager.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Users/usersmanager.jsx
@@ -99,7 +99,7 @@ class UsersManager extends React.Component {
 
     return (
       <AdminScreen
-        title="Groups"
+        title="Users"
         action={
           <NewItemButton
             title="Create new user"

--- a/modules/principals/src/main/frontend/src/Userboard/Users/usersmanager.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Users/usersmanager.jsx
@@ -26,6 +26,7 @@ import CreateUserDialogue from "./createuserdialogue.jsx";
 import DeletePrincipalDialogue from "../deleteprincipaldialogue.jsx";
 import ChangeUserPasswordDialogue from "./changeuserpassworddialogue.jsx";
 import NewItemButton from "../../components/NewItemButton.jsx";
+import AdminScreen from "../../adminDashboard/AdminScreen.jsx";
 
 import MaterialTable from 'material-table';
 
@@ -97,12 +98,19 @@ class UsersManager extends React.Component {
     const headerBackground = this.props.theme.palette.grey['200'];
 
     return (
-      <div>
+      <AdminScreen
+        title="Groups"
+        action={
+          <NewItemButton
+            title="Create new user"
+            onClick={(event) => this.setState({deployCreateUser: true})}
+          />
+        }>
         <CreateUserDialogue isOpen={this.state.deployCreateUser} handleClose={() => {this.setState({deployCreateUser: false});}} reload={() => this.handleReload()}/>
         <DeletePrincipalDialogue isOpen={this.state.deployDeleteUser} handleClose={() => {this.setState({deployDeleteUser: false});}} name={this.state.currentUserName} reload={() => this.handleReload()} url={USER_URL} type={"user"} />
         <ChangeUserPasswordDialogue isOpen={this.state.deployChangeUserPassword} handleClose={() => {this.setState({deployChangeUserPassword: false});}} name={this.state.currentUserName}/>
 
-        <div>
+        <div className={classes.root}>
             <MaterialTable
               title=""
               style={{ boxShadow : 'none' }}
@@ -166,11 +174,7 @@ class UsersManager extends React.Component {
               }}
             />
         </div>
-        <NewItemButton
-          title="Create new user"
-          onClick={(event) => this.setState({deployCreateUser: true})}
-        />
-      </div>
+      </AdminScreen>
     );
   }
 }

--- a/modules/principals/src/main/frontend/src/Userboard/userboardStyle.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/userboardStyle.jsx
@@ -18,6 +18,12 @@
 // Taken from https://www.creative-tim.com/product/material-dashboard-react
 
 const userboardStyle = theme => ({
+    root: {
+      marginTop: theme.spacing(-6),
+      "& .MuiPaper-root" : {
+        backgroundColor: "transparent",
+      },
+    },
     containerButton: {
       marginRight: theme.spacing(1),
     },

--- a/modules/statistics/src/main/frontend/src/Statistics/AdminStatistics.jsx
+++ b/modules/statistics/src/main/frontend/src/Statistics/AdminStatistics.jsx
@@ -33,7 +33,7 @@ import {
 import withStyles from '@mui/styles/withStyles';
 import statisticsStyle from "./statisticsStyle.jsx";
 import ResponsiveDialog from "../components/ResponsiveDialog.jsx";
-import ResourceListing from "../dataHomepage/ResourceListing.jsx";
+import AdminResourceListing from "../adminDashboard/AdminResourceListing.jsx";
 import DeleteButton from "../dataHomepage/DeleteButton.jsx";
 import Fields from "../questionnaireEditor/Fields.jsx";
 import EditIcon from "@mui/icons-material/Edit";
@@ -149,7 +149,7 @@ function AdminStatistics(props) {
 
   return (
     <>
-      <ResourceListing
+      <AdminResourceListing
         title="Statistics"
         buttonProps={{
           title: "Create new statistic",

--- a/modules/statistics/src/main/frontend/src/Statistics/AdminStatistics.jsx
+++ b/modules/statistics/src/main/frontend/src/Statistics/AdminStatistics.jsx
@@ -20,10 +20,7 @@ import React, { useContext, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { v4 as uuidv4 } from 'uuid';
 import { 
-  Button, 
-  Card, 
-  CardContent,
-  CardHeader,
+  Button,
   Dialog, 
   DialogActions, 
   DialogContent, 
@@ -35,9 +32,8 @@ import {
 } from "@mui/material";
 import withStyles from '@mui/styles/withStyles';
 import statisticsStyle from "./statisticsStyle.jsx";
-import NewItemButton from "../components/NewItemButton.jsx";
 import ResponsiveDialog from "../components/ResponsiveDialog.jsx";
-import LiveTable from "../dataHomepage/LiveTable.jsx";
+import ResourceListing from "../dataHomepage/ResourceListing.jsx";
 import DeleteButton from "../dataHomepage/DeleteButton.jsx";
 import Fields from "../questionnaireEditor/Fields.jsx";
 import EditIcon from "@mui/icons-material/Edit";
@@ -153,30 +149,22 @@ function AdminStatistics(props) {
 
   return (
     <>
-      <Card>
-       <CardHeader
-        title={
-          <Button className={classes.cardHeaderButton}>
-            Statistics
-          </Button>
-        }
-        action={
-          <NewItemButton
-            title="Create new statistic"
-            onClick={() => {setDialogOpen(true); setNewStat(true); setCurrentId();}}
-            inProgress={dialogOpen && newStat}
-            />
-        }
-        />
-        <CardContent>
-          <LiveTable
-            columns={columns}
-            entryType={"Statistic"}
-            admin={true}
-            updateData={numNewEntries}
-            />
-        </CardContent>
-      </Card>
+      <ResourceListing
+        title="Statistics"
+        buttonProps={{
+          title: "Create new statistic",
+          onClick: () => {
+            setDialogOpen(true);
+            setNewStat(true);
+            setCurrentId();
+          },
+          inProgress: (dialogOpen && newStat)
+        }}
+        columns={columns}
+        entryType={"Statistic"}
+        admin={true}
+        updateData={numNewEntries}
+      />
       <StatisticDialog open={dialogOpen} onClose={dialogClose} classes={classes} onSuccess={dialogSuccess} isNewStatistic={newStat} currentId={currentId}/>
     </>
   );

--- a/modules/vocabularies/src/main/frontend/src/vocabulariesAdminPage.jsx
+++ b/modules/vocabularies/src/main/frontend/src/vocabulariesAdminPage.jsx
@@ -30,6 +30,7 @@ import makeStyles from '@mui/styles/makeStyles';
 
 import React, {useEffect} from "react";
 
+import AdminScreen from "./adminDashboard/AdminScreen.jsx";
 import VocabularyDirectory from "./vocabularyDirectory";
 import OwlInstaller from "./owlInstaller";
 import { BioPortalApiKey } from "./bioportalApiKey";
@@ -201,12 +202,8 @@ export default function VocabulariesAdminPage() {
   }
 
   return (
+    <AdminScreen title="Vocabularies">
     <Grid container direction="column" spacing={6} justifyContent="space-around">
-      <Grid item>
-        <Typography variant="h2">
-          Vocabularies
-        </Typography>
-      </Grid>
 
       {wrapSection(<>
       <Grid item>
@@ -259,5 +256,6 @@ export default function VocabulariesAdminPage() {
       /> }
       </>)}
     </Grid>
+    </AdminScreen>
   );
 }

--- a/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
@@ -19,9 +19,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import {
   Button,
-  Card,
-  CardContent,
-  CardHeader,
   DialogActions,
   DialogContent,
   DialogTitle,
@@ -30,8 +27,7 @@ import {
 } from "@mui/material";
 
 import Fields from "../questionnaireEditor/Fields.jsx";
-import LiveTable from "../dataHomepage/LiveTable.jsx";
-import NewItemButton from "../components/NewItemButton.jsx";
+import ResourceListing from "../dataHomepage/ResourceListing.jsx";
 import ResponsiveDialog from "../components/ResponsiveDialog.jsx";
 import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
 import { camelCaseToWords } from "../questionnaireEditor/LabeledField.jsx";
@@ -71,30 +67,21 @@ function Clinics(props) {
 
   return (
     <>
-      <Card>
-        <CardHeader
-          title={
-            <Button>
-              Clinics
-          </Button>
-          }
-          action={
-            <NewItemButton
-              title="On-board a new clinic"
-              onClick={() => { setDialogOpen(true); setIsNewClinic(true); }}
-              inProgress={dialogOpen}
-            />
-          }
-        />
-        <CardContent>
-          <LiveTable
-            columns={columns}
-            entryType={"Proms/ClinicMapping"}
-            customUrl={"Proms/ClinicMapping.paginate"}
-            admin={true}
-          />
-        </CardContent>
-      </Card>
+      <ResourceListing
+        title="Clinics"
+        buttonProps={{
+          title: "On-board a new clinic",
+          onClick: () => {
+            setDialogOpen(true);
+            setIsNewClinic(true);
+          },
+          inProgress: (dialogOpen && isNewClinic)
+        }}
+        columns={columns}
+        entryType={"Proms/ClinicMapping"}
+        customUrl={"Proms/ClinicMapping.paginate"}
+        admin={true}
+      />
       <OnboardNewClinicDialog currentClinicName={currentClinicName} open={dialogOpen} onClose={dialogClose} onSuccess={dialogSuccess} isNewClinic={isNewClinic} />
     </>
   );

--- a/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/Clinics.jsx
@@ -27,7 +27,7 @@ import {
 } from "@mui/material";
 
 import Fields from "../questionnaireEditor/Fields.jsx";
-import ResourceListing from "../dataHomepage/ResourceListing.jsx";
+import AdminResourceListing from "../adminDashboard/AdminResourceListing.jsx";
 import ResponsiveDialog from "../components/ResponsiveDialog.jsx";
 import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
 import { camelCaseToWords } from "../questionnaireEditor/LabeledField.jsx";
@@ -67,7 +67,7 @@ function Clinics(props) {
 
   return (
     <>
-      <ResourceListing
+      <AdminResourceListing
         title="Clinics"
         buttonProps={{
           title: "On-board a new clinic",

--- a/proms-resources/frontend/src/main/frontend/src/proms/WelcomeMessageConfiguration.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/WelcomeMessageConfiguration.jsx
@@ -18,6 +18,7 @@
 //
 import React, { useState } from 'react';
 import {
+    Alert,
     Button,
     Card,
     CardContent,
@@ -25,11 +26,11 @@ import {
     Grid,
     List,
     ListItem,
-    Typography
 } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import MarkdownText from "../questionnaireEditor/MarkdownText";
 import FormattedText from "../components/FormattedText.jsx";
+import AdminScreen from "../adminDashboard/AdminScreen.jsx";
 
 const useStyles = makeStyles(theme => ({
   editorContainer: {
@@ -117,17 +118,14 @@ function WelcomeMessageConfiguration() {
   }
 
   return (
-    <Card>
-      <CardHeader
+      <AdminScreen
         title="Patient Portal Welcome Message"
-        titleTypographyProps={{variant: "h6"}}
-      />
-      <CardContent>
-        {error && <Typography paragraph color='error'>{error}</Typography>}
-        <Typography paragraph variant="body2">
+      >
+        {error && <Alert severity="error">{error}</Alert>}
+        <Alert severity="info">
           Use APP_NAME to refer to the name configured for the application.
           On the Patient identification screen, all occurrences of APP_NAME will appear as {appName}.
-        </Typography>
+        </Alert>
         <form onSubmit={handleSubmit}>
           <List>
             <ListItem key="form">
@@ -173,8 +171,7 @@ function WelcomeMessageConfiguration() {
             </ListItem>
           </List>
         </form>
-      </CardContent>
-    </Card>
+      </AdminScreen>
   );
 }
 


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/CARDS-1826)

**Other misc changes:**
* Usability issue fix: the (+) button overlaps pagination controls of full livetables on Admin listings such as Questionnaires, Clinics, Subject types (this issue is related to [CARDS-1376](https://phenotips.atlassian.net/browse/CARDS-1376))
* Add breadcrumbs on admin screens to easily return to the admin dashboard
* Reduce the default page size of livetables
* Polish the appearance of the input in Quick Search Settings

**Testing:**
* All admin screens have been refactored and the (+) buttons reworked where applicable. The entire admin functionality needs to be retested, including creating, editing and deleting all types of admin-managed entries such as subject types or clinics.

**Preview:**

![image](https://user-images.githubusercontent.com/651980/175985329-95a48cc7-8872-48d9-915a-076078950e52.png)

![image](https://user-images.githubusercontent.com/651980/175985731-41b9b4d6-72d6-4925-9f03-248288df728e.png)
