### PR TITLE
Misc: Ensure that the response to /fetch_requires_saml_login.html and /goto_saml_login are never cached

### DIFF
--- a/compose-cluster/proxy/http_saml_000-default.conf
+++ b/compose-cluster/proxy/http_saml_000-default.conf
@@ -25,6 +25,7 @@
 
 	<Location "/">
 		Header edit Location ${SAML_IDP_DESTINATION}.* http://${CARDS_HOST_AND_PORT}/login "expr=(%{REQUEST_STATUS} == 302) && (%{REQUEST_URI} != '/fetch_requires_saml_login.html') && (%{REQUEST_URI} != '/goto_saml_login')"
+		Header set Cache-Control no-store "expr=(%{REQUEST_URI} == '/fetch_requires_saml_login.html') || (%{REQUEST_URI} == '/goto_saml_login')"
 		ProxyPass http://cardsinitial:8080/
 		ProxyPassReverse http://cardsinitial:8080/
 	</Location>

--- a/compose-cluster/proxy/https_saml_000-default.conf
+++ b/compose-cluster/proxy/https_saml_000-default.conf
@@ -35,6 +35,7 @@
 
 	<Location "/">
 		Header edit Location ${SAML_IDP_DESTINATION}.* https://${CARDS_HOST_AND_PORT}/login "expr=(%{REQUEST_STATUS} == 302) && (%{REQUEST_URI} != '/fetch_requires_saml_login.html') && (%{REQUEST_URI} != '/goto_saml_login')"
+		Header set Cache-Control no-store "expr=(%{REQUEST_URI} == '/fetch_requires_saml_login.html') || (%{REQUEST_URI} == '/goto_saml_login')"
 		ProxyPass http://cardsinitial:8080/
 		ProxyPassReverse http://cardsinitial:8080/
 	</Location>


### PR DESCRIPTION
This PR fixes a bug where, if SAML authentication is being used in a Docker Compose deployment, the responses to `GET /fetch_requires_saml_login.html` and `GET /goto_saml_login` would be obtained from the browser's cache instead of being requested from the CARDS server and thus fails to trigger (re)authentication with the SAML Identity Provider (IdP).

To reproduce this bug:

- Build the latest CARDS `dev` branch and Docker image with `mvn clean install -Pdocker`
- Follow the instructions at https://github.com/data-team-uhn/cards/pull/815#issuecomment-971914228 (1st bullet point) to set up CARDS in a Docker Compose environment with SAML authentication - please ensure that your `cards/cards` image is built from `dev` and not `CARDS-1374`.
1. Login to http://localhost:8080 as the `myuser@keycloakdemo` user. Logout.
2. Login to http://localhost:8080 as `admin`:`admin` and add `myuser@keycloakdemo` to the _TrustedUsers_ group. Logout.
3. Login once again as the `myuser@keycloakdemo` user.
4. Open a new browser tab to http://localhost:8080 and logout.
5. Return to the first browser tab and click something to trigger the _fetchWithReLogin_ dialog. Login as the `myuser@keycloakdemo` user.
6. Keep repeating steps _4_ and _5_ and soon _step 5_ will fail as `/fetch_requires_saml_login.html` is cached in the browser and thus attempting to access it never actually redirects to Keycloak (`localhost:8484`) thus re-authenticating the user via SAML.

To test this fix, repeat the above bug reproduction steps but this time use a build of this branch (`misc-saml-cache-control`) instead of `dev` and observe that the _fetchWithReLogin_ step always works as opposed to just for the first time that it is used.