### PR TITLE
CARDS-1917: Patient portal: unresponsive ui when trying to accept the Terms of Use in absence of the Patient information form

### DIFF
--- a/modules/patient-interface/src/main/frontend/src/proms/PatientIdentification.jsx
+++ b/modules/patient-interface/src/main/frontend/src/proms/PatientIdentification.jsx
@@ -244,7 +244,7 @@ function PatientIdentification(props) {
     <ToUDialog
       open={showTou}
       actionRequired={true}
-      onClose={() => setShowTou(false)}
+      onClose={(withError) => withError ? window.location.href = window.location.pathname : setShowTou(false)}
       onCleared={() => {
         setShowTou(false);
         setTouCleared(true);

--- a/modules/patient-interface/src/main/frontend/src/proms/PatientIdentification.jsx
+++ b/modules/patient-interface/src/main/frontend/src/proms/PatientIdentification.jsx
@@ -244,7 +244,7 @@ function PatientIdentification(props) {
     <ToUDialog
       open={showTou}
       actionRequired={true}
-      onClose={(withError) => withError ? window.location.href = window.location.pathname : setShowTou(false)}
+      onClose={(withError) => withError ? window.location.href = "/system/sling/logout?resource=" + encodeURIComponent(window.location.pathname) : setShowTou(false)}
       onCleared={() => {
         setShowTou(false);
         setTouCleared(true);

--- a/modules/patient-interface/src/main/frontend/src/proms/ToUDialog.jsx
+++ b/modules/patient-interface/src/main/frontend/src/proms/ToUDialog.jsx
@@ -47,6 +47,10 @@ const useStyles = makeStyles(theme => ({
       fontStyle: "italic",
     }
   },
+  actionErrorMessage: {
+    marginLeft: theme.spacing(2),
+    marginRight: "auto",
+  },
   reviewButton : {
     marginRight: "auto",
   }
@@ -84,6 +88,7 @@ function ToUDialog(props) {
   const [ touAcceptedVersion, setTouAcceptedVersion ] = useState();
   const [ tou, setTou ] = useState();
   const [ error, setError ] = useState();
+  const [ actionError, setActionError ] = useState();
 
   const classes = useStyles();
 
@@ -138,7 +143,8 @@ function ToUDialog(props) {
       .then( json => json.status == "success" ? onCleared && onCleared() : Promise.reject(json.error))
       .catch((response) => {
         let errMsg = "Recording acceptance of Terms of Use failed";
-        setError(errMsg + (response.status ? ` with error code ${response.status}: ${response.statusText}` : response));
+        console.log(errMsg + (response.status ? ` with error code ${response.status}: ${response.statusText}` : response));
+        setActionError("Error: your preference could not be recorded.");
       });
   }
 
@@ -176,7 +182,7 @@ function ToUDialog(props) {
       }
       </DialogContent>
       <DialogActions>
-      { actionRequired && !error ?
+      { actionRequired && !error && !actionError ?
         <>
           <Button color="primary" onClick={() => saveTouAccepted(tou.version)} variant="contained">
             Accept
@@ -186,9 +192,14 @@ function ToUDialog(props) {
           </Button>
         </>
         :
-        <Button color="primary" onClick={onClose} variant="outlined">
-          Close
-        </Button>
+        <>
+          { actionError &&
+            <FormattedText color="error" className={classes.actionErrorMessage}>{actionError}</FormattedText>
+          }
+          <Button color="primary" onClick={() => onClose(!!actionError)} variant="outlined">
+            Close
+          </Button>
+        </>
       }
       </DialogActions>
     </ResponsiveDialog>


### PR DESCRIPTION
**Steps to replicate**: [see CARDS-1917 on Jira](https://phenotips.atlassian.net/browse/CARDS-1917).