### PR TITLE
CARDS-1895: Publish the yarn.lock file for each CARDS Docker image that is in deployment

### DIFF
--- a/Utilities/SecurityScanning/get_yarn_lock_file_for_docker_image.sh
+++ b/Utilities/SecurityScanning/get_yarn_lock_file_for_docker_image.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+DOCKER_IMAGE=$1
+OUTPUT_YARN_LOCK_FILE=$2
+
+docker run --rm --entrypoint /bin/sh $DOCKER_IMAGE -c "cat /metadata/yarn.lock" > $OUTPUT_YARN_LOCK_FILE

--- a/distribution/Dockerfile
+++ b/distribution/Dockerfile
@@ -35,6 +35,12 @@ ADD COMPLETE_SOURCE_CODE.tar /cards
 WORKDIR /cards
 RUN if [[ "$build_jars" == "true" ]] ; then /make_filled_m2.sh ; else mkdir /root/.m2 ; fi
 
+# Create a directory for storing basic metadata about the built image
+RUN mkdir /metadata
+
+# Copy in the yarn.lock file as metadata
+RUN if [[ "$build_jars" == "true" ]] ; then cp /cards/aggregated-frontend/src/main/frontend/yarn.lock /metadata/yarn.lock ; fi
+
 # Production Image: Start from a small Alpine Linux base image
 FROM alpine:3.14
 
@@ -72,6 +78,9 @@ EXPOSE 5005
 
 # Copy in the dependency JARs
 COPY --from=0 /root/.m2 /root/.m2
+
+# Copy in the build metadata
+COPY --from=0 /metadata /metadata
 
 # This is the default command executed when starting the container
 COPY docker_entry.sh /docker_entry.sh


### PR DESCRIPTION
This PR introduces the `/metadata` directory to the CARDS Docker image. When a CARDS Docker image is built in _self-contained_ mode, to be used in _production_, the `yarn.lock` file containing the versions of the Yarn JavaScript packages that are used by that CARDS build is written into this `/metadata` directory. This PR also provides the `get_yarn_lock_file_for_docker_image.sh` script which copies the `yarn.lock` file from a _self-contained_ CARDS Docker image to the host where it can be scanned for security vulnerabilities.

Testing
----------

1. Build a _self-contained_ Docker image from this (`CARDS-1895`) branch with `MAVEN_OPTS="-Ddocker.verbose -Ddocker.buildArg.build_jars=true" mvn clean install -Pdocker`.
2. Obtain the `yarn.lock` file from the recently built Docker image by running `./get_yarn_lock_file_for_docker_image.sh cards/cards ~/test_yarn.lock` in the `Utilities/SecurityScanning` directory. Verify that `~/test_yarn.lock` contains a list of Yarn JavaScript packages.
3. Build a _development_ Docker image from this (`CARDS-1895`) branch with `mvn clean install -Pdocker`.
4. Running `./get_yarn_lock_file_for_docker_image.sh cards/cards ~/test_yarn.lock` in the `Utilities/SecurityScanning` directory should fail - this is expected.