### PR TITLE
CARDS-1401: Creating forms via API ignores the maxPerSubject setting

### DIFF
--- a/modules/data-entry/src/main/features/feature.json
+++ b/modules/data-entry/src/main/features/feature.json
@@ -73,13 +73,9 @@
         "create path (cards:dataQuery) /query \n\n # Allow all users to query; the actual results will obey their access rights \n set ACL for everyone \n   allow  jcr:read  on /query \n end \n\n create path (cards:QuestionnairesHomepage) /Questionnaires \n create path (cards:FormsHomepage) /Forms \n create path (cards:SubjectsHomepage) /Subjects \n create path (cards:SubjectTypesHomepage) /SubjectTypes "
       ]
     },
-    "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~computedAnswers":{
+    "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~cards-data-entry":{
       "user.mapping":[
-        "io.uhndata.cards.dataentry:computedAnswers=[sling-readall]"
-      ]
-    },
-    "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~maxFormsOfTypePerSubjectValidator":{
-      "user.mapping":[
+        "io.uhndata.cards.dataentry:computedAnswers=[sling-readall]",
         "io.uhndata.cards.dataentry:maxFormsOfTypePerSubjectValidator=[sling-readall]"
       ]
     }

--- a/modules/data-entry/src/main/features/feature.json
+++ b/modules/data-entry/src/main/features/feature.json
@@ -77,6 +77,11 @@
       "user.mapping":[
         "io.uhndata.cards.dataentry:computedAnswers=[sling-readall]"
       ]
+    },
+    "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~maxFormsOfTypePerSubjectValidator":{
+      "user.mapping":[
+        "io.uhndata.cards.dataentry:maxFormsOfTypePerSubjectValidator=[sling-readall]"
+      ]
     }
   }
 }

--- a/modules/data-entry/src/main/java/io/uhndata/cards/internal/MaxFormsOfTypePerSubjectValidator.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/internal/MaxFormsOfTypePerSubjectValidator.java
@@ -29,8 +29,6 @@ import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A {@link Validator} that ensures that the number of created Forms of
@@ -41,8 +39,6 @@ import org.slf4j.LoggerFactory;
  */
 public class MaxFormsOfTypePerSubjectValidator implements Validator
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MaxFormsOfTypePerSubjectValidator.class);
-
     private final ResourceResolverFactory rrf;
 
     public MaxFormsOfTypePerSubjectValidator(final ResourceResolverFactory rrf)
@@ -94,7 +90,6 @@ public class MaxFormsOfTypePerSubjectValidator implements Validator
             long maxPerSubject = questionnaire.getValueMap().get("maxPerSubject", -1);
             if (maxPerSubject > 0) {
                 long formNumber = countFormsPerSubject(subjectUUID, questionnaireUUID, serviceResolver) + 1;
-                LOGGER.warn("The number of existing forms is {} and allowed is {}", formNumber, maxPerSubject);
                 if (formNumber > maxPerSubject) {
                     throw new CommitFailedException(CommitFailedException.STATE, 400,
                             "The number of created forms is bigger then is allowed");

--- a/modules/data-entry/src/main/java/io/uhndata/cards/internal/MaxFormsOfTypePerSubjectValidator.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/internal/MaxFormsOfTypePerSubjectValidator.java
@@ -94,8 +94,7 @@ public class MaxFormsOfTypePerSubjectValidator implements Validator
             }
             long maxPerSubject = questionnaire.getValueMap().get("maxPerSubject", -1);
             if (maxPerSubject > 0) {
-                long formNumber = countFormsPerSubject(subjectUUID,
-                        questionnaire.getValueMap().get("jcr:uuid", "any"), serviceResolver) + 1;
+                long formNumber = countFormsPerSubject(subjectUUID, questionnaireUUID, serviceResolver) + 1;
                 LOGGER.warn("The number of existing forms is {} and allowed is {}", formNumber, maxPerSubject);
                 if (formNumber > maxPerSubject) {
                     throw new CommitFailedException(CommitFailedException.STATE, 400,

--- a/modules/data-entry/src/main/java/io/uhndata/cards/internal/MaxFormsOfTypePerSubjectValidator.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/internal/MaxFormsOfTypePerSubjectValidator.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.internal;
+
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.api.PropertyState;
+import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.spi.commit.Validator;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link Validator} that ensures that the number of created Forms of
+ * a specifc type does not exceed the maximum value allowed for a
+ * Subject.
+ *
+ * @version $Id$
+ */
+public class MaxFormsOfTypePerSubjectValidator implements Validator
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(MaxFormsOfTypePerSubjectValidator.class);
+
+    @Override
+    public void enter(NodeState before, NodeState after) throws CommitFailedException
+    {
+    }
+
+    @Override
+    public void leave(NodeState before, NodeState after) throws CommitFailedException
+    {
+    }
+
+    @Override
+    public void propertyAdded(PropertyState after) throws CommitFailedException
+    {
+    }
+
+    @Override
+    public void propertyChanged(PropertyState before, PropertyState after) throws CommitFailedException
+    {
+    }
+
+    @Override
+    public void propertyDeleted(PropertyState before) throws CommitFailedException
+    {
+    }
+
+    @Override
+    public Validator childNodeAdded(String name, NodeState after) throws CommitFailedException
+    {
+        String childNodeType = after.getName("jcr:primaryType");
+        if ("cards:Form".equals(childNodeType)) {
+            String questionnaireUUID = after.getProperty("questionnaire").getValue(Type.REFERENCE).toString();
+            String subjectUUID = after.getProperty("subject").getValue(Type.REFERENCE).toString();
+            LOGGER.warn("Added this --> {}", after);
+            LOGGER.warn("A cards:Form node was just added with questionnaire={} and subject={} !!!",
+                questionnaireUUID,
+                subjectUUID
+            );
+        }
+        return this;
+    }
+
+    @Override
+    public Validator childNodeChanged(String name, NodeState before, NodeState after) throws CommitFailedException
+    {
+        return this;
+    }
+
+    @Override
+    public Validator childNodeDeleted(String name, NodeState before) throws CommitFailedException
+    {
+        return this;
+    }
+}

--- a/modules/data-entry/src/main/java/io/uhndata/cards/internal/MaxFormsOfTypePerSubjectValidator.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/internal/MaxFormsOfTypePerSubjectValidator.java
@@ -85,11 +85,6 @@ public class MaxFormsOfTypePerSubjectValidator implements Validator
         }
         String questionnaireUUID = after.getProperty("questionnaire").getValue(Type.REFERENCE).toString();
         String subjectUUID = after.getProperty("subject").getValue(Type.REFERENCE).toString();
-        LOGGER.warn("Added this --> {}", after);
-        LOGGER.warn("A cards:Form node was just added with questionnaire={} and subject={} !!!",
-            questionnaireUUID,
-            subjectUUID
-        );
         final Map<String, Object> parameters =
             Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "maxFormsOfTypePerSubjectValidator");
         try (ResourceResolver serviceResolver = this.rrf.getServiceResourceResolver(parameters)) {

--- a/modules/data-entry/src/main/java/io/uhndata/cards/internal/MaxFormsOfTypePerSubjectValidator.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/internal/MaxFormsOfTypePerSubjectValidator.java
@@ -43,7 +43,6 @@ public class MaxFormsOfTypePerSubjectValidator implements Validator
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(MaxFormsOfTypePerSubjectValidator.class);
 
-    private static final String END = "'";
     private final ResourceResolverFactory rrf;
 
     public MaxFormsOfTypePerSubjectValidator(final ResourceResolverFactory rrf)
@@ -119,8 +118,8 @@ public class MaxFormsOfTypePerSubjectValidator implements Validator
     {
         long count = 0;
         Iterator<Resource> results = serviceResolver.findResources(
-                "SELECT f.* FROM [cards:Form] AS f WHERE f.'subject'='" + subjectUUID + END
-                        + " AND f.'questionnaire'='" + questionnaireUUID + END,
+                "SELECT f.* FROM [cards:Form] AS f WHERE f.'subject'='" + subjectUUID + "'"
+                        + " AND f.'questionnaire'='" + questionnaireUUID + "'",
                 "JCR-SQL2"
         );
 
@@ -134,7 +133,7 @@ public class MaxFormsOfTypePerSubjectValidator implements Validator
     private Resource getQuestionnaireResourceByUuid(ResourceResolver serviceResolver, String uuid)
     {
         Iterator<Resource> resourceIterator = serviceResolver.findResources(
-                "SELECT * FROM [cards:Questionnaire] as q WHERE q.'jcr:uuid'='" + uuid + END, "JCR-SQL2");
+                "SELECT * FROM [cards:Questionnaire] as q WHERE q.'jcr:uuid'='" + uuid + "'", "JCR-SQL2");
         if (!resourceIterator.hasNext()) {
             return null;
         }

--- a/modules/data-entry/src/main/java/io/uhndata/cards/internal/MaxFormsOfTypePerSubjectValidator.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/internal/MaxFormsOfTypePerSubjectValidator.java
@@ -21,8 +21,8 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.apache.jackrabbit.oak.api.CommitFailedException;
-import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.spi.commit.DefaultValidator;
 import org.apache.jackrabbit.oak.spi.commit.Validator;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.sling.api.resource.LoginException;
@@ -31,13 +31,12 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 
 /**
- * A {@link Validator} that ensures that the number of created Forms of
- * a specifc type does not exceed the maximum value allowed for a
- * Subject.
+ * A {@link Validator} that ensures that the number of created Forms of a specifc type does not exceed the maximum value
+ * allowed for a Subject.
  *
  * @version $Id$
  */
-public class MaxFormsOfTypePerSubjectValidator implements Validator
+public class MaxFormsOfTypePerSubjectValidator extends DefaultValidator
 {
     private final ResourceResolverFactory rrf;
 
@@ -47,42 +46,17 @@ public class MaxFormsOfTypePerSubjectValidator implements Validator
     }
 
     @Override
-    public void enter(NodeState before, NodeState after) throws CommitFailedException
-    {
-    }
-
-    @Override
-    public void leave(NodeState before, NodeState after) throws CommitFailedException
-    {
-    }
-
-    @Override
-    public void propertyAdded(PropertyState after) throws CommitFailedException
-    {
-    }
-
-    @Override
-    public void propertyChanged(PropertyState before, PropertyState after) throws CommitFailedException
-    {
-    }
-
-    @Override
-    public void propertyDeleted(PropertyState before) throws CommitFailedException
-    {
-    }
-
-    @Override
-    public Validator childNodeAdded(String name, NodeState after) throws CommitFailedException
+    public Validator childNodeAdded(final String name, final NodeState after) throws CommitFailedException
     {
         // Get the type of this node. Return immediately if it's not a cards:Form node
-        String childNodeType = after.getName("jcr:primaryType");
+        final String childNodeType = after.getName("jcr:primaryType");
         if (!("cards:Form".equals(childNodeType))) {
             return this;
         }
 
         // Get the jcr:uuid values for the Form's associated Questionnaire and Subject
-        String questionnaireUUID = after.getProperty("questionnaire").getValue(Type.REFERENCE).toString();
-        String subjectUUID = after.getProperty("subject").getValue(Type.REFERENCE).toString();
+        final String questionnaireUUID = after.getProperty("questionnaire").getValue(Type.REFERENCE).toString();
+        final String subjectUUID = after.getProperty("subject").getValue(Type.REFERENCE).toString();
 
         // Obtain a ResourceResolver for querying the JCR
         final Map<String, Object> parameters =
@@ -90,25 +64,32 @@ public class MaxFormsOfTypePerSubjectValidator implements Validator
         try (ResourceResolver serviceResolver = this.rrf.getServiceResourceResolver(parameters)) {
 
             // Get the Questionnaire Resource associated with this Form
-            Resource questionnaire = getQuestionnaireResourceByUuid(serviceResolver, questionnaireUUID);
+            final Resource questionnaire = getQuestionnaireResourceByUuid(serviceResolver, questionnaireUUID);
             if (questionnaire == null) {
                 return this;
             }
 
             // Get the maxPerSubject value for the Questionnaire
-            long maxPerSubject = questionnaire.getValueMap().get("maxPerSubject", -1);
+            final long maxPerSubject = questionnaire.getValueMap().get("maxPerSubject", -1);
 
             // Should this commit be allowed or does it exceed the maxPerSubject constraint?
             if (maxPerSubject > 0) {
-                long formNumber = countFormsPerSubject(subjectUUID, questionnaireUUID, serviceResolver) + 1;
+                final long formNumber = countFormsPerSubject(subjectUUID, questionnaireUUID, serviceResolver) + 1;
                 if (formNumber > maxPerSubject) {
                     throw new CommitFailedException(CommitFailedException.STATE, 400,
-                            "The number of created forms is bigger then is allowed");
+                        "The number of created forms is bigger then is allowed");
                 }
             }
-        } catch (LoginException e) {
+        } catch (final LoginException e) {
             // Should not happen
         }
+        return this;
+    }
+
+    @Override
+    public Validator childNodeChanged(final String name, final NodeState before, final NodeState after)
+        throws CommitFailedException
+    {
         return this;
     }
 
@@ -120,15 +101,14 @@ public class MaxFormsOfTypePerSubjectValidator implements Validator
      * @param ResourceResolver a ResourceResolver that can be used for querying the JCR
      * @return a long-typed number of the number of Forms with the specified questionnaire and subject
      */
-    private long countFormsPerSubject(String subjectUUID, String questionnaireUUID,
-                                      ResourceResolver serviceResolver)
+    private long countFormsPerSubject(final String subjectUUID, final String questionnaireUUID,
+        final ResourceResolver serviceResolver)
     {
         long count = 0;
-        Iterator<Resource> results = serviceResolver.findResources(
-                "SELECT f.* FROM [cards:Form] AS f WHERE f.'subject'='" + subjectUUID + "'"
-                        + " AND f.'questionnaire'='" + questionnaireUUID + "'",
-                "JCR-SQL2"
-        );
+        final Iterator<Resource> results = serviceResolver.findResources(
+            "SELECT f.* FROM [cards:Form] AS f WHERE f.'subject'='" + subjectUUID + "'"
+                + " AND f.'questionnaire'='" + questionnaireUUID + "'",
+            "JCR-SQL2");
 
         while (results.hasNext()) {
             count += 1;
@@ -144,25 +124,13 @@ public class MaxFormsOfTypePerSubjectValidator implements Validator
      * @param uuid the jcr:uuid of the Questionnaire Resource which we wish to obtain
      * @return the matching Questionnaire Resource or null if none can be found
      */
-    private Resource getQuestionnaireResourceByUuid(ResourceResolver serviceResolver, String uuid)
+    private Resource getQuestionnaireResourceByUuid(final ResourceResolver serviceResolver, final String uuid)
     {
-        Iterator<Resource> resourceIterator = serviceResolver.findResources(
-                "SELECT * FROM [cards:Questionnaire] as q WHERE q.'jcr:uuid'='" + uuid + "'", "JCR-SQL2");
+        final Iterator<Resource> resourceIterator = serviceResolver.findResources(
+            "SELECT * FROM [cards:Questionnaire] as q WHERE q.'jcr:uuid'='" + uuid + "'", "JCR-SQL2");
         if (!resourceIterator.hasNext()) {
             return null;
         }
         return resourceIterator.next();
-    }
-
-    @Override
-    public Validator childNodeChanged(String name, NodeState before, NodeState after) throws CommitFailedException
-    {
-        return this;
-    }
-
-    @Override
-    public Validator childNodeDeleted(String name, NodeState before) throws CommitFailedException
-    {
-        return this;
     }
 }

--- a/modules/data-entry/src/main/java/io/uhndata/cards/internal/MaxFormsOfTypePerSubjectValidator.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/internal/MaxFormsOfTypePerSubjectValidator.java
@@ -88,14 +88,11 @@ public class MaxFormsOfTypePerSubjectValidator implements Validator
         final Map<String, Object> parameters =
             Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "maxFormsOfTypePerSubjectValidator");
         try (ResourceResolver serviceResolver = this.rrf.getServiceResourceResolver(parameters)) {
-            LOGGER.warn("Yay! We were able to get a ResourceResolver");
             Resource questionnaire = getQuestionnaireResourceByUuid(serviceResolver, questionnaireUUID);
-            LOGGER.warn("Resolved /Questionnaires/Patient information --> {}", questionnaire);
             if (questionnaire == null) {
                 return this;
             }
             long maxPerSubject = questionnaire.getValueMap().get("maxPerSubject", -1);
-            LOGGER.warn("/Questionnaires/Patient information/maxPerSubject = {}", maxPerSubject);
             if (maxPerSubject > 0) {
                 long formNumber = countFormsPerSubject(subjectUUID,
                         questionnaire.getValueMap().get("jcr:uuid", "any"), serviceResolver) + 1;

--- a/modules/data-entry/src/main/java/io/uhndata/cards/internal/MaxFormsOfTypePerSubjectValidatorProvider.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/internal/MaxFormsOfTypePerSubjectValidatorProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.internal;
+
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
+import org.apache.jackrabbit.oak.spi.commit.EditorProvider;
+import org.apache.jackrabbit.oak.spi.commit.Validator;
+import org.apache.jackrabbit.oak.spi.commit.ValidatorProvider;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * The {@link ValidatorProvider} for the
+ * MaxFormsOfTypePerSubjectValidator {@link Validator}.
+ *
+ * @version $Id$
+ */
+@Component(name = "MaxFormsOfTypePerSubjectValidatorProvider", service = EditorProvider.class)
+public class MaxFormsOfTypePerSubjectValidatorProvider extends ValidatorProvider
+{
+    @Override
+    protected Validator getRootValidator(NodeState before, NodeState after, CommitInfo info)
+    {
+        return new MaxFormsOfTypePerSubjectValidator();
+    }
+}

--- a/modules/data-entry/src/main/java/io/uhndata/cards/internal/MaxFormsOfTypePerSubjectValidatorProvider.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/internal/MaxFormsOfTypePerSubjectValidatorProvider.java
@@ -21,7 +21,9 @@ import org.apache.jackrabbit.oak.spi.commit.EditorProvider;
 import org.apache.jackrabbit.oak.spi.commit.Validator;
 import org.apache.jackrabbit.oak.spi.commit.ValidatorProvider;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * The {@link ValidatorProvider} for the
@@ -32,9 +34,15 @@ import org.osgi.service.component.annotations.Component;
 @Component(name = "MaxFormsOfTypePerSubjectValidatorProvider", service = EditorProvider.class)
 public class MaxFormsOfTypePerSubjectValidatorProvider extends ValidatorProvider
 {
+    @Reference
+    private ResourceResolverFactory rrf;
+
     @Override
     protected Validator getRootValidator(NodeState before, NodeState after, CommitInfo info)
     {
-        return new MaxFormsOfTypePerSubjectValidator();
+        if (this.rrf != null) {
+            return new MaxFormsOfTypePerSubjectValidator(this.rrf);
+        }
+        return null;
     }
 }


### PR DESCRIPTION
This PR implements CARDS-1401 by adding a _commit validator_ to ensure that commits of `cards:Form` nodes conform to the `maxPerSubject` constraint defined by their associated Questionnaire.

To test:

1. Build this `CARDS-1401-v2` branch with `mvn clean install`.
2. Start CARDS in `cards4proms` mode - `./start_cards.sh --dev --project cards4proms`
3. Create a new _Patient information_ Form along with its associated _Patient_ Subject
4. In a new browser tab, visit `http://localhost:8080/bin/browser.html`
5. _Check out_ the `Questionnaires/Patient information` node
6. Change the `Questionnaires/Patient information` `maxPerSubject` property from `1` to `10`
7. Using the CARDS Web UI, start the process of creating a new _Patient information_ Form for the previously created patient but before clicking _Create Form_, go to the browser tab with Composum open and change the `maxPerSubject` property of `/Questionnaires/Patient information` back to `1`.
8. Go back to the browser tab with the CARDS Web UI and click _Create Form_
9. Form creation should fail with the message `New form request failed with error code 409: Conflict`