### PR TITLE
CARDS-1935: Add support for the --demo and --demo_banner flags to the generate_compose_yaml.py script

### DIFF
--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -38,6 +38,7 @@ argparser.add_argument('--config_replicas', help='Number of MongoDB cluster conf
 argparser.add_argument('--custom_env_file', help='Enable a custom file with environment variables')
 argparser.add_argument('--cards_project', help='The CARDS project to deploy (eg. cards4proms, cards4lfs, etc...')
 argparser.add_argument('--demo', help='Enable the Demo Banner, Upgrade Marker Flag, and Demo Forms', action='store_true')
+argparser.add_argument('--demo_banner', help='Enable only the Demo Banner', action='store_true')
 argparser.add_argument('--dev_docker_image', help='Indicate that the CARDS Docker image being used was built for development, not production.', action='store_true')
 argparser.add_argument('--composum', help='Enable Composum for the CARDS admin account', action='store_true')
 argparser.add_argument('--enable_backup_server', help='Add a cards/backup_recorder service to the cluster', action='store_true')
@@ -452,6 +453,9 @@ if args.composum:
 
 if args.demo:
   yaml_obj['services']['cardsinitial']['environment'].append("DEMO=true")
+
+if args.demo_banner:
+  yaml_obj['services']['cardsinitial']['environment'].append("DEMO_BANNER=true")
 
 if args.saml:
   yaml_obj['services']['cardsinitial']['environment'].append("SAML_AUTH_ENABLED=true")

--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -37,6 +37,7 @@ argparser.add_argument('--replicas', help='Number of MongoDB replicas per shard 
 argparser.add_argument('--config_replicas', help='Number of MongoDB cluster configuration servers (must be an odd number)', default=3, type=int)
 argparser.add_argument('--custom_env_file', help='Enable a custom file with environment variables')
 argparser.add_argument('--cards_project', help='The CARDS project to deploy (eg. cards4proms, cards4lfs, etc...')
+argparser.add_argument('--demo', help='Enable the Demo Banner, Upgrade Marker Flag, and Demo Forms', action='store_true')
 argparser.add_argument('--dev_docker_image', help='Indicate that the CARDS Docker image being used was built for development, not production.', action='store_true')
 argparser.add_argument('--composum', help='Enable Composum for the CARDS admin account', action='store_true')
 argparser.add_argument('--enable_backup_server', help='Add a cards/backup_recorder service to the cluster', action='store_true')
@@ -448,6 +449,9 @@ if args.cards_project:
 
 if args.composum:
   yaml_obj['services']['cardsinitial']['environment'].append("DEV=true")
+
+if args.demo:
+  yaml_obj['services']['cardsinitial']['environment'].append("DEMO=true")
 
 if args.saml:
   yaml_obj['services']['cardsinitial']['environment'].append("SAML_AUTH_ENABLED=true")

--- a/distribution/docker_entry.sh
+++ b/distribution/docker_entry.sh
@@ -63,6 +63,11 @@ then
   featureFlagString="$featureFlagString -f mvn:io.uhndata.cards/cards-modules-demo-banner/${PROJECT_VERSION}/slingosgifeature,"
   featureFlagString="${featureFlagString}mvn:io.uhndata.cards/cards-modules-upgrade-marker/${PROJECT_VERSION}/slingosgifeature,"
   featureFlagString="${featureFlagString}mvn:io.uhndata.cards/cards-dataentry/${PROJECT_VERSION}/slingosgifeature/forms_demo"
+else
+  if [ ! -z $DEMO_BANNER ]
+  then
+    featureFlagString="$featureFlagString -f mvn:io.uhndata.cards/cards-modules-demo-banner/${PROJECT_VERSION}/slingosgifeature"
+  fi
 fi
 
 if [ ! -z $ENABLE_TEST_FEATURES ]


### PR DESCRIPTION
This PR implements CARDS-1935 by adding support for the `--demo` and `--demo_banner` flags to the `generate_compose_yaml.py` script.

When `--demo` is specified; the UI Demo Banner is enabled, the `/UpgradeMarker` JCR node is created, and the `github` user and appropriate restrictions are created.

When `--demo_banner` is specified, only the UI Demo Banner is enabled.

Testing
---------

1. Build this (`CARDS-1935`) branch, including a development Docker image, with `mvn clean install -Pdocker`.
2. `cd compose-cluster`
3. Clean up any previous configurations with `./cleanup.sh`.
4. `python3 generate_compose_yaml.py --dev_docker_image --oak_filesystem --composum`
5. `docker-compose build`
6. `docker-compose up -d`
7. Visit http://localhost:8080 and login as `admin`:`admin`. The _Demo Warning Banner_ should _not_ be present.
8. Click on _Administration_ --> _Users_. Only `anonymous` and `admin` should be present. The `github` user should _not_ be present.
9. Visit http://localhost:8080/bin/browser.html. The `UpgradeMarker` JCR node should _not_ be present.
10. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`
11. `python3 generate_compose_yaml.py --dev_docker_image --oak_filesystem --composum --demo_banner`
12. `docker-compose build`
13. `docker-compose up -d`
14. Visit http://localhost:8080 and login as `admin`:`admin`. The _Demo Warning Banner_ _should_ be present.
15. Click on _Administration_ --> _Users_. Only `anonymous` and `admin` should be present. The `github` user should _not_ be present.
16. Visit http://localhost:8080/bin/browser.html. The `UpgradeMarker` JCR node should _not_ be present.
17. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`
18. `python3 generate_compose_yaml.py --dev_docker_image --oak_filesystem --composum --demo`
19. `docker-compose build`
20. `docker-compose up -d`
21. Visit http://localhost:8080 and login as `admin`:`admin`. The _Demo Warning Banner_ _should_ be present.
22. Click on _Administration_ --> _Users_. The `anonymous`, `admin` and `github` users _should_ be present.
23. Visit http://localhost:8080/bin/browser.html. The `UpgradeMarker` JCR node _should_ be present.
24. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`