### PR TITLE
[misc] start_cards.sh - unary operator expected fix

### DIFF
--- a/start_cards.sh
+++ b/start_cards.sh
@@ -369,12 +369,12 @@ then
   else
     HEADERMOD_PROXY_LISTEN_PORT=9090
   fi
-fi
 
-if [ $HEADERMOD_PROXY_LISTEN_PORT = $BIND_PORT ]
-then
-  message_saml_proxy_port_conflict_fail
-  exit -1
+  if [ $HEADERMOD_PROXY_LISTEN_PORT = $BIND_PORT ]
+  then
+    message_saml_proxy_port_conflict_fail
+    exit -1
+  fi
 fi
 
 #Start CARDS in the background


### PR DESCRIPTION
In `start_cards.sh`, `HEADERMOD_PROXY_LISTEN_PORT` is only assigned a value if `SAML_IN_USE` is set to `true`, therefore only perform the `HEADERMOD_PROXY_LISTEN_PORT = BIND_PORT` check if `SAML_IN_USE = true`.

This error was introduced in https://github.com/data-team-uhn/cards/pull/1156.

Testing
---------

- On the `dev` branch, running `start_cards.sh --dev` will print the error `./start_cards.sh: line 374: [: =: unary operator expected`.
- On this `misc-port-conflict-check-fix` branch, running `start_cards.sh --dev` will not show the above error.