### PR TITLE
[misc] Center horizontal sliders horizontally in the question box

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
@@ -78,6 +78,7 @@ const useSliderStyles = makeStyles(theme => ({
     display: "flex",
     flexDirection: "row",
     alignItems: "center",
+    justifyContent: "center",
     "& > .MuiTypography-root:first-child" : {
       marginRight: theme.spacing(1.5),
       textAlign: "right",


### PR DESCRIPTION
Makes 2 consecutive questions with displayMode: slider and min/max value labels of different lengths look better than the current left alignment.