### PR TITLE
CARDS-1704: Uninformative error message displayed when attempting to create a subject with an identifier that already exists

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -380,7 +380,7 @@ export function NewSubjectDialog (props) {
       // HTTP Conflict occurs when the given user does not have permission to create a subject
       setError("You do not have permissions to create this subject.");
     } else {
-      setError("Error while creating subject: " + error.statusText);
+      setError(error.statusText || "The subject could not be created due to an unknown error.");
     }
 
     // Since the error will always be during the creation of a subject, we'll revert back to the create subject page and remove all details
@@ -766,7 +766,7 @@ export function createSubjects(globalLoginDisplay, newSubjects, subjectType, sub
             error_msg += ` for ${parentType} ${id}.`;
           }
 
-          return Promise.reject(error_msg);
+          return Promise.reject({statusText: error_msg});
         }
       });
 


### PR DESCRIPTION
See [CARDS-1704 on Jira](https://phenotips.atlassian.net/browse/CARDS-1704) for steps to reproduce / testing instructions.