### PR TITLE
CARDS-1376: Froms/Subjects pages: Livetable pagination controls become inaccessible under the fixed + button - Fixed JS Console warning

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -75,7 +75,7 @@ function Forms(props) {
   ]
 
   return (
-    <Grid container class={classes.dashboardContainer}>
+    <Grid container className={classes.dashboardContainer}>
       <Grid item className={classes.dashboardEntry}>
         <FormView
           expanded

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
@@ -73,7 +73,7 @@ function Subjects(props) {
   ];
 
   return (
-    <Grid container class={classes.dashboardContainer}>
+    <Grid container className={classes.dashboardContainer}>
       <Grid item className={classes.dashboardEntry}>
         <SubjectView
           expanded


### PR DESCRIPTION
Before this fix, when navigating to Subjects or Forms, the following warning would be generated in the console:

`react-dom.development.js:67 Warning: Invalid DOM property class. Did you mean className?`

Introduced by #1083 .
