### PR TITLE
CARDS-1103: As a user, I can see answers from other forms in the form I am filling in

### DIFF
--- a/modules/data-entry/src/main/features/feature.json
+++ b/modules/data-entry/src/main/features/feature.json
@@ -70,19 +70,16 @@
     "org.apache.sling.jcr.repoinit.RepositoryInitializer~forms":{
       "service.ranking:Integer":150,
       "scripts":[
-        "create path (cards:dataQuery) /query \n\n # Allow all users to query; the actual results will obey their access rights \n set ACL for everyone \n   allow  jcr:read  on /query \n end \n\n create path (cards:QuestionnairesHomepage) /Questionnaires \n create path (cards:FormsHomepage) /Forms \n create path (cards:SubjectsHomepage) /Subjects \n create path (cards:SubjectTypesHomepage) /SubjectTypes "
+        "create path (cards:dataQuery) /query \n\n # Allow all users to query; the actual results will obey their access rights \n set ACL for everyone \n   allow  jcr:read  on /query \n end \n\n create path (cards:QuestionnairesHomepage) /Questionnaires \n create path (cards:FormsHomepage) /Forms \n create path (cards:SubjectsHomepage) /Subjects \n create path (cards:SubjectTypesHomepage) /SubjectTypes ",
+        "create service user cards-answer-editor \n set ACL on /Questionnaires \n   allow jcr:read for cards-answer-editor \n end"
       ]
     },
     "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~cards-data-entry":{
       "user.mapping":[
-        "io.uhndata.cards.data-model-forms-impl:computedAnswers=[sling-readall]",
+        "io.uhndata.cards.data-model-forms-impl:computedAnswers=[cards-answer-editor]",
+        "io.uhndata.cards.data-model-forms-impl:referenceAnswers=[cards-answer-editor]",
         "io.uhndata.cards.data-model-forms-impl:maxFormsOfTypePerSubjectValidator=[sling-readall]",
         "io.uhndata.cards.data-model-forms-impl:requiredSubjectTypesValidator=[sling-readall]"
-      ]
-    },
-    "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~referenceAnswers":{
-      "user.mapping":[
-        "io.uhndata.cards.dataentry:referenceAnswers=[sling-readall]"
       ]
     }
   }

--- a/modules/data-entry/src/main/features/feature.json
+++ b/modules/data-entry/src/main/features/feature.json
@@ -79,6 +79,11 @@
         "io.uhndata.cards.data-model-forms-impl:maxFormsOfTypePerSubjectValidator=[sling-readall]",
         "io.uhndata.cards.data-model-forms-impl:requiredSubjectTypesValidator=[sling-readall]"
       ]
+    },
+    "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~referenceAnswers":{
+      "user.mapping":[
+        "io.uhndata.cards.dataentry:referenceAnswers=[sling-readall]"
+      ]
     }
   }
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -40,6 +40,7 @@ import FileQuestion from "./FileQuestion";
 import QuestionMatrix from "./QuestionMatrix";
 import ResourceQuestion from "./ResourceQuestion";
 import DicomQuestion from "./DicomQuestion";
+import ReferenceQuestion from "./ReferenceQuestion";
 
 import FormattedText from "../components/FormattedText";
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ReferenceQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ReferenceQuestion.jsx
@@ -19,48 +19,34 @@
 
 import React, { useEffect, useState } from "react";
 import PropTypes from 'prop-types';
-import { InputAdornment, TextField, Typography } from "@mui/material";
+import { InputAdornment, TextField } from "@mui/material";
 
 import withStyles from '@mui/styles/withStyles';
 
-import Answer from "./Answer";
 import AnswerComponentManager from "./AnswerComponentManager";
 import DateQuestionUtilities from "./DateQuestionUtilities";
 import Question from "./Question";
 import {Time} from "./TimeQuestion";
 import FormattedText from "../components/FormattedText";
 import QuestionnaireStyle from './QuestionnaireStyle';
-import { useFormReaderContext } from "./FormContext";
-import { MakeRequest } from "../vocabQuery/util.jsx";
 
 
-// Component that renders a computed value as a question field
-// Computed value is placed in a <input type="hidden"> tag for submission.
+// Component that displays a reference question of any type.
 //
 // Mandatory props:
 // text: the question to be displayed
-// expression: the javascript run to determine the value.
-//   Values between the tags `@{` and `}` will be interpreted as input variables.
-//   These tags will be removed and the value of the question named by the
-//     input variable will be provided as a function argument.
+// dataType: the type of answer to be displayed
 //
 // Other options are passed to the <question> widget
-//
-// Sample usage, given question_a and question_b are number questions:
-//<ReferenceQuestion
-//  />
 let ReferenceQuestion = (props) => {
   const { existingAnswer, classes, pageActive, questionDefinition, ...rest} = props;
-  const { text, unitOfMeasurement, dataType, displayMode, dateFormat } = {...props.questionDefinition, ...props};
+  const { unitOfMeasurement, dataType, displayMode, dateFormat } = {...props.questionDefinition, ...props};
 
   let initialValue = existingAnswer?.[1].value || "";
   const [displayValue, changeDisplayValue] = useState(initialValue);
-  const [answer, changeAnswer] = useState(initialValue === "" ? [] : [["value", initialValue]]);
   const [fieldType, changeFieldType] = useState("string")
   const [muiInputProps, changeMuiInputProps] = useState({});
   const [isFormatted, changeIsFormatted] = useState(false);
-
-  const form = useFormReaderContext();
 
   let setFieldType = (value) => {
     if (fieldType !== value) {
@@ -147,15 +133,6 @@ let ReferenceQuestion = (props) => {
           }
         </>
       }
-      <Answer
-        answers={answer}
-        questionDefinition={props.questionDefinition}
-        existingAnswer={existingAnswer}
-        answerNodeType={answerNodeType}
-        valueType={answerType}
-        pageActive={pageActive}
-        {...rest}
-        />
     </Question>
   )
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ReferenceQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ReferenceQuestion.jsx
@@ -23,6 +23,7 @@ import { InputAdornment, TextField } from "@mui/material";
 
 import withStyles from '@mui/styles/withStyles';
 
+import Answer from "./Answer";
 import AnswerComponentManager from "./AnswerComponentManager";
 import DateQuestionUtilities from "./DateQuestionUtilities";
 import Question from "./Question";
@@ -44,6 +45,7 @@ let ReferenceQuestion = (props) => {
 
   let initialValue = existingAnswer?.[1].value || "";
   const [displayValue, changeDisplayValue] = useState(initialValue);
+  const [answer, changeAnswer] = useState(initialValue === "" ? [] : [["value", initialValue]]);
   const [fieldType, changeFieldType] = useState("string")
   const [muiInputProps, changeMuiInputProps] = useState({});
   const [isFormatted, changeIsFormatted] = useState(false);
@@ -104,9 +106,9 @@ let ReferenceQuestion = (props) => {
       setFieldType(newFieldType);
       break;
     case "text":
-    default: // Fallthrough default to string reference
+      default:
       answerType = "String";
-      answerNodeType = "cards:TextAnswer"
+      answerNodeType = "cards:TextAnswer";
       break;
   }
 
@@ -133,6 +135,19 @@ let ReferenceQuestion = (props) => {
           }
         </>
       }
+      {/*
+       * Need to generate an answer so this question can be used for computations and conditional sections.
+       * This will never be editable by the user.
+       */}
+      <Answer
+        answers={answer}
+        questionDefinition={props.questionDefinition}
+        existingAnswer={existingAnswer}
+        answerNodeType={answerNodeType}
+        valueType={answerType}
+        pageActive={pageActive}
+        {...rest}
+        />
     </Question>
   )
 }
@@ -142,8 +157,7 @@ ReferenceQuestion.propTypes = {
   questionDefinition: PropTypes.shape({
     text: PropTypes.string.isRequired,
     description: PropTypes.string,
-    questionnaire: PropTypes.string.isRequired,
-    question: PropTypes.string.isRequired,
+    // displayValue: PropTypes.string.isRequired,
     displayMode: PropTypes.oneOf(['input', 'formatted', 'hidden', 'summary']),
     unitOfMeasurement: PropTypes.string
   }).isRequired

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ReferenceQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ReferenceQuestion.jsx
@@ -1,0 +1,182 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React, { useEffect, useState } from "react";
+import PropTypes from 'prop-types';
+import { InputAdornment, TextField, Typography } from "@mui/material";
+
+import withStyles from '@mui/styles/withStyles';
+
+import Answer from "./Answer";
+import AnswerComponentManager from "./AnswerComponentManager";
+import DateQuestionUtilities from "./DateQuestionUtilities";
+import Question from "./Question";
+import {Time} from "./TimeQuestion";
+import FormattedText from "../components/FormattedText";
+import QuestionnaireStyle from './QuestionnaireStyle';
+import { useFormReaderContext } from "./FormContext";
+import { MakeRequest } from "../vocabQuery/util.jsx";
+
+
+// Component that renders a computed value as a question field
+// Computed value is placed in a <input type="hidden"> tag for submission.
+//
+// Mandatory props:
+// text: the question to be displayed
+// expression: the javascript run to determine the value.
+//   Values between the tags `@{` and `}` will be interpreted as input variables.
+//   These tags will be removed and the value of the question named by the
+//     input variable will be provided as a function argument.
+//
+// Other options are passed to the <question> widget
+//
+// Sample usage, given question_a and question_b are number questions:
+//<ReferenceQuestion
+//  />
+let ReferenceQuestion = (props) => {
+  const { existingAnswer, classes, pageActive, questionDefinition, ...rest} = props;
+  const { text, unitOfMeasurement, dataType, displayMode, dateFormat } = {...props.questionDefinition, ...props};
+
+  let initialValue = existingAnswer?.[1].value || "";
+  const [displayValue, changeDisplayValue] = useState(initialValue);
+  const [answer, changeAnswer] = useState(initialValue === "" ? [] : [["value", initialValue]]);
+  const [fieldType, changeFieldType] = useState("string")
+  const [muiInputProps, changeMuiInputProps] = useState({});
+  const [isFormatted, changeIsFormatted] = useState(false);
+
+  const form = useFormReaderContext();
+
+  let setFieldType = (value) => {
+    if (fieldType !== value) {
+      changeFieldType(value);
+    }
+  }
+
+  useEffect(() => {
+    if (unitOfMeasurement) {
+      muiInputProps.endAdornment = <InputAdornment position="end">{unitOfMeasurement}</InputAdornment>;
+    } else {
+      delete muiInputProps.endAdornment;
+    }
+  }, [unitOfMeasurement])
+
+  useEffect(() => {
+    let formatted = (displayMode === "formatted" || displayMode === "summary");
+    if (formatted !== isFormatted) {
+      changeIsFormatted(formatted)
+    };
+  }, [displayMode])
+
+  let capitalizedDataType = dataType.substring(0, 1).toUpperCase() + dataType.substring(1);
+  let answerType, answerNodeType = `cards:${capitalizedDataType}Answer`, newFieldType;
+  switch (dataType) {
+    case "boolean":
+      answerType = "Long"; // Long, not Boolean
+      break;
+    case "date":
+      newFieldType = DateQuestionUtilities.getFieldType(dateFormat);
+      setFieldType(newFieldType);
+      switch (newFieldType) {
+        case "long":
+          answerType = "Long";
+          break;
+        case "string":
+          answerType = "Date";
+          break;
+        default:
+          answerType = "Date";
+          break;
+      }
+      break;
+    case "long":
+    case "double":
+    case "decimal":
+      answerType = capitalizedDataType;
+      break;
+    case "vocabulary":
+      answerType = "String";
+      break;
+    case "time":
+      answerType = "String";
+      newFieldType = Time.timeQuestionFieldType(dateFormat);
+      setFieldType(newFieldType);
+      break;
+    case "text":
+    default: // Fallthrough default to string reference
+      answerType = "String";
+      answerNodeType = "cards:TextAnswer"
+      break;
+  }
+
+  return (
+    <Question
+      defaultDisplayFormatter={isFormatted ? (label, idx) => <FormattedText>{label}</FormattedText> : undefined}
+      currentAnswers={typeof(displayValue) !== "undefined" && displayValue !== "" ? 1 : 0}
+      {...props}
+      >
+      {
+        pageActive && <>
+          { isFormatted ? <FormattedText>
+              {displayValue + (unitOfMeasurement ? (" " + unitOfMeasurement) : '')}
+            </FormattedText>
+          :
+          <TextField
+            variant="standard"
+            type={fieldType}
+            disabled={true}
+            className={classes.textField + " " + classes.answerField}
+            value={displayValue}
+            InputProps={muiInputProps}
+          />
+          }
+        </>
+      }
+      <Answer
+        answers={answer}
+        questionDefinition={props.questionDefinition}
+        existingAnswer={existingAnswer}
+        answerNodeType={answerNodeType}
+        valueType={answerType}
+        pageActive={pageActive}
+        {...rest}
+        />
+    </Question>
+  )
+}
+
+ReferenceQuestion.propTypes = {
+  classes: PropTypes.object.isRequired,
+  questionDefinition: PropTypes.shape({
+    text: PropTypes.string.isRequired,
+    description: PropTypes.string,
+    questionnaire: PropTypes.string.isRequired,
+    question: PropTypes.string.isRequired,
+    displayMode: PropTypes.oneOf(['input', 'formatted', 'hidden', 'summary']),
+    unitOfMeasurement: PropTypes.string
+  }).isRequired
+};
+
+const StyledReferenceQuestion = withStyles(QuestionnaireStyle)(ReferenceQuestion);
+export default StyledReferenceQuestion;
+
+AnswerComponentManager.registerAnswerComponent((definition) => {
+  if (definition.entryMode === "reference") {
+    return [StyledReferenceQuestion, 80];
+  }
+});

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -38,6 +38,15 @@
               "hidden": {},
               "summary": {}
             }
+          },
+          "reference": {
+            "questionnaire": "string",
+            "question": "string",
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
           }
         }
       },
@@ -69,6 +78,15 @@
           },
           "computed": {
             "expression": "code",
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
+          },
+          "reference": {
+            "questionnaire": "string",
+            "question": "string",
             "displayMode" : {
               "input" : {},
               "formatted" : {},
@@ -121,6 +139,15 @@
               "formatted" : {},
               "hidden": {}
             }
+          },
+          "reference": {
+            "questionnaire": "string",
+            "question": "string",
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
           }
         }
       },
@@ -168,6 +195,15 @@
               "formatted" : {},
               "hidden": {}
             }
+          },
+          "reference": {
+            "questionnaire": "string",
+            "question": "string",
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
           }
         }
       },
@@ -196,6 +232,15 @@
           "computed": {
             "minAnswers": {"0":{}, "1":{}},
             "expression": "code",
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
+          },
+          "reference": {
+            "questionnaire": "string",
+            "question": "string",
             "displayMode" : {
               "input" : {},
               "formatted" : {},
@@ -251,6 +296,15 @@
               "formatted" : {},
               "hidden": {}
             }
+          },
+          "reference": {
+            "questionnaire": "string",
+            "question": "string",
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
           }
         }
       },
@@ -284,6 +338,15 @@
               "formatted" : {},
               "hidden": {}
             }
+          },
+          "reference": {
+            "questionnaire": "string",
+            "question": "string",
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
           }
         }
       },
@@ -298,6 +361,15 @@
           },
           "computed": {
             "expression": "code",
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
+          },
+          "reference": {
+            "questionnaire": "string",
+            "question": "string",
             "displayMode" : {
               "input" : {},
               "formatted" : {},

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -40,7 +40,6 @@
             }
           },
           "reference": {
-            "questionnaire": "string",
             "question": "string",
             "displayMode" : {
               "input" : {},
@@ -85,7 +84,6 @@
             }
           },
           "reference": {
-            "questionnaire": "string",
             "question": "string",
             "displayMode" : {
               "input" : {},
@@ -141,7 +139,6 @@
             }
           },
           "reference": {
-            "questionnaire": "string",
             "question": "string",
             "displayMode" : {
               "input" : {},
@@ -197,7 +194,6 @@
             }
           },
           "reference": {
-            "questionnaire": "string",
             "question": "string",
             "displayMode" : {
               "input" : {},
@@ -239,7 +235,6 @@
             }
           },
           "reference": {
-            "questionnaire": "string",
             "question": "string",
             "displayMode" : {
               "input" : {},
@@ -298,7 +293,6 @@
             }
           },
           "reference": {
-            "questionnaire": "string",
             "question": "string",
             "displayMode" : {
               "input" : {},
@@ -340,7 +334,6 @@
             }
           },
           "reference": {
-            "questionnaire": "string",
             "question": "string",
             "displayMode" : {
               "input" : {},
@@ -368,7 +361,6 @@
             }
           },
           "reference": {
-            "questionnaire": "string",
             "question": "string",
             "displayMode" : {
               "input" : {},

--- a/modules/data-model/forms/api/src/main/java/io/uhndata/cards/forms/api/FormUtils.java
+++ b/modules/data-model/forms/api/src/main/java/io/uhndata/cards/forms/api/FormUtils.java
@@ -16,6 +16,9 @@
  */
 package io.uhndata.cards.forms.api;
 
+import java.util.Collection;
+import java.util.EnumSet;
+
 import javax.jcr.Node;
 
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
@@ -41,6 +44,9 @@ public interface FormUtils
 
     /** The name of the property of a Form node that links to the Subject the form belongs to. */
     String SUBJECT_PROPERTY = "subject";
+
+    /** The name of the property of a Form node that links to other Subjects the form relates to. */
+    String RELATED_SUBJECTS_PROPERTY = "relatedSubjects";
 
     /**
      * The primary node type for an Answer Section, a group of related answers and subsections in a Form, corresponding
@@ -69,6 +75,14 @@ public interface FormUtils
 
     /** The name of the property of an Answer node that holds the actual value. */
     String VALUE_PROPERTY = "value";
+
+    enum SearchType
+    {
+        FORM,
+        SUBJECT_FORMS,
+        ANCESTORS_FORMS,
+        DESCENDANTS_FORMS
+    }
 
     // Form methods
 
@@ -279,6 +293,42 @@ public interface FormUtils
      * @return an Answer node, may be {@code null}
      */
     Node getAnswer(Node form, Node question);
+
+    /**
+     * Get all the answers for a specific question, if any.
+     *
+     * @param form a Form node
+     * @param question a question node, part of the questionnaire that the form is answering
+     * @return a series of Answer nodes, may be empty list
+     */
+    Collection<Node> getAllAnswers(Node form, Node question);
+
+    /**
+     * Get all the answers for a specific question related to a form. This may be answers in the form itself, or answers
+     * in other forms belonging to the same subject or a related subject.
+     *
+     * @param startingForm the form which is the basis of the answer search, does not need to be answering the same
+     *            questionnaire as the target question
+     * @param question the question being answered
+     * @param scope where to search for answers
+     * @return a collection of answers, may be empty if no answers are found, containing answers sorter by how close to
+     *         the target form they are: first answers from the form, then from its subject's other forms, then
+     *         descendant subjects, then ancestor subjects
+     */
+    Collection<Node> findAllFormRelatedAnswers(Node startingForm, Node question, EnumSet<SearchType> scope);
+
+    /**
+     * Get all the answers for a specific question related to a subject. This may be answers for the subject itself, or
+     * answers in descendant or ancestor subjects.
+     *
+     * @param startingSubject the subject which is the basis of the answer search
+     * @param question the question being answered
+     * @param scope where to search for answers
+     * @return a collection of answers, may be empty if no answers are found, containing answers sorter by how close to
+     *         the target subject they are: first answers from the subject's own forms, then descendant subjects, then
+     *         ancestor subjects
+     */
+    Collection<Node> findAllSubjectRelatedAnswers(Node startingSubject, Node question, EnumSet<SearchType> scope);
 
     /**
      * Check if the given node is an Answer node.

--- a/modules/data-model/forms/api/src/main/java/io/uhndata/cards/forms/api/QuestionnaireUtils.java
+++ b/modules/data-model/forms/api/src/main/java/io/uhndata/cards/forms/api/QuestionnaireUtils.java
@@ -123,7 +123,7 @@ public interface QuestionnaireUtils
      * Check if the given node is a Question node for a reference question.
      *
      * @param node the node to check, a JCR Node, may be {@code null}
-     * @return {@code true} if the node is not {@code null}, is computed and is of type {@code cards:Question},
+     * @return {@code true} if the node is not {@code null}, is of type {@code cards:Question} and is a reference,
      *         {@code false} otherwise
      */
     boolean isReferenceQuestion(Node node);

--- a/modules/data-model/forms/api/src/main/java/io/uhndata/cards/forms/api/QuestionnaireUtils.java
+++ b/modules/data-model/forms/api/src/main/java/io/uhndata/cards/forms/api/QuestionnaireUtils.java
@@ -120,6 +120,15 @@ public interface QuestionnaireUtils
     boolean isComputedQuestion(Node node);
 
     /**
+     * Check if the given node is a Question node for a reference question.
+     *
+     * @param node the node to check, a JCR Node, may be {@code null}
+     * @return {@code true} if the node is not {@code null}, is computed and is of type {@code cards:Question},
+     *         {@code false} otherwise
+     */
+    boolean isReferenceQuestion(Node node);
+
+    /**
      * Retrieve the Question with the given UUID.
      *
      * @param identifier an UUID that references a question.

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/AnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/AnswersEditor.java
@@ -63,9 +63,6 @@ public abstract class AnswersEditor extends DefaultEditor
     /** The current user session. **/
     protected Session currentSession;
 
-    /** A session that has access to all the questionnaire questions and can access restricted questions. */
-    protected Session serviceSession;
-
     protected final QuestionnaireUtils questionnaireUtils;
 
     protected final FormUtils formUtils;
@@ -77,6 +74,12 @@ public abstract class AnswersEditor extends DefaultEditor
     protected AbstractAnswerChangeTracker answerChangeTracker;
 
     private final String serviceName;
+
+    /**
+     * A session that has access to all the questionnaire questions and can access restricted questions.
+     * This session should not be used for accessing any user data.
+    */
+    private Session serviceSession;
 
     /**
      * Simple constructor.

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/AnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/AnswersEditor.java
@@ -63,6 +63,12 @@ public abstract class AnswersEditor extends DefaultEditor
     /** The current user session. **/
     protected Session currentSession;
 
+    /**
+     * A session that has access to all the questionnaire questions and can access restricted questions. This session
+     * should not be used for accessing any user data.
+     */
+    protected Session serviceSession;
+
     protected final QuestionnaireUtils questionnaireUtils;
 
     protected final FormUtils formUtils;
@@ -74,12 +80,6 @@ public abstract class AnswersEditor extends DefaultEditor
     protected AbstractAnswerChangeTracker answerChangeTracker;
 
     private final String serviceName;
-
-    /**
-     * A session that has access to all the questionnaire questions and can access restricted questions.
-     * This session should not be used for accessing any user data.
-    */
-    private Session serviceSession;
 
     /**
      * Simple constructor.
@@ -104,9 +104,13 @@ public abstract class AnswersEditor extends DefaultEditor
     }
 
     protected abstract Logger getLogger();
+
     protected abstract AbstractAnswerChangeTracker getAnswerChangeTracker();
+
     protected abstract AnswersEditor getNewEditor(String name);
+
     protected abstract AnswerNodeTypes getNewAnswerNodeTypes(Node node) throws RepositoryException;
+
     protected abstract boolean isQuestionNodeMatchingType(Node node) throws RepositoryException;
 
     @Override

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/AnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/AnswersEditor.java
@@ -1,0 +1,486 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.forms.internal;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jackrabbit.oak.api.PropertyState;
+import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.spi.commit.DefaultEditor;
+import org.apache.jackrabbit.oak.spi.commit.Editor;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.slf4j.Logger;
+
+import io.uhndata.cards.forms.api.FormUtils;
+import io.uhndata.cards.forms.api.QuestionnaireUtils;
+
+/**
+ *
+ *
+ * @version $Id$
+ */
+public abstract class AnswersEditor extends DefaultEditor
+{
+    // This holds the builder for the current node. The methods called for editing specific properties don't receive the
+    // actual parent node of those properties, so we must manually keep track of the current node.
+    protected final NodeBuilder currentNodeBuilder;
+
+    protected final ResourceResolverFactory rrf;
+
+    /** The current user session. **/
+    protected Session currentSession;
+
+    /** A session that has access to all the questionnaire questions and can access restricted questions. */
+    protected Session serviceSession;
+
+    protected final QuestionnaireUtils questionnaireUtils;
+
+    protected final FormUtils formUtils;
+
+    protected boolean isFormNode;
+
+    protected boolean shouldRunOnLeave;
+
+    protected AbstractAnswerChangeTracker answerChangeTracker;
+
+    private final String serviceName;
+
+    /**
+     * Simple constructor.
+     *
+     * @param nodeBuilder the builder for the current node
+     * @param rrf the resource resolver factory which can provide access to JCR sessions
+     * @param questionnaireUtils for working with questionnaire data
+     * @param formUtils for working with form data
+     * @param serviceName the name of the service resource resolver that should be used to handle any changes
+     */
+    public AnswersEditor(final NodeBuilder nodeBuilder, final ResourceResolverFactory rrf,
+        final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils, final String serviceName)
+    {
+        this.serviceName = serviceName;
+        this.currentNodeBuilder = nodeBuilder;
+        this.rrf = rrf;
+        this.questionnaireUtils = questionnaireUtils;
+        this.formUtils = formUtils;
+        this.answerChangeTracker = getAnswerChangeTracker();
+        this.isFormNode = this.formUtils.isForm(this.currentNodeBuilder);
+        this.shouldRunOnLeave = false;
+    }
+
+    protected abstract Logger getLogger();
+    protected abstract AbstractAnswerChangeTracker getAnswerChangeTracker();
+    protected abstract AnswersEditor getNewEditor(String name);
+    protected abstract AnswerNodeTypes getNewAnswerNodeTypes(Node node) throws RepositoryException;
+    protected abstract boolean isQuestionNodeMatchingType(Node node) throws RepositoryException;
+
+    @Override
+    public Editor childNodeAdded(final String name, final NodeState after)
+    {
+        if (this.isFormNode) {
+            // No need to descend further down, we already know that this is a form that has changes
+            return this.answerChangeTracker;
+        } else {
+            return getNewEditor(name);
+        }
+    }
+
+    @Override
+    public Editor childNodeChanged(final String name, final NodeState before, final NodeState after)
+    {
+        return childNodeAdded(name, after);
+    }
+
+    @Override
+    public void leave(final NodeState before, final NodeState after)
+    {
+        if (!this.isFormNode || !this.shouldRunOnLeave) {
+            return;
+        }
+
+        final Map<String, Object> parameters =
+            Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, this.serviceName);
+        final ResourceResolver sessionResolver = this.rrf.getThreadResourceResolver();
+        try (ResourceResolver serviceResolver = this.rrf.getServiceResourceResolver(parameters)) {
+            if (sessionResolver != null && serviceResolver != null) {
+                this.currentSession = sessionResolver.adaptTo(Session.class);
+                this.serviceSession = serviceResolver.adaptTo(Session.class);
+                handleLeave(after);
+            }
+        } catch (LoginException e) {
+            // Should not happen
+        }
+    }
+
+    protected abstract void handleLeave(NodeState after);
+
+    protected Node getQuestionnaire()
+    {
+        final String questionnaireId = this.currentNodeBuilder.getProperty("questionnaire").getValue(Type.REFERENCE);
+        try {
+            return this.serviceSession.getNodeByIdentifier(questionnaireId);
+        } catch (RepositoryException e) {
+            return null;
+        }
+    }
+
+    // Returns a QuestionTree if any children of this node contains an unanswered matching question, else null
+    protected QuestionTree getUnansweredMatchingQuestions(final Node currentNode)
+    {
+        QuestionTree currentTree = null;
+
+        try {
+            if (isQuestionNodeMatchingType(currentNode)) {
+                // Ignore questions that do not match the question type this editor is looking for
+                // Skip already answered questions
+                if (!this.answerChangeTracker.getModifiedAnswers().contains(currentNode.getIdentifier())) {
+                    currentTree = new QuestionTree(currentNode, true);
+                }
+            } else if (this.questionnaireUtils.isQuestionnaire(currentNode)
+                || this.questionnaireUtils.isSection(currentNode)) {
+                // Recursively check if any children have a matching question
+                QuestionTree newTree = new QuestionTree(currentNode, false);
+                for (NodeIterator i = currentNode.getNodes(); i.hasNext();) {
+                    Node child = i.nextNode();
+                    QuestionTree childTree = getUnansweredMatchingQuestions(child);
+                    if (childTree != null) {
+                        // Child has data that should be stored
+                        newTree.getChildren().put(child.getName(), childTree);
+                    }
+                }
+
+                // If this node has a child with a matching question, return this information
+                if (newTree.getChildren().size() > 0) {
+                    currentTree = newTree;
+                }
+            }
+        } catch (RepositoryException e) {
+            // Unable to retrieve type: skip
+            getLogger().warn(e.getMessage());
+        }
+
+        return currentTree;
+    }
+
+    protected Map<QuestionTree, NodeBuilder> createMissingNodes(
+        final QuestionTree questionTree, final NodeBuilder currentNode)
+    {
+        try {
+            if (questionTree.isQuestion()) {
+                if (!currentNode.hasProperty("jcr:" + "primaryType")) {
+                    AnswerNodeTypes types = getNewAnswerNodeTypes(questionTree.getNode());
+                    // New node, insert all required properties
+                    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+                    currentNode.setProperty("jcr:created", dateFormat.format(new Date()), Type.DATE);
+                    currentNode.setProperty("jcr:createdBy", this.currentSession.getUserID(), Type.NAME);
+                    String questionReference = questionTree.getNode().getIdentifier();
+                    currentNode.setProperty(FormUtils.QUESTION_PROPERTY, questionReference, Type.REFERENCE);
+                    currentNode.setProperty("jcr:primaryType", types.getPrimaryType(), Type.NAME);
+                    currentNode.setProperty("sling:resourceSuperType", FormUtils.ANSWER_RESOURCE, Type.STRING);
+                    currentNode.setProperty("sling:resourceType", types.getResourceType(), Type.STRING);
+                    currentNode.setProperty("statusFlags", Collections.emptyList(), Type.STRINGS);
+                }
+                return Collections.singletonMap(questionTree, currentNode);
+            } else {
+                // Section
+                if (!currentNode.hasProperty("jcr:primaryType")) {
+                    // Section must be created before primary type
+                    currentNode.setProperty(FormUtils.SECTION_PROPERTY, questionTree.getNode().getIdentifier(),
+                        Type.REFERENCE);
+                    currentNode.setProperty("jcr:primaryType", FormUtils.ANSWER_SECTION_NODETYPE, Type.NAME);
+                    currentNode.setProperty("sling:resourceSuperType", "cards/Resource", Type.STRING);
+                    currentNode.setProperty("sling:resourceType", FormUtils.ANSWER_SECTION_RESOURCE, Type.STRING);
+                    currentNode.setProperty("statusFlags", Collections.emptyList(), Type.STRINGS);
+                }
+                Map<String, List<NodeBuilder>> childNodesByReference = getChildNodesByReference(currentNode);
+                return createChildrenNodes(questionTree, childNodesByReference, currentNode);
+            }
+        } catch (RepositoryException e) {
+            getLogger().error("Error creating " + (questionTree.isQuestion() ? "question. " : "section. ")
+                + e.getMessage());
+            return Collections.emptyMap();
+        }
+    }
+
+    protected Map<QuestionTree, NodeBuilder> createChildrenNodes(
+        final QuestionTree questionTree,
+        final Map<String, List<NodeBuilder>> childNodesByReference, final NodeBuilder nodeBuilder)
+    {
+        Map<QuestionTree, NodeBuilder> result = new HashMap<>();
+        for (Map.Entry<String, QuestionTree> childQuestion
+            : questionTree.getChildren().entrySet()) {
+            QuestionTree childTree = childQuestion.getValue();
+            try {
+                Node childQuestionNode = childTree.getNode();
+                String referenceKey = childQuestionNode.getIdentifier();
+                int expectedNumberOfInstances = 1;
+                int numberOfInstances = 0;
+                if (childQuestionNode.hasProperty("recurrent")
+                    && childQuestionNode.getProperty("recurrent").getBoolean()
+                    && childQuestionNode.hasProperty("initialNumberOfInstances")) {
+                    expectedNumberOfInstances = (int) childQuestionNode.getProperty("initialNumberOfInstances")
+                        .getLong();
+                }
+
+                if (childNodesByReference.containsKey(referenceKey)) {
+                    List<NodeBuilder> matchingChildren = childNodesByReference.get(referenceKey);
+                    numberOfInstances += matchingChildren.size();
+
+                    for (NodeBuilder childNode : matchingChildren) {
+                        result.putAll(createMissingNodes(childTree, childNode));
+                    }
+                }
+                while (numberOfInstances < expectedNumberOfInstances) {
+                    NodeBuilder childNodeBuilder = nodeBuilder.setChildNode(UUID.randomUUID().toString());
+                    result.putAll(createMissingNodes(childTree, childNodeBuilder));
+                    numberOfInstances++;
+                }
+            } catch (RepositoryException e) {
+                // Node has no accessible identifier, skip
+            }
+        }
+        return result;
+    }
+
+    protected Map<String, List<NodeBuilder>> getChildNodesByReference(final NodeBuilder nodeBuilder)
+    {
+        Map<String, List<NodeBuilder>> result = new HashMap<>();
+        for (String childNodeName : nodeBuilder.getChildNodeNames()) {
+            NodeBuilder childNode = nodeBuilder.getChildNode(childNodeName);
+            String childIdentifier;
+            if (this.formUtils.isAnswerSection(childNode)) {
+                childIdentifier = this.formUtils.getSectionIdentifier(childNode);
+            } else if (this.formUtils.isAnswer(childNode)) {
+                childIdentifier = this.formUtils.getQuestionIdentifier(childNode);
+            } else {
+                continue;
+            }
+
+            List<NodeBuilder> childNodes = result.containsKey(childIdentifier)
+                ? result.get(childIdentifier)
+                : new ArrayList<>();
+            childNodes.add(childNode);
+            result.put(childIdentifier, childNodes);
+        }
+        return result;
+    }
+
+
+
+
+
+
+    protected abstract static class AbstractAnswerChangeTracker extends DefaultEditor
+    {
+        private final FormUtils formUtils;
+
+        private final Set<String> modifiedAnswers = new HashSet<>();
+
+        private boolean inMatchedAnswer;
+
+        private String currentAnswer;
+
+        public AbstractAnswerChangeTracker(final FormUtils formUtils)
+        {
+            this.formUtils = formUtils;
+        }
+
+        public abstract boolean isMatchedAnswerNode(NodeState after, String questionId);
+
+        @Override
+        public void enter(NodeState before, NodeState after)
+        {
+            String questionId = this.formUtils.getQuestionIdentifier(after);
+            if (isMatchedAnswerNode(after, questionId)) {
+                this.inMatchedAnswer = true;
+                this.currentAnswer = questionId;
+            }
+        }
+
+        @Override
+        public void leave(NodeState before, NodeState after)
+        {
+            this.inMatchedAnswer = false;
+            this.currentAnswer = null;
+        }
+
+        @Override
+        public void propertyAdded(PropertyState after)
+        {
+            if (this.inMatchedAnswer) {
+                this.modifiedAnswers.add(this.currentAnswer);
+            }
+        }
+
+        @Override
+        public void propertyChanged(PropertyState before, PropertyState after)
+        {
+            propertyAdded(after);
+        }
+
+        @Override
+        public void propertyDeleted(PropertyState before)
+        {
+            propertyAdded(before);
+        }
+
+        @Override
+        public Editor childNodeAdded(String name, NodeState after)
+        {
+            return this;
+        }
+
+        @Override
+        public Editor childNodeChanged(String name, NodeState before, NodeState after)
+        {
+            return this;
+        }
+
+        @Override
+        public Editor childNodeDeleted(String name, NodeState before)
+        {
+            return this;
+        }
+
+        public Set<String> getModifiedAnswers()
+        {
+            return this.modifiedAnswers;
+        }
+    }
+
+    protected static class QuestionTree
+    {
+        private Map<String, QuestionTree> children;
+
+        private Node node;
+
+        private boolean isQuestion;
+
+        QuestionTree(final Node node, final boolean isQuestion)
+        {
+            this.isQuestion = isQuestion;
+            this.node = node;
+            this.children = isQuestion ? null : new HashMap<>();
+        }
+
+        public Map<String, QuestionTree> getChildren()
+        {
+            return this.children;
+        }
+
+        public Node getNode()
+        {
+            return this.node;
+        }
+
+        public boolean isQuestion()
+        {
+            return this.isQuestion;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "{question:" + this.isQuestion
+                + (this.children == null ? "" : " children: " + this.children.toString())
+                + (this.node == null ? "" : " node: " + this.node.toString()) + " }";
+        }
+    }
+
+    protected static class AnswerNodeTypes
+    {
+        private String primaryType;
+
+        private String resourceType;
+
+        private Type<?> dataType;
+
+        @SuppressWarnings("checkstyle:CyclomaticComplexity")
+        AnswerNodeTypes(final Node questionNode, String defaultPrimaryType, String defaultResourceType)
+            throws RepositoryException
+        {
+            final String dataTypeString = questionNode.getProperty("dataType").getString();
+            final String capitalizedType = StringUtils.capitalize(dataTypeString);
+            this.primaryType = "cards:" + capitalizedType + "Answer";
+            this.resourceType = "cards/" + capitalizedType + "Answer";
+            switch (dataTypeString) {
+                case "long":
+                    this.dataType = Type.LONG;
+                    break;
+                case "double":
+                    this.dataType = Type.DOUBLE;
+                    break;
+                case "decimal":
+                    this.dataType = Type.DECIMAL;
+                    break;
+                case "boolean":
+                    // Long, not boolean
+                    this.dataType = Type.LONG;
+                    break;
+                case "date":
+                    this.dataType = (questionNode.hasProperty("dateFormat") && "yyyy".equals(
+                        questionNode.getProperty("dateFormat").getString().toLowerCase()))
+                            ? Type.LONG
+                            : Type.DATE;
+                    break;
+                case "time":
+                case "vocabulary":
+                case "text":
+                    this.dataType = Type.STRING;
+                    break;
+                default:
+                    this.primaryType = defaultPrimaryType;
+                    this.resourceType = defaultResourceType;
+                    this.dataType = Type.STRING;
+            }
+        }
+
+        public String getPrimaryType()
+        {
+            return this.primaryType;
+        }
+
+        public String getResourceType()
+        {
+            return this.resourceType;
+        }
+
+        public Type<?> getDataType()
+        {
+            return this.dataType;
+        }
+    }
+
+}

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
@@ -16,34 +16,23 @@
  */
 package io.uhndata.cards.forms.internal;
 
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import javax.jcr.Node;
-import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
-import org.apache.jackrabbit.oak.spi.commit.DefaultEditor;
 import org.apache.jackrabbit.oak.spi.commit.Editor;
 import org.apache.jackrabbit.oak.spi.state.ChildNodeEntry;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
-import org.apache.sling.api.resource.LoginException;
-import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,33 +46,11 @@ import io.uhndata.cards.forms.api.QuestionnaireUtils;
  *
  * @version $Id$
  */
-public class ComputedAnswersEditor extends DefaultEditor
+public class ComputedAnswersEditor extends AnswersEditor
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(ComputedAnswersEditor.class);
 
-    // This holds the builder for the current node. The methods called for editing specific properties don't receive the
-    // actual parent node of those properties, so we must manually keep track of the current node.
-    private final NodeBuilder currentNodeBuilder;
-
-    private final ResourceResolverFactory rrf;
-
-    /** The current user session. **/
-    private Session currentSession;
-
-    /** A session that has access to all the questionnaire questions and can access restricted questions. */
-    private Session serviceSession;
-
-    private final QuestionnaireUtils questionnaireUtils;
-
-    private final FormUtils formUtils;
-
     private final ExpressionUtils expressionUtils;
-
-    private boolean isFormNode;
-
-    private boolean formEditorHasChanged;
-
-    private ComputedAnswerChangeTracker computedAnswerChangeTracker;
 
     /**
      * Simple constructor.
@@ -97,58 +64,56 @@ public class ComputedAnswersEditor extends DefaultEditor
     public ComputedAnswersEditor(final NodeBuilder nodeBuilder, final ResourceResolverFactory rrf,
         final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils, final ExpressionUtils expressionUtils)
     {
-        this.currentNodeBuilder = nodeBuilder;
-        this.rrf = rrf;
-        this.questionnaireUtils = questionnaireUtils;
-        this.formUtils = formUtils;
+        super(nodeBuilder, rrf, questionnaireUtils, formUtils, "computedAnswers");
         this.expressionUtils = expressionUtils;
-        this.computedAnswerChangeTracker = new ComputedAnswerChangeTracker();
-        this.isFormNode = this.formUtils.isForm(this.currentNodeBuilder);
+    }
+
+    @Override
+    protected Logger getLogger()
+    {
+        return this.LOGGER;
+    }
+
+    @Override
+    protected ComputedAnswerChangeTracker getAnswerChangeTracker()
+    {
+        return new ComputedAnswerChangeTracker();
+    }
+
+    @Override
+    protected ComputedAnswersEditor getNewEditor(String name)
+    {
+        return new ComputedAnswersEditor(this.currentNodeBuilder.getChildNode(name),
+            this.rrf, this.questionnaireUtils, this.formUtils, this.expressionUtils);
+    }
+
+    @Override
+    protected ComputedAnswerNodeTypes getNewAnswerNodeTypes(Node node)
+        throws RepositoryException
+    {
+        return new ComputedAnswerNodeTypes(node);
+    }
+
+    @Override
+    protected boolean isQuestionNodeMatchingType(Node node)
+    {
+        return this.questionnaireUtils.isComputedQuestion(node);
     }
 
     @Override
     public Editor childNodeAdded(final String name, final NodeState after)
     {
         if (this.isFormNode) {
-            // Found a modified form. Flag for the current editor to checking computed answers.
-            // No need to make any child editors.
-            this.formEditorHasChanged = true;
+            this.shouldRunOnLeave = true;
             // No need to descend further down, we already know that this is a form that has changes
-            return this.computedAnswerChangeTracker;
+            return this.answerChangeTracker;
         } else {
-            return new ComputedAnswersEditor(this.currentNodeBuilder.getChildNode(name),
-                this.rrf, this.questionnaireUtils, this.formUtils, this.expressionUtils);
+            return getNewEditor(name);
         }
     }
 
     @Override
-    public Editor childNodeChanged(final String name, final NodeState before, final NodeState after)
-    {
-        return childNodeAdded(name, after);
-    }
-
-    @Override
-    public void leave(final NodeState before, final NodeState after)
-    {
-        if (!this.formEditorHasChanged) {
-            return;
-        }
-
-        final Map<String, Object> parameters =
-            Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "computedAnswers");
-        final ResourceResolver sessionResolver = this.rrf.getThreadResourceResolver();
-        try (ResourceResolver serviceResolver = this.rrf.getServiceResourceResolver(parameters)) {
-            if (sessionResolver != null && serviceResolver != null) {
-                this.currentSession = sessionResolver.adaptTo(Session.class);
-                this.serviceSession = serviceResolver.adaptTo(Session.class);
-                computeMissingAnswers(after);
-            }
-        } catch (LoginException e) {
-            // Should not happen
-        }
-    }
-
-    private void computeMissingAnswers(final NodeState form)
+    protected void handleLeave(final NodeState form)
     {
         // Get a list of all current answers for the form for use in computing answers
         final Map<String, Object> answersByQuestionName = getNodeAnswers(form);
@@ -158,7 +123,8 @@ public class ComputedAnswersEditor extends DefaultEditor
         if (questionnaireNode == null) {
             return;
         }
-        final QuestionTree computedQuestionsTree = getUnansweredComputedQuestions(questionnaireNode);
+        final QuestionTree computedQuestionsTree =
+            getUnansweredMatchingQuestions(questionnaireNode);
 
         // There are missing computed questions, let's create them!
         if (computedQuestionsTree != null) {
@@ -201,7 +167,7 @@ public class ComputedAnswersEditor extends DefaultEditor
         final NodeBuilder answer = entry.getValue();
         Type<?> resultType = Type.STRING;
         try {
-            AnswerNodeTypes types = new AnswerNodeTypes(question.getNode());
+            ComputedAnswerNodeTypes types = new ComputedAnswerNodeTypes(question.getNode());
             resultType = types.getDataType();
         } catch (RepositoryException e) {
             LOGGER.error("Error typing value for question. " + e.getMessage());
@@ -224,16 +190,6 @@ public class ComputedAnswersEditor extends DefaultEditor
             // TODO: Implement better recurrent section handling
         } else {
             answersByQuestionName.put(questionName, result);
-        }
-    }
-
-    private Node getQuestionnaire()
-    {
-        final String questionnaireId = this.currentNodeBuilder.getProperty("questionnaire").getValue(Type.REFERENCE);
-        try {
-            return this.serviceSession.getNodeByIdentifier(questionnaireId);
-        } catch (RepositoryException e) {
-            return null;
         }
     }
 
@@ -281,325 +237,39 @@ public class ComputedAnswersEditor extends DefaultEditor
         return currentAnswers;
     }
 
-    // Returns a QuestionTree if any children of this node contains an unanswered computed question, else null
-    private QuestionTree getUnansweredComputedQuestions(final Node currentNode)
+    private final class ComputedAnswerChangeTracker extends AbstractAnswerChangeTracker
     {
-        QuestionTree currentTree = null;
-
-        try {
-            if (this.questionnaireUtils.isComputedQuestion(currentNode)) {
-                // Ignore questions that are not computed questions
-                // Skip already answered questions
-                if (!this.computedAnswerChangeTracker.getModifiedAnswers().contains(currentNode.getIdentifier())) {
-                    currentTree = new QuestionTree(currentNode, true);
-                }
-            } else if (this.questionnaireUtils.isQuestionnaire(currentNode)
-                || this.questionnaireUtils.isSection(currentNode)) {
-                // Recursively check if any children have a computed question
-                QuestionTree newTree = new QuestionTree(currentNode, false);
-                for (NodeIterator i = currentNode.getNodes(); i.hasNext();) {
-                    Node child = i.nextNode();
-                    QuestionTree childTree = getUnansweredComputedQuestions(child);
-                    if (childTree != null) {
-                        // Child has data that should be stored
-                        newTree.getChildren().put(child.getName(), childTree);
-                    }
-                }
-
-                // If this node has a child with a computed question, return this information
-                if (newTree.getChildren().size() > 0) {
-                    currentTree = newTree;
-                }
-            }
-        } catch (RepositoryException e) {
-            // Unable to retrieve type: skip
-            LOGGER.warn(e.getMessage());
+        ComputedAnswerChangeTracker()
+        {
+            super(ComputedAnswersEditor.this.formUtils);
         }
-
-        return currentTree;
-    }
-
-    private Map<QuestionTree, NodeBuilder> createMissingNodes(final QuestionTree questionTree,
-        final NodeBuilder currentNode)
-    {
-        try {
-            if (questionTree.isQuestion()) {
-                if (!currentNode.hasProperty("jcr:" + "primaryType")) {
-                    AnswerNodeTypes types = new AnswerNodeTypes(questionTree.getNode());
-                    // New node, insert all required properties
-                    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-                    currentNode.setProperty("jcr:created", dateFormat.format(new Date()), Type.DATE);
-                    currentNode.setProperty("jcr:createdBy", this.currentSession.getUserID(), Type.NAME);
-                    String questionReference = questionTree.getNode().getIdentifier();
-                    currentNode.setProperty(FormUtils.QUESTION_PROPERTY, questionReference, Type.REFERENCE);
-                    currentNode.setProperty("jcr:primaryType", types.getPrimaryType(), Type.NAME);
-                    currentNode.setProperty("sling:resourceSuperType", FormUtils.ANSWER_RESOURCE, Type.STRING);
-                    currentNode.setProperty("sling:resourceType", types.getResourceType(), Type.STRING);
-                    currentNode.setProperty("statusFlags", Collections.emptyList(), Type.STRINGS);
-                }
-                return Collections.singletonMap(questionTree, currentNode);
-            } else {
-                // Section
-                if (!currentNode.hasProperty("jcr:primaryType")) {
-                    // Section must be created before primary type
-                    currentNode.setProperty(FormUtils.SECTION_PROPERTY, questionTree.getNode().getIdentifier(),
-                        Type.REFERENCE);
-                    currentNode.setProperty("jcr:primaryType", FormUtils.ANSWER_SECTION_NODETYPE, Type.NAME);
-                    currentNode.setProperty("sling:resourceSuperType", "cards/Resource", Type.STRING);
-                    currentNode.setProperty("sling:resourceType", FormUtils.ANSWER_SECTION_RESOURCE, Type.STRING);
-                    currentNode.setProperty("statusFlags", Collections.emptyList(), Type.STRINGS);
-                }
-                Map<String, List<NodeBuilder>> childNodesByReference = getChildNodesByReference(currentNode);
-                return createChildrenNodes(questionTree, childNodesByReference, currentNode);
-            }
-        } catch (RepositoryException e) {
-            LOGGER.error("Error creating " + (questionTree.isQuestion() ? "question. " : "section. ")
-                + e.getMessage());
-            return Collections.emptyMap();
-        }
-    }
-
-    private Map<String, List<NodeBuilder>> getChildNodesByReference(final NodeBuilder nodeBuilder)
-    {
-        Map<String, List<NodeBuilder>> result = new HashMap<>();
-        for (String childNodeName : nodeBuilder.getChildNodeNames()) {
-            NodeBuilder childNode = nodeBuilder.getChildNode(childNodeName);
-            String childIdentifier;
-            if (this.formUtils.isAnswerSection(childNode)) {
-                childIdentifier = this.formUtils.getSectionIdentifier(childNode);
-            } else if (this.formUtils.isAnswer(childNode)) {
-                childIdentifier = this.formUtils.getQuestionIdentifier(childNode);
-            } else {
-                continue;
-            }
-
-            List<NodeBuilder> childNodes = result.containsKey(childIdentifier)
-                ? result.get(childIdentifier)
-                : new ArrayList<>();
-            childNodes.add(childNode);
-            result.put(childIdentifier, childNodes);
-        }
-        return result;
-    }
-
-    private Map<QuestionTree, NodeBuilder> createChildrenNodes(final QuestionTree computedQuestionTree,
-        final Map<String, List<NodeBuilder>> childNodesByReference, final NodeBuilder nodeBuilder)
-    {
-        Map<QuestionTree, NodeBuilder> result = new HashMap<>();
-        for (Map.Entry<String, QuestionTree> childQuestion : computedQuestionTree.getChildren().entrySet()) {
-            QuestionTree childTree = childQuestion.getValue();
-            try {
-                Node childQuestionNode = childTree.getNode();
-                String referenceKey = childQuestionNode.getIdentifier();
-                int expectedNumberOfInstances = 1;
-                int numberOfInstances = 0;
-                if (childQuestionNode.hasProperty("recurrent")
-                    && childQuestionNode.getProperty("recurrent").getBoolean()
-                    && childQuestionNode.hasProperty("initialNumberOfInstances")) {
-                    expectedNumberOfInstances = (int) childQuestionNode.getProperty("initialNumberOfInstances")
-                        .getLong();
-                }
-
-                if (childNodesByReference.containsKey(referenceKey)) {
-                    List<NodeBuilder> matchingChildren = childNodesByReference.get(referenceKey);
-                    numberOfInstances += matchingChildren.size();
-
-                    for (NodeBuilder childNode : matchingChildren) {
-                        result.putAll(createMissingNodes(childTree, childNode));
-                    }
-                }
-                while (numberOfInstances < expectedNumberOfInstances) {
-                    NodeBuilder childNodeBuilder = nodeBuilder.setChildNode(UUID.randomUUID().toString());
-                    result.putAll(createMissingNodes(childTree, childNodeBuilder));
-                    numberOfInstances++;
-                }
-            } catch (RepositoryException e) {
-                // Node has no accessible identifier, skip
-            }
-        }
-        return result;
-    }
-
-    private final class ComputedAnswerChangeTracker extends DefaultEditor
-    {
-        private final Set<String> modifiedAnswers = new HashSet<>();
-
-        private boolean inComputedAnswer;
-
-        private String currentAnswer;
 
         @Override
-        public void enter(NodeState before, NodeState after)
+        public boolean isMatchedAnswerNode(NodeState after, String questionId)
         {
-            String questionId = ComputedAnswersEditor.this.formUtils.getQuestionIdentifier(after);
             if ("cards:ComputedAnswer".equals(after.getName("jcr:primaryType"))) {
-                this.inComputedAnswer = true;
-                this.currentAnswer = questionId;
+                return true;
             } else if (questionId != null) {
                 Node questionNode = ComputedAnswersEditor.this.questionnaireUtils.getQuestion(questionId);
                 try {
                     if (questionNode != null && questionNode.hasProperty("entryMode")
                         && "computed".equals(questionNode.getProperty("entryMode").getString())) {
-                        this.inComputedAnswer = true;
-                        this.currentAnswer = questionId;
+                        return true;
                     }
                 } catch (RepositoryException e) {
                     // Can't access this answer's question. Ignore
+                    return false;
                 }
             }
-        }
-
-        @Override
-        public void leave(NodeState before, NodeState after)
-        {
-            this.inComputedAnswer = false;
-            this.currentAnswer = null;
-        }
-
-        @Override
-        public void propertyAdded(PropertyState after)
-        {
-            if (this.inComputedAnswer) {
-                this.modifiedAnswers.add(this.currentAnswer);
-            }
-        }
-
-        @Override
-        public void propertyChanged(PropertyState before, PropertyState after)
-        {
-            propertyAdded(after);
-        }
-
-        @Override
-        public void propertyDeleted(PropertyState before)
-        {
-            propertyAdded(before);
-        }
-
-        @Override
-        public Editor childNodeAdded(String name, NodeState after)
-        {
-            return this;
-        }
-
-        @Override
-        public Editor childNodeChanged(String name, NodeState before, NodeState after)
-        {
-            return this;
-        }
-
-        @Override
-        public Editor childNodeDeleted(String name, NodeState before)
-        {
-            return this;
-        }
-
-        public Set<String> getModifiedAnswers()
-        {
-            return this.modifiedAnswers;
+            return false;
         }
     }
 
-    private static final class QuestionTree
+    private final class ComputedAnswerNodeTypes extends AnswerNodeTypes
     {
-        private Map<String, QuestionTree> children;
-
-        private Node node;
-
-        private boolean isQuestion;
-
-        QuestionTree(final Node node, final boolean isQuestion)
+        ComputedAnswerNodeTypes(final Node questionNode) throws RepositoryException
         {
-            this.isQuestion = isQuestion;
-            this.node = node;
-            this.children = isQuestion ? null : new HashMap<>();
-        }
-
-        public Map<String, QuestionTree> getChildren()
-        {
-            return this.children;
-        }
-
-        public Node getNode()
-        {
-            return this.node;
-        }
-
-        public boolean isQuestion()
-        {
-            return this.isQuestion;
-        }
-
-        @Override
-        public String toString()
-        {
-            return "{question:" + this.isQuestion
-                + (this.children == null ? "" : " children: " + this.children.toString())
-                + (this.node == null ? "" : " node: " + this.node.toString()) + " }";
-        }
-    }
-
-    private static final class AnswerNodeTypes
-    {
-        private String primaryType;
-
-        private String resourceType;
-
-        private Type<?> dataType;
-
-        @SuppressWarnings("checkstyle:CyclomaticComplexity")
-        AnswerNodeTypes(final Node questionNode) throws RepositoryException
-        {
-            final String dataTypeString = questionNode.getProperty("dataType").getString();
-            final String capitalizedType = StringUtils.capitalize(dataTypeString);
-            this.primaryType = "cards:" + capitalizedType + "Answer";
-            this.resourceType = "cards/" + capitalizedType + "Answer";
-            switch (dataTypeString) {
-                case "long":
-                    this.dataType = Type.LONG;
-                    break;
-                case "double":
-                    this.dataType = Type.DOUBLE;
-                    break;
-                case "decimal":
-                    this.dataType = Type.DECIMAL;
-                    break;
-                case "boolean":
-                    // Long, not boolean
-                    this.dataType = Type.LONG;
-                    break;
-                case "date":
-                    this.dataType = (questionNode.hasProperty("dateFormat") && "yyyy".equals(
-                        questionNode.getProperty("dateFormat").getString().toLowerCase()))
-                            ? Type.LONG
-                            : Type.DATE;
-                    break;
-                case "time":
-                case "vocabulary":
-                case "text":
-                    this.dataType = Type.STRING;
-                    break;
-                case "computed":
-                default:
-                    this.primaryType = "cards:ComputedAnswer";
-                    this.resourceType = "cards/ComputedAnswer";
-                    this.dataType = Type.STRING;
-            }
-        }
-
-        public String getPrimaryType()
-        {
-            return this.primaryType;
-        }
-
-        public String getResourceType()
-        {
-            return this.resourceType;
-        }
-
-        public Type<?> getDataType()
-        {
-            return this.dataType;
+            super(questionNode, "cards:ComputedAnswer", "cards/ComputedAnswer");
         }
     }
 }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
@@ -71,7 +71,7 @@ public class ComputedAnswersEditor extends AnswersEditor
     @Override
     protected Logger getLogger()
     {
-        return this.LOGGER;
+        return LOGGER;
     }
 
     @Override

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/QuestionnaireUtilsImpl.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/QuestionnaireUtilsImpl.java
@@ -127,6 +127,17 @@ public final class QuestionnaireUtilsImpl extends AbstractNodeUtils implements Q
     }
 
     @Override
+    public boolean isReferenceQuestion(final Node node)
+    {
+        try {
+            return isQuestion(node)
+                && ("reference".equals(node.getProperty("entryMode").getString()));
+        } catch (final RepositoryException e) {
+            return false;
+        }
+    }
+
+    @Override
     public Node getQuestion(final String identifier)
     {
         final Node result = getNodeByIdentifier(identifier, getSession(this.rrf));

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
@@ -162,23 +162,18 @@ public class ReferenceAnswersEditor extends AnswersEditor
         }
     }
 
-    @SuppressWarnings("checkstyle:NestedIfDepth")
     private Object getAnswer(NodeState form, String questionPath)
     {
         Node subject = this.formUtils.getSubject(form);
         try {
-            if (this.subjectUtils.isSubject(subject)) {
-                for (final PropertyIterator subjectReferences = subject.getReferences(); subjectReferences.hasNext();) {
-                    Node subjectForm = subjectReferences.nextProperty().getParent();
-                    if (this.formUtils.isForm(subjectForm)) {
-                        Node subjectQuestionnaire = this.formUtils.getQuestionnaire(subjectForm);
-                        if (this.questionnaireUtils.isQuestionnaire(subjectQuestionnaire)
-                            && questionPath.startsWith(subjectQuestionnaire.getPath())) {
-                            Object value = getAnswerFromParentNode(subjectForm, questionPath);
-                            if (value != null) {
-                                return serializeValue(value);
-                            }
-                        }
+            for (final PropertyIterator subjectReferences = subject.getReferences(); subjectReferences.hasNext();) {
+                Node subjectForm = subjectReferences.nextProperty().getParent();
+                Node subjectQuestionnaire = this.formUtils.getQuestionnaire(subjectForm);
+                if (this.questionnaireUtils.isQuestionnaire(subjectQuestionnaire)
+                    && questionPath.startsWith(subjectQuestionnaire.getPath())) {
+                    Object value = getAnswerFromParentNode(subjectForm, questionPath);
+                    if (value != null) {
+                        return serializeValue(value);
                     }
                 }
             }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.forms.internal;
+
+import java.util.Map;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.PropertyIterator;
+import javax.jcr.RepositoryException;
+
+import org.apache.jackrabbit.oak.api.PropertyState;
+import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.spi.commit.Editor;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.uhndata.cards.forms.api.FormUtils;
+import io.uhndata.cards.forms.api.QuestionnaireUtils;
+import io.uhndata.cards.subjects.api.SubjectUtils;
+
+/**
+ * An {@link Editor} that calculates any computed answers that were not submitted by the client.
+ *
+ * @version $Id$
+ */
+public class ReferenceAnswersEditor extends AnswersEditor
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(ComputedAnswersEditor.class);
+
+    private final SubjectUtils subjectUtils;
+
+    /**
+     * Simple constructor.
+     *
+     * @param nodeBuilder the builder for the current node
+     * @param rrf the resource resolver factory which can provide access to JCR sessions
+     * @param questionnaireUtils for working with questionnaire data
+     * @param formUtils for working with form data
+     * @param subjectUtils for working with subject data
+     */
+    public ReferenceAnswersEditor(final NodeBuilder nodeBuilder, final ResourceResolverFactory rrf,
+        final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils, SubjectUtils subjectUtils)
+    {
+        super(nodeBuilder, rrf, questionnaireUtils, formUtils, "referenceAnswers");
+        this.subjectUtils = subjectUtils;
+    }
+
+    @Override
+    protected Logger getLogger()
+    {
+        return this.LOGGER;
+    }
+
+    @Override
+    protected ReferenceAnswerChangeTracker getAnswerChangeTracker()
+    {
+        return new ReferenceAnswerChangeTracker();
+    }
+
+    @Override
+    protected ReferenceAnswersEditor getNewEditor(String name)
+    {
+        return new ReferenceAnswersEditor(this.currentNodeBuilder.getChildNode(name),
+            this.rrf, this.questionnaireUtils, this.formUtils, this.subjectUtils);
+    }
+
+    @Override
+    protected ReferenceAnswerNodeTypes getNewAnswerNodeTypes(Node node)
+        throws RepositoryException
+    {
+        return new ReferenceAnswerNodeTypes(node);
+    }
+
+    @Override
+    protected boolean isQuestionNodeMatchingType(Node node)
+    {
+        return this.questionnaireUtils.isReferenceQuestion(node);
+    }
+
+    @Override
+    public void propertyAdded(final PropertyState after)
+    {
+        if (this.isFormNode && "questionnaire".equals(after.getName()))
+        {
+            // Only run on a newly created questionnaire
+            this.shouldRunOnLeave = true;
+        }
+    }
+
+    @Override
+    protected void handleLeave(final NodeState form)
+    {
+        // Get a list of all unanswered reference questions
+        final Node questionnaireNode = getQuestionnaire();
+        if (questionnaireNode == null) {
+            return;
+        }
+        final QuestionTree referenceQuestionsTree =
+            getUnansweredMatchingQuestions(questionnaireNode);
+
+        // There are missing reference questions, let's create them!
+        if (referenceQuestionsTree != null) {
+            // Create the missing structure, i.e. AnswerSection and Answer nodes
+            final Map<QuestionTree, NodeBuilder> answersToFinish =
+                createMissingNodes(referenceQuestionsTree, this.currentNodeBuilder);
+
+            // Retrieve all the referenced answers
+            answersToFinish.entrySet().stream().forEach(entry -> {
+                Node question = entry.getKey().getNode();
+                final String referencedQuestionnaire;
+                final String referencedQuestion;
+                try {
+                    referencedQuestionnaire = question.getProperty("questionnaire").getString();
+                    referencedQuestion = question.getProperty("question").getString();
+                } catch (final RepositoryException e) {
+                    LOGGER.warn("Skipping referenced question due to missing property");
+                    return;
+                }
+
+                NodeBuilder answer = entry.getValue();
+                Type<?> resultType = Type.STRING;
+                try {
+                    ReferenceAnswerNodeTypes types = new ReferenceAnswerNodeTypes(question);
+                    resultType = types.getDataType();
+                } catch (RepositoryException e) {
+                    LOGGER.warn("Error typing value for question. " + e.getMessage());
+                }
+
+                Object result = getAnswer(form, referencedQuestionnaire, referencedQuestion);
+
+                if (result == null) {
+                    answer.removeProperty(FormUtils.VALUE_PROPERTY);
+                } else {
+                    // Type erasure makes the actual type irrelevant, there's only one real implementation method
+                    // The implementation can extract the right type from the type object
+                    @SuppressWarnings("unchecked")
+                    Type<Object> untypedResultType = (Type<Object>) resultType;
+                    answer.setProperty(FormUtils.VALUE_PROPERTY, result, untypedResultType);
+                }
+
+            });
+        }
+    }
+
+    @SuppressWarnings("checkstyle:NestedIfDepth")
+    private Object getAnswer(NodeState form, String questionnaireName, String questionName)
+    {
+        Node subject = this.formUtils.getSubject(form);
+        try {
+            if (this.subjectUtils.isSubject(subject)) {
+                for (final PropertyIterator subjectReferences = subject.getReferences();
+                    subjectReferences.hasNext();) {
+                    Node subjectForm = subjectReferences.nextProperty().getParent();
+                    if (this.formUtils.isForm(subjectForm)) {
+                        Node subjectQuestionnaire = this.formUtils.getQuestionnaire(subjectForm);
+                        if (this.questionnaireUtils.isQuestionnaire(subjectQuestionnaire)
+                            && questionnaireName.equals(subjectQuestionnaire.getName())) {
+                            Object value = getAnswerFromParentNode(subjectForm, questionName);
+                            if (value != null) {
+                                return value;
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (RepositoryException e) {
+            LOGGER.error("Skipping referenced question due to error finding the referenced answer. "
+                + e.getMessage());
+        }
+        return null;
+    }
+
+    private Object getAnswerFromParentNode(Node currentNode, String questionName) throws RepositoryException
+    {
+        if (this.formUtils.isAnswerSection(currentNode) || this.formUtils.isForm(currentNode)) {
+            // Found a section: Recursively get all of this section's answers
+            for (final NodeIterator childNodes = currentNode.getNodes(); childNodes.hasNext();) {
+                Node childNode = childNodes.nextNode();
+                Object value = getAnswerFromParentNode(childNode, questionName);
+                if (value != null) {
+                    return value;
+                }
+            }
+        } else if (this.formUtils.isAnswer(currentNode)) {
+            String currentQuestionName
+                = this.questionnaireUtils.getQuestionName(this.formUtils.getQuestion(currentNode));
+            if (questionName.equals(currentQuestionName)) {
+                return this.formUtils.getValue(currentNode);
+            }
+        }
+        return null;
+    }
+
+    private final class ReferenceAnswerChangeTracker extends AbstractAnswerChangeTracker
+    {
+        ReferenceAnswerChangeTracker()
+        {
+            super(ReferenceAnswersEditor.this.formUtils);
+        }
+
+        @Override
+        public boolean isMatchedAnswerNode(NodeState after, String questionId)
+        {
+            if ("cards:ReferenceAnswer".equals(after.getName("jcr:primaryType"))) {
+                return true;
+            } else if (questionId != null) {
+                Node questionNode = ReferenceAnswersEditor.this.questionnaireUtils.getQuestion(questionId);
+                try {
+                    if (questionNode != null && questionNode.hasProperty("entryMode")
+                        && "refernce".equals(questionNode.getProperty("entryMode").getString())) {
+                        return true;
+                    }
+                } catch (RepositoryException e) {
+                    // Can't access this answer's question. Ignore
+                    return false;
+                }
+            }
+            return false;
+        }
+    }
+
+    private final class ReferenceAnswerNodeTypes extends AnswerNodeTypes
+    {
+        ReferenceAnswerNodeTypes(final Node questionNode) throws RepositoryException
+        {
+            super(questionNode, "cards:ReferenceAnswer", "cards/ReferenceAnswer");
+        }
+    }
+}

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
@@ -37,7 +37,7 @@ import io.uhndata.cards.forms.api.QuestionnaireUtils;
 import io.uhndata.cards.subjects.api.SubjectUtils;
 
 /**
- * An {@link Editor} that calculates any computed answers that were not submitted by the client.
+ * An {@link Editor} that fills out any reference answers for a new form.
  *
  * @version $Id$
  */

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
@@ -66,7 +66,7 @@ public class ReferenceAnswersEditor extends AnswersEditor
     @Override
     protected Logger getLogger()
     {
-        return this.LOGGER;
+        return LOGGER;
     }
 
     @Override

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditorProvider.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditorProvider.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.forms.internal;
+
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
+import org.apache.jackrabbit.oak.spi.commit.Editor;
+import org.apache.jackrabbit.oak.spi.commit.EditorProvider;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.FieldOption;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import io.uhndata.cards.forms.api.FormUtils;
+import io.uhndata.cards.forms.api.QuestionnaireUtils;
+import io.uhndata.cards.subjects.api.SubjectUtils;
+
+/**
+ * A {@link EditorProvider} returning {@link ReferenceAnswersEditor}.
+ *
+ * @version $Id$
+ */
+@Component
+public class ReferenceAnswersEditorProvider implements EditorProvider
+{
+    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
+        policyOption = ReferencePolicyOption.GREEDY)
+    private ResourceResolverFactory rrf;
+
+    @Reference
+    private QuestionnaireUtils questionnaireUtils;
+
+    @Reference
+    private FormUtils formUtils;
+
+    @Reference
+    private SubjectUtils subjectUtils;
+
+    @Override
+    public Editor getRootEditor(NodeState before, NodeState after, NodeBuilder builder, CommitInfo info)
+        throws CommitFailedException
+    {
+        if (this.rrf != null) {
+            // Each ReferenceEditor maintains a state, so a new instance must be returned each time
+            return new ReferenceAnswersEditor(builder, this.rrf,
+                this.questionnaireUtils, this.formUtils, this.subjectUtils);
+        }
+        return null;
+    }
+}

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/AbstractAnswerCopyProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/AbstractAnswerCopyProcessor.java
@@ -146,20 +146,14 @@ public abstract class AbstractAnswerCopyProcessor implements ResourceJsonProcess
         }
     }
 
-    private Node getAnswer(final Node source, final Node question)
-    {
-        final Node targetForm = findForm(source, question);
-        return this.formUtils.getAnswer(targetForm, question);
-    }
-
     /**
-     * Find a form related to the target {@code source}, answering the target {@code question}.
+     * Find the first answer related to the target {@code source}, answering the target {@code question}.
      *
      * @param source the resource being serialized
      * @param question a question whose answer needs to be copied
-     * @return a relevant form or {@code null}
+     * @return a relevant answer node or {@code null}
      */
-    protected abstract Node findForm(Node source, Node question);
+    protected abstract Node getAnswer(Node source, Node question);
 
     /**
      * Compute the relative path to the copy configuration that applies to the resource being serialized, excluding the

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/VisitChangeListener.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/VisitChangeListener.java
@@ -713,7 +713,8 @@ public class VisitChangeListener implements ResourceChangeListener
                 VisitChangeListener.this.questionnaireUtils.getQuestion(questionnaire, "clinic");
             final String clinicName = (String) VisitChangeListener.this.formUtils
                 .getValue(VisitChangeListener.this.formUtils.getAnswer(form, this.clinicQuestion));
-            final Node clinicNode = session.nodeExists(clinicName) ? session.getNode(clinicName) : null;
+            final Node clinicNode = StringUtils.isNotBlank(clinicName) && session.nodeExists(clinicName)
+                ? session.getNode(clinicName) : null;
             if (clinicNode != null) {
                 this.questionnaireSet = session.nodeExists("/Proms/" + clinicNode.getProperty("survey").getString())
                     ? clinicNode.getProperty("survey").getString() : null;

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ReferenceTestCopied.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ReferenceTestCopied.xml
@@ -83,6 +83,80 @@ Then, verify that all the answers have been copied over successfully</value>
 		</property>
     </node>
     <node>
+        <name>testComputed</name>
+        <primaryNodeType>cards:Question</primaryNodeType>
+        <property>
+            <name>text</name>
+            <value>Computed question, returns value of Referenced Text question</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>dataType</name>
+            <value>text</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>entryMode</name>
+            <value>computed</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>dateType</name>
+            <value>text</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>expression</name>
+            <value>return @{textQuestion}</value>
+            <type>String</type>
+        </property>
+    </node>
+    <node>
+        <name>conditionalSection</name>
+        <primaryNodeType>cards:Section</primaryNodeType>
+        <property>
+            <name>label</name>
+            <value>Test Conditional Section. Displayed if text question != "hello"</value>
+            <type>String</type>
+        </property>
+		<node>
+			<name>condition</name>
+			<primaryNodeType>cards:Conditional</primaryNodeType>
+			<property>
+				<name>comparator</name>
+				<value><![CDATA[<>]]></value>
+				<type>String</type>
+			</property>
+			<node>
+				<name>operandA</name>
+				<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+				<property>
+					<name>value</name>
+					<values>
+						<value>textQuestion</value>
+					</values>
+					<type>String</type>
+				</property>
+				<property>
+					<name>isReference</name>
+					<value>True</value>
+					<type>Boolean</type>
+				</property>
+			</node>
+			<node>
+				<name>operandB</name>
+				<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+				<property>
+					<name>value</name>
+					<values>
+						<value>hello</value>
+					</values>
+					<type>String</type>
+				</property>
+			</node>
+		</node>
+    </node>
+    <node>
         <name>section</name>
         <primaryNodeType>cards:Section</primaryNodeType>
         <property>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ReferenceTestCopied.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ReferenceTestCopied.xml
@@ -165,7 +165,7 @@ Then, verify that all the answers have been copied over successfully</value>
         </property>
         <property>
             <name>question</name>
-            <value>dateQuestion</value>
+            <value>longQuestion</value>
             <type>String</type>
         </property>
     </node>
@@ -208,4 +208,43 @@ Then, verify that all the answers have been copied over successfully</value>
             <type>String</type>
         </property>
     </node>
+    <!-- <node>
+        <name>dateQuestion</name>
+        <primaryNodeType>cards:Question</primaryNodeType>
+        <property>
+            <name>text</name>
+            <value>Date question</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>dataType</name>
+            <value>date</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>compact</name>
+            <value>True</value>
+            <type>Boolean</type>
+        </property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+        <property>
+            <name>entryMode</name>
+            <value>reference</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>questionnaire</name>
+            <value>ReferenceTestUser</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>question</name>
+            <value>dateQuestion</value>
+            <type>String</type>
+        </property>
+    </node> -->
 </node>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ReferenceTestCopied.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ReferenceTestCopied.xml
@@ -67,13 +67,8 @@ Then, verify that all the answers have been copied over successfully</value>
             <type>String</type>
         </property>
         <property>
-            <name>questionnaire</name>
-            <value>ReferenceTestUser</value>
-            <type>String</type>
-        </property>
-        <property>
             <name>question</name>
-            <value>textQuestion</value>
+            <value>/Questionnaires/ReferenceTestUser/textQuestion</value>
             <type>String</type>
         </property>
 		<property>
@@ -188,13 +183,8 @@ Then, verify that all the answers have been copied over successfully</value>
                 <type>String</type>
             </property>
             <property>
-                <name>questionnaire</name>
-                <value>ReferenceTestUser</value>
-                <type>String</type>
-            </property>
-            <property>
                 <name>question</name>
-                <value>sectionTextQuestion</value>
+                <value>/Questionnaires/ReferenceTestUser/section/sectionTextQuestion</value>
                 <type>String</type>
             </property>
             <property>
@@ -233,13 +223,8 @@ Then, verify that all the answers have been copied over successfully</value>
             <type>String</type>
         </property>
         <property>
-            <name>questionnaire</name>
-            <value>ReferenceTestUser</value>
-            <type>String</type>
-        </property>
-        <property>
             <name>question</name>
-            <value>longQuestion</value>
+            <value>/Questionnaires/ReferenceTestUser/longQuestion</value>
             <type>String</type>
         </property>
     </node>
@@ -272,13 +257,8 @@ Then, verify that all the answers have been copied over successfully</value>
             <type>String</type>
         </property>
         <property>
-            <name>questionnaire</name>
-            <value>ReferenceTestUser</value>
-            <type>String</type>
-        </property>
-        <property>
             <name>question</name>
-            <value>doubleQuestion</value>
+            <value>/Questionnaires/ReferenceTestUser/doubleQuestion</value>
             <type>String</type>
         </property>
     </node>
@@ -311,13 +291,8 @@ Then, verify that all the answers have been copied over successfully</value>
             <type>String</type>
         </property>
         <property>
-            <name>questionnaire</name>
-            <value>ReferenceTestUser</value>
-            <type>String</type>
-        </property>
-        <property>
             <name>question</name>
-            <value>dateQuestion</value>
+            <value>/Questionnaires/ReferenceTestUser/dateQuestion</value>
             <type>String</type>
         </property>
     </node> -->

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ReferenceTestCopied.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ReferenceTestCopied.xml
@@ -71,11 +71,11 @@ Then, verify that all the answers have been copied over successfully</value>
             <value>/Questionnaires/ReferenceTestUser/textQuestion</value>
             <type>String</type>
         </property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
+        <property>
+            <name>maxAnswers</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
     </node>
     <node>
         <name>testComputed</name>
@@ -114,42 +114,42 @@ Then, verify that all the answers have been copied over successfully</value>
             <value>Test Conditional Section. Displayed if text question != "hello"</value>
             <type>String</type>
         </property>
-		<node>
-			<name>condition</name>
-			<primaryNodeType>cards:Conditional</primaryNodeType>
-			<property>
-				<name>comparator</name>
-				<value><![CDATA[<>]]></value>
-				<type>String</type>
-			</property>
-			<node>
-				<name>operandA</name>
-				<primaryNodeType>cards:ConditionalValue</primaryNodeType>
-				<property>
-					<name>value</name>
-					<values>
-						<value>textQuestion</value>
-					</values>
-					<type>String</type>
-				</property>
-				<property>
-					<name>isReference</name>
-					<value>True</value>
-					<type>Boolean</type>
-				</property>
-			</node>
-			<node>
-				<name>operandB</name>
-				<primaryNodeType>cards:ConditionalValue</primaryNodeType>
-				<property>
-					<name>value</name>
-					<values>
-						<value>hello</value>
-					</values>
-					<type>String</type>
-				</property>
-			</node>
-		</node>
+        <node>
+            <name>condition</name>
+            <primaryNodeType>cards:Conditional</primaryNodeType>
+            <property>
+                <name>comparator</name>
+                <value><![CDATA[<>]]></value>
+                <type>String</type>
+            </property>
+            <node>
+                <name>operandA</name>
+                <primaryNodeType>cards:ConditionalValue</primaryNodeType>
+                <property>
+                    <name>value</name>
+                    <values>
+                        <value>textQuestion</value>
+                    </values>
+                    <type>String</type>
+                </property>
+                <property>
+                    <name>isReference</name>
+                    <value>True</value>
+                    <type>Boolean</type>
+                </property>
+            </node>
+            <node>
+                <name>operandB</name>
+                <primaryNodeType>cards:ConditionalValue</primaryNodeType>
+                <property>
+                    <name>value</name>
+                    <values>
+                        <value>hello</value>
+                    </values>
+                    <type>String</type>
+                </property>
+            </node>
+        </node>
     </node>
     <node>
         <name>section</name>
@@ -212,11 +212,11 @@ Then, verify that all the answers have been copied over successfully</value>
             <value>True</value>
             <type>Boolean</type>
         </property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
+        <property>
+            <name>maxAnswers</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
         <property>
             <name>entryMode</name>
             <value>reference</value>
@@ -246,11 +246,11 @@ Then, verify that all the answers have been copied over successfully</value>
             <value>True</value>
             <type>Boolean</type>
         </property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
+        <property>
+            <name>maxAnswers</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
         <property>
             <name>entryMode</name>
             <value>reference</value>
@@ -262,7 +262,7 @@ Then, verify that all the answers have been copied over successfully</value>
             <type>String</type>
         </property>
     </node>
-    <!-- <node>
+    <node>
         <name>dateQuestion</name>
         <primaryNodeType>cards:Question</primaryNodeType>
         <property>
@@ -280,11 +280,11 @@ Then, verify that all the answers have been copied over successfully</value>
             <value>True</value>
             <type>Boolean</type>
         </property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
+        <property>
+            <name>maxAnswers</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
         <property>
             <name>entryMode</name>
             <value>reference</value>
@@ -295,5 +295,5 @@ Then, verify that all the answers have been copied over successfully</value>
             <value>/Questionnaires/ReferenceTestUser/dateQuestion</value>
             <type>String</type>
         </property>
-    </node> -->
+    </node>
 </node>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ReferenceTestCopied.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ReferenceTestCopied.xml
@@ -1,0 +1,211 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+    <name>ReferenceTestCopied</name>
+    <primaryNodeType>cards:Questionnaire</primaryNodeType>
+    <property>
+        <name>title</name>
+        <value>Reference Test - Copied Answers</value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>description</name>
+        <value>CARDS-1103</value>
+        <type>String</type>
+    </property>
+    <node>
+        <name>testing-instructions</name>
+        <primaryNodeType>cards:Information</primaryNodeType>
+        <property>
+            <name>text</name>
+            <value>This form is designed to test reference questions.
+
+To test these questions, fill out the answers in a `Reference Test - User Answers` form for a sbject then create a new instance of this form(`Reference Test - Copied Answers`) for the same subject.
+Then, verify that all the answers have been copied over successfully</value>
+            <type>String</type>
+        </property>
+    </node>
+
+    <node>
+        <name>textQuestion</name>
+        <primaryNodeType>cards:Question</primaryNodeType>
+        <property>
+            <name>text</name>
+            <value>Referenced Text question</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>dataType</name>
+            <value>text</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>compact</name>
+            <value>True</value>
+            <type>Boolean</type>
+        </property>
+        <property>
+            <name>entryMode</name>
+            <value>reference</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>questionnaire</name>
+            <value>ReferenceTestUser</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>question</name>
+            <value>textQuestion</value>
+            <type>String</type>
+        </property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+    </node>
+    <node>
+        <name>section</name>
+        <primaryNodeType>cards:Section</primaryNodeType>
+        <property>
+            <name>label</name>
+            <value>Section</value>
+            <type>String</type>
+        </property>
+        <node>
+            <name>sectionTextQuestion</name>
+            <primaryNodeType>cards:Question</primaryNodeType>
+            <property>
+                <name>text</name>
+                <value>Text question in section</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>dataType</name>
+                <value>text</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>compact</name>
+                <value>True</value>
+                <type>Boolean</type>
+            </property>
+            <property>
+                <name>entryMode</name>
+                <value>reference</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>questionnaire</name>
+                <value>ReferenceTestUser</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>question</name>
+                <value>sectionTextQuestion</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>maxAnswers</name>
+                <value>1</value>
+                <type>Long</type>
+            </property>
+        </node>
+    </node>
+    <node>
+        <name>longQuestion</name>
+        <primaryNodeType>cards:Question</primaryNodeType>
+        <property>
+            <name>text</name>
+            <value>Long question</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>dataType</name>
+            <value>long</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>compact</name>
+            <value>True</value>
+            <type>Boolean</type>
+        </property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+        <property>
+            <name>entryMode</name>
+            <value>reference</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>questionnaire</name>
+            <value>ReferenceTestUser</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>question</name>
+            <value>dateQuestion</value>
+            <type>String</type>
+        </property>
+    </node>
+    <node>
+        <name>doubleQuestion</name>
+        <primaryNodeType>cards:Question</primaryNodeType>
+        <property>
+            <name>text</name>
+            <value>Double question</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>dataType</name>
+            <value>double</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>compact</name>
+            <value>True</value>
+            <type>Boolean</type>
+        </property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+        <property>
+            <name>entryMode</name>
+            <value>reference</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>questionnaire</name>
+            <value>ReferenceTestUser</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>question</name>
+            <value>doubleQuestion</value>
+            <type>String</type>
+        </property>
+    </node>
+</node>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ReferenceTestUser.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ReferenceTestUser.xml
@@ -148,4 +148,28 @@ Then, verify that all the answers have been copied over successfully</value>
 			<type>Long</type>
 		</property>
     </node>
+    <!-- <node>
+        <name>dateQuestion</name>
+        <primaryNodeType>cards:Question</primaryNodeType>
+        <property>
+            <name>text</name>
+            <value>Date question</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>dataType</name>
+            <value>date</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>compact</name>
+            <value>True</value>
+            <type>Boolean</type>
+        </property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+    </node> -->
 </node>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ReferenceTestUser.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ReferenceTestUser.xml
@@ -61,11 +61,11 @@ Then, verify that all the answers have been copied over successfully</value>
             <value>True</value>
             <type>Boolean</type>
         </property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
+        <property>
+            <name>maxAnswers</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
     </node>
     <node>
         <name>section</name>
@@ -118,11 +118,11 @@ Then, verify that all the answers have been copied over successfully</value>
             <value>True</value>
             <type>Boolean</type>
         </property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
+        <property>
+            <name>maxAnswers</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
     </node>
     <node>
         <name>doubleQuestion</name>
@@ -142,13 +142,13 @@ Then, verify that all the answers have been copied over successfully</value>
             <value>True</value>
             <type>Boolean</type>
         </property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
+        <property>
+            <name>maxAnswers</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
     </node>
-    <!-- <node>
+    <node>
         <name>dateQuestion</name>
         <primaryNodeType>cards:Question</primaryNodeType>
         <property>
@@ -166,10 +166,10 @@ Then, verify that all the answers have been copied over successfully</value>
             <value>True</value>
             <type>Boolean</type>
         </property>
-		<property>
-			<name>maxAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
-    </node> -->
+        <property>
+            <name>maxAnswers</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
+    </node>
 </node>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ReferenceTestUser.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ReferenceTestUser.xml
@@ -1,0 +1,151 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+    <name>ReferenceTestUser</name>
+    <primaryNodeType>cards:Questionnaire</primaryNodeType>
+    <property>
+        <name>title</name>
+        <value>Reference Test - User Answers</value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>description</name>
+        <value>CARDS-1103</value>
+        <type>String</type>
+    </property>
+    <node>
+        <name>testing-instructions</name>
+        <primaryNodeType>cards:Information</primaryNodeType>
+        <property>
+            <name>text</name>
+            <value>This form is designed to test reference questions.
+
+To test these questions, fill out this form for a subject (`Reference Test - User Answers`) then create a new `Reference Test - Copied Answers` form for the same subject.
+Then, verify that all the answers have been copied over successfully</value>
+            <type>String</type>
+        </property>
+    </node>
+
+    <node>
+        <name>textQuestion</name>
+        <primaryNodeType>cards:Question</primaryNodeType>
+        <property>
+            <name>text</name>
+            <value>Text question</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>dataType</name>
+            <value>text</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>compact</name>
+            <value>True</value>
+            <type>Boolean</type>
+        </property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+    </node>
+    <node>
+        <name>section</name>
+        <primaryNodeType>cards:Section</primaryNodeType>
+        <property>
+            <name>label</name>
+            <value>Section</value>
+            <type>String</type>
+        </property>
+        <node>
+            <name>sectionTextQuestion</name>
+            <primaryNodeType>cards:Question</primaryNodeType>
+            <property>
+                <name>text</name>
+                <value>Text question in section</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>dataType</name>
+                <value>text</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>compact</name>
+                <value>True</value>
+                <type>Boolean</type>
+            </property>
+            <property>
+                <name>maxAnswers</name>
+                <value>1</value>
+                <type>Long</type>
+            </property>
+        </node>
+    </node>
+    <node>
+        <name>longQuestion</name>
+        <primaryNodeType>cards:Question</primaryNodeType>
+        <property>
+            <name>text</name>
+            <value>Long question</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>dataType</name>
+            <value>long</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>compact</name>
+            <value>True</value>
+            <type>Boolean</type>
+        </property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+    </node>
+    <node>
+        <name>doubleQuestion</name>
+        <primaryNodeType>cards:Question</primaryNodeType>
+        <property>
+            <name>text</name>
+            <value>Double question</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>dataType</name>
+            <value>double</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>compact</name>
+            <value>True</value>
+            <type>Boolean</type>
+        </property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+    </node>
+</node>


### PR DESCRIPTION
Add in reference questions, which take a questionnaire and quest as a property.
If there is a form for the current subject with that questionnaire and question,
  copy of that answer once when the reference answer is created.
  
To create a new reference question, set the question's `entryMode` to reference and `dataType` to any other question dataType.

2 testing forms were created in the --test runmode, `ReferenceTestUser` and ReferenceTestCopied`. To test these forms, fill in a single copy of ReferenceTestUser for a subject, then create a ReferenceTestCopied form for that same subject

To test:
- Reference questions
- Backend computed questions (via the backend computed questions test form)
- FormAnswerCopyProcessor and SubjectAnswerCopyProcessor (test via PROMS run mode, instructions available [here](https://github.com/data-team-uhn/cards/pull/964) with merged implementation available [here](https://github.com/data-team-uhn/cards/pull/984))