### PR TITLE
CARDS-1916: Trying to log in as a patient with a token while the Patient Information form doesn't exist ends with a white screen

### DIFF
--- a/modules/patient-interface/src/main/frontend/src/proms/PatientIdentification.jsx
+++ b/modules/patient-interface/src/main/frontend/src/proms/PatientIdentification.jsx
@@ -187,7 +187,7 @@ function PatientIdentification(props) {
     hc && requestData.append("health_card", hc);
     visit && requestData.append("visit", visit);
 
-    sendFetch(requestData, (error) => {setError(error.statusText ? error.statusText : error);});
+    sendFetch(requestData, (error) => setError(error.statusText || "Invalid credentials"));
   }
 
   // On submitting the patient login form, make a request to identify the patient


### PR DESCRIPTION
Quick fix of JS error - displaying a generic message.

**Steps to replicate**: [see CARDS-1916 on Jira](https://phenotips.atlassian.net/browse/CARDS-1916).