### PR TITLE
CARDS-1649: SAML login: Disable NEXT button when username is blank

### DIFF
--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -192,6 +192,7 @@ class SignIn extends React.Component {
                       color="primary"
                       className={classes.submit}
                       onClick={nextButtonCallback}
+                      disabled={this.state.username.length == 0}
                     >
                       Next
                     </Button>


### PR DESCRIPTION
This PR causes the _Next_ button to be disabled when no _username_ has been entered during a two-step login procedure (ie. when SAML-based authentications are enabled).

To test:

- Build this `CARDS-1649` branch with `mvn clean install`.
- Start CARDS with SAML enabled (`./start_cards.sh --dev --test --saml --uhn_ad_fs`).
- Visit http://localhost:8080.
- The _Next_ button and _pressing Enter_ should be disabled if the _username_ is blank.

The following screen (password entry) has an improperly rendered _Sign In_ button. This is a known issue that is outside the scope of CARDS-1649 and has been logged as a separate bug - CARDS-1872.