### PR TITLE
CARDS-1876 & CARDS-1699: Recurring section styling improvements

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
@@ -32,7 +32,7 @@ import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js"
  * A component that renders an icon to open a dialog to delete an entry.
  */
 function DeleteButton(props) {
-  const { classes, entryPath, entryName, onComplete, entryType, entryLabel, size, shouldGoBack, buttonClass, variant, label } = props;
+  const { classes, entryPath, entryName, onClick, onClose, onComplete, entryType, entryLabel, size, navigateBack, className, variant, label } = props;
 
   const [ open, setOpen ] = useState(false);
   const [ errorOpen, setErrorOpen ] = useState(false);
@@ -44,7 +44,7 @@ function DeleteButton(props) {
 
   const buttonText = label || ("Delete " + (entryType?.toLowerCase() || '')).trim();
   const defaultDialogAction = `Are you sure you want to delete ${entryType} ${entryName}?`;
-  const defaultErrorMessage = entryName + " could not be removed.";
+  const defaultErrorMessage = `${entryName || "The item"} could not be removed.`;
   const history = useHistory();
 
   const globalLoginDisplay = useContext(GlobalLoginContext);
@@ -56,6 +56,7 @@ function DeleteButton(props) {
 
   let closeDialog = () => {
     if (open) {setOpen(false);}
+    onClose?.();
   }
 
   let openError = () => {
@@ -70,7 +71,7 @@ function DeleteButton(props) {
     if (entryNotFound) {
       // Can't delete. Assume already deleted and exit if required
       if (onComplete) {onComplete();}
-      if (shouldGoBack) {goBack();}
+      if (navigateBack) {goBack();}
     }
   }
 
@@ -118,9 +119,9 @@ function DeleteButton(props) {
     // If no path is provided, display the button but don't do any delete calls
     // and consider deletion successful since there's nothing to do
     if (!entryPath) {
-      closeDialog();
       if (onComplete) {onComplete();}
-      if (shouldGoBack) {goBack();}
+      closeDialog();
+      if (navigateBack) {goBack();}
       return;
     }
     let url = new URL(entryPath, window.location.origin);
@@ -134,9 +135,9 @@ function DeleteButton(props) {
       }
     }).then((response) => {
       if (response.ok)  {
-        closeDialog();
         if (onComplete) {onComplete();}
-        if (shouldGoBack) {goBack();}
+        closeDialog();
+        if (navigateBack) {goBack();}
       } else {
         handleError(response.status, response);
       }
@@ -144,6 +145,7 @@ function DeleteButton(props) {
   }
 
   let handleClick = () => {
+    onClick?.();
     setDialogMessage(null);
     setDialogAction(defaultDialogAction);
     setDeleteRecursive(false);
@@ -188,7 +190,7 @@ function DeleteButton(props) {
       </Dialog>
       {variant == "icon" ?
         <Tooltip title={buttonText}>
-          <IconButton component="span" onClick={handleClick} className={buttonClass} size={size}>
+          <IconButton component="span" onClick={handleClick} className={className} size={size}>
             <Delete fontSize={size == "small" ? size : undefined}/>
           </IconButton>
         </Tooltip>
@@ -207,12 +209,24 @@ function DeleteButton(props) {
 }
 
 DeleteButton.propTypes = {
+  entryPath: PropTypes.string,
+  entryName: PropTypes.string,
+  entryType: PropTypes.string,
+  entryLabel: PropTypes.string,
+  onClick: PropTypes.func,
+  onClose: PropTypes.func,
+  onComplete: PropTypes.func,
+  navigateBack: PropTypes.bool,
   variant: PropTypes.oneOf(["icon", "text", "extended"]), // "extended" means both icon and text
   label: PropTypes.string,
   size: PropTypes.oneOf(["small", "medium", "large"]),
+  className: PropTypes.string,
 }
 
 DeleteButton.defaultProps = {
+  entryName: "",
+  entryType: "",
+  entryLabel: "",
   variant: "icon",
   size: "large",
 }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/EditButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/EditButton.jsx
@@ -18,6 +18,7 @@
 //
 import React from "react";
 import { withRouter } from "react-router-dom";
+import PropTypes from "prop-types";
 
 import { IconButton, Tooltip } from "@mui/material";
 import withStyles from '@mui/styles/withStyles';
@@ -30,16 +31,29 @@ import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
  * A component that renders an icon to open the edit URL for an entry.
  */
 function EditButton(props) {
-  const { entryPath, entryType, buttonClass, admin } = props;
+  const { entryPath, entryType, size, className, admin } = props;
   return(
     <Link to={(admin ? "/content.html/admin" : "/content.html") + entryPath + ".edit"} underline="hover">
       <Tooltip title={entryType ? "Edit " + entryType : "Edit"}>
-        <IconButton className={buttonClass} size="large">
+        <IconButton className={className} size={size}>
           <EditIcon />
         </IconButton>
       </Tooltip>
     </Link>
   )
+}
+
+EditButton.propTypes = {
+  entryPath: PropTypes.string,
+  entryType: PropTypes.string,
+  size: PropTypes.oneOf(["small", "medium", "large"]),
+  className: PropTypes.string,
+  admin: PropTypes.bool,
+}
+
+EditButton.defaultProps = {
+  entryType: "",
+  size: "large",
 }
 
 export default withStyles(QuestionnaireStyle)(withRouter(EditButton));

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/PrintButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/PrintButton.jsx
@@ -40,7 +40,7 @@ import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
  * date: String displayed with breadcrumb in the preview header above the title, providing the time context for the printed resource  
  * variant: String defining the render component and view of the print action button, default "icon"
  * size: String regulating the size of an icon button, default "medium"
- * buttonClass: String of class name that applies to the button element if the IconButton when variant == "icon"
+ * className: String of class name that applies to the button element if the IconButton when variant == "icon"
  * buttonText: String specifying the text to be displayed on the button or the tooltip, default "Print preview"
  * fullScreen: Boolean specifying if the preview is full screen or displayed as a modal, default true
  * disableShortcut: Boolean specifying if Ctrl+P should activate this button or not. Default is false, meaning the shortcut is active.
@@ -57,7 +57,7 @@ import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
  *
  */
 function PrintButton(props) {
-  const { resourcePath, resourceData, title, date, breadcrumb, onOpen, onClose, size, variant, label, buttonClass, disablePreview, fullScreen, disableShortcut } = props;
+  const { resourcePath, resourceData, title, date, breadcrumb, onOpen, onClose, size, variant, label, className, disablePreview, fullScreen, disableShortcut } = props;
 
   const [ open, setOpen ] = useState(false);
 
@@ -106,7 +106,7 @@ function PrintButton(props) {
     />
     { variant == "icon" ?
         <Tooltip title={buttonText}>
-          <IconButton component="span" onClick={onOpenView} className={buttonClass} size={size}>
+          <IconButton component="span" onClick={onOpenView} className={className} size={size}>
             <PrintIcon fontSize={size == "small" ? size : undefined}/>
           </IconButton>
         </Tooltip>
@@ -128,7 +128,7 @@ PrintButton.propTypes = {
   resourcePath: PropTypes.string.isRequired,
   resourceData: PropTypes.object,
   buttonText: PropTypes.string,
-  buttonClass: PropTypes.string,
+  className: PropTypes.string,
   breadcrumb: PropTypes.string,
   fullScreen: PropTypes.bool,
   disableShortcut: PropTypes.bool,

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FileQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FileQuestion.jsx
@@ -324,7 +324,6 @@ function FileQuestion(props) {
                   size="small"
                   entryName={filepath}
                   entryType={"file"}
-                  shouldGoBack={false}
                   onComplete={() => deletePath(idx)}
                 />
                 { previewRenderer && previewRenderer(fixFileURL(uploadedFiles[filepath], filepath), filepath, idx) }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
@@ -138,7 +138,6 @@ function PedigreeQuestion(props) {
                 <DeleteButton
                   entryName={"pedigree"}
                   entryType={"Pedigree"}
-                  shouldGoBack={false}
                   onComplete={() => {setPedigree({});}}
                 />
               </Grid>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -209,6 +209,7 @@ const questionnaireStyle = theme => ({
         "& > h5" : {
           padding: theme.spacing(1, GRID_SPACE_UNIT),
           background: theme.palette.action.hover,
+          borderBottom: "1px solid transparent",
         },
         "& > .MuiTypography-caption" : {
           padding: theme.spacing(0, GRID_SPACE_UNIT),
@@ -396,59 +397,19 @@ const questionnaireStyle = theme => ({
         borderColor: "transparent",
       },
     },
-    addSectionButton: {
-        marginTop: theme.spacing(GRID_SPACE_UNIT * 2)
-    },
-    childSection: {
-        paddingLeft: theme.spacing(GRID_SPACE_UNIT)
-    },
     entryActionIcon: {
-        padding: theme.spacing(1),
-        verticalAlign: "baseline",
-        marginRight: theme.spacing(-1),
         float: "right",
-        color: theme.palette.text.primary
-    },
-    recurrentSection: {
-        marginLeft: theme.spacing(GRID_SPACE_UNIT),
-        paddingLeft: "0 !important",
-        width: "auto"
-    },
-    recurrentHeader: {
-        marginLeft: theme.spacing(-GRID_SPACE_UNIT) + " !important",
-        paddingLeft: "0 !important"
-    },
-    collapseWrapper: {
-        // Select only questions that occur immediately after padded sections,
-        // and add a large margin before them
-        "& +.questionContainer": {
-            marginTop: theme.spacing(GRID_SPACE_UNIT * 2)
-        },
-        "& .recurrentSectionInstance:not(:first-child)": {
-            marginTop: theme.spacing(GRID_SPACE_UNIT * 3)
-        }
+        marginRight: theme.spacing(1),
     },
     recurrentSectionInstance: {
-        // Select the add section button that occurs immediately after padded sections,
-        // and add a large margin before it
-        "& +.addSectionContainer": {
-            marginTop: theme.spacing(GRID_SPACE_UNIT * 2)
-        }
+        marginBottom: theme.spacing(2*GRID_SPACE_UNIT),
     },
-    // When the user is deleting a section, highlight it via a border on the left
-
+    // When the user is deleting a section, highlight it with a border
     highlightedSection: {
-        borderLeftWidth: theme.spacing(GRID_SPACE_UNIT),
-        borderLeftColor: theme.palette.primary.light,
-        borderLeftStyle: "solid",
-        marginLeft: theme.spacing(-GRID_SPACE_UNIT),
-        marginTop: theme.spacing(GRID_SPACE_UNIT),
-        marginBottom: theme.spacing(GRID_SPACE_UNIT),
-        paddingTop: theme.spacing(0) + " !important",
-        paddingBottom: theme.spacing(0) + " !important"
-    },
-    highlightedTitle: {
-        color: theme.palette.primary.light,
+        "& .MuiGrid-item > .MuiCard-root, .MuiGrid-item > .MuiTypography-h5": {
+          borderColor: theme.palette.warning.main,
+          boxShadow: `1px 1px 2px ${theme.palette.warning.main}`,
+        },
     },
     notesContainer: {
         whiteSpace: "pre-wrap",

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -50,7 +50,7 @@ const MIN_HEADING_LEVEL = 4;
  * @param {int} idx Zero-indexed section number
  */
 function createTitle(label, idx, isRecurrent) {
-  return (`${label}${isRecurrent ? (" #" + (idx+1)) : ""}`);
+  return (`${label || ""}${isRecurrent ? (" #" + (idx+1)) : ""}`);
 }
 
 /**
@@ -74,7 +74,7 @@ function Section(props) {
   const headerVariant = "h5";
   const titleEl = sectionDefinition["label"] &&
     ((idx, uuid) =>
-      <Typography variant={headerVariant} className={uuid == selectedUUID ? classes.highlightedTitle: undefined}>
+      <Typography variant={headerVariant}>
         {createTitle(sectionDefinition["label"], idx, isRecurrent)}
       </Typography>
     );
@@ -200,9 +200,12 @@ function Section(props) {
           const sectionPath = path + "/" + uuid;
           const existingSectionAnswer = existingAnswer?.find((answer) => answer[0] == uuid)?.[1];
           const hiddenSection = conditionIsMet && labelsToHide[uuid];
+          const classNames = [];
+          if (isRecurrent) classNames.push(classes.recurrentSectionInstance);
+          if (uuid == selectedUUID) classNames.push(classes.highlightedSection);
           return <div
             key={uuid}
-            className={"recurrentSectionInstance " + classes.recurrentSectionInstance}
+            className={classNames.join(" ")}
             >
             <input type="hidden" name={`${sectionPath}/jcr:primaryType`} value={"cards:AnswerSection"}></input>
             <input type="hidden" name={`${sectionPath}/section`} value={sectionDefinition['jcr:uuid']}></input>
@@ -210,14 +213,11 @@ function Section(props) {
 
             <Grid
               container
-              className={
-                (isRecurrent ? classes.recurrentSection : undefined)
-              }
               {...FORM_ENTRY_CONTAINER_PROPS}
               >
               {/* Section header */
                 (hasHeader || isRecurrent) &&
-                  <Grid item className={classes.sectionHeader + " " + (isRecurrent ? classes.recurrentHeader : "")}>
+                  <Grid item className={classes.sectionHeader}>
                     {/* Delete this entry and expand this entry button */}
                     {isEdit && isRecurrent &&
                       <Tooltip title="Delete section" aria-label="Delete section" >
@@ -260,7 +260,6 @@ function Section(props) {
                 unmountOnExit
                 in={!hiddenSection}
                 component={Grid}
-                className={(uuid == selectedUUID ? classes.highlightedSection : undefined)}
                 item
                 >
                 <Grid container {...FORM_ENTRY_CONTAINER_PROPS}>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -469,7 +469,7 @@ function SubjectMemberInternal (props) {
                    resourceData={data}
                    breadcrumb={getTextHierarchy(data, true)}
                    date={DateTime.fromISO(data['jcr:created']).toLocaleString(DateTime.DATE_MED)}
-                   buttonClass={classes.childSubjectHeaderButton}
+                   className={classes.childSubjectHeaderButton}
                    disableShortcut
                  />
                  <DeleteButton
@@ -477,7 +477,7 @@ function SubjectMemberInternal (props) {
                    entryName={title}
                    entryType={label}
                    onComplete={onDelete}
-                   buttonClass={classes.childSubjectHeaderButton}
+                   className={classes.childSubjectHeaderButton}
                  />
                </>
 

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/RecurringSectionTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/RecurringSectionTest.xml
@@ -1,0 +1,192 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>RecurringSectionTest</name>
+	<primaryNodeType>cards:Questionnaire</primaryNodeType>
+	<property>
+		<name>title</name>
+		<value>Recurring Section Test</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>description</name>
+		<value>CARDS-1876</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>requiredSubjectTypes</name>
+		<values>
+			<value>/SubjectTypes/Patient</value>
+		</values>
+		<type>Reference</type>
+	</property>
+    <node>
+		<name>section_0</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>label</name>
+			<value>Not a recurring section</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>description</name>
+			<value>This section is one of a kind</value>
+			<type>String</type>
+		</property>
+		<node>
+			<name>question_0</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>First question</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>text</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+		</node>
+	</node>
+	<node>
+		<name>section_1</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>label</name>
+			<value>Recurring section</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>description</name>
+			<value>This section can have multiple instances: #1, 2, #3, ...</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>recurrent</name>
+			<value>True</value>
+			<type>Boolean</type>
+		</property>
+		<node>
+			<name>question_1</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Outer question</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>text</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>minAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+		</node>
+		<node>
+			<name>section_1_1</name>
+			<primaryNodeType>cards:Section</primaryNodeType>
+			<property>
+				<name>label</name>
+				<value>Inner section</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>This section is inside the recurring one</value>
+				<type>String</type>
+			</property>
+			<node>
+				<name>info_1</name>
+				<primaryNodeType>cards:Information</primaryNodeType>
+				<property>
+					<name>text</name>
+					<value>Info</value>
+					<type>String</type>
+				</property>
+			</node>
+			<node>
+				<name>question_2</name>
+				<primaryNodeType>cards:Question</primaryNodeType>
+				<property>
+					<name>text</name>
+					<value>Inner question</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>dataType</name>
+					<value>text</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>minAnswers</name>
+					<value>1</value>
+					<type>Long</type>
+				</property>
+				<property>
+					<name>maxAnswers</name>
+					<value>1</value>
+					<type>Long</type>
+				</property>
+			</node>
+		</node>
+	</node>
+	<node>
+		<name>question_3</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Last question</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>text</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>minAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+	</node>
+</node>


### PR DESCRIPTION
**Includes:**

* [CARDS-1876](https://phenotips.atlassian.net/browse/CARDS-1876) - Recurrent section instances have unnecessary indentation
* [CARDS-1699](https://phenotips.atlassian.net/browse/CARDS-1699) - Fix minor UI issue that appears in repeatable sections
* Replaced the custom delete button for deleting repeatable sections with the reusable `DeleteButton`
* Some minor refactoring of `DeleteButton`, `EditButton`, `PrintButton`
* New test questionnaire with recurring sections

**Testing:**
* Recurring sections UI: run cards with `--test` and test using the new `Recurring Section Test` questionnaire
* Regression testing: DeleteButton, EditButton and PrintButton have been minorly refactored. These buttons need to be retested (dashboard, form pages, subject pages)

**Reviewing:**
* It is easier to follow what changed and why by going commit by commit