### PR TITLE
CARDS-1835: Update the ui with the new status as the form gets saved

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -224,7 +224,7 @@ function Form (props) {
         setLastSaveStatus(true);
         setLastSaveTimestamp(new Date());
         if (!disableHeader) {
-          fetchWithReLogin(globalLoginDisplay, `${formURL}.-dereference.json`)
+          fetchWithReLogin(globalLoginDisplay, `${formURL}/statusFlags.json`)
             .then((response) => response.ok ? response.json() : Promise.reject(response))
             .then(json => setStatusFlags(json.statusFlags))
             .catch(err => console.log("The form status flags could not be updated after saving"));

--- a/modules/utils/src/main/java/io/uhndata/cards/serialize/ResourceToTextAdapterFactory.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/serialize/ResourceToTextAdapterFactory.java
@@ -50,7 +50,8 @@ public class ResourceToTextAdapterFactory
     @Override
     public <A> A getAdapter(final Object adaptable, final Class<A> type)
     {
-        if (adaptable == null) {
+        if (adaptable == null || adaptable.getClass().getName()
+            .equals("org.apache.sling.jcr.resource.internal.helper.jcr.JcrPropertyResource")) {
             return null;
         }
         final Resource resource = (Resource) adaptable;


### PR DESCRIPTION
Fetch only the status flags, not the whole form.

Not tested.