### PR TITLE
[Misc] Subject Creation Scripts

### DIFF
--- a/Utilities/Development/create_n_level_deep_subject.py
+++ b/Utilities/Development/create_n_level_deep_subject.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+"""
+
+from create_subject_type import create_subject_type
+from create_subject_for_type import create_subject_for_type
+
+import argparse
+
+def create_n_level_deep_subject(n):
+  # Create the Subject Types
+  new_subject_type_parent = "/SubjectTypes"
+  new_subject_parent = "/Subjects"
+  for subject_type_level in range(n):
+    new_subject_type_name = "subjectlevel" + str(subject_type_level)
+    new_subject_type_path = new_subject_type_parent + "/" + new_subject_type_name
+    create_subject_type(new_subject_type_parent, new_subject_type_name)
+    print("Created {} ...".format(new_subject_type_path))
+    new_subject_identifier = "S" + str(subject_type_level)
+    new_subject_parent = create_subject_for_type(new_subject_parent, new_subject_identifier, new_subject_type_path)
+    print("Created {} ...".format(new_subject_parent))
+    new_subject_type_parent += "/" + new_subject_type_name
+
+if __name__ == '__main__':
+  argparser = argparse.ArgumentParser()
+  argparser.add_argument('--n', help='How many levels deep this subject should be created at', type=int, required=True)
+  args = argparser.parse_args()
+  create_n_level_deep_subject(args.n)

--- a/Utilities/Development/create_subject_for_type.py
+++ b/Utilities/Development/create_subject_for_type.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+"""
+
+import os
+import uuid
+import argparse
+import requests
+
+
+CARDS_URL = "http://localhost:8080"
+if "CARDS_URL" in os.environ:
+  CARDS_URL = os.environ["CARDS_URL"].rstrip('/')
+
+ADMIN_PASSWORD = "admin"
+if "ADMIN_PASSWORD" in os.environ:
+  ADMIN_PASSWORD = os.environ["ADMIN_PASSWORD"]
+
+
+def create_subject_for_type(parent_subject_path, subject_identifier, subject_type_jcr_path):
+  # Get the jcr:uuid for subject_type_jcr_path
+  resp = requests.get(CARDS_URL + subject_type_jcr_path + ".json", auth=('admin', ADMIN_PASSWORD))
+  if (resp.status_code != 200):
+    raise Exception("ERROR: Could not get jcr:uuid for {}".format(subject_type_jcr_path))
+
+  subject_type_jcr_uuid = resp.json()['jcr:uuid']
+
+  creation_form_data = []
+  creation_form_data.append(("jcr:primaryType", (None, "cards:Subject")))
+  creation_form_data.append(("identifier", (None, subject_identifier)))
+  creation_form_data.append(("type", (None, subject_type_jcr_uuid)))
+  creation_form_data.append(("type@TypeHint", (None, "Reference")))
+
+  new_subject_jcr_path = parent_subject_path + "/" + str(uuid.uuid4())
+  resp = requests.post(CARDS_URL + new_subject_jcr_path, files=tuple(creation_form_data), auth=('admin', ADMIN_PASSWORD))
+
+  if resp.status_code in range(200, 300):
+    return new_subject_jcr_path
+  else:
+    raise Exception("ERROR: Cound not create {}".format(new_subject_jcr_path))
+
+
+if __name__ == '__main__':
+  argparser = argparse.ArgumentParser()
+  argparser.add_argument('--parent', help='JCR node that this Subject node should be a child of', required=True)
+  argparser.add_argument('--type_path', help='JCR path to the Subject Type of this Subject node', required=True)
+  argparser.add_argument('--identifier', help='Subject identifier', required=True)
+  args = argparser.parse_args()
+  subject_jcr_path = create_subject_for_type(args.parent, args.identifier, args.type_path)
+  print(subject_jcr_path)

--- a/Utilities/Development/create_subject_type.py
+++ b/Utilities/Development/create_subject_type.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+"""
+
+import os
+import sys
+import json
+import argparse
+import requests
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('--parent', help='JCR node that this Subject Type node should be a child of', required=True)
+argparser.add_argument('--name', help='Name of this Subject Type', required=True)
+args = argparser.parse_args()
+
+CARDS_URL = "http://localhost:8080"
+if "CARDS_URL" in os.environ:
+  CARDS_URL = os.environ["CARDS_URL"].rstrip('/')
+
+ADMIN_PASSWORD = "admin"
+if "ADMIN_PASSWORD" in os.environ:
+  ADMIN_PASSWORD = os.environ["ADMIN_PASSWORD"]
+
+subject_type_parent = args.parent
+subject_type_name = args.name
+
+subject_type_properties = {}
+subject_type_properties["jcr:primaryType"] = "cards:SubjectType"
+subject_type_properties["label"] = subject_type_name
+subject_type_properties["cards:defaultOrder"] = 0
+subject_type_properties["subjectListLabel"] = ""
+
+creation_form_data = []
+creation_form_data.append((":contentType", (None, "json")))
+creation_form_data.append((":operation", (None, "import")))
+creation_form_data.append((":nameHint", (None, subject_type_name)))
+creation_form_data.append((":content", (None, json.dumps(subject_type_properties))))
+
+resp = requests.post(CARDS_URL + subject_type_parent, auth=('admin', ADMIN_PASSWORD), files=tuple(creation_form_data))
+if resp.status_code in range(200, 300):
+  print("OK")
+  sys.exit(0)
+else:
+  print("ERROR")
+  sys.exit(1)

--- a/Utilities/Development/create_subject_type.py
+++ b/Utilities/Development/create_subject_type.py
@@ -59,4 +59,3 @@ if __name__ == '__main__':
   args = argparser.parse_args()
   create_subject_type(args.parent, args.name)
   print("OK")
-  


### PR DESCRIPTION
This PR introduces the development utility scripts:

- `Utilities/Development/create_subject_type.py` - For creating a new CARDS _Subject Type_ via the command line.
- `Utilities/Development/create_subject_for_type.py` - For creating a new CARDS _Subject_ with a given _Subject Type_ via the command line.
- `Utilities/Development/create_n_level_deep_subject.py` - For creating _N_ levels deep of _Subject Types_ (eg. `/SubjectTypes/level1/level2/level3/.../levelN`) with one _Subject_ of each _Subject Type_.

To test:

- Build this branch with `mvn clean install`.
- Start a plain CARDS instance with `./start_cards.sh --dev`.
- Create a new _Subject Type_ with the `create_subject_type.py` utility. Run `python3 create_subject_type.py -h` for help on how to do so. Verify that this node is present in the JCR via Composum and the CARDS web UI.
- Create a new _Subject_ with the `create_subject_for_type.py` utility. Run `python3 create_subject_for_type.py -h` for help on how to do so. Verify that this node is present in the JCR via Composum and the CARDS web UI.
- Create _N_ levels deep of _Subjects_ and _Subject Types_ with the `create_n_level_deep_subject.py` utility. Run `python3 create_n_level_deep_subject.py -h` for help on how to do so. Verify that the _Subject_ and _Subject Type_ nodes are present in the JCR via Composum and the CARDS web UI.