### PR TITLE
CARDS-1918: .token.html ignores the configured token expiry setting

### DIFF
--- a/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
+++ b/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
@@ -30,7 +30,7 @@ if (time.hasNext()) {
         time = time.getProperty("value").getDate();
         var config = sling.getService(Packages.io.uhndata.cards.patients.api.PatientAccessConfiguration);
         var days = config.getAllowedPostVisitCompletionTime();
-        time.add(java.util.Calendar.DATE, days);
+        time.add(java.util.Calendar.DATE, days + 1);
         time.set(java.util.Calendar.HOUR_OF_DAY, 0);
         time.set(java.util.Calendar.MINUTE, 0);
         time.set(java.util.Calendar.SECOND, 0);

--- a/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
+++ b/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
@@ -28,6 +28,13 @@ if (time.hasNext()) {
     time = time.next();
     if (time.hasProperty("value")) {
         time = time.getProperty("value").getDate();
+        var config = sling.getService(Packages.io.uhndata.cards.patients.api.PatientAccessConfiguration);
+        var days = config.getAllowedPostVisitCompletionTime();
+        time.add(java.util.Calendar.DATE, days);
+        time.set(java.util.Calendar.HOUR_OF_DAY, 0);
+        time.set(java.util.Calendar.MINUTE, 0);
+        time.set(java.util.Calendar.SECOND, 0);
+        time.set(java.util.Calendar.MILLISECOND, 0);
     } else {
         time = get10MinExpiry();
     }


### PR DESCRIPTION
This is a PR for [CARDS-1918](https://phenotips.atlassian.net/browse/CARDS-1918)
To test:
- start with `-P prems`,
- make a visit information form with the visit time sometime in the past 30 days (per [prems configuration](https://github.com/data-team-uhn/cards/blob/dev/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/PatientIdentification.xml#L33-L34), the token should be valid for 30 days)
- generate the token by going to `/Subjects/PATIENT_UUID/VISIT_UUID.token.html`
- sign out as admin (or switch to a different browser)
- go to `/Survey.html?auth_token=THE_GENERATED_TOKEN` and check that it lets you fill in the form (not telling you the link has expired)