### PR TITLE
[misc] Bump com.h2database:h2-mvstore dependency version to 2+

### DIFF
--- a/distribution/src/main/features/oak/persistence/oak_persistence_mongods.json
+++ b/distribution/src/main/features/oak/persistence/oak_persistence_mongods.json
@@ -7,7 +7,7 @@
     },
     "bundles":[
          {
-             "id":"com.h2database:h2-mvstore:1.4.200",
+             "id":"com.h2database:h2-mvstore:2.1.214",
              "start-order":"15"
         },
         {


### PR DESCRIPTION
**The upgrade to Oak 1.44 (#1127) broke MongoDB storage**. It appears that this dependency needs to be upgraded as well.

Steps to reproduce the issue on `dev` (via @IntegralProgrammer):
1. Build the latest dev including the development Docker image (`mvn clean install -Pdocker`)
2. `cd compose-cluster`
3. `python3 generate_compose_yaml.py --shards 2 --replicas 3 --dev_docker_image`
4. `docker-compose build`
5. `docker-compose up -d`
6. No matter how long you wait, CARDS never becomes available at http://localhost:8080/ and running `docker-compose logs cardsinitial` shows the error` java.lang.NoClassDefFoundError: org/h2/mvstore/MVMap$MapBuilder`.

7. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`
8. Edit `pom.xml` and replace `<oak.version>1.44.0</oak.version>` with `<oak.version>1.42.0</oak.version>`. Rebuild with `mvn clean install -Pdocke`r.
9. Repeat steps 2 - 5 but this time CARDS will become available at http://localhost:8080/ and the error `java.lang.NoClassDefFoundError: org/h2/mvstore/MVMap$MapBuilder` will not be generated.