### PR TITLE
[misc] Add missing js variable export

### DIFF
--- a/modules/data-entry/src/main/frontend/src/resourceQuery/ResourceQuery.jsx
+++ b/modules/data-entry/src/main/frontend/src/resourceQuery/ResourceQuery.jsx
@@ -36,7 +36,7 @@ import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js"
 
 const NO_RESULTS_TEXT = "No results, use:";
 const NONE_OF_ABOVE_TEXT = "None of the above, use:";
-const MAX_RESULTS = 10;
+export const MAX_RESULTS = 10;
 
 // Component that renders a search bar for resources.
 //


### PR DESCRIPTION
Before this change, the following warning was logged when building:
```
[INFO] WARNING in ./src/vocabQuery/VocabularyQuery.jsx 108:28-39
[INFO] export 'MAX_RESULTS' (imported as 'MAX_RESULTS') was not found in '../resourceQuery/ResourceQuery' (possible exports: default)
[INFO]  @ ./src/questionnaire/VocabularyQuestion.jsx 35:0-64 64:17-32
```