### PR TITLE
CARDS-1867: As an admin, I can configure the patient identification process

### DIFF
--- a/modules/commons/src/main/frontend/src/components/ErrorPage.jsx
+++ b/modules/commons/src/main/frontend/src/components/ErrorPage.jsx
@@ -23,6 +23,8 @@ import makeStyles from '@mui/styles/makeStyles';
 
 import NavigationIcon from '@mui/icons-material/Navigation';
 
+import FormattedText from "./FormattedText";
+
 const useStyles = makeStyles(theme => ({
   paper: {
     display: 'flex',
@@ -43,11 +45,11 @@ const useStyles = makeStyles(theme => ({
 }));
 
 export default function ErrorPage(props) {
-  const { errorCode, errorCodeColor, title, titleColor, message, buttonLink, buttonLabel } = props;
+  const { errorCode, errorCodeColor, title, titleColor, message, messageColor, buttonLink, buttonLabel, ...rest } = props;
   const classes = useStyles();
 
   return (
-      <Paper className={classes.paper} elevation={0}>
+      <Paper className={classes.paper} elevation={0} {...rest}>
         <Grid
           container
           direction="column"
@@ -62,12 +64,12 @@ export default function ErrorPage(props) {
             {errorCode && <Typography variant="h1" color={errorCodeColor || "primary"}>
               {errorCode}
             </Typography> }
-            <Typography variant="h1" color={titleColor || "primary"} gutterBottom>
+            {title && <Typography variant="h1" color={titleColor || "primary"} gutterBottom>
               {title}
-            </Typography>
-            {message && <Typography variant="subtitle1" color="textSecondary">
-              {message}
             </Typography> }
+            {message && <FormattedText variant="subtitle1" color={messageColor || "textSecondary"}>
+              {message}
+            </FormattedText> }
           </Grid>
           { buttonLabel &&
             <Grid item>

--- a/modules/commons/src/main/frontend/src/components/FormattedText.jsx
+++ b/modules/commons/src/main/frontend/src/components/FormattedText.jsx
@@ -25,8 +25,11 @@ import MDEditor from '@uiw/react-md-editor';
 
 const useStyles = makeStyles(theme => ({
   markdown: {
-      fontSize: "inherit",
-      fontFamily: "inherit"
+    fontSize: "inherit",
+    fontFamily: "inherit",
+    "& .anchor" : {
+      display: "none",
+    },
   }
 }));
 

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ValidateCredentialsServlet.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ValidateCredentialsServlet.java
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
 import io.uhndata.cards.auth.token.TokenManager;
 import io.uhndata.cards.forms.api.FormUtils;
 import io.uhndata.cards.forms.api.QuestionnaireUtils;
-import io.uhndata.cards.proms.api.PatientAuthConfigUtils;
+import io.uhndata.cards.proms.api.PatientAccessConfiguration;
 import io.uhndata.cards.subjects.api.SubjectTypeUtils;
 import io.uhndata.cards.subjects.api.SubjectUtils;
 
@@ -108,7 +108,7 @@ public class ValidateCredentialsServlet extends SlingAllMethodsServlet
     private TokenManager tokenManager;
 
     @Reference
-    private PatientAuthConfigUtils patientAuthConfigUtils;
+    private PatientAccessConfiguration patientAccessConfiguration;
 
     @Override
     public void doPost(final SlingHttpServletRequest request, final SlingHttpServletResponse response)
@@ -153,7 +153,7 @@ public class ValidateCredentialsServlet extends SlingAllMethodsServlet
         Node patientInformationForm = findMatchingPatientInformation(request, session, rr);
         final Node patientSubject = this.formUtils.getSubject(patientInformationForm);
 
-        if (patientSubject == null || !this.patientAuthConfigUtils.isTokenlessAuthEnabled()) {
+        if (patientSubject == null || !this.patientAccessConfiguration.isTokenlessAuthEnabled()) {
             writeInvalidCredentialsError(response);
             return;
         }
@@ -212,7 +212,7 @@ public class ValidateCredentialsServlet extends SlingAllMethodsServlet
     {
         final Node visitSubject = session.getNodeByIdentifier(sessionSubjectIdentifier);
 
-        if (this.patientAuthConfigUtils.isPatientIdentificationRequired()) {
+        if (this.patientAccessConfiguration.isPatientIdentificationRequired()) {
             // Look for the patient's information in the repository
             final Node patientInformationQuestionniare = getPatientInformationQuestionnaire(session);
             final Node patientInformationForm = getPatientInformationForm(visitSubject,

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ValidateCredentialsServlet.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/ValidateCredentialsServlet.java
@@ -137,10 +137,9 @@ public class ValidateCredentialsServlet extends SlingAllMethodsServlet
             }
 
             if (sessionSubjectIdentifier == null) {
-                LOGGER.warn("Tokenless session");
+                // Not a token authenticated session. Verify based on provided patient details
                 handleTokenlessAuthentication(request, response, session, rr);
             } else {
-                LOGGER.warn("Token session");
                 handleTokenAuthentication(request, response, session, sessionSubjectIdentifier);
             }
         } catch (final LoginException e) {
@@ -181,10 +180,17 @@ public class ValidateCredentialsServlet extends SlingAllMethodsServlet
         }
     }
 
+    /**
+     * Returns the property specified in the configuration node. The resource resolver must have {@code jcr:read}
+     * access to the Proms configuration node. Returns null if the configuration cannot be found.
+     *
+     * @param session Session to use when finding the configuration node.
+     * @param prop Name of the property to use.
+     * @return The property specified in the configuration. If the configuration cannot be found, returns null.
+     */
     private Property getConfig(final Session session, final String prop) throws RepositoryException
     {
         if (!session.nodeExists(CONFIG_NODE)) {
-            // If we cannot find the config, assume the most restrictive setting (false).
             LOGGER.error("Could not find configuration node while evaluating credentials servlet");
             return null;
         }

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/api/PatientAccessConfiguration.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/api/PatientAccessConfiguration.java
@@ -23,7 +23,7 @@ package io.uhndata.cards.proms.api;
  *
  * @version $Id$
  */
-public interface PatientAuthConfigUtils
+public interface PatientAccessConfiguration
 {
     /**
      * Check if tokenless authentication is enabled.

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/api/PatientAuthConfigUtils.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/api/PatientAuthConfigUtils.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.uhndata.cards.proms.api;
+
+/**
+ * Basic utilities for grabbing configuration details from the patient identification node.
+ *
+ * @version $Id$
+ */
+public interface PatientAuthConfigUtils
+{
+    /** The location of the configuration node for patient auth. */
+    String CONFIG_NODE = "/Proms/PatientIdentification";
+
+    /** Property on config node for whether or not tokenless auth is enabled. */
+    String TOKENLESS_AUTH_ENABLED_PROP = "enableTokenlessAuth";
+
+    /** Property on config node for whether or not patient identification is required. */
+    String PATIENT_IDENTIFICATION_REQUIRED_PROP = "requirePIIAuth";
+
+    /** Property on config node for the number of days a token is valid for. */
+    String TOKEN_LIFETIME_PROP = "tokenLifetime";
+
+    /** Whether or not tokenless auth is enabled by default (used in case of errors). */
+    Boolean TOKENLESS_AUTH_ENABLED_DEFAULT = false;
+
+    /** Whether or not patient identification is required by default (used in case of errors). */
+    Boolean PATIENT_IDENTIFICATION_REQUIRED_DEFAULT = true;
+
+    /** The number of days a token is valid for by default (used in case of errors). */
+    int TOKEN_LIFETIME_DEFAULT = 0;
+
+    /**
+     * Check if tokenless authentication is enabled.
+     *
+     * @return True if tokenless authentication is enabled, {@code false} if the configuration could not be found or
+     *         it is disabled
+     */
+    boolean tokenlessAuthEnabled();
+
+    /**
+     * Check if patient self-identification is required.
+     *
+     * @return True if patient identification is required or if the configuration could not be found,
+     *         {@code false} otherwise
+     */
+    boolean patientIdentificationRequired();
+
+    /**
+     * Obtain the amount of time after an appointment ends that tokens to questionnaires should be valid for.
+     *
+     * @return The amount of time after an appointment ends that tokens to questionnaires should be valid for
+     */
+    int tokenLifetime();
+}

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/api/PatientAuthConfigUtils.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/api/PatientAuthConfigUtils.java
@@ -19,40 +19,19 @@
 package io.uhndata.cards.proms.api;
 
 /**
- * Basic utilities for grabbing configuration details from the patient identification node.
+ * Configuration for how the patient can access the patient-facing UI.
  *
  * @version $Id$
  */
 public interface PatientAuthConfigUtils
 {
-    /** The location of the configuration node for patient auth. */
-    String CONFIG_NODE = "/Proms/PatientIdentification";
-
-    /** Property on config node for whether or not tokenless auth is enabled. */
-    String TOKENLESS_AUTH_ENABLED_PROP = "enableTokenlessAuth";
-
-    /** Property on config node for whether or not patient identification is required. */
-    String PATIENT_IDENTIFICATION_REQUIRED_PROP = "requirePIIAuth";
-
-    /** Property on config node for the number of days a token is valid for. */
-    String TOKEN_LIFETIME_PROP = "tokenLifetime";
-
-    /** Whether or not tokenless auth is enabled by default (used in case of errors). */
-    Boolean TOKENLESS_AUTH_ENABLED_DEFAULT = false;
-
-    /** Whether or not patient identification is required by default (used in case of errors). */
-    Boolean PATIENT_IDENTIFICATION_REQUIRED_DEFAULT = true;
-
-    /** The number of days a token is valid for by default (used in case of errors). */
-    int TOKEN_LIFETIME_DEFAULT = 0;
-
     /**
      * Check if tokenless authentication is enabled.
      *
      * @return True if tokenless authentication is enabled, {@code false} if the configuration could not be found or
      *         it is disabled
      */
-    boolean tokenlessAuthEnabled();
+    boolean isTokenlessAuthEnabled();
 
     /**
      * Check if patient self-identification is required.
@@ -60,12 +39,14 @@ public interface PatientAuthConfigUtils
      * @return True if patient identification is required or if the configuration could not be found,
      *         {@code false} otherwise
      */
-    boolean patientIdentificationRequired();
+    boolean isPatientIdentificationRequired();
 
     /**
-     * Obtain the amount of time after an appointment ends that tokens to questionnaires should be valid for.
+     * Get the configured amount of time, in days, after an appointment ends that the patient can still fill in the
+     * visit surveys. {@code -1} means the patient can fill in the forms until the midnight right before the visit,
+     * {@code 0} means until the midnight right after the visit, {@code 7} means until one week after the visit.
      *
-     * @return The amount of time after an appointment ends that tokens to questionnaires should be valid for
+     * @return A number of days
      */
-    int tokenLifetime();
+    int getAllowedPostVisitCompletionTime();
 }

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AbstractEmailNotification.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AbstractEmailNotification.java
@@ -198,7 +198,7 @@ abstract class AbstractEmailNotification
         try
         {
             if (!session.nodeExists(CONFIG_NODE)) {
-                // If we cannot find the config, assume the most restrictive setting (false).
+                // If we cannot find the config, assume the most restrictive setting (0 days).
                 LOGGER.error("Could not find configuration node while evaluating credentials servlet");
                 return 0;
             }

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AbstractEmailNotification.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AbstractEmailNotification.java
@@ -48,11 +48,6 @@ abstract class AbstractEmailNotification
 
     private static final String CLINIC_SLING_PATH = "/Proms.html";
 
-    /** The following parameters are used to grab token lifetime configuration. */
-    private static final String CONFIG_NODE = "/Proms/PatientIdentification";
-
-    private static final String TOKEN_LIFETIME_PROP = "tokenLifetime";
-
     /** Provides access to resources. */
     protected final ResourceResolverFactory resolverFactory;
 
@@ -164,7 +159,7 @@ abstract class AbstractEmailNotification
                 String patientFullName = AppointmentUtils.getPatientFullName(resolver, patientSubject);
                 Calendar tokenExpiryDate = AppointmentUtils.parseDate(appointmentDate.getValueMap().get("value", ""));
                 // Note the tokenExpiry-1, since atMidnight will go to the next day
-                tokenExpiryDate.add(Calendar.DATE, this.patientAuthConfigUtils.tokenLifetime() - 1);
+                tokenExpiryDate.add(Calendar.DATE, this.patientAuthConfigUtils.getAllowedPostVisitCompletionTime() - 1);
                 atMidnight(tokenExpiryDate);
                 final String token = this.tokenManager.create(
                     "patient",

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AbstractEmailNotification.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AbstractEmailNotification.java
@@ -162,7 +162,7 @@ abstract class AbstractEmailNotification
                 tokenExpiryDate.add(
                     Calendar.DATE,
                     this.patientAccessConfiguration.getAllowedPostVisitCompletionTime() - 1
-                    );
+                );
                 atMidnight(tokenExpiryDate);
                 final String token = this.tokenManager.create(
                     "patient",

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AbstractEmailNotification.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AbstractEmailNotification.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import io.uhndata.cards.auth.token.TokenManager;
 import io.uhndata.cards.emailnotifications.EmailUtils;
-import io.uhndata.cards.proms.api.PatientAuthConfigUtils;
+import io.uhndata.cards.proms.api.PatientAccessConfiguration;
 import jakarta.mail.MessagingException;
 
 abstract class AbstractEmailNotification
@@ -55,16 +55,16 @@ abstract class AbstractEmailNotification
 
     private final MailService mailService;
 
-    private final PatientAuthConfigUtils patientAuthConfigUtils;
+    private final PatientAccessConfiguration patientAccessConfiguration;
 
     AbstractEmailNotification(final ResourceResolverFactory resolverFactory,
         final TokenManager tokenManager, final MailService mailService,
-        final PatientAuthConfigUtils patientAuthConfigUtils)
+        final PatientAccessConfiguration patientAccessConfiguration)
     {
         this.resolverFactory = resolverFactory;
         this.tokenManager = tokenManager;
         this.mailService = mailService;
-        this.patientAuthConfigUtils = patientAuthConfigUtils;
+        this.patientAccessConfiguration = patientAccessConfiguration;
 
     }
 
@@ -159,7 +159,10 @@ abstract class AbstractEmailNotification
                 String patientFullName = AppointmentUtils.getPatientFullName(resolver, patientSubject);
                 Calendar tokenExpiryDate = AppointmentUtils.parseDate(appointmentDate.getValueMap().get("value", ""));
                 // Note the tokenExpiry-1, since atMidnight will go to the next day
-                tokenExpiryDate.add(Calendar.DATE, this.patientAuthConfigUtils.getAllowedPostVisitCompletionTime() - 1);
+                tokenExpiryDate.add(
+                    Calendar.DATE,
+                    this.patientAccessConfiguration.getAllowedPostVisitCompletionTime() - 1
+                    );
                 atMidnight(tokenExpiryDate);
                 final String token = this.tokenManager.create(
                     "patient",

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AbstractEmailNotification.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AbstractEmailNotification.java
@@ -162,7 +162,8 @@ abstract class AbstractEmailNotification
 
                 String patientFullName = AppointmentUtils.getPatientFullName(resolver, patientSubject);
                 Calendar tokenExpiryDate = AppointmentUtils.parseDate(appointmentDate.getValueMap().get("value", ""));
-                tokenExpiryDate.add(Calendar.DATE, getTokenExpiryInDays(session));
+                // Note the tokenExpiry-1, since atMidnight will go to the next day
+                tokenExpiryDate.add(Calendar.DATE, getTokenExpiryInDays(session) - 1);
                 atMidnight(tokenExpiryDate);
                 final String token = this.tokenManager.create(
                     "patient",

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AppointmentEmailNotificationsFactory.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AppointmentEmailNotificationsFactory.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import io.uhndata.cards.auth.token.TokenManager;
 import io.uhndata.cards.metrics.Metrics;
+import io.uhndata.cards.proms.api.PatientAuthConfigUtils;
 
 @Designate(ocd = AppointmentEmailNotificationsFactory.Config.class, factory = true)
 @Component(configurationPolicy = ConfigurationPolicy.REQUIRE)
@@ -57,6 +58,10 @@ public final class AppointmentEmailNotificationsFactory
     /** The TokenManager for generating patient-access tokens. */
     @Reference
     private TokenManager tokenManager;
+
+    /** Grab details on patient authentication for token lifetime purposes. */
+    @Reference
+    private PatientAuthConfigUtils patientAuthConfigUtils;
 
     @ObjectClassDefinition(name = "Appointment email notification",
         description = "Send emails for past and future appointments")
@@ -106,7 +111,7 @@ public final class AppointmentEmailNotificationsFactory
 
         // Instantiate the Runnable
         final Runnable notificationsJob = new GeneralNotificationsTask(this.resolverFactory, this.tokenManager,
-            this.mailService, config.name(), config.clinicId(), config.emailSubject(),
+            this.mailService, this.patientAuthConfigUtils, config.name(), config.clinicId(), config.emailSubject(),
             config.plainTextEmailTemplatePath(), config.htmlEmailTemplatePath(),
             config.daysToVisit());
 

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AppointmentEmailNotificationsFactory.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/AppointmentEmailNotificationsFactory.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import io.uhndata.cards.auth.token.TokenManager;
 import io.uhndata.cards.metrics.Metrics;
-import io.uhndata.cards.proms.api.PatientAuthConfigUtils;
+import io.uhndata.cards.proms.api.PatientAccessConfiguration;
 
 @Designate(ocd = AppointmentEmailNotificationsFactory.Config.class, factory = true)
 @Component(configurationPolicy = ConfigurationPolicy.REQUIRE)
@@ -61,7 +61,7 @@ public final class AppointmentEmailNotificationsFactory
 
     /** Grab details on patient authentication for token lifetime purposes. */
     @Reference
-    private PatientAuthConfigUtils patientAuthConfigUtils;
+    private PatientAccessConfiguration patientAccessConfiguration;
 
     @ObjectClassDefinition(name = "Appointment email notification",
         description = "Send emails for past and future appointments")
@@ -111,7 +111,7 @@ public final class AppointmentEmailNotificationsFactory
 
         // Instantiate the Runnable
         final Runnable notificationsJob = new GeneralNotificationsTask(this.resolverFactory, this.tokenManager,
-            this.mailService, this.patientAuthConfigUtils, config.name(), config.clinicId(), config.emailSubject(),
+            this.mailService, this.patientAccessConfiguration, config.name(), config.clinicId(), config.emailSubject(),
             config.plainTextEmailTemplatePath(), config.htmlEmailTemplatePath(),
             config.daysToVisit());
 

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/GeneralNotificationsTask.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/GeneralNotificationsTask.java
@@ -24,7 +24,7 @@ import org.apache.sling.commons.messaging.mail.MailService;
 
 import io.uhndata.cards.auth.token.TokenManager;
 import io.uhndata.cards.metrics.Metrics;
-import io.uhndata.cards.proms.api.PatientAuthConfigUtils;
+import io.uhndata.cards.proms.api.PatientAccessConfiguration;
 
 public class GeneralNotificationsTask extends AbstractEmailNotification implements Runnable
 {
@@ -60,11 +60,11 @@ public class GeneralNotificationsTask extends AbstractEmailNotification implemen
     @SuppressWarnings({ "checkstyle:ParameterNumber" })
     GeneralNotificationsTask(final ResourceResolverFactory resolverFactory,
         final TokenManager tokenManager, final MailService mailService,
-        final PatientAuthConfigUtils patientAuthConfigUtils, final String taskName,
+        final PatientAccessConfiguration patientAccessConfiguration, final String taskName,
         final String clinicId, final String emailSubject, final String plainTemplatePath,
         final String htmlTemplatePath, final int daysToVisit)
     {
-        super(resolverFactory, tokenManager, mailService, patientAuthConfigUtils);
+        super(resolverFactory, tokenManager, mailService, patientAccessConfiguration);
         this.taskName = taskName;
         this.clinicId = clinicId;
         this.emailSubject = emailSubject;

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/GeneralNotificationsTask.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/emailnotifications/GeneralNotificationsTask.java
@@ -24,6 +24,7 @@ import org.apache.sling.commons.messaging.mail.MailService;
 
 import io.uhndata.cards.auth.token.TokenManager;
 import io.uhndata.cards.metrics.Metrics;
+import io.uhndata.cards.proms.api.PatientAuthConfigUtils;
 
 public class GeneralNotificationsTask extends AbstractEmailNotification implements Runnable
 {
@@ -58,11 +59,12 @@ public class GeneralNotificationsTask extends AbstractEmailNotification implemen
      */
     @SuppressWarnings({ "checkstyle:ParameterNumber" })
     GeneralNotificationsTask(final ResourceResolverFactory resolverFactory,
-        final TokenManager tokenManager, final MailService mailService, final String taskName,
+        final TokenManager tokenManager, final MailService mailService,
+        final PatientAuthConfigUtils patientAuthConfigUtils, final String taskName,
         final String clinicId, final String emailSubject, final String plainTemplatePath,
         final String htmlTemplatePath, final int daysToVisit)
     {
-        super(resolverFactory, tokenManager, mailService);
+        super(resolverFactory, tokenManager, mailService, patientAuthConfigUtils);
         this.taskName = taskName;
         this.clinicId = clinicId;
         this.emailSubject = emailSubject;

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/PatientAccessConfigurationImpl.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/PatientAccessConfigurationImpl.java
@@ -102,7 +102,8 @@ public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements
         try
         {
             Property required = getConfig(PATIENT_IDENTIFICATION_REQUIRED_PROP);
-            return required == null ? PATIENT_IDENTIFICATION_REQUIRED_DEFAULT : required.getBoolean();
+            return (!isTokenlessAuthEnabled())
+                || (required == null ? PATIENT_IDENTIFICATION_REQUIRED_DEFAULT : required.getBoolean());
         } catch (RepositoryException e) {
             return PATIENT_IDENTIFICATION_REQUIRED_DEFAULT;
         }

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/PatientAccessConfigurationImpl.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/PatientAccessConfigurationImpl.java
@@ -102,7 +102,7 @@ public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements
         try
         {
             Property required = getConfig(PATIENT_IDENTIFICATION_REQUIRED_PROP);
-            return (!isTokenlessAuthEnabled())
+            return isTokenlessAuthEnabled()
                 || (required == null ? PATIENT_IDENTIFICATION_REQUIRED_DEFAULT : required.getBoolean());
         } catch (RepositoryException e) {
             return PATIENT_IDENTIFICATION_REQUIRED_DEFAULT;

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/PatientAccessConfigurationImpl.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/PatientAccessConfigurationImpl.java
@@ -30,7 +30,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 
-import io.uhndata.cards.proms.api.PatientAuthConfigUtils;
+import io.uhndata.cards.proms.api.PatientAccessConfiguration;
 import io.uhndata.cards.spi.AbstractNodeUtils;
 
 /**
@@ -39,7 +39,7 @@ import io.uhndata.cards.spi.AbstractNodeUtils;
  * @version $Id$
  */
 @Component
-public class PatientAuthConfigUtilsImpl extends AbstractNodeUtils implements PatientAuthConfigUtils
+public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements PatientAccessConfiguration
 {
     /** The location of the configuration node for patient auth. */
     private static final String CONFIG_NODE = "/Proms/PatientIdentification";

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/PatientAuthConfigUtilsImpl.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/PatientAuthConfigUtilsImpl.java
@@ -41,6 +41,27 @@ import io.uhndata.cards.spi.AbstractNodeUtils;
 @Component
 public class PatientAuthConfigUtilsImpl extends AbstractNodeUtils implements PatientAuthConfigUtils
 {
+    /** The location of the configuration node for patient auth. */
+    private static final String CONFIG_NODE = "/Proms/PatientIdentification";
+
+    /** Property on config node for whether or not tokenless auth is enabled. */
+    private static final String TOKENLESS_AUTH_ENABLED_PROP = "tokenlessAuthEnabled";
+
+    /** Property on config node for whether or not patient identification is required. */
+    private static final String PATIENT_IDENTIFICATION_REQUIRED_PROP = "PIIAuthRequired";
+
+    /** Property on config node for the number of days a token is valid for. */
+    private static final String TOKEN_LIFETIME_PROP = "allowedPostVisitCompletionTime";
+
+    /** Whether or not tokenless auth is enabled by default (used in case of errors). */
+    private static final Boolean TOKENLESS_AUTH_ENABLED_DEFAULT = false;
+
+    /** Whether or not patient identification is required by default (used in case of errors). */
+    private static final Boolean PATIENT_IDENTIFICATION_REQUIRED_DEFAULT = true;
+
+    /** The number of days a token is valid for by default (used in case of errors). */
+    private static final int TOKEN_LIFETIME_DEFAULT = 0;
+
     @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
         policyOption = ReferencePolicyOption.GREEDY)
     private ResourceResolverFactory rrf;
@@ -64,7 +85,7 @@ public class PatientAuthConfigUtilsImpl extends AbstractNodeUtils implements Pat
     }
 
     @Override
-    public boolean tokenlessAuthEnabled()
+    public boolean isTokenlessAuthEnabled()
     {
         try
         {
@@ -76,7 +97,7 @@ public class PatientAuthConfigUtilsImpl extends AbstractNodeUtils implements Pat
     }
 
     @Override
-    public boolean patientIdentificationRequired()
+    public boolean isPatientIdentificationRequired()
     {
         try
         {
@@ -88,7 +109,7 @@ public class PatientAuthConfigUtilsImpl extends AbstractNodeUtils implements Pat
     }
 
     @Override
-    public int tokenLifetime()
+    public int getAllowedPostVisitCompletionTime()
     {
         try
         {

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/PatientAuthConfigUtilsImpl.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/PatientAuthConfigUtilsImpl.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.uhndata.cards.proms.internal;
+
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.FieldOption;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import io.uhndata.cards.proms.api.PatientAuthConfigUtils;
+import io.uhndata.cards.spi.AbstractNodeUtils;
+
+/**
+ * Basic utilities for grabbing patient authentication config details.
+ *
+ * @version $Id$
+ */
+@Component
+public class PatientAuthConfigUtilsImpl extends AbstractNodeUtils implements PatientAuthConfigUtils
+{
+    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
+        policyOption = ReferencePolicyOption.GREEDY)
+    private ResourceResolverFactory rrf;
+
+    /**
+     * Returns the property specified in the configuration node. The resource resolver must have {@code jcr:read}
+     * access to the Proms configuration node. Returns null if the configuration cannot be found.
+     *
+     * @param prop Name of the property to use.
+     * @return The property specified in the configuration. If the configuration cannot be found, returns null.
+     */
+    private Property getConfig(final String prop) throws RepositoryException
+    {
+        Session session = getSession(this.rrf);
+        if (!session.nodeExists(CONFIG_NODE)) {
+            return null;
+        }
+
+        Node config = session.getNode(CONFIG_NODE);
+        return config.getProperty(prop);
+    }
+
+    @Override
+    public boolean tokenlessAuthEnabled()
+    {
+        try
+        {
+            Property enabled = getConfig(TOKENLESS_AUTH_ENABLED_PROP);
+            return enabled == null ? TOKENLESS_AUTH_ENABLED_DEFAULT : enabled.getBoolean();
+        } catch (RepositoryException e) {
+            return TOKENLESS_AUTH_ENABLED_DEFAULT;
+        }
+    }
+
+    @Override
+    public boolean patientIdentificationRequired()
+    {
+        try
+        {
+            Property required = getConfig(PATIENT_IDENTIFICATION_REQUIRED_PROP);
+            return required == null ? PATIENT_IDENTIFICATION_REQUIRED_DEFAULT : required.getBoolean();
+        } catch (RepositoryException e) {
+            return PATIENT_IDENTIFICATION_REQUIRED_DEFAULT;
+        }
+    }
+
+    @Override
+    public int tokenLifetime()
+    {
+        try
+        {
+            Property lifetime = getConfig(TOKEN_LIFETIME_PROP);
+            return lifetime == null ? TOKEN_LIFETIME_DEFAULT : (int) lifetime.getLong();
+        } catch (RepositoryException e) {
+            return TOKEN_LIFETIME_DEFAULT;
+        }
+    }
+}

--- a/proms-resources/clinical-data/pom.xml
+++ b/proms-resources/clinical-data/pom.xml
@@ -47,6 +47,8 @@
               SLING-INF/content/Homepage/Proms/Cardio.xml;path:=/Proms/Cardio;overwrite:=true,
               SLING-INF/content/Homepage/Proms/Mood.xml;path:=/Proms/Mood;overwrite:=true,
               SLING-INF/content/Homepage/Proms/ClinicMapping.xml;path:=/Proms/ClinicMapping;overwrite:=true,
+              SLING-INF/content/Homepage/Proms/PatientIdentification.xml;path:=/Proms/PatientIdentification;overwrite:=true,
+              SLING-INF/content/Homepage/Proms/WelcomeMessage.xml;path:=/Proms/WelcomeMessage;overwrite:=true,
               SLING-INF/content/Homepage/Proms/TermsOfUse.xml;path:=/Proms/TermsOfUse;overwrite:=true,
               SLING-INF/content/Homepage/Proms/SurveyInstructions.xml;path:=/Proms/SurveyInstructions;overwrite:=true,
               SLING-INF/content/Homepage/Proms/DashboardSettings.xml;path:=/Proms/DashboardSettings;overwrite:=true,

--- a/proms-resources/clinical-data/pom.xml
+++ b/proms-resources/clinical-data/pom.xml
@@ -47,8 +47,6 @@
               SLING-INF/content/Homepage/Proms/Cardio.xml;path:=/Proms/Cardio;overwrite:=true,
               SLING-INF/content/Homepage/Proms/Mood.xml;path:=/Proms/Mood;overwrite:=true,
               SLING-INF/content/Homepage/Proms/ClinicMapping.xml;path:=/Proms/ClinicMapping;overwrite:=true,
-              SLING-INF/content/Homepage/Proms/PatientIdentification.xml;path:=/Proms/PatientIdentification;overwrite:=true,
-              SLING-INF/content/Homepage/Proms/WelcomeMessage.xml;path:=/Proms/WelcomeMessage;overwrite:=true,
               SLING-INF/content/Homepage/Proms/TermsOfUse.xml;path:=/Proms/TermsOfUse;overwrite:=true,
               SLING-INF/content/Homepage/Proms/SurveyInstructions.xml;path:=/Proms/SurveyInstructions;overwrite:=true,
               SLING-INF/content/Homepage/Proms/DashboardSettings.xml;path:=/Proms/DashboardSettings;overwrite:=true,

--- a/proms-resources/clinical-data/pom.xml
+++ b/proms-resources/clinical-data/pom.xml
@@ -47,6 +47,7 @@
               SLING-INF/content/Homepage/Proms/Cardio.xml;path:=/Proms/Cardio;overwrite:=true,
               SLING-INF/content/Homepage/Proms/Mood.xml;path:=/Proms/Mood;overwrite:=true,
               SLING-INF/content/Homepage/Proms/ClinicMapping.xml;path:=/Proms/ClinicMapping;overwrite:=true,
+              SLING-INF/content/Homepage/Proms/PatientIdentification.xml;path:=/Proms/PatientIdentification;overwrite:=true,
               SLING-INF/content/Homepage/Proms/TermsOfUse.xml;path:=/Proms/TermsOfUse;overwrite:=true,
               SLING-INF/content/Homepage/Proms/SurveyInstructions.xml;path:=/Proms/SurveyInstructions;overwrite:=true,
               SLING-INF/content/Homepage/Proms/DashboardSettings.xml;path:=/Proms/DashboardSettings;overwrite:=true,

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms.json
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms.json
@@ -4,6 +4,7 @@
     { "principal": "everyone", "granted": ["jcr:read"] },
     { "principal": "anonymous", "granted": ["jcr:read"] },
     { "principal": "proms-visit-backend", "granted": ["jcr:read"] },
-    { "principal": "proms-import-backend", "granted": ["jcr:read"] }
+    { "principal": "proms-import-backend", "granted": ["jcr:read"] },
+    { "principal": "proms-patient-validation", "granted": ["jcr:read"] }
   ]
 }

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms/PatientIdentification.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms/PatientIdentification.xml
@@ -31,7 +31,7 @@
     </property>
     <property>
         <name>tokenLifetime</name>
-        <value>2</value>
+        <value>0</value>
         <type>Long</type>
     </property>
 </node>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms/PatientIdentification.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms/PatientIdentification.xml
@@ -1,0 +1,37 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+    <name>PatientIdentification</name>
+    <property>
+        <name>enableTokenlessAuth</name>
+        <value>True</value>
+        <type>Boolean</type>
+    </property>
+    <property>
+        <name>requirePIIAuth</name>
+        <value>True</value>
+        <type>Boolean</type>
+    </property>
+    <property>
+        <name>tokenLifetime</name>
+        <value>2</value>
+        <type>Long</type>
+    </property>
+</node>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms/PatientIdentification.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms/PatientIdentification.xml
@@ -20,17 +20,17 @@
 <node>
     <name>PatientIdentification</name>
     <property>
-        <name>enableTokenlessAuth</name>
+        <name>tokenlessAuthEnabled</name>
         <value>True</value>
         <type>Boolean</type>
     </property>
     <property>
-        <name>requirePIIAuth</name>
+        <name>PIIAuthRequired</name>
         <value>True</value>
         <type>Boolean</type>
     </property>
     <property>
-        <name>tokenLifetime</name>
+        <name>allowedPostVisitCompletionTime</name>
         <value>0</value>
         <type>Long</type>
     </property>

--- a/proms-resources/frontend/src/main/frontend/src/proms/Header.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/Header.jsx
@@ -105,7 +105,7 @@ function PromsHeader (props) {
           </div>
           <Breadcrumbs separator = "·">
             {greeting && <span className={classes.greeting}>{ greeting }</span>}
-            <Link href="/system/sling/logout" underline="hover">Sign out</Link>
+            <Link href="/system/sling/logout" underline="hover" onClick={() => {event.preventDefault(); window.location = "/system/sling/logout?resource=" + encodeURIComponent(window.location.pathname);}}>Sign out</Link>
           </Breadcrumbs>
         </Toolbar>
       </Collapse>

--- a/proms-resources/frontend/src/main/frontend/src/proms/PatientIdentification.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PatientIdentification.jsx
@@ -170,7 +170,6 @@ function PatientIdentification(props) {
   const checkBypass = () => {
     // Check if we are given a token and can bypass patient identification
     let authToken = window.location.search ? new URLSearchParams(window.location.search).get("auth_token") : "";
-    console.log(document.cookie);
     if (authToken) {
       let requestData = new FormData();
       requestData.append("auth_token", authToken);

--- a/proms-resources/frontend/src/main/frontend/src/proms/PatientIdentification.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PatientIdentification.jsx
@@ -145,16 +145,7 @@ function PatientIdentification(props) {
     return str?.toUpperCase().replaceAll(/[^A-Z0-9]*/g, "") || "";
   }
 
-  const identify = () => {
-    if (!dob || !mrn && !hc) {
-      return null;
-    }
-    let requestData = new FormData();
-    dob && requestData.append("date_of_birth", dob);
-    mrn && requestData.append("mrn", mrn);
-    hc && requestData.append("health_card", hc);
-    visit && requestData.append("visit", visit);
-
+  const sendFetch = (requestData, onError) => {
     fetch("/Proms.validateCredentials", {
       "method": "POST",
       "body": requestData
@@ -172,8 +163,32 @@ function PatientIdentification(props) {
         setShowTou(true);
       })
       .catch((error) => {
-        setError(error.statusText ? error.statusText : error);
+        onError(error);
       });
+  }
+
+  const checkBypass = () => {
+    // Check if we are given a token and can bypass patient identification
+    let authToken = window.location.search ? new URLSearchParams(window.location.search).get("auth_token") : "";
+    console.log(document.cookie);
+    if (authToken) {
+      let requestData = new FormData();
+      requestData.append("auth_token", authToken);
+      sendFetch(requestData, () => {});
+    }
+  }
+
+  const identify = () => {
+    if (!dob || !mrn && !hc) {
+      return null;
+    }
+    let requestData = new FormData();
+    dob && requestData.append("date_of_birth", dob);
+    mrn && requestData.append("mrn", mrn);
+    hc && requestData.append("health_card", hc);
+    visit && requestData.append("visit", visit);
+
+    sendFetch(requestData, (error) => {setError(error.statusText ? error.statusText : error);});
   }
 
   // On submitting the patient login form, make a request to identify the patient
@@ -188,6 +203,11 @@ function PatientIdentification(props) {
     setVisit(null);
     identify();
   }
+
+  useEffect(() => {
+    // When we first load, check to see if the user is authenticated and the patient identification check is disabled
+    checkBypass();
+  }, []);
 
   useEffect(() => {
     if (!visit || !visitList) return;

--- a/proms-resources/frontend/src/main/frontend/src/proms/PatientIdentificationConfiguration.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PatientIdentificationConfiguration.jsx
@@ -58,7 +58,7 @@ function PatientIdentificationConfiguration() {
   const labels = {
     tokenlessAuthEnabled: "Patients can answer surveys without a personalized link",
     PIIAuthRequired: "Patients must confirm their identity by providing their date of birth and either MRN or HCN",
-    allowedPostVisitCompletionTime: "Patients can fill out forms after their associated appointment for:"
+    allowedPostVisitCompletionTime: "Patients can fill out surveys after the associated event for:"
   };
 
   let buildConfigData = (formData) => {
@@ -76,7 +76,7 @@ function PatientIdentificationConfiguration() {
         <FormControlLabel control={
           <Checkbox
             name={key}
-            checked={patientIdentification?.[key] || DEFAULT_PATIENT_ID_CONFIG[key]}
+            checked={valueOverride || patientIdentification?.[key] || DEFAULT_PATIENT_ID_CONFIG[key]}
             disabled={valueOverride}
             onChange={event => setPatientIdentification({...patientIdentification, [key]: valueOverride || event.target.checked})}
           />}

--- a/proms-resources/frontend/src/main/frontend/src/proms/PatientIdentificationConfiguration.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PatientIdentificationConfiguration.jsx
@@ -33,9 +33,9 @@ import AdminConfigScreen from "../adminDashboard/AdminConfigScreen.jsx";
 
 export const PATIENT_IDENTIFICATION_PATH = "/Proms/PatientIdentification";
 export const DEFAULT_PATIENT_ID_CONFIG = {
-    enableTokenlessAuth: false,
-    requirePIIAuth: false,
-    tokenLifetime: "0"
+    tokenlessAuthEnabled: false,
+    PIIAuthRequired: false,
+    allowedPostVisitCompletionTime: "0"
 };
 
 const useStyles = makeStyles(theme => ({
@@ -56,9 +56,9 @@ function PatientIdentificationConfiguration() {
   const [ hasChanges, setHasChanges ] = useState(false);
 
   const labels = {
-    enableTokenlessAuth: "Patients can answer surveys without a personalized link",
-    requirePIIAuth: "Patients must confirm their identity by providing their date of birth and either MRN or HCN",
-    tokenLifetime: "The authentication token is valid after the associated event for:"
+    tokenlessAuthEnabled: "Patients can answer surveys without a personalized link",
+    PIIAuthRequired: "Patients must confirm their identity by providing their date of birth and either MRN or HCN",
+    allowedPostVisitCompletionTime: "Patients can fill out forms after their associated appointment for:"
   };
 
   let buildConfigData = (formData) => {
@@ -114,9 +114,9 @@ function PatientIdentificationConfiguration() {
           onConfigSaved={() => setHasChanges(false)}
           >
           <List>
-            { renderConfigCheckbox("enableTokenlessAuth") }
-            { renderConfigCheckbox("requirePIIAuth", patientIdentification?.enableTokenlessAuth) }
-            { renderConfigInput("tokenLifetime", "days") }
+            { renderConfigCheckbox("tokenlessAuthEnabled") }
+            { renderConfigCheckbox("PIIAuthRequired", patientIdentification?.tokenlessAuthEnabled) }
+            { renderConfigInput("allowedPostVisitCompletionTime", "days") }
           </List>
       </AdminConfigScreen>
   );

--- a/proms-resources/frontend/src/main/frontend/src/proms/PatientIdentificationConfiguration.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PatientIdentificationConfiguration.jsx
@@ -1,0 +1,108 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+import React, { useEffect, useState } from 'react';
+import {
+    Checkbox,
+    FormGroup,
+    FormControlLabel,
+    List,
+    ListItem,
+    Typography
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import AdminConfigScreen from "../adminDashboard/AdminConfigScreen.jsx";
+import { camelCaseToWords } from "../questionnaireEditor/LabeledField.jsx";
+
+export const PATIENT_IDENTIFICATION_PATH = "/Proms/PatientIdentification";
+export const DEFAULT_PLACEHOLDER = {
+};
+
+const useStyles = makeStyles(theme => ({
+  formEntries: {
+    "& .MuiListItem-root:not(:first-child) .MuiTypography-root": {
+      marginTop: theme.spacing(3),
+    },
+  },
+}));
+
+function PatientIdentificationConfiguration() {
+  const classes = useStyles();
+
+  const [ patientIdentification, setPatientIdentification ] = useState();
+  const [ hasChanges, setHasChanges ] = useState(false);
+
+  const labels = {
+    enableTokenlessAuth: "Patients can answer surveys without a personalized link",
+    requirePIIAuth: "Patients must confirm their identity by providing their date of birth and either MRN or HCN",
+    tokenLifetime: "The authentication token is valid after the associated event for"
+  };
+
+  let buildConfigData = (formData) => {
+    for (let key of Object.keys(patientIdentification)) {
+      !key.startsWith("jcr:") && formData.append(key, patientIdentification[key] || "");
+    }
+  }
+
+  useEffect(() => {
+    setHasChanges(true);
+  }, [patientIdentification]);
+
+  function ConfigCheckbox(props) {
+    const { id } = props;
+  
+    return(
+      <ListItem>
+          <FormGroup>
+              <FormControlLabel control={
+                  <Checkbox
+                      id={id}
+                      name={id}
+                      value={patientIdentification?.[id] || false}
+                      onChange={(event) => { setPatientIdentification({...patientIdentification, [id]: event.target.value}); }}
+                  />
+                  }
+                  label={labels[id]}
+              />
+          </FormGroup>
+      </ListItem>
+    );
+  }
+
+  return (
+      <AdminConfigScreen
+          title="Patient Identification Configuration"
+          configPath={PATIENT_IDENTIFICATION_PATH}
+          onConfigFetched={setPatientIdentification}
+          hasChanges={hasChanges}
+          buildConfigData={buildConfigData}
+          onConfigSaved={() => setHasChanges(false)}
+          >
+          <List className={classes.formEntries}>
+              <ListItem>
+                  <Typography variant="h6">{camelCaseToWords("Configuration")}</Typography>
+              </ListItem>
+              <ConfigCheckbox id="enableTokenlessAuth" />
+              <ConfigCheckbox id="requirePIIAuth" />
+              <ConfigCheckbox id="tokenLifetime" />
+          </List>
+      </AdminConfigScreen>
+  );
+}
+
+export default PatientIdentificationConfiguration;

--- a/proms-resources/frontend/src/main/frontend/src/proms/PatientIdentificationConfiguration.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PatientIdentificationConfiguration.jsx
@@ -116,7 +116,7 @@ function PatientIdentificationConfiguration() {
           <List>
             { renderConfigCheckbox("enableTokenlessAuth") }
             { renderConfigCheckbox("requirePIIAuth", patientIdentification?.enableTokenlessAuth) }
-            { renderConfigInput("tokenLifetime", "hours") }
+            { renderConfigInput("tokenLifetime", "days") }
           </List>
       </AdminConfigScreen>
   );

--- a/proms-resources/frontend/src/main/frontend/src/proms/PromsLandingPage.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PromsLandingPage.jsx
@@ -64,10 +64,18 @@ function PromsLandingPage(props) {
 
   const USER_TYPE_PARAM = "usertype";
   const USER_TYPE_HCP = "hcp";
+  const CONFIG = "/Proms/PatientIdentification.json";
+  const ENABLED_PROP = "enableTokenlessAuth";
 
   useEffect(() => {
     let userType = (new URLSearchParams(window.location.search || ""))?.get(USER_TYPE_PARAM);
-    setIsOpen(!(userType == USER_TYPE_HCP));
+
+    // If tokenless auth is disabled or if the USER_TYPE_PARAM is set, we do not display ourselves
+    fetch(CONFIG)
+      .then((response) => response.ok ? response.json() : undefined)
+      .then((data) => {
+        setIsOpen((data ? data[ENABLED_PROP] : true) && !(userType == USER_TYPE_HCP));
+      });
   }, [window.location]);
 
   return (

--- a/proms-resources/frontend/src/main/frontend/src/proms/PromsLandingPage.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/PromsLandingPage.jsx
@@ -65,7 +65,7 @@ function PromsLandingPage(props) {
   const USER_TYPE_PARAM = "usertype";
   const USER_TYPE_HCP = "hcp";
   const CONFIG = "/Proms/PatientIdentification.json";
-  const ENABLED_PROP = "enableTokenlessAuth";
+  const ENABLED_PROP = "tokenlessAuthEnabled";
 
   useEffect(() => {
     let userType = (new URLSearchParams(window.location.search || ""))?.get(USER_TYPE_PARAM);

--- a/proms-resources/frontend/src/main/frontend/src/proms/QuestionnaireSet.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/QuestionnaireSet.jsx
@@ -645,11 +645,11 @@ function QuestionnaireSet(props) {
         </Grid>
       ))}
       </Grid>,
-      <Fab variant="extended" color="primary" onClick={() => window.location = "/system/sling/logout"}>Close</Fab>
+      <Fab variant="extended" color="primary" onClick={() => window.location = "/system/sling/logout?resource=" + encodeURIComponent(window.location.pathname)}>Close</Fab>
     ] : [
       <Typography variant="h4">Thank you for your submission</Typography>,
       disclaimer,
-      <Fab variant="extended" color="primary" onClick={() => window.location = "/system/sling/logout"}>Close</Fab>
+      <Fab variant="extended" color="primary" onClick={() => window.location = "/system/sling/logout?resource=" + encodeURIComponent(window.location.pathname)}>Close</Fab>
     ];
 
   let loadingScreen = [ <CircularProgress /> ];

--- a/proms-resources/frontend/src/main/frontend/src/proms/QuestionnaireSet.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/QuestionnaireSet.jsx
@@ -93,7 +93,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 function QuestionnaireSet(props) {
-  const { subject, username, displayText, contentOffset, expiryOffset } = props;
+  const { subject, username, displayText, contentOffset, allowedPostVisitCompletionTime } = props;
 
   // Identifier of the questionnaire set used for the visit
   const [ id, setId ] = useState();
@@ -503,7 +503,7 @@ function QuestionnaireSet(props) {
     let date = getVisitDate();
     if (date?.isValid) {
       // Compute the moment the token expired: the configured number of days after the visit, at midnight
-      date = date.plus({days: expiryOffset}).endOf('day');
+      date = date.plus({days: allowedPostVisitCompletionTime}).endOf('day');
 
       // Get the date difference in the format: X days, Y hours and Z minutes,
       // skipping any time division that has a value of 0

--- a/proms-resources/frontend/src/main/frontend/src/proms/QuestionnaireSet.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/QuestionnaireSet.jsx
@@ -480,11 +480,10 @@ function QuestionnaireSet(props) {
       .then((response) =>
         response.ok ? response.json() : Promise.resolve({tokenLifetime: 0}) // At midnight the day-of by default
       ).then((json) => {
-        // Convert that number of days from now into midnight
-        let lifetime = DateTime.utc().plus({days: json["tokenLifetime"]}).endOf('day').diff(DateTime.utc(), 'hours').hours;
-        setExpiryOffset(lifetime);
+        setExpiryOffset(json.tokenLifetime);
       });
   }
+
   const appointmentDate = () => {
     let date = getVisitDate();
     return !date?.isValid ? "" : date.toLocaleString(DateTime.DATETIME_MED_WITH_WEEKDAY);
@@ -518,12 +517,13 @@ function QuestionnaireSet(props) {
     let result = "";
     let date = getVisitDate();
     if (date?.isValid) {
-      // If the visit date could be retrieved, this is an emailed token and will expire hours after the visit
-      if (!expiryOffset) {
+      // If the visit date could be retrieved, this is an emailed token and will expire a configured number of days after the visit day
+      if (typeof(expiryOffset) == "undefined") {
         fetchVisitExpiry();
         return "";
       }
-      date = date.plus({hours: expiryOffset});
+      // Compute the moment the token expired: the configured number of days after the visit, at midnight
+      date = date.plus({days: expiryOffset}).endOf('day');
 
       // Get the date difference in the format: X days, Y hours and Z minutes,
       // skipping any time division that has a value of 0

--- a/proms-resources/frontend/src/main/frontend/src/proms/QuestionnaireSet.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/QuestionnaireSet.jsx
@@ -60,9 +60,6 @@ const useStyles = makeStyles(theme => ({
     "& #cards-resource-footer .MuiMobileStepper-progress" : {
       width: "100%",
     },
-    "& .wmde-markdown .anchor" : {
-      display: "none",
-    },
   },
   screen : {
     alignItems: "center",

--- a/proms-resources/frontend/src/main/frontend/src/proms/index.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/index.jsx
@@ -80,10 +80,15 @@ function PromsHomepage (props) {
   }
 
   if (unableToProceed) {
+    let appName = document.querySelector('meta[name="title"]')?.content;
+    let message = (surveyInstructions.welcomeMessage)?.replaceAll("APP_NAME", appName) || '';
+    message = `${message}\n\n### To fill out surveys, please follow the personalized link that was emailed to you.`;
     return (
       <ErrorPage
-        title="Invalid link"
-        message="This link is invalid, please use the personalized link that was emailed to you to proceed"
+        sx={{maxWidth: 500, margin: "0 auto"}}
+        title=""
+        message={message}
+        messageColor="textPrimary"
       />)
   }
 

--- a/proms-resources/frontend/src/main/frontend/src/proms/index.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/index.jsx
@@ -32,7 +32,7 @@ import { DEFAULT_INSTRUCTIONS, SURVEY_INSTRUCTIONS_PATH } from "./SurveyInstruct
 const CONFIG = "/Proms/PatientIdentification.json";
 const TOKENLESS_AUTH_ENABLED_PROP = "tokenlessAuthEnabled";
 const AUTH_TOKEN_PARAM = "auth_token";
-const EXPIRY_OFFSET_PARAM = "allowedPostVisitCompletionTime";
+const ALLOWED_POST_VISIT_COMPLETION_TIME_PROP = "allowedPostVisitCompletionTime";
 
 function PromsHomepage (props) {
   // Current user and associated subject
@@ -41,7 +41,7 @@ function PromsHomepage (props) {
   // Patient Survey UI texts from Patient Portal Survey Instructions
   const [ surveyInstructions, setSurveyInstructions ] = useState();
   const [ unableToProceed, setUnableToProceed ] = useState();
-  const [ expiryOffset, setExpiryOffset ] = useState();
+  const [ allowedPostVisitCompletionTime, setAllowedPostVisitCompletionTime ] = useState();
 
   // Fetch saved settings for Patient Portal Survey Instructions
   useEffect(() => {
@@ -60,7 +60,7 @@ function PromsHomepage (props) {
     fetch(CONFIG)
       .then((response) => response.ok ? response.json() : Promise.reject(response))
       .then((json) => {
-        setExpiryOffset(json[EXPIRY_OFFSET_PARAM]);
+        setAllowedPostVisitCompletionTime(json[ALLOWED_POST_VISIT_COMPLETION_TIME_PROP]);
 
         let auth_token = new URLSearchParams(window.location.search).get(AUTH_TOKEN_PARAM);
         if (!(json[TOKENLESS_AUTH_ENABLED_PROP] || auth_token)) {
@@ -104,7 +104,7 @@ function PromsHomepage (props) {
   }
 
   return (<>
-    <QuestionnaireSet subject={subject} username={username} displayText={displayText} expiryOffset={expiryOffset}/>
+    <QuestionnaireSet subject={subject} username={username} displayText={displayText} allowedPostVisitCompletionTime={allowedPostVisitCompletionTime}/>
     <PromsFooter />
   </>);
 }

--- a/proms-resources/frontend/src/main/frontend/src/proms/index.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/index.jsx
@@ -30,7 +30,7 @@ import ErrorPage from "../components/ErrorPage.jsx";
 import { DEFAULT_INSTRUCTIONS, SURVEY_INSTRUCTIONS_PATH } from "./SurveyInstructionsConfiguration.jsx"
 
 const CONFIG = "/Proms/PatientIdentification.json";
-const ENABLED_PROP = "enableTokenlessAuth";
+const TOKENLESS_AUTH_ENABLED_PROP = "enableTokenlessAuth";
 const AUTH_TOKEN_PARAM = "auth_token";
 
 function PromsHomepage (props) {
@@ -59,7 +59,7 @@ function PromsHomepage (props) {
       .then((response) => response.ok ? response.json() : Promise.reject(response))
       .then((json) => {
         let auth_token = new URLSearchParams(window.location.search).get(AUTH_TOKEN_PARAM);
-        if (!(json[ENABLED_PROP] || auth_token)) {
+        if (!(json[TOKENLESS_AUTH_ENABLED_PROP] || auth_token)) {
           // The user cannot continue without an authentication token
           setUnableToProceed(true);
         }

--- a/proms-resources/frontend/src/main/frontend/src/proms/index.jsx
+++ b/proms-resources/frontend/src/main/frontend/src/proms/index.jsx
@@ -30,8 +30,9 @@ import ErrorPage from "../components/ErrorPage.jsx";
 import { DEFAULT_INSTRUCTIONS, SURVEY_INSTRUCTIONS_PATH } from "./SurveyInstructionsConfiguration.jsx"
 
 const CONFIG = "/Proms/PatientIdentification.json";
-const TOKENLESS_AUTH_ENABLED_PROP = "enableTokenlessAuth";
+const TOKENLESS_AUTH_ENABLED_PROP = "tokenlessAuthEnabled";
 const AUTH_TOKEN_PARAM = "auth_token";
+const EXPIRY_OFFSET_PARAM = "allowedPostVisitCompletionTime";
 
 function PromsHomepage (props) {
   // Current user and associated subject
@@ -40,6 +41,7 @@ function PromsHomepage (props) {
   // Patient Survey UI texts from Patient Portal Survey Instructions
   const [ surveyInstructions, setSurveyInstructions ] = useState();
   const [ unableToProceed, setUnableToProceed ] = useState();
+  const [ expiryOffset, setExpiryOffset ] = useState();
 
   // Fetch saved settings for Patient Portal Survey Instructions
   useEffect(() => {
@@ -58,6 +60,8 @@ function PromsHomepage (props) {
     fetch(CONFIG)
       .then((response) => response.ok ? response.json() : Promise.reject(response))
       .then((json) => {
+        setExpiryOffset(json[EXPIRY_OFFSET_PARAM]);
+
         let auth_token = new URLSearchParams(window.location.search).get(AUTH_TOKEN_PARAM);
         if (!(json[TOKENLESS_AUTH_ENABLED_PROP] || auth_token)) {
           // The user cannot continue without an authentication token
@@ -100,7 +104,7 @@ function PromsHomepage (props) {
   }
 
   return (<>
-    <QuestionnaireSet subject={subject} username={username} displayText={displayText}/>
+    <QuestionnaireSet subject={subject} username={username} displayText={displayText} expiryOffset={expiryOffset}/>
     <PromsFooter />
   </>);
 }

--- a/proms-resources/frontend/src/main/frontend/webpack.config.js
+++ b/proms-resources/frontend/src/main/frontend/webpack.config.js
@@ -16,6 +16,8 @@ module.exports = {
     [module_name + 'clinicIcon']: '@mui/icons-material/Event.js',
     [module_name + 'Clinics']: './src/proms/Clinics.jsx',
     [module_name + 'PrintHeader']: './src/proms/PrintHeader.jsx',
+    [module_name + 'PatientIdentificationConfiguration']: './src/proms/PatientIdentificationConfiguration.jsx',
+    [module_name + 'PatientIdentificationConfigurationIcon']: '@mui/icons-material/MedicalInformation.js',
     [module_name + 'ToUConfiguration']: './src/proms/ToUConfiguration.jsx',
     [module_name + 'ToUConfigurationIcon']: '@mui/icons-material/Handshake.js',
     [module_name + 'SurveyInstructionsConfiguration']: './src/proms/SurveyInstructionsConfiguration.jsx',

--- a/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/AdminDashboard/PatientIdentificationConfiguration.json
+++ b/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/AdminDashboard/PatientIdentificationConfiguration.json
@@ -1,0 +1,9 @@
+{
+  "jcr:primaryType": "cards:Extension",
+  "cards:extensionPointId": "cards/coreUI/admindashboard/entry",
+  "cards:extensionName": "Patient Identification",
+  "cards:targetURL": "/content.html/admin/PatientIdentificationConfiguration",
+  "cards:icon": "asset:proms-homepage.PatientIdentificationConfigurationIcon.js",
+  "cards:hint": "Configure how patient users can authenticate",
+  "cards:defaultOrder": 430
+}

--- a/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/Views/PatientIdentificationConfiguration.json
+++ b/proms-resources/frontend/src/main/resources/SLING-INF/content/Extensions/Views/PatientIdentificationConfiguration.json
@@ -1,0 +1,7 @@
+{
+  "jcr:primaryType": "cards:Extension",
+  "cards:extensionPointId": "cards/coreUI/view",
+  "cards:extensionName": "Patient Identification",
+  "cards:targetURL": "/content.html/admin/PatientIdentificationConfiguration",
+  "cards:extensionRenderURL": "asset:proms-homepage.PatientIdentificationConfiguration.js"
+}


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/CARDS-1867)

In implementing CARDS-1867, this also covers [CARDS-1771](https://phenotips.atlassian.net/browse/CARDS-1771), [CARDS-1772](https://phenotips.atlassian.net/browse/CARDS-1772), and [CARDS-1845](https://phenotips.atlassian.net/browse/CARDS-1845).

This commit adds a new administration page, Patient Identification, which changes how the Proms homepage works.
![image](https://user-images.githubusercontent.com/4656440/185635819-e0bf89a0-1738-44e4-a658-df367d27225d.png)

1. `Patients can answer surveys without a personalized link` will change the default login page, preventing people from logging in as a patient when they enter it.

2. `Patients must confirm their identity by providing their date of birth and either MRN or HCN` will control the patient login page. This can only be turned off if users are required to use a personalized link (i.e. 1. is disabled), as without a token we otherwise have no means of determining which patient a user is.

3. `The authentication token is valid after the associated event for:` alters how long authentication tokens provided by the email service are valid for. Prior to this PR, they were valid until midnight the day of the event. They are now set to 0 days after the event (the night of) by default.

*To test*:
1. While logged in as admin, you can alter Patient Identification settings from Administration/Patient Identification on the sidebar.
2. You can confirm the behaviour of 1. by altering it and logging out. The patient login will no longer be available.
3. You can confirm the behaviour of 2. by generating a patient login token. To do this, create a Patient Information form and a Visit Information form (or import some from the Proms importer using the instructions at #979 ). Then, try logging in with the token by visiting localhost:8080/Proms/?auth_token=<token>.
4. You can confirm the behaviour of 3. by forcing an email to be sent (see [these instructions](https://github.com/data-team-uhn/cards/blob/dev/Utilities/Development/EmailServer/README.md)), and checking the expiry date of the token generated. Easiest way to look at all tokens generated is by visiting http://localhost:8080/jcr:system/cards:tokens.2.json .