### PR TITLE
CARDS-1933: PREMs Email notification Scheduling

### DIFF
--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
@@ -703,8 +703,7 @@ public class VisitChangeListener implements ResourceChangeListener
 
         public boolean hasRequiredInformation()
         {
-            // TODO: Test if !! is needed to convert to boolean
-            return !!(this.visitDate != null && StringUtils.isNotBlank(this.questionnaireSet));
+            return this.visitDate != null && StringUtils.isNotBlank(this.questionnaireSet);
         }
 
         public Calendar getVisitDate()

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
@@ -725,7 +725,9 @@ public class VisitChangeListener implements ResourceChangeListener
 
     private static final class QuestionnaireSetInfo
     {
+        // Conflict with any questionnaire
         private static final String CONFLICT_ANY = "any";
+        // Only conflict with questionnaires included in the map of conflicts
         private static final String CONFLICT_ANY_LISTED = "anyListed";
         private final Map<String, Integer> conflicts;
         private final Map<String, QuestionnaireRef> members;

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
@@ -196,7 +196,7 @@ public class VisitChangeListener implements ResourceChangeListener
             return;
         }
 
-        // Prune the quesionnaires to be created based on frequency.
+        // Prune the questionnaires to be created based on frequency.
         // If all the frequencies are 0, skip this step.
         if (!questionnaireSetInfo.getMembers().values().stream().allMatch(member -> 0 == member.getFrequency())) {
             pruneQuestionnaireSet(visitSubject, visitInformation, questionnaireSetInfo);

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
@@ -752,9 +752,8 @@ public class VisitChangeListener implements ResourceChangeListener
         {
             // Treat default as any listed case
             for (final String questionnaireIdentifier : questionnaires.keySet()) {
-                int frequencyPeriod;
+                int frequencyPeriod = 0;
                 if (CONFLICT_ANY.equals(this.conflictMode)) {
-                    frequencyPeriod = 0;
                     frequencyPeriod = this.members.values().stream()
                         .map(ref -> ref.getFrequency())
                         .max(Integer::compare).get();

--- a/modules/patient-portal/src/main/resources/SLING-INF/nodetypes/patient-portal.cnd
+++ b/modules/patient-portal/src/main/resources/SLING-INF/nodetypes/patient-portal.cnd
@@ -39,9 +39,6 @@
   // Hardcode the resource type.
   - sling:resourceType (STRING) = "cards/QuestionnaireConflict" mandatory autocreated protected
 
-  // Hardcode the resource supertype.
-  - sling:resourceSuperType (STRING) = "cards/Resource" mandatory autocreated protected
-
   // A questionnaire path
   // Mandatory, each QuestionnaireConflict must point to a questionnaire.
   - questionnaire (reference) mandatory
@@ -114,6 +111,9 @@
   - frequencyIgnoreClinic (boolean)
 
   // How any questionnaires not included in this set should be checked for conflicts
+  // Supported values are:
+  // "anyListed" (default): Only conflict with questionnaires listed as a cards:QuestionnaireConflict
+  // "any": Conflict with any questionnaires
   - conflictMode (STRING)
 
   // Any forms which should prevent this questionnaire set from being created if present

--- a/modules/patient-portal/src/main/resources/SLING-INF/nodetypes/patient-portal.cnd
+++ b/modules/patient-portal/src/main/resources/SLING-INF/nodetypes/patient-portal.cnd
@@ -27,6 +27,29 @@
 //-----------------------------------------------------------------------------
 
 //-----------------------------------------------------------------------------
+// QuestionnaireConflict: a reference to a questionnaire that should prevent a QuestionnaireSet from being generated
+[cards:QuestionnaireConflict] > sling:Folder, mix:referenceable, mix:versionable
+  // Attributes
+
+  // We can use questionnaire references in a query.
+  query
+
+  // Properties
+
+  // Hardcode the resource type.
+  - sling:resourceType (STRING) = "cards/QuestionnaireConflict" mandatory autocreated protected
+
+  // Hardcode the resource supertype.
+  - sling:resourceSuperType (STRING) = "cards/Resource" mandatory autocreated protected
+
+  // A questionnaire path
+  // Mandatory, each QuestionnaireRef must point to a questionnaire.
+  - questionnaire (reference) mandatory
+
+  // A frequency for how long the conflict should prevent the questionnaire set from being used for
+  - frequency (long) mandatory
+
+//-----------------------------------------------------------------------------
 // QuestionnaireRef: a reference to a questionnaire included in a QuestionnaireSet
 [cards:QuestionnaireRef] > sling:Folder, mix:referenceable, mix:versionable
   // Attributes
@@ -86,6 +109,12 @@
 
   // An emergency contact for the clinic
   - emergencyContact (string)
+
+  // If true, apply the questionnaire's frequency across all clinics for these questionnaires
+  - frequencyIgnoreClinic (boolean)
+
+  // Any forms which should prevent this questionnaire set from being created if present
+  + * (cards:QuestionnaireConflict) = cards:QuestionnaireConflict
 
   // Children
 

--- a/modules/patient-portal/src/main/resources/SLING-INF/nodetypes/patient-portal.cnd
+++ b/modules/patient-portal/src/main/resources/SLING-INF/nodetypes/patient-portal.cnd
@@ -43,7 +43,7 @@
   - sling:resourceSuperType (STRING) = "cards/Resource" mandatory autocreated protected
 
   // A questionnaire path
-  // Mandatory, each QuestionnaireRef must point to a questionnaire.
+  // Mandatory, each QuestionnaireConflict must point to a questionnaire.
   - questionnaire (reference) mandatory
 
   // A frequency for how long the conflict should prevent the questionnaire set from being used for
@@ -112,6 +112,9 @@
 
   // If true, apply the questionnaire's frequency across all clinics for these questionnaires
   - frequencyIgnoreClinic (boolean)
+
+  // How any questionnaires not included in this set should be checked for conflicts
+  - conflictMode (STRING)
 
   // Any forms which should prevent this questionnaire set from being created if present
   + * (cards:QuestionnaireConflict) = cards:QuestionnaireConflict

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/AIP.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/AIP.xml
@@ -26,6 +26,11 @@
         <type>String</type>
     </property>
     <property>
+        <name>frequencyIgnoreClinic</name>
+        <value>True</value>
+        <type>Boolean</type>
+    </property>
+    <property>
         <name>conflictMode</name>
         <value>any</value>
         <type>String</type>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/AIP.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/AIP.xml
@@ -59,11 +59,6 @@
             <type>Long</type>
         </property>
         <property>
-            <name>frequency</name>
-            <value>26</value>
-            <type>Long</type>
-        </property>
-        <property>
             <name>view</name>
             <value>
 [

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/AIP.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/AIP.xml
@@ -30,34 +30,11 @@
         <value>True</value>
         <type>Boolean</type>
     </property>
-    <node>
-        <name>conflict1</name>
-        <primaryNodeType>cards:QuestionnaireConflict</primaryNodeType>
-        <property>
-            <name>questionnaire</name>
-            <value>/Questionnaires/OAIP</value>
-            <type>Reference</type>
-        </property>
-        <property>
-            <name>frequency</name>
-            <value>26</value>
-            <type>Long</type>
-        </property>
-    </node>
-    <node>
-        <name>conflict2</name>
-        <primaryNodeType>cards:QuestionnaireConflict</primaryNodeType>
-        <property>
-            <name>questionnaire</name>
-            <value>/Questionnaires/OED</value>
-            <type>Reference</type>
-        </property>
-        <property>
-            <name>frequency</name>
-            <value>26</value>
-            <type>Long</type>
-        </property>
-    </node>
+    <property>
+        <name>conflictMode</name>
+        <value>any</value>
+        <type>String</type>
+    </property>
     <node>
         <name>Step1</name>
         <primaryNodeType>cards:QuestionnaireRef</primaryNodeType>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/AIP.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/AIP.xml
@@ -26,11 +26,6 @@
         <type>String</type>
     </property>
     <property>
-        <name>frequencyIgnoreClinic</name>
-        <value>True</value>
-        <type>Boolean</type>
-    </property>
-    <property>
         <name>conflictMode</name>
         <value>any</value>
         <type>String</type>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/AIP.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/AIP.xml
@@ -25,6 +25,39 @@
         <value></value>
         <type>String</type>
     </property>
+    <property>
+        <name>frequencyIgnoreClinic</name>
+        <value>True</value>
+        <type>Boolean</type>
+    </property>
+    <node>
+        <name>conflict1</name>
+        <primaryNodeType>cards:QuestionnaireConflict</primaryNodeType>
+        <property>
+            <name>questionnaire</name>
+            <value>/Questionnaires/OAIP</value>
+            <type>Reference</type>
+        </property>
+        <property>
+            <name>frequency</name>
+            <value>26</value>
+            <type>Long</type>
+        </property>
+    </node>
+    <node>
+        <name>conflict2</name>
+        <primaryNodeType>cards:QuestionnaireConflict</primaryNodeType>
+        <property>
+            <name>questionnaire</name>
+            <value>/Questionnaires/OED</value>
+            <type>Reference</type>
+        </property>
+        <property>
+            <name>frequency</name>
+            <value>26</value>
+            <type>Long</type>
+        </property>
+    </node>
     <node>
         <name>Step1</name>
         <primaryNodeType>cards:QuestionnaireRef</primaryNodeType>
@@ -46,6 +79,11 @@
         <property>
             <name>order</name>
             <value>1</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>frequency</name>
+            <value>26</value>
             <type>Long</type>
         </property>
         <property>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/CPES.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/CPES.xml
@@ -26,6 +26,11 @@
         <type>String</type>
     </property>
     <property>
+        <name>frequencyIgnoreClinic</name>
+        <value>True</value>
+        <type>Boolean</type>
+    </property>
+    <property>
         <name>conflictMode</name>
         <value>any</value>
         <type>String</type>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/CPES.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/CPES.xml
@@ -25,6 +25,11 @@
         <value></value>
         <type>String</type>
     </property>
+    <property>
+        <name>conflictMode</name>
+        <value>any</value>
+        <type>String</type>
+    </property>
     <node>
         <name>Step1</name>
         <primaryNodeType>cards:QuestionnaireRef</primaryNodeType>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/ED.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/ED.xml
@@ -26,6 +26,11 @@
         <type>String</type>
     </property>
     <property>
+        <name>frequencyIgnoreClinic</name>
+        <value>True</value>
+        <type>Boolean</type>
+    </property>
+    <property>
         <name>conflictMode</name>
         <value>any</value>
         <type>String</type>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/ED.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/ED.xml
@@ -59,11 +59,6 @@
             <type>Long</type>
         </property>
         <property>
-            <name>frequency</name>
-            <value>26</value>
-            <type>Long</type>
-        </property>
-        <property>
             <name>view</name>
             <value>
 [

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/ED.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/ED.xml
@@ -30,34 +30,11 @@
         <value>True</value>
         <type>Boolean</type>
     </property>
-    <node>
-        <name>conflict1</name>
-        <primaryNodeType>cards:QuestionnaireConflict</primaryNodeType>
-        <property>
-            <name>questionnaire</name>
-            <value>/Questionnaires/OAIP</value>
-            <type>Reference</type>
-        </property>
-        <property>
-            <name>frequency</name>
-            <value>26</value>
-            <type>Long</type>
-        </property>
-    </node>
-    <node>
-        <name>conflict2</name>
-        <primaryNodeType>cards:QuestionnaireConflict</primaryNodeType>
-        <property>
-            <name>questionnaire</name>
-            <value>/Questionnaires/OED</value>
-            <type>Reference</type>
-        </property>
-        <property>
-            <name>frequency</name>
-            <value>26</value>
-            <type>Long</type>
-        </property>
-    </node>
+    <property>
+        <name>conflictMode</name>
+        <value>any</value>
+        <type>String</type>
+    </property>
     <node>
         <name>Step1</name>
         <primaryNodeType>cards:QuestionnaireRef</primaryNodeType>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/ED.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/ED.xml
@@ -26,11 +26,6 @@
         <type>String</type>
     </property>
     <property>
-        <name>frequencyIgnoreClinic</name>
-        <value>True</value>
-        <type>Boolean</type>
-    </property>
-    <property>
         <name>conflictMode</name>
         <value>any</value>
         <type>String</type>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/ED.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/ED.xml
@@ -25,6 +25,39 @@
         <value></value>
         <type>String</type>
     </property>
+    <property>
+        <name>frequencyIgnoreClinic</name>
+        <value>True</value>
+        <type>Boolean</type>
+    </property>
+    <node>
+        <name>conflict1</name>
+        <primaryNodeType>cards:QuestionnaireConflict</primaryNodeType>
+        <property>
+            <name>questionnaire</name>
+            <value>/Questionnaires/OAIP</value>
+            <type>Reference</type>
+        </property>
+        <property>
+            <name>frequency</name>
+            <value>26</value>
+            <type>Long</type>
+        </property>
+    </node>
+    <node>
+        <name>conflict2</name>
+        <primaryNodeType>cards:QuestionnaireConflict</primaryNodeType>
+        <property>
+            <name>questionnaire</name>
+            <value>/Questionnaires/OED</value>
+            <type>Reference</type>
+        </property>
+        <property>
+            <name>frequency</name>
+            <value>26</value>
+            <type>Long</type>
+        </property>
+    </node>
     <node>
         <name>Step1</name>
         <primaryNodeType>cards:QuestionnaireRef</primaryNodeType>
@@ -46,6 +79,11 @@
         <property>
             <name>order</name>
             <value>1</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>frequency</name>
+            <value>26</value>
             <type>Long</type>
         </property>
         <property>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/EDIP.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/EDIP.xml
@@ -26,6 +26,11 @@
         <type>String</type>
     </property>
     <property>
+        <name>frequencyIgnoreClinic</name>
+        <value>True</value>
+        <type>Boolean</type>
+    </property>
+    <property>
         <name>conflictMode</name>
         <value>any</value>
         <type>String</type>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/EDIP.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/EDIP.xml
@@ -25,6 +25,11 @@
         <value></value>
         <type>String</type>
     </property>
+    <property>
+        <name>conflictMode</name>
+        <value>any</value>
+        <type>String</type>
+    </property>
     <node>
         <name>Step1</name>
         <primaryNodeType>cards:QuestionnaireRef</primaryNodeType>


### PR DESCRIPTION
Adapt PROMs scheduling to PREMs use case
- Remove AUDIT-C special handling (now unneeded, can be replaced by reference questions)
- Add option to check frequency across different clinics for the same form
- Add conflict questionnaires to the questionnaire set

Test in PREMs run mode. Verify that patients will only receive a single OED or OAIP form every 26 weeks, regardless of which form they received previously and which clinic the visits are for.