### PR TITLE
CARDS-1376: Froms/Subjects pages: Livetable pagination controls become inaccessible under the fixed + button

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -76,7 +76,7 @@ function Forms(props) {
 
   return (
     <Grid container className={classes.dashboardContainer}>
-      <Grid item className={classes.dashboardEntry}>
+      <Grid item className={classes.dashboardEntry} xs={12}>
         <FormView
           expanded
           columns={columns}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
@@ -74,7 +74,7 @@ function Subjects(props) {
 
   return (
     <Grid container className={classes.dashboardContainer}>
-      <Grid item className={classes.dashboardEntry}>
+      <Grid item className={classes.dashboardEntry} xs={12}>
         <SubjectView
           expanded
           columns={columns}


### PR DESCRIPTION
Fixed the width of the data listing on Forms and Subjects pages.

Issue introduced in #1083 / #1085.

**Screenshot of the bug:**

![image](https://user-images.githubusercontent.com/651980/175427660-b4a4a8a4-707c-42e4-8e43-663dc0e10dda.png)
