### PR TITLE
CARDS-1912: cards:unsubmittedForms restriction is not being evaluated

### DIFF
--- a/proms-resources/feature/src/main/features/feature.json
+++ b/proms-resources/feature/src/main/features/feature.json
@@ -117,7 +117,7 @@
         "io.uhndata.cards.proms-backend:tou=[proms-patient-tou]",
         "io.uhndata.cards.proms-backend:unsubscribe=[proms-patient-unsubscribe]",
         "io.uhndata.cards.proms-backend:EmailNotifications=[sling-readall]",
-        "io.uhndata.cards.proms-backend:UnsubmittedFormsRestriction=[sling-readall]",
+        "io.uhndata.cards.proms-permissions:UnsubmittedFormsRestriction=[sling-readall]",
         "io.uhndata.cards.proms-backend:TorchImporter=[proms-import-backend]",
         "io.uhndata.cards.proms-backend:MetricLogger=[cards-metrics]",
         "io.uhndata.cards.proms-backend:SlackNotifications=[cards-metrics]"


### PR DESCRIPTION
**This branch includes the changes in #1166 as it cannot be tested without them.**

[Jira link](https://phenotips.atlassian.net/browse/CARDS-1912)

`cards:unsubmittedForms` restrictions are not currently being evaluated, due to a bug that prevents the service user from being obtained. This PR fixes that.

Before (while logged in as a TrustedUser on a visit that has a bunch of unsubmitted forms):
![image](https://user-images.githubusercontent.com/4656440/187983654-398d402b-dbdf-42f5-bf0d-16c05ffdbc8a.png)

After (while logged in as a TrustedUser on a visit that has a bunch of unsubmitted forms):
![image](https://user-images.githubusercontent.com/4656440/187983538-0e318617-69dd-442d-b342-f6d4e06c06ef.png)
