### PR TITLE
CARDS-1911: All custom cards ACL restrictions are failing to be evaluated

### DIFF
--- a/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/FormsRestrictionProvider.java
+++ b/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/FormsRestrictionProvider.java
@@ -112,19 +112,16 @@ public class FormsRestrictionProvider extends AbstractRestrictionProvider
 
     private RestrictionPattern processRestriction(Restriction restriction)
     {
-        String name = restriction.getDefinition().getName();
-        RestrictionFactory factory = getFactory(name);
-        if (factory != null) {
-            return factory.forValue(restriction.getProperty());
-        } else {
-            LOGGER.debug("Ignoring unsupported restriction {}", name);
-        }
-        return null;
+        return processRestriction(restriction.getDefinition().getName(), restriction.getProperty());
     }
 
     private RestrictionPattern processRestriction(PropertyState property)
     {
-        String name = property.getName();
+        return processRestriction(property.getName(), property);
+    }
+
+    private RestrictionPattern processRestriction(String name, PropertyState property)
+    {
         RestrictionFactory factory = getFactory(name);
         if (factory != null) {
             return factory.forValue(property);

--- a/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/FormsRestrictionProvider.java
+++ b/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/FormsRestrictionProvider.java
@@ -128,6 +128,6 @@ public class FormsRestrictionProvider extends AbstractRestrictionProvider
         } else {
             LOGGER.debug("Ignoring unsupported restriction {}", name);
         }
-        return RestrictionPattern.EMPTY;
+        return null;
     }
 }


### PR DESCRIPTION
This fixes a regression introduced by the Oak upgrade in #1127 .

The easiest bug to check is that a TrustedUser should be able to see the list of Questionnaires without erroring out.

Before:
![image](https://user-images.githubusercontent.com/4656440/187975300-5516915e-697c-4740-86c2-f3bd74b71768.png)

After:
![image](https://user-images.githubusercontent.com/4656440/187975110-cf8defb0-a909-4f2b-8413-adce00065b7e.png)
