### PR TITLE
CARDS-1879: Add a 'Last modified' column to CSV export

### DIFF
--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/QuestionnaireToCsvProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/QuestionnaireToCsvProcessor.java
@@ -223,8 +223,7 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
             processFormSubjects(form.getJsonObject("subject"), csvData);
         }
         csvData.get(CREATED_HEADER).put(0, form.getString("jcr:created"));
-        csvData.get(LAST_MODIFIED_HEADER).put(0, form.getString("jcr:lastModified")
-                .substring(0, form.getString("jcr:lastModified").lastIndexOf(".")));
+        csvData.get(LAST_MODIFIED_HEADER).put(0, form.getString("jcr:lastModified"));
 
         // Compute on which row each answer is supposed to be.
         // Without repeatable sections, this would be easy, since everything in a flat form is on the same row.

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/QuestionnaireToCsvProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/QuestionnaireToCsvProcessor.java
@@ -61,6 +61,7 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
     private static final String IDENTIFIER_HEADER = "Identifier";
 
     private static final String CREATED_HEADER = "Created";
+    private static final String LAST_MODIFIED_HEADER = "Last modified";
 
     private static final String PRIMARY_TYPE_PROP = "jcr:primaryType";
 
@@ -108,7 +109,9 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
                 getSubjectTypes(resolver, csvData, columns);
             }
             csvData.put(CREATED_HEADER, new HashMap<>());
+            csvData.put(LAST_MODIFIED_HEADER, new HashMap<>());
             columns.add(CREATED_HEADER);
+            columns.add(LAST_MODIFIED_HEADER);
 
             // Get header titles from the questionnaire question objects
             processSectionToHeaderRow(questionnaire, csvData, columns);
@@ -220,6 +223,8 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
             processFormSubjects(form.getJsonObject("subject"), csvData);
         }
         csvData.get(CREATED_HEADER).put(0, form.getString("jcr:created"));
+        csvData.get(LAST_MODIFIED_HEADER).put(0, form.getString("jcr:lastModified")
+                .substring(0, form.getString("jcr:lastModified").lastIndexOf(".")));
 
         // Compute on which row each answer is supposed to be.
         // Without repeatable sections, this would be easy, since everything in a flat form is on the same row.


### PR DESCRIPTION
[CARDS-1879](https://phenotips.atlassian.net/browse/CARDS-1879)
To test:

- Create some forms

- go to `http: localhost:8080//Questionnaires/<Questionnaire name>.csv` (or: in the Administration > Questionnaires, click on a questionnaire name, then remove from that url `/content.html/admin` and add `.csv` at the end)

Expected:

A CSV file will be offered to download with a new 'Last modified' column after 'Created' in ISO datetime format without timezone yyyy-MM-ddTHH:mm:ss.