### PR TITLE
CARDS-1841: Create a utility for verifying that a JSON backup is complete

### DIFF
--- a/Utilities/Administration/Backup-To-JSON/README.md
+++ b/Utilities/Administration/Backup-To-JSON/README.md
@@ -47,11 +47,12 @@ Verification Of Archived Data
 =============================
 
 To verify that a data backup is valid, that is:
-	- Every Subject listed in a Subjects list points to an existing and valid JSON file with a matching timestamp.
-	- Every Form listed in a Forms list points to an existing and valid JSON file with a matching timestamp.
-	- Every Form's Subject is included in the backup Subjects list.
-	- Every file-like response in every Form is included in the backup.
-	- Every non-root Subject listed in a Subjects list file has its parent Subject also listed in the Subjects list file.
+
+- Every Subject listed in a Subjects list points to an existing and valid JSON file with a matching timestamp.
+- Every Form listed in a Forms list points to an existing and valid JSON file with a matching timestamp.
+- Every Form's Subject is included in the backup Subjects list.
+- Every file-like response in every Form is included in the backup.
+- Every non-root Subject listed in a Subjects list file has its parent Subject also listed in the Subjects list file.
 
 run:
 

--- a/Utilities/Administration/Backup-To-JSON/README.md
+++ b/Utilities/Administration/Backup-To-JSON/README.md
@@ -42,3 +42,22 @@ variable to the address of the CARDS server and set the `ADMIN_PASSWORD`
 environment variable to the `admin` password for the CARDS server.
 
 3. Restart CARDS without the `COMPUTED_ANSWERS_DISABLED` environment variable.
+
+Verification Of Archived Data
+=============================
+
+To verify that a data backup is valid, that is:
+	- Every Subject listed in a Subjects list points to an existing and valid JSON file with a matching timestamp.
+	- Every Form listed in a Forms list points to an existing and valid JSON file with a matching timestamp.
+	- Every Form's Subject is included in the backup Subjects list.
+	- Every file-like response in every Form is included in the backup.
+	- Every non-root Subject listed in a Subjects list file has its parent Subject also listed in the Subjects list file.
+
+run:
+
+```bash
+python3 verify_complete_json_backup.py \
+	--backup_directory /path/to/backup/directory \
+	--form_list_file /path/to/backup/directory/form-list-file.json \
+	--subject_list_file /path/to/backup/directory/subject-list-file.json
+```

--- a/Utilities/Administration/Backup-To-JSON/README.md
+++ b/Utilities/Administration/Backup-To-JSON/README.md
@@ -50,6 +50,8 @@ To verify that a data backup is valid, that is:
 
 - Every Subject listed in a Subjects list points to an existing and valid JSON file with a matching timestamp.
 - Every Form listed in a Forms list points to an existing and valid JSON file with a matching timestamp.
+  - The matching timestamp constraint can be relaxed with the `--relax_timestamp_constraint` flag and the maximum
+  and minimum times before and after the backup snapshot will be printed at the end of the verification.
 - Every Form's Subject is included in the backup Subjects list.
 - Every file-like response in every Form is included in the backup.
 - Every non-root Subject listed in a Subjects list file has its parent Subject also listed in the Subjects list file.

--- a/Utilities/Administration/Backup-To-JSON/backup_recorder.js
+++ b/Utilities/Administration/Backup-To-JSON/backup_recorder.js
@@ -138,6 +138,10 @@ const cleanupForm = (formObject) => {
       cleanForm["jcr:lastModified"] = formObject["jcr:lastModified"];
       continue;
     }
+    if (key === "@path") {
+      cleanForm["@path"] = formObject["@path"];
+      continue;
+    }
     if (typeof(formObject[key]) !== "object") {
       continue;
     }

--- a/Utilities/Administration/Backup-To-JSON/verify_complete_json_backup.py
+++ b/Utilities/Administration/Backup-To-JSON/verify_complete_json_backup.py
@@ -86,6 +86,11 @@ for form in FORM_LIST:
           print("ERROR: The backup is incomplete because {} is corrupt.".format(blobpath))
           sys.exit(-1)
 
+  # Verify that this Form belongs to a Subject that is included in the backup
+  if form_data["subject"] not in [x[0] for x in SUBJECT_LIST]:
+    print("ERROR: The backup is incomplete because {} makes reference to {} which is not included in the backup.".format(form_path, form_data["subject"]))
+    sys.exit(-1)
+
 for subject in SUBJECT_LIST:
   subject_path = subject[0]
   subject_last_modified = subject[1]

--- a/Utilities/Administration/Backup-To-JSON/verify_complete_json_backup.py
+++ b/Utilities/Administration/Backup-To-JSON/verify_complete_json_backup.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+"""
+
+import os
+import sys
+import json
+import argparse
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('--backup_directory', help='Path to backup directory', type=str, required=True)
+argparser.add_argument('--form_list_file', help='Path to the Form list file', type=str, required=True)
+argparser.add_argument('--subject_list_file', help='Path to the Subject list file', type=str, required=True)
+args = argparser.parse_args()
+
+BACKUP_DIRECTORY = args.backup_directory
+FORM_LIST_FILE = args.form_list_file
+SUBJECT_LIST_FILE = args.subject_list_file
+
+with open(FORM_LIST_FILE, 'r') as f:
+  FORM_LIST = json.loads(f.read())
+
+with open(SUBJECT_LIST_FILE, 'r') as f:
+  SUBJECT_LIST = json.loads(f.read())
+
+for form in FORM_LIST:
+  form_path = form[0]
+  form_last_modified = form[1]
+  form_uuid_name = form_path.split('/')[-1]
+
+  # Do we have this Form backed up in JSON format?
+  # That is - do we have a Form with an @path of $form_path and
+  # a jcr:lastModified value of $form_last_modified
+
+  json_path = os.path.join(BACKUP_DIRECTORY, "Forms", form_uuid_name + ".json")
+  if not os.path.isfile(json_path):
+    print("ERROR: The backup is incomplete due to missing file: {}.".format(json_path))
+    sys.exit(-1)
+  with open(json_path, 'r') as f_json:
+    form_data = json.load(f_json)
+  if form_path != form_data['@path']:
+    print("ERROR: The backup is incomplete due to a missing {} JCR node.".format(form_path))
+    sys.exit(-1)
+  if form_last_modified != form_data['jcr:lastModified']:
+    print("ERROR: The backup is incomplete due to an invalid jcr:lastModified property in {}.".format(form_path))
+    sys.exit(-1)
+
+for subject in SUBJECT_LIST:
+  subject_path = subject[0]
+  subject_last_modified = subject[1]
+  subject_uuid_name = subject_path.split('/')[-1]
+
+  # Do we have this Subject backed up in JSON format?
+  # We can ignore subject_last_modified as Subjects are only created
+  # and deleted. They are never modified.
+
+  json_path = os.path.join(BACKUP_DIRECTORY, "Subjects", subject_uuid_name + ".json")
+  if not os.path.isfile(json_path):
+    print("ERROR: The backup is incomplete due to missing file: {}.".format(json_path))
+    sys.exit(-1)
+  with open(json_path, 'r') as f_json:
+    subject_data = json.load(f_json)
+  if subject_path != subject_data["@path"]:
+    print("ERROR: The backup is incomplete due to a missing {} JCR node.".format(subject_path))
+    sys.exit(-1)
+
+print("OK: Backup is valid.")

--- a/Utilities/Administration/Backup-To-JSON/verify_complete_json_backup.py
+++ b/Utilities/Administration/Backup-To-JSON/verify_complete_json_backup.py
@@ -110,4 +110,11 @@ for subject in SUBJECT_LIST:
     print("ERROR: The backup is incomplete due to a missing {} JCR node.".format(subject_path))
     sys.exit(-1)
 
+  # If this Subject is a non-root Subject (eg. not a child of /Subjects/), check that its parent Subject is included in the list
+  if ("/Subjects/" + subject_uuid_name) != subject_path:
+    subject_parent_path = "/".join(subject_path.split('/')[0:-1])
+    if subject_parent_path not in [x[0] for x in SUBJECT_LIST]:
+      print("ERROR: The backup is incomplete as the parent of {} is not included in the Subject list backup.".format(subject_path))
+      sys.exit(-1)
+
 print("OK: Backup is valid.")


### PR DESCRIPTION
This PR introduces the `verify_complete_json_backup.py` script which verifies that a backup directory contains all the necessary data for restoring all the _Subjects_ listed in a _Subjects list_ JSON file and all the _Forms_ listed in a _Forms list_ JSON file.

To test this PR:

- Generate a populated JSON backup directory by following the instructions in the _Forms / Subjects Backup_ section of https://github.com/data-team-uhn/cards/blob/CARDS-1841/Utilities/Administration/Backup-To-JSON/README.md#forms--subjects-backup
- Run the `verify_complete_json_backup.py` script as per the instructions in the _Verification Of Archived Data_ section of https://github.com/data-team-uhn/cards/blob/CARDS-1841/Utilities/Administration/Backup-To-JSON/README.md#verification-of-archived-data. The script should print `OK: Backup is valid`, and exit with a _zero_ exit status.
- Now, verify that making any of these changes causes the `verify_complete_json_backup.py` script to print an error and exit with a _non-zero_ exit status:
  - Deleting a _Form_ JSON file that is referenced in the _FormsListBackup_ file.
  - Deleting a _Subject_ JSON file that is referenced in the _SubjectsListBackup_ file.
  - Editing the `@path` value of a _Form_ JSON file.
  - Editing the `@path` value of a _Subject_ JSON file.
  - Removing a _Subject_ entry from the _SubjectsListBackup_ file where such _Subject_ has _Forms_ associated with it.
  - Removing a _Subject_ entry from the _SubjectsListBackup_ file that is a _parent Subject_ of another _Subject_ listed in that file.
  - Deleting a file under `blobs/` that is referenced by a _Form_ JSON file. (You can use a _DICOM Imaging Test_ Form for this)
  - Modifying a file under `blobs/` that is referenced by a _Form_ JSON file. (You can use a _DICOM Imaging Test_ Form for this)
  - Editing the `jcr:lastModified` property of a _Form_ JSON file.
    - The script should not fail under this condition if and only if the `--relax_timestamp_constraint` has been set. In this case, the maximum and minimum of the time differences between the `jcr:lastModified` value recorded in the _FormsListBackup_ file and the `jcr:lastModified` value recorded in the actual _Form_ JSON file will be printed to the console before the script exits with a _zero_ exit status.