### PR TITLE
CARDS-1900: Optimize VisitChangeListener when no frequencies are specified

### DIFF
--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/VisitChangeListener.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/VisitChangeListener.java
@@ -191,7 +191,11 @@ public class VisitChangeListener implements ResourceChangeListener
             return;
         }
 
-        pruneQuestionnaireSet(visit, visitInformation, questionnaireSetInfo);
+        // Prune the quesionnaires to be created based on frequency.
+        // If all the frequencies are 0, skip this step.
+        if (!questionnaireSetInfo.values().stream().allMatch(value -> 0 == value.getFrequency())) {
+            pruneQuestionnaireSet(visit, visitInformation, questionnaireSetInfo);
+        }
 
         if (questionnaireSetInfo.size() < 1) {
             // No questionnaires were created as all missing questionnaires from the questionnaire set


### PR DESCRIPTION
To test: Change the mood questionnaire sets so all the frequencies are 0. This can be done either using composum, or by editing the xml (`proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms/Mood.xml`)

Verify that visits created for the mood clinic will create questionnaires regardless of how close together visits occur. Verify that cardio clinic visits follow standard PROMs rules for creating forms.