### PR TITLE
[misc] Fix expiry date of visit token generated for email links

### DIFF
--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
@@ -164,10 +164,9 @@ abstract class AbstractEmailNotification
 
                 String patientFullName = AppointmentUtils.getPatientFullName(resolver, patientSubject);
                 Calendar tokenExpiryDate = AppointmentUtils.parseDate(appointmentDate.getValueMap().get("value", ""));
-                // Note the tokenExpiry-1, since atMidnight will go to the next day
                 tokenExpiryDate.add(
                     Calendar.DATE,
-                    this.patientAccessConfiguration.getAllowedPostVisitCompletionTime() - 1
+                    this.patientAccessConfiguration.getAllowedPostVisitCompletionTime()
                 );
                 atMidnight(tokenExpiryDate);
                 final String token = this.tokenManager.create(


### PR DESCRIPTION
If `allowedPostVisitCompletionTime` is 0, the patient should be allowed to complete the survey until the end of the day of the visit.