### PR TITLE
CARDS-1872: Sign In button is improperly rendered when using two-step login

### DIFF
--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -190,7 +190,7 @@ class SignIn extends React.Component {
                       fullWidth
                       variant="contained"
                       color="primary"
-                      className={classes.submit}
+                      className={`${classes.actions} ${classes.submit}`}
                       onClick={nextButtonCallback}
                       disabled={this.state.username.length == 0}
                     >
@@ -220,9 +220,9 @@ class SignIn extends React.Component {
                       }
                     />
                   </FormControl>
-                  <Grid container direction="row" justifyContent="center" alignItems="center" columns={15}>
+                  <Grid container direction="row" justifyContent="center" alignItems="center" spacing={2} className={classes.actions}>
                     {  (!this.state.singleStepEntry) &&
-                      <Grid item xs={7} style={{textAlign: "right"}}>
+                      <Grid item>
                         <Button
                           fullWidth
                           variant="contained"
@@ -241,15 +241,7 @@ class SignIn extends React.Component {
                         </Button>
                       </Grid>
                     }
-                    {  (!this.state.singleStepEntry) &&
-                      <Grid item xs={1}>
-                      </Grid>
-                    }
-                    <Grid
-                      item
-                      xs={this.state.singleStepEntry ? 15: 7}
-                      style={{textAlign: this.state.singleStepEntry ? "center" : "left"}}
-                    >
+                    <Grid item>
                       <Button
                         type="submit"
                         fullWidth

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -220,13 +220,9 @@ class SignIn extends React.Component {
                       }
                     />
                   </FormControl>
-                  <Grid container direction="row" justifyContent="center" alignItems="center">
+                  <Grid container direction="row" justifyContent="center" alignItems="center" columns={15}>
                     {  (!this.state.singleStepEntry) &&
-                      <Grid item xs={3}>
-                      </Grid>
-                    }
-                    {  (!this.state.singleStepEntry) &&
-                      <Grid item xs={3}>
+                      <Grid item xs={7} style={{textAlign: "right"}}>
                         <Button
                           fullWidth
                           variant="contained"
@@ -245,7 +241,15 @@ class SignIn extends React.Component {
                         </Button>
                       </Grid>
                     }
-                    <Grid item xs={this.state.singleStepEntry ? 12: 3}>
+                    {  (!this.state.singleStepEntry) &&
+                      <Grid item xs={1}>
+                      </Grid>
+                    }
+                    <Grid
+                      item
+                      xs={this.state.singleStepEntry ? 15: 7}
+                      style={{textAlign: this.state.singleStepEntry ? "center" : "left"}}
+                    >
                       <Button
                         type="submit"
                         fullWidth
@@ -256,10 +260,6 @@ class SignIn extends React.Component {
                         Sign in
                       </Button>
                     </Grid>
-                    {  (!this.state.singleStepEntry) &&
-                      <Grid item xs={3}>
-                      </Grid>
-                    }
                   </Grid>
                 </React.Fragment>
               }

--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -19,6 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
+    Alert,
     Button,
     FormControl,
     Grid,
@@ -27,7 +28,6 @@ import {
     InputAdornment,
     InputLabel,
     Tooltip,
-    Typography
 } from '@mui/material';
 import withStyles from '@mui/styles/withStyles';
 import VisibilityIcon from '@mui/icons-material/Visibility';
@@ -166,7 +166,7 @@ class SignIn extends React.Component {
 
     return (
         <div className={classes.main}>
-            {this.state.failedLogin && <Typography component="h2" className={classes.errorMessage}>{this.state.failedLogin}</Typography>}
+            {this.state.failedLogin && <Alert severity="error">{this.state.failedLogin}</Alert>}
 
             <form
               className={classes.form}
@@ -225,7 +225,7 @@ class SignIn extends React.Component {
                       <Grid item>
                         <Button
                           fullWidth
-                          variant="contained"
+                          variant="outlined"
                           color="primary"
                           className={classes.submit}
                           onClick={() => {

--- a/modules/login/src/main/frontend/src/styling/styles.js
+++ b/modules/login/src/main/frontend/src/styling/styles.js
@@ -18,7 +18,7 @@
 //
 const styles = theme => ({
   main: {
-    width: '400px',
+    width: 'auto',
     display: 'block', // Fix IE 11 issue.
     marginLeft: theme.spacing(3),
     marginRight: theme.spacing(3),

--- a/modules/login/src/main/frontend/src/styling/styles.js
+++ b/modules/login/src/main/frontend/src/styling/styles.js
@@ -51,8 +51,11 @@ const styles = theme => ({
     marginTop: theme.spacing(3),
     marginLeft: theme.spacing(2)
   },
-  submit: {
+  actions: {
     marginTop: theme.spacing(4),
+  },
+  submit: {
+    whiteSpace: "pre",
     width: "auto !important",
   },
   appInfo: {

--- a/modules/login/src/main/frontend/src/styling/styles.js
+++ b/modules/login/src/main/frontend/src/styling/styles.js
@@ -20,8 +20,6 @@ const styles = theme => ({
   main: {
     width: 'auto',
     display: 'block', // Fix IE 11 issue.
-    marginLeft: theme.spacing(3),
-    marginRight: theme.spacing(3),
     [theme.breakpoints.up(400 + theme.spacing(6))]: {
       width: 400,
       marginLeft: 'auto',
@@ -60,6 +58,10 @@ const styles = theme => ({
   },
   appInfo: {
     marginTop: theme.spacing(6),
+    textAlign: "center",
+    "& ol, li": {
+      display: "inline-block",
+    },
   },
   closeButton: {
     float: 'right',
@@ -78,11 +80,6 @@ const styles = theme => ({
     top: theme.spacing(1),
     color: theme.palette.grey[500]
   },
-  errorMessage: {
-    background: theme.palette.error.dark,
-    padding: theme.spacing(1, 2),
-    color: theme.palette.error.contrastText,
-  }
 });
 
 export default styles;

--- a/modules/login/src/main/frontend/src/styling/styles.js
+++ b/modules/login/src/main/frontend/src/styling/styles.js
@@ -18,7 +18,7 @@
 //
 const styles = theme => ({
   main: {
-    width: 'auto',
+    width: '400px',
     display: 'block', // Fix IE 11 issue.
     marginLeft: theme.spacing(3),
     marginRight: theme.spacing(3),


### PR DESCRIPTION
This PR fixes the bug described in https://phenotips.atlassian.net/browser/CARDS-1872.

To test:

- Build this `CARDS-1872` branch with `mvn clean install`.
- Start CARDS with `./start_cards.sh --dev --test --saml --uhn_ad_fs`.
- Visit http://localhost:8080 and login as `admin`.
- The login process should now display properly rendered and formatted _Back_ and _Sign In_ buttons.