### PR TITLE
[misc] Dockerize backup_recorder.js

### DIFF
--- a/Utilities/Administration/Backup-To-JSON/backup_recorder.js
+++ b/Utilities/Administration/Backup-To-JSON/backup_recorder.js
@@ -15,9 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-const LISTEN_HOST = '127.0.0.1';
-const LISTEN_PORT = 8012;
-
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
@@ -27,6 +24,9 @@ const express = require('express');
 const webApp = express();
 webApp.use(bodyParser.json({type: 'application/json', limit: '10mb'}));
 const webServer = require('http').createServer(webApp);
+
+const LISTEN_HOST = process.env.LISTEN_HOST || "127.0.0.1";
+const LISTEN_PORT = process.env.LISTEN_PORT || 8012;
 
 if (process.argv.length < 3) {
   console.error("Please specify a backup directory location.");

--- a/Utilities/Administration/Backup-To-JSON/backup_recorder.js
+++ b/Utilities/Administration/Backup-To-JSON/backup_recorder.js
@@ -263,7 +263,7 @@ webServer.listen(LISTEN_PORT, LISTEN_HOST, (err) => {
   if (err) {
     console.log("Backup Recorder server failed to start");
   } else {
-    console.log("Backup Recorder server listening on port " + LISTEN_PORT);
+    console.log("Backup Recorder server listening on " + LISTEN_HOST + ":" + LISTEN_PORT);
     console.log("Backups will be saved to " + BACKUP_DIRECTORY);
     console.log("")
     console.log("===");

--- a/Utilities/ExpressJS-Docker/Dockerfile
+++ b/Utilities/ExpressJS-Docker/Dockerfile
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM debian:11-slim
+
+RUN apt-get update
+RUN apt-get -y install \
+	nodejs \
+	node-express \
+	node-body-parser

--- a/Utilities/ExpressJS-Docker/README.md
+++ b/Utilities/ExpressJS-Docker/README.md
@@ -1,0 +1,23 @@
+Provides a Docker container for running ExpressJS servers
+
+Build
+-----
+
+```bash
+docker build -t cards/expressjs .
+```
+
+Using
+-----
+
+- Read-only volume mount the script which you wish to run and specify it
+as the entrypoint.
+
+- For example:
+
+```bash
+cd Utilities/Development
+docker run --rm --name mockslack -v $(realpath mock_slack.js):/mock_slack.js:ro -p 8000:8000 -d cards/expressjs nodejs /mock_slack.js
+docker logs mockslack
+docker stop mockslack
+```

--- a/Utilities/ExpressJS-Docker/docker_entry.sh
+++ b/Utilities/ExpressJS-Docker/docker_entry.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,16 +17,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM debian:11-slim
-
-RUN apt-get update
-RUN apt-get -y install \
-	nodejs \
-	node-express \
-	node-body-parser \
-	sudo
-
-COPY docker_entry.sh /
-RUN chmod u+x /docker_entry.sh
-
-ENTRYPOINT ["/docker_entry.sh"]
+if [[ ! -z $HOST_USER  && ! -z $HOST_UID ]]
+then
+  adduser --uid $HOST_UID --disabled-password --gecos "" $HOST_USER
+  exec sudo -u $HOST_USER "$@"
+else
+  exec "$@"
+fi

--- a/Utilities/ExpressJS-Docker/docker_entry.sh
+++ b/Utilities/ExpressJS-Docker/docker_entry.sh
@@ -20,7 +20,7 @@
 if [[ ! -z $HOST_USER  && ! -z $HOST_UID ]]
 then
   adduser --uid $HOST_UID --disabled-password --gecos "" $HOST_USER
-  exec sudo -u $HOST_USER "$@"
+  exec sudo -E -u $HOST_USER "$@"
 else
   exec "$@"
 fi

--- a/Utilities/ExpressJS-Docker/pom.xml
+++ b/Utilities/ExpressJS-Docker/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.uhndata.cards</groupId>
+    <artifactId>cards-utilities</artifactId>
+    <version>0.9-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>expressjs-docker</artifactId>
+  <packaging>pom</packaging>
+  <name>CARDS - ExpressJS container</name>
+  <description>ExpressJS minimal container for CARDS</description>
+
+  <profiles>
+    <profile>
+      <!-- If Docker is available, build a Docker image -->
+      <id>docker</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <version>0.39.0</version>
+            <executions>
+              <execution>
+                <id>build</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <image>
+                <name>cards/expressjs:%l</name>
+              </image>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/Utilities/pom.xml
+++ b/Utilities/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.uhndata.cards</groupId>
+    <artifactId>cards-parent</artifactId>
+    <version>0.9-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>cards-utilities</artifactId>
+  <packaging>pom</packaging>
+  <name>CARDS Utilities</name>
+
+  <modules>
+    <module>ExpressJS-Docker</module>
+  </modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1146,5 +1146,6 @@
     <module>proms-resources</module>
     <module>test-resources</module>
     <module>distribution</module>
+    <module>Utilities</module>
   </modules>
 </project>


### PR DESCRIPTION
This PR:

- Introduces the `cards/expressjs` Docker container which can be used for running, in a container, many of the NodeJS-based CARDS utilities - including `backup_recorder.js`.
- Adds the `--enable_backup_server` and `--backup_server_path` flags to `generate_compose_yaml.py` so that a `cards/expressjs` Docker container running `backup_recorder.js` can be added to the cluster of services.
- Adds support for the `LISTEN_HOST` and `LISTEN_PORT` environment variables for `backup_recorder.js` as is needed for running it in a container.

To test:

- Build this branch with the _Docker profile_ enabled (`mvn clean install -Pdocker`)
- Build the `cards/expressjs` Docker image by entering the `Utilities/ExpressJS-Docker` directory and running `docker build -t cards/expressjs`.
- `mkdir ~/backup_test_dockerized`
- `cd compose-cluster`
- `python3 generate_compose_yaml.py --cards_project cards4proms --dev_docker_image --composum --enable_backup_server --backup_server_path ~/backup_test_dockerized --oak_filesystem && docker-compose build && docker-compose up -d`
- Visit `http://localhost:8080` and login as `admin`.
- Create some _Patients_, _Visits_, and _Forms_.
- Backup the data by visiting `http://localhost:8080/Subjects.webhookbackup?dateLowerBound=LOWER&dateUpperBound=UPPER`, replacing `LOWER` and `UPPER` with the start of _today_ and _tomorrow_ respectively. For example if today is July 7th 2022, `LOWER` would be `2022-07-07T00:00:00` and `UPPER` would be `2022-07-08T00:00:00`.
- Stop the cluster by running `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`
- Bring the cluster back up again with `python3 generate_compose_yaml.py --cards_project cards4proms --dev_docker_image --composum --enable_backup_server --backup_server_path ~/backup_test_dockerized --oak_filesystem && docker-compose build && docker-compose up -d`
- Visit `http://localhost:8080` and login as `admin`. No data should be present.
- Restore the data by entering the `Utilities/Administration/Backup-To-JSON` directory and running `python3 restore_json_backup.py --backup_directory ~/backup_test_dockerized --form_list_file ~/backup_test_dockerized/FormListBackup* --subject_list_file ~/backup_test_dockerized/SubjectListBackup*`
- Refresh the CARDS webpage and verify that the data has been restored.