### PR TITLE
CARDS-1848: The patient identification should not send "undefined" for unfilled inputs

### DIFF
--- a/proms-resources/frontend/src/main/frontend/src/proms/PatientIdentification.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PatientIdentification.jsx
@@ -151,12 +151,11 @@ function PatientIdentification(props) {
       return null;
     }
     let requestData = new FormData();
-    requestData.append("date_of_birth", dob);
-    requestData.append("mrn", mrn);
-    requestData.append("health_card", hc);
-    if (visit) {
-      requestData.append("visit", visit);
-    }
+    dob && requestData.append("date_of_birth", dob);
+    mrn && requestData.append("mrn", mrn);
+    hc && requestData.append("health_card", hc);
+    visit && requestData.append("visit", visit);
+
     fetch("/Proms.validateCredentials", {
       "method": "POST",
       "body": requestData


### PR DESCRIPTION
[Jira issue](https://phenotips.atlassian.net/browse/CARDS-1848)

To test:
- start in proms mode
- open the patient authentication page, open the network monitor
- try to log in with DoB and MRN, check that the request does not have HC=undefined
- try to log in with DoB and HC, check that the request does not have MRN=undefined
- try to log in with DoB, MRN and HC, check that the all 3 fields are sent