### PR TITLE
CARDS-1807: Add support for specifying different selectors to use for serializing a subject's forms

### DIFF
--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/DataProcessor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/DataProcessor.java
@@ -158,9 +158,11 @@ public class DataProcessor implements ResourceJsonProcessor
 
             final Map<String, JsonArrayBuilder> formsJsons = new HashMap<>();
             final ResourceResolver currentResolver = this.resolver.get();
-            final String currentSelectors = this.selectors.get();
-            forms.forEachRemaining(f ->
-                storeForm(currentResolver.resolve(f.getPath() + currentSelectors), formsJsons, isQuestionnaire));
+
+            final String currentSelectors = getCurrentSelectors();
+            forms.forEachRemaining(f -> {
+                    storeForm(currentResolver.resolve(f.getPath() + currentSelectors), formsJsons, isQuestionnaire);
+            });
             // The data JSONs have been collected, add them to the subject's JSON
             formsJsons.forEach(json::add);
             final JsonObjectBuilder filtersJson = Json.createObjectBuilder();
@@ -174,6 +176,14 @@ public class DataProcessor implements ResourceJsonProcessor
         } catch (RepositoryException e) {
             // Really shouldn't happen
         }
+    }
+
+    private String getCurrentSelectors()
+    {
+        if (this.options.get().containsKey("formSelectors")) {
+            return "." + this.options.get().get("formSelectors") + ".json";
+        }
+        return this.selectors.get();
     }
 
     private int depthLevelCounter(Node currentNode) throws RepositoryException

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/DataProcessor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/DataProcessor.java
@@ -113,8 +113,8 @@ public class DataProcessor implements ResourceJsonProcessor
 
         final Map<String, String> optionsMap = new HashMap<>();
         Arrays.asList(this.selectors.get().split("(?<!\\\\)(?:\\\\\\\\)*\\.")).stream()
-            .filter(s -> StringUtils.startsWith(s, "dataOptions:"))
-            .map(s -> StringUtils.substringAfter(s, "dataOptions:"))
+            .filter(s -> StringUtils.startsWith(s, "dataOption:"))
+            .map(s -> StringUtils.substringAfter(s, "dataOption:"))
             .forEach(s -> optionsMap.put(StringUtils.substringBefore(s, "="),
                 StringUtils.substringAfter(s, "=").replaceAll("\\\\\\.", ".")));
         this.options.set(optionsMap);

--- a/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/DataProcessor.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/dataentry/internal/serialize/DataProcessor.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -36,9 +38,12 @@ import javax.json.JsonObjectBuilder;
 import javax.json.JsonValue;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.uhndata.cards.dataentry.api.QuestionnaireUtils;
 import io.uhndata.cards.serialize.spi.ResourceJsonProcessor;
@@ -51,6 +56,8 @@ import io.uhndata.cards.serialize.spi.ResourceJsonProcessor;
 @Component(immediate = true)
 public class DataProcessor implements ResourceJsonProcessor
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataProcessor.class);
+
     private ThreadLocal<ResourceResolver> resolver = new ThreadLocal<>();
 
     private ThreadLocal<String> selectors = new ThreadLocal<>();
@@ -58,6 +65,14 @@ public class DataProcessor implements ResourceJsonProcessor
     private ThreadLocal<String> rootNode = new ThreadLocal<>();
 
     private ThreadLocal<Map<String, String>> filters = new ThreadLocal<>();
+
+    private ThreadLocal<Map<String, String>> options = new ThreadLocal<>();
+
+    // Node uuid and its depth level relative to the root node
+    private ThreadLocal<Map<String, Integer>> depthLevels = ThreadLocal.withInitial(HashMap::new);
+
+    // Max depth level of the root node
+    private ThreadLocal<Integer> depth = ThreadLocal.withInitial(() -> 0);
 
     @Override
     public String getName()
@@ -96,6 +111,14 @@ public class DataProcessor implements ResourceJsonProcessor
                 StringUtils.substringAfter(s, "=").replaceAll("\\\\\\.", ".")));
         this.filters.set(filtersMap);
 
+        final Map<String, String> optionsMap = new HashMap<>();
+        Arrays.asList(this.selectors.get().split("(?<!\\\\)(?:\\\\\\\\)*\\.")).stream()
+            .filter(s -> StringUtils.startsWith(s, "dataOptions:"))
+            .map(s -> StringUtils.substringAfter(s, "dataOptions:"))
+            .forEach(s -> optionsMap.put(StringUtils.substringBefore(s, "="),
+                StringUtils.substringAfter(s, "=").replaceAll("\\\\\\.", ".")));
+        this.options.set(optionsMap);
+
     }
 
     @Override
@@ -110,11 +133,27 @@ public class DataProcessor implements ResourceJsonProcessor
         try {
             // Only the original subject or questionnaire node will have its data appended
             if (!node.getPath().equals(this.rootNode.get())) {
+                int currentDepth = depthLevelCounter(node);
+                if (currentDepth > this.depth.get()) {
+                    this.depth.set(currentDepth);
+                }
                 return;
             }
 
             boolean isQuestionnaire = node.isNodeType(QuestionnaireUtils.QUESTIONNAIRE_NODETYPE);
-            final String query = generateDataQuery(node, isQuestionnaire);
+
+            // Stores list of Subjects' uuids per each depth level
+            Map<Integer, LinkedList<String>> uuidsPerLevel = new HashMap<>();
+            for (Map.Entry<String, Integer> entry : this.depthLevels.get().entrySet()) {
+                if (uuidsPerLevel.containsKey(entry.getValue())) {
+                    uuidsPerLevel.get(entry.getValue()).add(entry.getKey());
+                } else {
+                    uuidsPerLevel.put(entry.getValue(), new LinkedList<>(List.of(entry.getKey())));
+                }
+            }
+            String additionalSubjectsQuery = generateAdditionalSubjectsQuery(this.options.get().get("descendantData"),
+                    uuidsPerLevel);
+            final String query = generateDataQuery(node, isQuestionnaire, additionalSubjectsQuery);
             Iterator<Resource> forms = this.resolver.get().findResources(query, Query.JCR_SQL2);
 
             final Map<String, JsonArrayBuilder> formsJsons = new HashMap<>();
@@ -125,13 +164,53 @@ public class DataProcessor implements ResourceJsonProcessor
             // The data JSONs have been collected, add them to the subject's JSON
             formsJsons.forEach(json::add);
             final JsonObjectBuilder filtersJson = Json.createObjectBuilder();
+            final JsonObjectBuilder optionsJson = Json.createObjectBuilder();
             this.filters.get().forEach(filtersJson::add);
+            this.options.get().forEach(optionsJson::add);
             json.add("dataFilters", filtersJson);
+            json.add("option", optionsJson);
             json.add("exportDate",
                 new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").format(Calendar.getInstance().getTime()));
         } catch (RepositoryException e) {
             // Really shouldn't happen
         }
+    }
+
+    private int depthLevelCounter(Node currentNode) throws RepositoryException
+    {
+        final String currentNodeIdentifier = currentNode.getIdentifier();
+        if (this.depthLevels.get().containsKey(currentNodeIdentifier)) {
+            return this.depthLevels.get().get(currentNodeIdentifier);
+        }
+
+        int depthLevel = 1;
+        while (!currentNode.getParent().getPath().equals(this.rootNode.get())) {
+            depthLevel += depthLevelCounter(currentNode.getParent());
+        }
+        this.depthLevels.get().put(currentNodeIdentifier, depthLevel);
+        return depthLevel;
+    }
+
+    private String generateAdditionalSubjectsQuery(String descendantDataValue,
+        Map<Integer, LinkedList<String>> uuidsPerLevel)
+    {
+        int displayLevel = 0;
+
+        if (NumberUtils.isParsable(descendantDataValue)) {
+            displayLevel = Integer.parseInt(descendantDataValue);
+        } else if ("true".equals(descendantDataValue)) {
+            displayLevel = this.depth.get();
+        }
+
+        StringBuilder allUuids = new StringBuilder();
+        for (int i = 1; i < displayLevel + 1; i++) {
+            if (uuidsPerLevel.containsKey(i)) {
+                for (String uuid : uuidsPerLevel.get(i)) {
+                    allUuids.append("or n.subject = '").append(uuid).append("'");
+                }
+            }
+        }
+        return allUuids.toString();
     }
 
     private void storeForm(final Resource form, final Map<String, JsonArrayBuilder> formsJsons,
@@ -151,11 +230,12 @@ public class DataProcessor implements ResourceJsonProcessor
         }
     }
 
-    private String generateDataQuery(final Node entity, final boolean isQuestionnaire) throws RepositoryException
+    private String generateDataQuery(final Node entity, final boolean isQuestionnaire, String additionalSubjectsQuery)
+            throws RepositoryException
     {
         final String entityFilter = isQuestionnaire ? "questionnaire" : "subject";
         final StringBuilder result = new StringBuilder("select * from [cards:Form] as n where n." + entityFilter
-            + " = '" + entity.getIdentifier() + "'");
+            + " = '" + entity.getIdentifier() + "'" + additionalSubjectsQuery);
         this.filters.get().forEach((key, value) -> {
             switch (key) {
                 case "createdAfter":

--- a/modules/data-model/subpatient/pom.xml
+++ b/modules/data-model/subpatient/pom.xml
@@ -7,9 +7,7 @@
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
-
   http://www.apache.org/licenses/LICENSE-2.0
-
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,19 +20,31 @@
 
   <parent>
     <groupId>io.uhndata.cards</groupId>
-    <artifactId>cards-modules</artifactId>
+    <artifactId>cards-data-model</artifactId>
     <version>0.9-SNAPSHOT</version>
   </parent>
 
-  <artifactId>cards-data-model</artifactId>
-  <packaging>pom</packaging>
-  <name>CARDS Data Model elements</name>
+  <artifactId>cards-subpatient-subject-type</artifactId>
+  <packaging>bundle</packaging>
+  <name>CARDS Data Model - Sub-Patient subject type</name>
 
-  <modules>
-    <module>patient</module>
-    <module>tumor</module>
-    <module>tumor-region</module>
-    <module>visit</module>
-    <module>subpatient</module>
-  </modules>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>slingfeature-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Sling-Initial-Content>SLING-INF/content/SubjectTypes/Subpatient.json;path:=/SubjectTypes/Patient/Subpatient;overwrite:=true</Sling-Initial-Content>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/modules/data-model/subpatient/src/main/resources/SLING-INF/content/SubjectTypes/Subpatient.json
+++ b/modules/data-model/subpatient/src/main/resources/SLING-INF/content/SubjectTypes/Subpatient.json
@@ -1,0 +1,6 @@
+{
+  "jcr:primaryType": "cards:SubjectType",
+  "label": "Sub-Patient",
+  "subjectListLabel" : "Sub-Patients",
+  "cards:defaultOrder": 0
+}

--- a/modules/data-model/subsubpatient/pom.xml
+++ b/modules/data-model/subsubpatient/pom.xml
@@ -7,9 +7,7 @@
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
-
   http://www.apache.org/licenses/LICENSE-2.0
-
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,20 +20,31 @@
 
   <parent>
     <groupId>io.uhndata.cards</groupId>
-    <artifactId>cards-modules</artifactId>
+    <artifactId>cards-data-model</artifactId>
     <version>0.9-SNAPSHOT</version>
   </parent>
 
-  <artifactId>cards-data-model</artifactId>
-  <packaging>pom</packaging>
-  <name>CARDS Data Model elements</name>
+  <artifactId>cards-subsubpatient-subject-type</artifactId>
+  <packaging>bundle</packaging>
+  <name>CARDS Data Model - Sub-Sub-Patient subject type</name>
 
-  <modules>
-    <module>patient</module>
-    <module>tumor</module>
-    <module>tumor-region</module>
-    <module>visit</module>
-    <module>subpatient</module>
-    <module>subsubpatient</module>
-  </modules>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>slingfeature-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Sling-Initial-Content>SLING-INF/content/SubjectTypes/Subsubpatient.json;path:=/SubjectTypes/Patient/Subpatient/Subsubpatient;overwrite:=true</Sling-Initial-Content>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/modules/data-model/subsubpatient/src/main/resources/SLING-INF/content/SubjectTypes/Subsubpatient.json
+++ b/modules/data-model/subsubpatient/src/main/resources/SLING-INF/content/SubjectTypes/Subsubpatient.json
@@ -1,0 +1,6 @@
+{
+  "jcr:primaryType": "cards:SubjectType",
+  "label": "Sub-Sub-Patient",
+  "subjectListLabel" : "Sub-Sub-Patients",
+  "cards:defaultOrder": 0
+}

--- a/test-resources/pom.xml
+++ b/test-resources/pom.xml
@@ -73,5 +73,11 @@
       <version>${project.version}</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cards-subsubpatient-subject-type</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/test-resources/pom.xml
+++ b/test-resources/pom.xml
@@ -67,5 +67,11 @@
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cards-subpatient-subject-type</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/test-resources/src/main/features/feature.json
+++ b/test-resources/src/main/features/feature.json
@@ -26,6 +26,10 @@
       "start-order":"26"
     },
     {
+      "id":"${project.groupId}:cards-subpatient-subject-type:${project.version}",
+      "start-order":"26"
+    },
+    {
       "id":"${project.groupId}:${project.artifactId}:${project.version}",
       "start-order":"25"
     }

--- a/test-resources/src/main/features/feature.json
+++ b/test-resources/src/main/features/feature.json
@@ -30,6 +30,10 @@
       "start-order":"26"
     },
     {
+      "id":"${project.groupId}:cards-subsubpatient-subject-type:${project.version}",
+      "start-order":"27"
+    },
+    {
       "id":"${project.groupId}:${project.artifactId}:${project.version}",
       "start-order":"25"
     }

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/SubpatientTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/SubpatientTest.xml
@@ -1,0 +1,74 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>SubpatientTest</name>
+	<primaryNodeType>cards:Questionnaire</primaryNodeType>
+	<property>
+		<name>title</name>
+		<value>Subpatient Serialization Test</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>description</name>
+		<value>CARDS-1806</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>requiredSubjectTypes</name>
+		<values>
+			<value>/SubjectTypes/Patient/Subpatient</value>
+		</values>
+		<type>Reference</type>
+	</property>
+	<node>
+		<name>text</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Sample Text</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>description</name>
+			<value>Sample Text - this should appear in the serialization for the top-level Patient subject</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>text</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>minAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>enableNotes</name>
+			<value>true</value>
+			<type>Boolean</type>
+		</property>
+	</node>
+</node>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/SubsubpatientTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/SubsubpatientTest.xml
@@ -1,0 +1,74 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>SubsubpatientTest</name>
+	<primaryNodeType>cards:Questionnaire</primaryNodeType>
+	<property>
+		<name>title</name>
+		<value>Subsubpatient Serialization Test</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>description</name>
+		<value>CARDS-1806</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>requiredSubjectTypes</name>
+		<values>
+			<value>/SubjectTypes/Patient/Subpatient/Subsubpatient</value>
+		</values>
+		<type>Reference</type>
+	</property>
+	<node>
+		<name>text</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Sample Text</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>description</name>
+			<value>Sample Text - this should appear in the serialization for the top-level Patient subject</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>text</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>minAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>enableNotes</name>
+			<value>true</value>
+			<type>Boolean</type>
+		</property>
+	</node>
+</node>

--- a/test-resources/src/main/resources/SLING-INF/content/Subjects/SamplePatient/SubSamplePatient.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Subjects/SamplePatient/SubSamplePatient.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
@@ -17,24 +16,23 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>io.uhndata.cards</groupId>
-    <artifactId>cards-modules</artifactId>
-    <version>0.9-SNAPSHOT</version>
-  </parent>
-
-  <artifactId>cards-data-model</artifactId>
-  <packaging>pom</packaging>
-  <name>CARDS Data Model elements</name>
-
-  <modules>
-    <module>patient</module>
-    <module>tumor</module>
-    <module>tumor-region</module>
-    <module>visit</module>
-    <module>subpatient</module>
-  </modules>
-</project>
+<node>
+	<name>SubSamplePatient</name>
+	<primaryNodeType>cards:Subject</primaryNodeType>
+	<property>
+		<name>fullIdentifier</name>
+		<value>SubSample</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>identifier</name>
+		<value>SubSample</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>type</name>
+		<value>/SubjectTypes/Patient/Subpatient</value>
+		<type>Reference</type>
+	</property>
+</node>

--- a/test-resources/src/main/resources/SLING-INF/content/Subjects/SamplePatient/SubSamplePatient/SubSubSamplePatient.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Subjects/SamplePatient/SubSamplePatient/SubSubSamplePatient.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
@@ -17,25 +16,23 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>io.uhndata.cards</groupId>
-    <artifactId>cards-modules</artifactId>
-    <version>0.9-SNAPSHOT</version>
-  </parent>
-
-  <artifactId>cards-data-model</artifactId>
-  <packaging>pom</packaging>
-  <name>CARDS Data Model elements</name>
-
-  <modules>
-    <module>patient</module>
-    <module>tumor</module>
-    <module>tumor-region</module>
-    <module>visit</module>
-    <module>subpatient</module>
-    <module>subsubpatient</module>
-  </modules>
-</project>
+<node>
+	<name>SubSubSamplePatient</name>
+	<primaryNodeType>cards:Subject</primaryNodeType>
+	<property>
+		<name>fullIdentifier</name>
+		<value>SubSubSample</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>identifier</name>
+		<value>SubSubSample</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>type</name>
+		<value>/SubjectTypes/Patient/Subpatient/Subsubpatient</value>
+		<type>Reference</type>
+	</property>
+</node>


### PR DESCRIPTION
[CARDS-1807](https://phenotips.atlassian.net/browse/CARDS-1807)

To check:
- in proms mode, create Patient Information and Visit Information forms for a patient/visit
- PATIENT.data.dataOption:formSelectors=deep serializes all the answers for the Patient Information form, but does not list the visit subject
- PATIENT.data.deep.dataOption:formSelectors= does not include answers, but includes the visit subject
- PATIENT.data.deep includes both form answers and the visit subject