### PR TITLE
CARDS-1807: Add support for specifying different selectors to use for serializing a subject's forms

### DIFF
--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/DataProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/DataProcessor.java
@@ -155,7 +155,7 @@ public class DataProcessor implements ResourceJsonProcessor
             this.filters.get().forEach(filtersJson::add);
             this.options.get().forEach(optionsJson::add);
             json.add("dataFilters", filtersJson);
-            json.add("option", optionsJson);
+            json.add("dataOptions", optionsJson);
             json.add("exportDate",
                 new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").format(Calendar.getInstance().getTime()));
         } catch (RepositoryException e) {
@@ -224,7 +224,7 @@ public class DataProcessor implements ResourceJsonProcessor
     private String generateDataQuery(String currentNodeIdentifier) throws RepositoryException
     {
         StringBuilder result = new StringBuilder("select * from [cards:Form] as n where n."
-                + this.uuidsWithEntityFilter.get().get(currentNodeIdentifier) + " = '" + currentNodeIdentifier + "'");
+            + this.uuidsWithEntityFilter.get().get(currentNodeIdentifier) + " = '" + currentNodeIdentifier + "'");
         this.uuidsWithEntityFilter.get().remove(currentNodeIdentifier);
         this.uuidsWithEntityFilter.get().forEach((key, value) ->
             result.append(" or n.").append(value).append(" = '").append(key).append("'"));

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/DataProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/DataProcessor.java
@@ -143,9 +143,11 @@ public class DataProcessor implements ResourceJsonProcessor
 
             final Map<String, JsonArrayBuilder> formsJsons = new HashMap<>();
             final ResourceResolver currentResolver = this.resolver.get();
-            final String currentSelectors = this.selectors.get();
-            forms.forEachRemaining(f ->
-                storeForm(currentResolver.resolve(f.getPath() + currentSelectors), formsJsons, isQuestionnaire));
+
+            final String currentSelectors = getCurrentSelectors();
+            forms.forEachRemaining(f -> {
+                storeForm(currentResolver.resolve(f.getPath() + currentSelectors), formsJsons, isQuestionnaire);
+            });
             // The data JSONs have been collected, add them to the subject's JSON
             formsJsons.forEach(json::add);
             final JsonObjectBuilder filtersJson = Json.createObjectBuilder();
@@ -159,6 +161,14 @@ public class DataProcessor implements ResourceJsonProcessor
         } catch (RepositoryException e) {
             // Really shouldn't happen
         }
+    }
+
+    private String getCurrentSelectors()
+    {
+        if (this.options.get().containsKey("formSelectors")) {
+            return "." + this.options.get().get("formSelectors") + ".json";
+        }
+        return this.selectors.get();
     }
 
     @Override


### PR DESCRIPTION
[CARDS-1807](https://phenotips.atlassian.net/browse/CARDS-1807)

To check:
- in proms mode, create Patient Information and Visit Information forms for a patient/visit
- PATIENT.data.dataOption:formSelectors=deep serializes all the answers for the Patient Information form, but does not list the visit subject
- PATIENT.data.deep.dataOption:formSelectors= does not include answers, but includes the visit subject
- PATIENT.data.deep includes both form answers and the visit subject