### PR TITLE
CARDS-1858: Update 6MWT xml to match prod

### DIFF
--- a/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/6MWT.xml
+++ b/cardiac-rehab-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/6MWT.xml
@@ -491,6 +491,15 @@
 						<type>String</type>
 					</property>
 				</node>
+				<node>
+					<name>not_available</name>
+					<primaryNodeType>lfs:AnswerOption</primaryNodeType>
+					<property>
+						<name>value</name>
+						<value>Not Available</value>
+						<type>String</type>
+					</property>
+				</node>				
 			</node>
 			<node>
 				<name>condition</name>


### PR DESCRIPTION
Modifying to have repo match prod; currently prod has "Not Available" option but XML does not reflext this