### PR TITLE
[misc] Upgrade org.codehaus.woodstox:stax2-api

### DIFF
--- a/modules/saml-support/src/main/features/base.json
+++ b/modules/saml-support/src/main/features/base.json
@@ -44,7 +44,7 @@
       "start-order":"15"
     },
     {
-      "id":"org.codehaus.woodstox:stax2-api:3.1.4",
+      "id":"org.codehaus.woodstox:stax2-api:4.2.1",
       "start-order":"15"
     },
     {


### PR DESCRIPTION
https://github.com/data-team-uhn/cards/pull/976 upgrades the `com.fasterxml.woodstox:woodstox-core` package from version `5.0.3` to `5.3.0`. `com.fasterxml.woodstox:woodstox-core:5.3.0` requires a version of `org.codehaus.woodstox:stax2-api` greater than `4.2` but before `5.0`. This PR upgrades `org.codehaus.woodstox:stax2-api` to the latest version, `4.2.1`. We can see this error if we build the latest `dev` and start CARDS with `./start_cards.sh --dev --saml --keycloak_demo`.

To test this PR, build this (`misc-stax2-api-upgrade`) branch with `mvn clean install` and follow the instructions in https://github.com/data-team-uhn/cards/blob/dev/Utilities/Administration/SAML/SAML_SETUP.md to ensure that SAML authentication works as expected. Also ensure that no `org.osgi.framework.BundleException` errors are printed to the console.