### PR TITLE
CARDS-1914 - Patient portal: improve the configurability of the survey start screen

### DIFF
--- a/modules/patient-interface/src/main/frontend/src/proms/SurveyInstructionsConfiguration.jsx
+++ b/modules/patient-interface/src/main/frontend/src/proms/SurveyInstructionsConfiguration.jsx
@@ -18,6 +18,8 @@
 //
 import React, { useEffect, useState } from 'react';
 import {
+    Checkbox,
+    FormControlLabel,
     List,
     ListItem,
     TextField,
@@ -51,15 +53,17 @@ function SurveyInstructionsConfiguration() {
   const labels = {
     welcomeMessage: ["welcomeMessage"],
     eventSelectionScreen: ["noEventsMessage", "eventSelectionMessage"],
-    startScreen: [ "eventLabel", "noSurveysMessage", "surveyIntro" ],
+    startScreen: [ "enableStartScreen", "eventLabel", "noSurveysMessage", "surveyIntro" ],
     summaryScreen: [ "disclaimer", "summaryInstructions", "interpretationInstructions" ]
   };
 
   let buildConfigData = (formData) => {
     for (let key of Object.keys(surveyInstructions)) {
-      !key.startsWith("jcr:") && formData.append(key, surveyInstructions[key] || "");
+      !key.startsWith("jcr:") && formData.append(key, surveyInstructions[key] || getUnsetValue(key));
     }
   }
+
+  let getUnsetValue = (key) => (key?.startsWith("enable") ? false : "");
 
   useEffect(() => {
     setHasChanges(true);
@@ -85,6 +89,15 @@ function SurveyInstructionsConfiguration() {
                       <WelcomeMessageConfiguration
                         welcomeMessage={surveyInstructions?.[key]}
                         onChange={(text) => { setSurveyInstructions({...surveyInstructions, [key]: text}); }}
+                      />
+                    :
+                    key.startsWith("enable") ?
+                      <FormControlLabel control={
+                        <Checkbox
+                          checked={!!(surveyInstructions?.[key])}
+                          onChange={event => setSurveyInstructions({...surveyInstructions, [key]: !!event.target.checked})}
+                        />}
+                        label={camelCaseToWords(key)}
                       />
                     :
                       <TextField

--- a/modules/patient-interface/src/main/frontend/src/proms/index.jsx
+++ b/modules/patient-interface/src/main/frontend/src/proms/index.jsx
@@ -32,7 +32,6 @@ import { DEFAULT_INSTRUCTIONS, SURVEY_INSTRUCTIONS_PATH } from "./SurveyInstruct
 const CONFIG = "/Proms/PatientIdentification.json";
 const TOKENLESS_AUTH_ENABLED_PROP = "tokenlessAuthEnabled";
 const AUTH_TOKEN_PARAM = "auth_token";
-const ALLOWED_POST_VISIT_COMPLETION_TIME_PROP = "allowedPostVisitCompletionTime";
 
 function PromsHomepage (props) {
   // Current user and associated subject
@@ -40,8 +39,8 @@ function PromsHomepage (props) {
   const [ subject, setSubject ] = useState();
   // Patient Survey UI texts from Patient Portal Survey Instructions
   const [ surveyInstructions, setSurveyInstructions ] = useState();
+  const [ accessConfig, setAccessConfig ] = useState({});
   const [ unableToProceed, setUnableToProceed ] = useState();
-  const [ allowedPostVisitCompletionTime, setAllowedPostVisitCompletionTime ] = useState();
 
   // Fetch saved settings for Patient Portal Survey Instructions
   useEffect(() => {
@@ -60,7 +59,7 @@ function PromsHomepage (props) {
     fetch(CONFIG)
       .then((response) => response.ok ? response.json() : Promise.reject(response))
       .then((json) => {
-        setAllowedPostVisitCompletionTime(json[ALLOWED_POST_VISIT_COMPLETION_TIME_PROP]);
+        setAccessConfig(json);
 
         let auth_token = new URLSearchParams(window.location.search).get(AUTH_TOKEN_PARAM);
         if (!(json[TOKENLESS_AUTH_ENABLED_PROP] || auth_token)) {
@@ -104,7 +103,7 @@ function PromsHomepage (props) {
   }
 
   return (<>
-    <QuestionnaireSet subject={subject} username={username} displayText={displayText} allowedPostVisitCompletionTime={allowedPostVisitCompletionTime}/>
+    <QuestionnaireSet subject={subject} username={username} displayText={displayText} config={{...accessConfig, enableStartScreen: surveyInstructions?.enableStartScreen}} />
     <PromsFooter />
   </>);
 }

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms/SurveyInstructions.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Homepage/Proms/SurveyInstructions.xml
@@ -55,6 +55,11 @@ If routine service evaluations or research projects are undertaken, your respons
         <type>String</type>
     </property>
     <property>
+        <name>enableStartScreen</name>
+        <value>True</value>
+        <type>Boolean</type>
+    </property>
+    <property>
         <name>surveyIntro</name>
         <value>Tell us about your symptoms prior to your appointment.</value>
         <type>String</type>


### PR DESCRIPTION
[Jira link](https://phenotips.atlassian.net/browse/CARDS-1914)

For testing: an "enable start screen" checkbox has been introduced in the "Survey instructions" admin screen. Combine with different settings of the "Patient identification" to obtain all test cases.