### PR TITLE
CARDS-1851: Add Cancel button to all single-configuration admin screens

### DIFF
--- a/modules/downtime-warning-banner/src/main/frontend/src/DowntimeWarningConfiguration.jsx
+++ b/modules/downtime-warning-banner/src/main/frontend/src/DowntimeWarningConfiguration.jsx
@@ -16,130 +16,79 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
-    Button,
     Checkbox,
     TextField,
     Tooltip,
-    Typography,
     FormControlLabel,
     List,
     ListItem,
 } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 
-import AdminScreen from "./adminDashboard/AdminScreen.jsx";
+import AdminConfigScreen from "./adminDashboard/AdminConfigScreen.jsx";
 
 const useStyles = makeStyles(theme => ({
   textField: {
     minWidth: "250px",
     paddingBottom: theme.spacing(2),
   },
-  saveButton: {
-    marginTop: theme.spacing(3),
-  },
 }));
 
 function DowntimeWarningConfiguration() {
   const classes = useStyles();
 
-  const [ path, setPath ] = useState();
-
-  // The the configuration values specified by the Administration
+  // The the configuration values
   const [ enabled, setEnabled ] = useState(false);
   const [ fromDate, setFromDate ] = useState();
   const [ toDate, setToDate ] = useState();
-  const [ isInvalidDateRange, setIsInvalidDateRange ] = useState(false);
+  const [ isDateRangeInvalid, setIsDateRangeInvalid ] = useState(false);
 
-  // Status tracking values of fetching/posting the data from/to the server
-  const [ error, setError ] = useState();
-  const [ isSaved, setIsSaved ] = useState(false);
-  const [ fetched, setFetched ] = useState(false);
+  // Tracking unsaved changes
+  const [ hasChanges, setHasChanges ] = useState(true);
 
   const dateFormat = "yyyy-MM-dd hh:mm";
 
-  // Fetch saved admin config settings
-  let getDowntimeWarningSettings = () => {
-    fetch('/apps/cards/config/DowntimeWarning.deep.json')
-      .then((response) => response.ok ? response.json() : Promise.reject(response))
-      .then((json) => {
-        setFetched(true);
-        setPath(json["@path"]);
-        setEnabled(json.enabled == 'true');
-        setFromDate(json.fromDate);
-        setToDate(json.toDate);
-      });
+  // Read the settings from the saved configuration
+  let getDowntimeWarningSettings = (json) => {
+    setEnabled(json.enabled == 'true');
+    setFromDate(json.fromDate);
+    setToDate(json.toDate);
   }
 
-  // Submit function
-  let handleSubmit = (event) => {
-
-    // This stops the normal browser form submission
-    event && event.preventDefault();
-
-    // Build formData object.
-    // We need to do this because sling does not accept JSON, need url encoded data
-    let formData = new URLSearchParams();
+  let buildConfigData = (formData) => {
     formData.append('enabled', enabled);
     formData.append('fromDate', fromDate);
     formData.append('toDate', toDate);
-
-    // Use native fetch, sort like the XMLHttpRequest so no need for other libraries.
-    fetch(path,
-      {
-        method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/x-www-form-urlencoded'
-        },
-        body: formData
-      })
-      .then((response) => {
-
-        // Important note about native fetch, it does not reject failed
-        // HTTP codes, it'll only fail when network error
-        // Therefore, you must handle the error code yourself.
-        if (!response.ok) {
-          throw Error(response.statusText);
-        }
-
-        setIsSaved(true);
-      })
-      .catch(error => {
-        console.log(error);
-      });
   }
 
-  let updateFromDate  = (event) => {
-    event.preventDefault();
-    setIsSaved(false);
-    setFromDate(event.target.value);
-  }
+  useEffect(() => {
+    // Determine if the end date is earlier than the start date
+    setIsDateRangeInvalid(fromDate && toDate && new Date(toDate).valueOf() < new Date(fromDate).valueOf());
+  }, [fromDate, toDate]);
 
-  let updateToDate  = (event) => {
-    event.preventDefault();
-    setIsSaved(false);
-    setToDate(event.target.value);
-    // Determine the end date is earlier than the start date
-    setIsInvalidDateRange(fromDate && event.target.value && new Date(event.target.value).valueOf() < new Date(fromDate).valueOf());
-  }
-
-  if (!fetched) {
-    getDowntimeWarningSettings();
-  }
+  useEffect(() => {
+    setHasChanges(true);
+  }, [enabled, fromDate, toDate]);
 
   return (
-    <AdminScreen title="Downtime Warning Banner Settings">
-        {error && <Typography color='error'>{errorText}</Typography>}
-        <form onSubmit={handleSubmit}>
+    <AdminConfigScreen
+        title="Downtime Warning Banner Settings"
+        configPath="/apps/cards/config/DowntimeWarning"
+        onConfigFetched={getDowntimeWarningSettings}
+        hasChanges={hasChanges}
+        configError={isDateRangeInvalid ? "Invalid date range" : undefined}
+        buildConfigData={buildConfigData}
+        onConfigSaved={() => setHasChanges(false)}
+      >
           <List>
             <ListItem key="enabled">
               <FormControlLabel
                 control={
                   <Checkbox
                     checked={enabled}
-                    onChange={(event) => { event.preventDefault(); setIsSaved(false); setEnabled(event.target.checked); }}
+                    onChange={ event => setEnabled(event.target.checked) }
                     name="enabled"
                   />
                 }
@@ -153,8 +102,8 @@ function DowntimeWarningConfiguration() {
                 type="datetime-local"
                 InputLabelProps={{ shrink: true }}
                 className={classes.textField}
-                onChange={(event) => { updateFromDate(event) }}
-                onBlur={(event) => { updateFromDate(event) }}
+                onChange={(event) => setFromDate(event.target.value) }
+                onBlur={(event) => setFromDate(event.target.value) }
                 placeholder={dateFormat.toLowerCase()}
                 value={fromDate || ""}
               />
@@ -166,29 +115,16 @@ function DowntimeWarningConfiguration() {
                 type="datetime-local"
                 InputLabelProps={{ shrink: true }}
                 className={classes.textField}
-                onChange={(event) => { updateToDate(event) }}
-                onBlur={(event) => { updateToDate(event) }}
+                onChange={(event) => setToDate(event.target.value) }
+                onBlur={(event) => setToDate(event.target.value) }
                 placeholder={dateFormat.toLowerCase()}
                 value={toDate || ""}
-                error={isInvalidDateRange}
-                helperText={isInvalidDateRange ? "End date should be after the start date." : ""}
+                error={isDateRangeInvalid}
+                helperText={isDateRangeInvalid ? "The end date should be after the start date." : ""}
               />
             </ListItem>
-            <ListItem key="button">
-              <Button
-                type="submit"
-                disabled={isInvalidDateRange}
-                variant="contained"
-                color="primary"
-                size="small"
-                className={classes.saveButton}
-              >
-                { isSaved ? "Saved" : "Save" }
-              </Button>
-            </ListItem>
           </List>
-        </form>
-    </AdminScreen>
+    </AdminConfigScreen>
   );
 }
 

--- a/modules/downtime-warning-banner/src/main/frontend/src/DowntimeWarningConfiguration.jsx
+++ b/modules/downtime-warning-banner/src/main/frontend/src/DowntimeWarningConfiguration.jsx
@@ -39,19 +39,19 @@ const useStyles = makeStyles(theme => ({
 function DowntimeWarningConfiguration() {
   const classes = useStyles();
 
-  // The the configuration values
+  // The configuration values
   const [ enabled, setEnabled ] = useState(false);
   const [ fromDate, setFromDate ] = useState();
   const [ toDate, setToDate ] = useState();
-  const [ isDateRangeInvalid, setIsDateRangeInvalid ] = useState(false);
+  const [ dateRangeIsInvalid, setDateRangeIsInvalid ] = useState(false);
 
   // Tracking unsaved changes
-  const [ hasChanges, setHasChanges ] = useState(true);
+  const [ hasChanges, setHasChanges ] = useState();
 
   const dateFormat = "yyyy-MM-dd hh:mm";
 
   // Read the settings from the saved configuration
-  let getDowntimeWarningSettings = (json) => {
+  let readDowntimeWarningSettings = (json) => {
     setEnabled(json.enabled == 'true');
     setFromDate(json.fromDate);
     setToDate(json.toDate);
@@ -65,7 +65,7 @@ function DowntimeWarningConfiguration() {
 
   useEffect(() => {
     // Determine if the end date is earlier than the start date
-    setIsDateRangeInvalid(fromDate && toDate && new Date(toDate).valueOf() < new Date(fromDate).valueOf());
+    setDateRangeIsInvalid(fromDate && toDate && new Date(toDate).valueOf() < new Date(fromDate).valueOf());
   }, [fromDate, toDate]);
 
   useEffect(() => {
@@ -76,9 +76,9 @@ function DowntimeWarningConfiguration() {
     <AdminConfigScreen
         title="Downtime Warning Banner Settings"
         configPath="/apps/cards/config/DowntimeWarning"
-        onConfigFetched={getDowntimeWarningSettings}
+        onConfigFetched={readDowntimeWarningSettings}
         hasChanges={hasChanges}
-        configError={isDateRangeInvalid ? "Invalid date range" : undefined}
+        configError={dateRangeIsInvalid ? "Invalid date range" : undefined}
         buildConfigData={buildConfigData}
         onConfigSaved={() => setHasChanges(false)}
       >
@@ -119,8 +119,8 @@ function DowntimeWarningConfiguration() {
                 onBlur={(event) => setToDate(event.target.value) }
                 placeholder={dateFormat.toLowerCase()}
                 value={toDate || ""}
-                error={isDateRangeInvalid}
-                helperText={isDateRangeInvalid ? "The end date should be after the start date." : ""}
+                error={dateRangeIsInvalid}
+                helperText={dateRangeIsInvalid ? "The end date should be after the start date." : ""}
               />
             </ListItem>
           </List>

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
@@ -18,6 +18,8 @@
 //
 import React, { useState, useEffect, useContext } from "react";
 
+import PropTypes from "prop-types";
+
 import { useHistory } from 'react-router-dom';
 
 import { Alert, Button, CardActions, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, Typography } from "@mui/material";
@@ -48,6 +50,51 @@ const useStyles = makeStyles(theme => ({
     },
   },
 }));
+
+/**
+ * Component that displays an administration screen allowing for a configuration node to be
+ * updated by an admin user.
+ *
+ * Given the path of the configuration node (specified by the `configPath` prop), it generates
+ * a form with two buttons, SAVE and RESET. The actual contents of the form are rendered
+ * by the parent component as the `children`. `AdminConfigScreen` loads the configuration
+ * from the backend and passes it on to the parent component via the `onConfigFetched` handler.
+ * It gets notified if any changes have been made to the form via the `hasChanges` prop.
+ * In case of data sanity issues as the user fills out a form (for example, a start date which
+ * is later than an end date), it receives an error to display via the `configError` prop.
+ * Data sanity errors will prevent the form from being saved by disabling the button.
+ * When the save button is pressed, the parent component is notified via the `buildConfigData`
+ * handler to build the form data, which is then sent to the server by `AdminConfigScreen`. Once
+ * successfully saved, the parent component is notified via the `onConfigSaved` handler.
+ * Resetting is done by reverting to the configuration that was first loaded when rendering
+ * this component, both on the frontend (the parent component is notified to populate the form
+ * with the original values) and on the backend (whatever has been saved in the current session
+ * is overwritted with the original values). The user is informed of the effects of resetting
+ * and is asked to confirm before actually performing it.
+ *
+ * @example
+ * <AdminConfigScreen
+ *  title="My feature's configuration"
+ *  configPath="/path/to/jcr/node"
+ *  onConfigFetched={readConfig}
+ *  hasChanges={hasChanges}
+ *  configError={error}
+ *  buildConfigData={buildConfigData}
+ *  onConfigSaved={resetHasChanges}
+ *  >
+ *    { renderConfigFormEntries() }
+ * </AdminConfigScreen>
+ *
+ * @param {string} title  - the title of the administration screen, required
+ * @param {string} configPath  - the path of the configuration node; will be used for loading and saving the data
+ * @param {function} onConfigFetched  - handler to pass the loaded configuration json to the parent component
+ * @param {boolean} hasChanges  - how the parent component notifies that the user changed the form values
+ * @param {string} configError  - how the parent component notifies that there's a data sanity issue
+ * @param {function} buildConfigData  - handler to pass the formData to be populated by the parent component before saving
+ * @param {function} onConfigSaved  - handler to notify the parent component that the data has been saved (no params passed)
+ * @param {node or Array.<node>} children - any content that will be displayed in the form, typically
+ *   labeled form controls for each property of the configuration node
+ */
 
 function AdminConfigScreen(props) {
   const { title, configPath, onConfigFetched, hasChanges, configError, buildConfigData, onConfigSaved, children } = props;
@@ -183,6 +230,20 @@ function AdminConfigScreen(props) {
       }
     </AdminScreen>
   );
+}
+
+AdminConfigScreen.propTypes = {
+  title: PropTypes.string.isRequired,
+  configPath: PropTypes.string,
+  onConfigFetched: PropTypes.func,
+  hasChanges: PropTypes.bool,
+  configError: PropTypes.string,
+  buildConfigData: PropTypes.func,
+  onConfigSaved: PropTypes.func,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]),
 }
 
 export default AdminConfigScreen;

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
@@ -1,0 +1,139 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+import React, { useState, useEffect, useContext } from "react";
+
+import { useHistory } from 'react-router-dom';
+
+import { Alert, Button, CardActions, CircularProgress } from "@mui/material";
+import { makeStyles } from '@mui/styles';
+
+import AdminScreen from "./AdminScreen.jsx";
+import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    "& .MuiAlert-root": {
+      margin: theme.spacing(0, 1, 2),
+    },
+    "& .MuiListItem-root": {
+      padding: theme.spacing(1),
+    },
+    "& .MuiCardActions-root": {
+      padding: theme.spacing(2, 1, 0),
+    },
+  },
+}));
+
+function AdminConfigScreen(props) {
+  const { title, configPath, onConfigFetched, hasChanges, configError, buildConfigData, onConfigSaved, children } = props;
+  const [ fetched, setFetched ] = useState();
+  const [ error, setError ] = useState();
+
+  const globalContext = useContext(GlobalLoginContext);
+  const history = useHistory();
+  const classes = useStyles();
+
+  useEffect(() => getConfig(), []);
+
+  // Loading the existing configuration
+  const getConfig = () => {
+    fetchWithReLogin(globalContext, `${configPath}.json`)
+      .then((response) => response.ok ? response.json() : Promise.reject(response))
+      .then(json => {
+         setFetched(true);
+         onConfigFetched?.(json);
+	  })
+      .catch(err => {
+         setFetched(false);
+         setError("The configuration could not be loaded.")
+      });
+  }
+
+  // Submitting the form to save the new configuration
+  const handleSubmit = (event) => {
+
+    // This stops the normal browser form submission
+    event && event.preventDefault();
+
+    // Abort if there's a data sanity error
+    if (configError) return;
+
+    // Reset any recorded fetch error
+    setError("");
+
+    // Build formData object.
+    let formData = new URLSearchParams();
+    buildConfigData?.(formData);
+
+    fetchWithReLogin(globalContext, configPath,
+      {
+        method: 'POST',
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: formData
+      })
+      .then((response) => {
+
+        // Important note about native fetch, it does not reject failed
+        // HTTP codes, it'll only fail when network error
+        // Therefore, you must handle the error code yourself.
+        if (!response.ok) {
+          throw Error(response.statusText);
+        }
+
+        onConfigSaved?.();
+      })
+      .catch(err => setError("The configuration could not be saved."));
+  }
+
+  return (
+    <AdminScreen title={title} className={classes.root}>
+      { (configError || error) && <Alert severity="error">{configError || error}</Alert> }
+      { typeof(fetched) == 'undefined' ? <CircularProgress/> :
+        !fetched ? "" :
+        <form onSubmit={handleSubmit}>
+          { children }
+          <CardActions>
+            <Button
+              type="submit"
+              variant="contained"
+              color="primary"
+              size="small"
+              disabled={configError || !hasChanges}
+            >
+              Save
+            </Button>
+            <Button
+              variant="outlined"
+              color="primary"
+              size="small"
+              onClick={() => history.push("/content.html/admin/") }
+            >
+              Cancel
+            </Button>
+          </CardActions>
+        </form>
+      }
+    </AdminScreen>
+  );
+}
+
+export default AdminConfigScreen;

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
@@ -125,6 +125,8 @@ function AdminConfigScreen(props) {
     onConfigFetched?.(config);
     // Save the initial config, overwriting any previously saved changes
     handleSubmit();
+    // Close the confirmation dialog
+    setResetConfirmationPending(false);
   }
 
   return (

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminScreen.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminScreen.jsx
@@ -40,7 +40,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 function AdminScreen(props) {
-  const { title, action, disableBreadcrumb, children } = props;
+  const { title, action, disableBreadcrumb, className, children } = props;
 
   const classes = useStyles();
   const appName = document.querySelector('meta[name="title"]')?.content;
@@ -54,6 +54,9 @@ function AdminScreen(props) {
   );
 
   let classNames = [classes.root];
+  if (className) {
+    classNames.push(className);
+  }
   if (!!action) {
     classNames.push(classes.withMainAction);
   }

--- a/modules/homepage/src/main/frontend/src/themePage/QuickSearchConfiguration.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/QuickSearchConfiguration.jsx
@@ -40,7 +40,7 @@ function QuickSearchConfiguration(props) {
   const resourceTypes = ["cards:Form", "cards:Subject", "cards:Questionnaire"];
 
   // Read the settings from the saved configuration
-  let getQuickSearchSettings = (json) => {
+  let readQuickSearchSettings = (json) => {
     setLimit(json["limit"]);
     setAllowedResourceTypes(json["allowedResourceTypes"]);
     setShowTotalRows(json["showTotalRows"]  == 'true');
@@ -55,7 +55,6 @@ function QuickSearchConfiguration(props) {
   }
 
   let onSourceTypeChange  = (checked, resourceName) => {
-    event.preventDefault();
     setHasChanges(true);
     let types = allowedResourceTypes.slice();
     if (checked) {
@@ -74,7 +73,7 @@ function QuickSearchConfiguration(props) {
     <AdminConfigScreen
         title="Quick Search Settings"
         configPath="/apps/cards/config/QuickSearch"
-        onConfigFetched={getQuickSearchSettings}
+        onConfigFetched={readQuickSearchSettings}
         hasChanges={hasChanges}
         buildConfigData={buildConfigData}
         onConfigSaved={() => setHasChanges(false)}

--- a/proms-resources/frontend/src/main/frontend/src/proms/ToUConfiguration.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/ToUConfiguration.jsx
@@ -44,7 +44,7 @@ function ToUConfiguration() {
   const [ hasChanges, setHasChanges ] = useState(true);
 
   // Read the ToU properties from the saved configuration
-  let getToUData = (json) => {
+  let readToUData = (json) => {
     setAcceptanceRequired(json.acceptanceRequired || false);
     setTitle(json.title || "");
     setVersion(json.version || "");
@@ -66,7 +66,7 @@ function ToUConfiguration() {
     <AdminConfigScreen
       title="Patient Portal Terms of Use"
       configPath="/Proms/TermsOfUse"
-      onConfigFetched={getToUData}
+      onConfigFetched={readToUData}
       hasChanges={hasChanges}
       buildConfigData={buildConfigData}
       onConfigSaved={() => setHasChanges(false)}

--- a/proms-resources/frontend/src/main/frontend/src/proms/WelcomeMessageConfiguration.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/WelcomeMessageConfiguration.jsx
@@ -59,7 +59,7 @@ function WelcomeMessageConfiguration() {
   const appName = document.querySelector('meta[name="title"]')?.content;
 
   // Read the welcome message from the saved configuration
-  let getWelcomeMessage = (configJson) => {
+  let readWelcomeMessage = (configJson) => {
     setWelcomeMessage(configJson.text || "");
   }
 
@@ -75,7 +75,7 @@ function WelcomeMessageConfiguration() {
       <AdminConfigScreen
         title="Patient Portal Welcome Message"
         configPath="/Proms/WelcomeMessage"
-        onConfigFetched={getWelcomeMessage}
+        onConfigFetched={readWelcomeMessage}
         hasChanges={hasChanges}
         buildConfigData={buildConfigData}
         onConfigSaved={() => setHasChanges(false)}

--- a/proms-resources/frontend/src/main/frontend/src/proms/WelcomeMessageConfiguration.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/WelcomeMessageConfiguration.jsx
@@ -16,24 +16,22 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
     Alert,
-    Button,
     Card,
     CardContent,
     CardHeader,
     Grid,
-    List,
-    ListItem,
 } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import MarkdownText from "../questionnaireEditor/MarkdownText";
 import FormattedText from "../components/FormattedText.jsx";
-import AdminScreen from "../adminDashboard/AdminScreen.jsx";
+import AdminConfigScreen from "../adminDashboard/AdminConfigScreen.jsx";
 
 const useStyles = makeStyles(theme => ({
   editorContainer: {
+    padding: theme.spacing(2, 1),
     "& > .MuiGrid-item > *": {
       height: "100% !important",
     },
@@ -50,128 +48,71 @@ const useStyles = makeStyles(theme => ({
     padding: theme.spacing(0, 0, 0, 2),
     height: "30px"
   },
-  saveButton: {
-    marginTop: theme.spacing(3),
-  },
 }));
 
 function WelcomeMessageConfiguration() {
   const classes = useStyles();
 
   const [ welcomeMessage, setWelcomeMessage ] = useState();
-
-  // Status tracking values of fetching/posting the data from/to the server
-  const [ error, setError ] = useState();
-  const [ isSaved, setIsSaved ] = useState(false);
-  const [ fetched, setFetched ] = useState(false);
+  const [ hasChanges, setHasChanges ] = useState(false);
 
   const appName = document.querySelector('meta[name="title"]')?.content;
 
-  // Fetch saved admin config settings
-  let getWelcomeMessage = () => {
-    fetch('/Proms/WelcomeMessage.json')
-      .then((response) => response.ok ? response.json() : Promise.reject(response))
-      .then((json) => {
-        setFetched(true);
-        setWelcomeMessage(json.text || "");
-      })
-      .catch(setError);
+  // Read the welcome message from the saved configuration
+  let getWelcomeMessage = (configJson) => {
+    setWelcomeMessage(configJson.text || "");
   }
 
-  // Submit function
-  let handleSubmit = (event) => {
-
-    // This stops the normal browser form submission
-    event && event.preventDefault();
-
-    // Build formData object.
-    // We need to do this because sling does not accept JSON, need url encoded data
-    let formData = new URLSearchParams();
+  let buildConfigData = (formData) => {
     formData.append('text', welcomeMessage);
-
-    // Use native fetch, sort like the XMLHttpRequest so no need for other libraries.
-    fetch("/Proms/WelcomeMessage",
-      {
-        method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/x-www-form-urlencoded'
-        },
-        body: formData
-      })
-      .then((response) => {
-
-        // Important note about native fetch, it does not reject failed
-        // HTTP codes, it'll only fail when network error
-        // Therefore, you must handle the error code yourself.
-        if (!response.ok) {
-          throw Error(response.statusText);
-        }
-
-        setIsSaved(true);
-      })
-      .catch(setError);
   }
 
-  if (!fetched) {
-    getWelcomeMessage();
-  }
+  useEffect(() => {
+    setHasChanges(true);
+  }, [welcomeMessage]);
 
   return (
-      <AdminScreen
+      <AdminConfigScreen
         title="Patient Portal Welcome Message"
+        configPath="/Proms/WelcomeMessage"
+        onConfigFetched={getWelcomeMessage}
+        hasChanges={hasChanges}
+        buildConfigData={buildConfigData}
+        onConfigSaved={() => setHasChanges(false)}
       >
-        {error && <Alert severity="error">{error}</Alert>}
         <Alert severity="info">
           Use APP_NAME to refer to the name configured for the application.
           On the Patient identification screen, all occurrences of APP_NAME will appear as {appName}.
         </Alert>
-        <form onSubmit={handleSubmit}>
-          <List>
-            <ListItem key="form">
-              { welcomeMessage != undefined &&
-                <Grid
-                  container
-                  spacing={2}
-                  justifyContent="center"
-                  alignItems="stretch"
-                  className={classes.editorContainer}
-                >
-                  <Grid item xs={12} md={6}>
-                    <MarkdownText value={welcomeMessage} height={350} preview="edit" visiableDragbar="false" onChange={ (newText) => { setWelcomeMessage(newText); setIsSaved(false); } } />
-                  </Grid>
-                  <Grid item xs={12} md={6}>
-                    <Card>
-                      <CardHeader
-                        className={classes.previewHeader}
-                        title="Preview"
-                        titleTypographyProps={{variant: "overline"}}
-                      />
-                      <CardContent>
-                        <FormattedText variant="body2">
-                          { welcomeMessage?.replaceAll("APP_NAME", appName) }
-                        </FormattedText>
-                      </CardContent>
-                    </Card>
-                  </Grid>
-                </Grid>
-              }
-            </ListItem>
-            <ListItem key="button">
-              <Button
-                type="submit"
-                disabled={welcomeMessage == undefined}
-                variant="contained"
-                color="primary"
-                size="small"
-                className={classes.saveButton}
-              >
-                { isSaved ? "Saved" : "Save" }
-              </Button>
-            </ListItem>
-          </List>
-        </form>
-      </AdminScreen>
+        { /* Wait for the welcomeMessage state to be set before displaying anything, as MDEditor sometimes gets stuck with an empty value */ }
+        { typeof(welcomeMessage) != 'undefined' &&
+          <Grid
+            container
+            spacing={2}
+            justifyContent="center"
+            alignItems="stretch"
+            className={classes.editorContainer}
+          >
+            <Grid item xs={12} md={6}>
+              <MarkdownText value={welcomeMessage} height={350} preview="edit" visiableDragbar="false" onChange={setWelcomeMessage} />
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <Card>
+                <CardHeader
+                  className={classes.previewHeader}
+                  title="Preview"
+                  titleTypographyProps={{variant: "overline"}}
+                />
+                <CardContent>
+                  <FormattedText variant="body2">
+                    { welcomeMessage?.replaceAll("APP_NAME", appName) }
+                  </FormattedText>
+                </CardContent>
+              </Card>
+            </Grid>
+          </Grid>
+        }
+      </AdminConfigScreen>
   );
 }
 


### PR DESCRIPTION
**Includes:**
* [CARDS-1851](https://phenotips.atlassian.net/browse/CARDS-1851) - _Add Cancel button to all single-configuration admin screens_
* Refactoring of all single-config admin screens with the introduction of a new component `AdminConfigScreen` that handles loading, saving, displaying buttons
* `fetchWithReLogin` is now used in these screens for loading and saving the configuration instead of simple `fetch`
* The `Save` button is now `disabled` when there are no pending changes instead of having the label `Saved`

**Testing:**
* Start in `proms` mode
* Navigate to `Administration`
* Test the entire functionality (loading the config, changing and saving the config, using the config) of these admin sections:
  * Quick search
  * Downtime warning
  * Patient Portal Welcome Message
  * Patient Portal Terms of Use

**Reviewing:**
* [Ignoring whitespace changes](https://github.com/data-team-uhn/cards/pull/1110/files?w=1) might help see better what parts of the affected admin section components have been moved to `AdminConfigScreen`.