### PR TITLE
CARDS-1947: Add support for an --adminer flag to generate_compose_yaml.py

### DIFF
--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -32,6 +32,7 @@ from CardsDockerTagProperty import CARDS_DOCKER_TAG
 from CloudIAMdemoKeystoreSha256Property import CLOUD_IAM_DEMO_KEYSTORE_SHA256
 from ServerMemorySplitConfig import MEMORY_SPLIT_CARDS_JAVA, MEMORY_SPLIT_MONGO_SHARDS_REPLICAS
 
+ADMINER_DOCKER_RELEASE_TAG = "4.8.1"
 MINIO_DOCKER_RELEASE_TAG = "RELEASE.2022-09-17T00-09-45Z"
 
 argparser = argparse.ArgumentParser()
@@ -42,6 +43,8 @@ argparser.add_argument('--custom_env_file', help='Enable a custom file with envi
 argparser.add_argument('--cards_project', help='The CARDS project to deploy (eg. cards4proms, cards4lfs, etc...')
 argparser.add_argument('--dev_docker_image', help='Indicate that the CARDS Docker image being used was built for development, not production.', action='store_true')
 argparser.add_argument('--composum', help='Enable Composum for the CARDS admin account', action='store_true')
+argparser.add_argument('--adminer', help='Add an Adminer Docker container for database interaction via web browser', action='store_true')
+argparser.add_argument('--adminer_port', help='If --adminer is specified, bind it to this localhost port [default: 1435]', default=1435, type=int)
 argparser.add_argument('--enable_backup_server', help='Add a cards/backup_recorder service to the cluster', action='store_true')
 argparser.add_argument('--backup_server_path', help='Host OS path where the backup_recorder container should store its backup files')
 argparser.add_argument('--enable_ncr', help='Add a Neural Concept Recognizer service to the cluster', action='store_true')
@@ -678,6 +681,15 @@ if args.s3_test_container:
   yaml_obj['services']['s3_test_container']['environment'].append("MINIO_ROOT_USER=minioadmin")
   yaml_obj['services']['s3_test_container']['environment'].append("MINIO_ROOT_PASSWORD=minioadmin")
   yaml_obj['services']['s3_test_container']['command'] = ["server", "/data", "--console-address", ":9001"]
+
+if args.adminer:
+  print("Configuring service: adminer")
+  yaml_obj['services']['adminer'] = {}
+  yaml_obj['services']['adminer']['image'] = "adminer:" + ADMINER_DOCKER_RELEASE_TAG
+  yaml_obj['services']['adminer']['networks'] = {}
+  yaml_obj['services']['adminer']['networks']['internalnetwork'] = {}
+  yaml_obj['services']['adminer']['networks']['internalnetwork']['aliases'] = ['adminer']
+  yaml_obj['services']['adminer']['ports'] = ["127.0.0.1:{}:8080".format(args.adminer_port)]
 
 #Setup the internal network
 print("Configuring the internal network")


### PR DESCRIPTION
This PR adds support for the `--adminer` flag to `generate_compose_yaml.py` When this flag is present, an _Adminer_ Docker container is started on `localhost:1435` when the Docker Compose environment is brought up with `docker-compose up -d`. The port which _Adminer_ binds to can be adjusted from the default `1435` value by using the `--adminer_port` parameter (eg. `--adminer_port 1234` would cause _Adminer_ to listen on `localhost:1234` instead of `localhost:1435`).

Testing
---------

1. Build this branch, including a Docker image with `mvn clean install -Pdocker`.
2. `cd compose-cluster`
3. `python3 generate_compose_yaml.py --dev_docker_image --oak_filesystem --adminer`
4. `docker-compose build`
5. `docker-compose up -d`
6. _CARDS_ should be available as usual at http://localhost:8080.
7. _Adminer_ should be available at http://localhost:1435.
8. `docker pull mcr.microsoft.com/mssql/server:2022-latest`
9. `docker run --rm --network compose-cluster_internalnetwork -e ACCEPT_EULA=y -e MSSQL_SA_PASSWORD=PaSSw0rd1234 --name mssql -d mcr.microsoft.com/mssql/server:2022-latest`
10. Visit http://localhost:1435 and connect to the MS-SQL database using the following parameters:
    - _System_: `MS SQL (beta)`
    - _Server_: `mssql`
    - _Username_: `sa`
    - _Password_: `PaSSw0rd1234`
    - _Database_: `master`
12. Verify that you are able to access and modify the MS SQL database using the web interface.
13. `docker stop mssql`
14. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`

Other Testing
------------------

- Verify that the `--adminer_port` parameter works as expected.
- Verify that the _Adminer_ container is _not_ created whenever the `--adminer` flag is _not_ specified.