### PR TITLE
CARDS-1887: Reference answers don't work in background jobs

### DIFF
--- a/distribution/src/main/features/core/cards.json
+++ b/distribution/src/main/features/core/cards.json
@@ -22,6 +22,10 @@
             "start-order":"2"
         },
         {
+            "id":"${project.groupId}:cards-resolver-provider:${project.version}",
+            "start-order":"15"
+        },
+        {
             "id":"${project.groupId}:cards-data-model-subjects-api:${project.version}",
             "start-order":"25"
         },

--- a/heracles-resources/backend/pom.xml
+++ b/heracles-resources/backend/pom.xml
@@ -63,6 +63,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>cards-resolver-provider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>cards-utils</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/PauseResumeFormEditor.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/PauseResumeFormEditor.java
@@ -16,7 +16,6 @@
  */
 package io.uhndata.cards.heracles.internal;
 
-
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -57,6 +56,7 @@ public class PauseResumeFormEditor extends DefaultEditor
     private final NodeBuilder currentNodeBuilder;
 
     private final ResourceResolverFactory rrf;
+
     private final ThreadResourceResolverProvider rrp;
 
     private final QuestionnaireUtils questionnaireUtils;
@@ -66,6 +66,7 @@ public class PauseResumeFormEditor extends DefaultEditor
     private final SubjectUtils subjectUtils;
 
     private boolean isFormNode;
+
     private boolean isNew;
 
     /**
@@ -101,7 +102,7 @@ public class PauseResumeFormEditor extends DefaultEditor
             return null;
         } else {
             return new PauseResumeFormEditor(this.currentNodeBuilder.getChildNode(name), this.rrf,
-            this.rrp, this.questionnaireUtils, this.formUtils, this.subjectUtils, true);
+                this.rrp, this.questionnaireUtils, this.formUtils, this.subjectUtils, true);
         }
     }
 

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/PauseResumeFormEditor.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/PauseResumeFormEditor.java
@@ -41,8 +41,8 @@ import org.slf4j.LoggerFactory;
 
 import io.uhndata.cards.forms.api.FormUtils;
 import io.uhndata.cards.forms.api.QuestionnaireUtils;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 import io.uhndata.cards.subjects.api.SubjectUtils;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * An {@link Editor} that fills out any reference answers for a new form.

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/PauseResumeFormEditor.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/PauseResumeFormEditor.java
@@ -126,9 +126,11 @@ public class PauseResumeFormEditor extends DefaultEditor
             return;
         }
 
+        boolean mustPopResolver = false;
         try (ResourceResolver localResolver = this.rrf
             .getServiceResourceResolver(Map.of(ResourceResolverFactory.SUBSERVICE, "PauseResumeEditor"))) {
             this.rrp.push(localResolver);
+            mustPopResolver = true;
 
             if (!isPauseResumeForm(after)) {
                 return;
@@ -138,9 +140,10 @@ public class PauseResumeFormEditor extends DefaultEditor
         } catch (final LoginException e) {
             LOGGER.warn("Failed to get service session: {}", e.getMessage(), e);
         } finally {
-            this.rrp.pop();
+            if (mustPopResolver) {
+                this.rrp.pop();
+            }
         }
-
     }
 
     private void processForm(NodeState after)

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/PauseResumeFormEditorProvider.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/PauseResumeFormEditorProvider.java
@@ -31,8 +31,8 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import io.uhndata.cards.forms.api.FormUtils;
 import io.uhndata.cards.forms.api.QuestionnaireUtils;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 import io.uhndata.cards.subjects.api.SubjectUtils;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * A {@link EditorProvider} returning {@link ComputedAnswersEditor}.

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportEndpoint.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportEndpoint.java
@@ -34,7 +34,7 @@ import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 @Component(service = { Servlet.class })
 @SlingServletResourceTypes(

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportEndpoint.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportEndpoint.java
@@ -41,6 +41,7 @@ import org.osgi.service.component.annotations.Reference;
 public class ExportEndpoint extends SlingSafeMethodsServlet
 {
     private static final long serialVersionUID = -1615592669184694095L;
+
     @Reference
     private ResourceResolverFactory resolverFactory;
 
@@ -49,10 +50,10 @@ public class ExportEndpoint extends SlingSafeMethodsServlet
     {
         final Writer out = response.getWriter();
 
-        //Ensure that this can only be run when logged in as admin
+        // Ensure that this can only be run when logged in as admin
         final String remoteUser = request.getRemoteUser();
         if (remoteUser == null || !"admin".equals(remoteUser)) {
-            //admin login required
+            // admin login required
             response.setStatus(403);
             out.write("Only admin can perform this operation.");
             return;

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportEndpoint.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportEndpoint.java
@@ -34,6 +34,8 @@ import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+
 @Component(service = { Servlet.class })
 @SlingServletResourceTypes(
     resourceTypes = { "cards/SubjectsHomepage" },
@@ -44,6 +46,9 @@ public class ExportEndpoint extends SlingSafeMethodsServlet
 
     @Reference
     private ResourceResolverFactory resolverFactory;
+
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     @Override
     public void doGet(final SlingHttpServletRequest request, final SlingHttpServletResponse response) throws IOException
@@ -66,8 +71,8 @@ public class ExportEndpoint extends SlingSafeMethodsServlet
             : (dateLowerBound != null && dateUpperBound == null) ? "manualAfter" : "manualToday";
 
         final Runnable exportJob = ("manualToday".equals(exportRunMode))
-            ? new ExportTask(this.resolverFactory, exportRunMode)
-            : new ExportTask(this.resolverFactory, exportRunMode, dateLowerBound, dateUpperBound);
+            ? new ExportTask(this.resolverFactory, this.rrp, exportRunMode)
+            : new ExportTask(this.resolverFactory, this.rrp, exportRunMode, dateLowerBound, dateUpperBound);
         final Thread thread = new Thread(exportJob);
         thread.start();
         out.write("S3 export started");

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
@@ -65,10 +65,7 @@ public class ExportTask implements Runnable
 
     ExportTask(final ResourceResolverFactory resolverFactory, final String exportRunMode)
     {
-        this.resolverFactory = resolverFactory;
-        this.exportRunMode = exportRunMode;
-        this.exportLowerBound = null;
-        this.exportUpperBound = null;
+        this(resolverFactory, exportRunMode, null, null);
     }
 
     ExportTask(final ResourceResolverFactory resolverFactory, final String exportRunMode,

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
@@ -48,6 +48,7 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 public class ExportTask implements Runnable
 {
@@ -57,21 +58,26 @@ public class ExportTask implements Runnable
     /** Provides access to resources. */
     private final ResourceResolverFactory resolverFactory;
 
+    private final ThreadResourceResolverProvider rrp;
+
     private final String exportRunMode;
 
     private final LocalDate exportLowerBound;
 
     private final LocalDate exportUpperBound;
 
-    ExportTask(final ResourceResolverFactory resolverFactory, final String exportRunMode)
+    ExportTask(final ResourceResolverFactory resolverFactory, final ThreadResourceResolverProvider rrp,
+        final String exportRunMode)
     {
-        this(resolverFactory, exportRunMode, null, null);
+        this(resolverFactory, rrp, exportRunMode, null, null);
     }
 
-    ExportTask(final ResourceResolverFactory resolverFactory, final String exportRunMode,
+    ExportTask(final ResourceResolverFactory resolverFactory, final ThreadResourceResolverProvider rrp,
+        final String exportRunMode,
         final LocalDate exportLowerBound, final LocalDate exportUpperBound)
     {
         this.resolverFactory = resolverFactory;
+        this.rrp = rrp;
         this.exportRunMode = exportRunMode;
         this.exportLowerBound = exportLowerBound;
         this.exportUpperBound = exportUpperBound;
@@ -266,7 +272,10 @@ public class ExportTask implements Runnable
             + ".dataFilter:modifiedAfter=%s" + (requestDateStringUpper != null ? ".dataFilter:modifiedBefore=%s" : "")
             + ".dataFilter:statusNot=INCOMPLETE",
             path, requestDateStringLower, requestDateStringUpper);
+        boolean mustPopResolver = false;
         try (ResourceResolver resolver = this.resolverFactory.getServiceResourceResolver(null)) {
+            this.rrp.push(resolver);
+            mustPopResolver = true;
             Resource subjectData = resolver.resolve(subjectDataUrl);
             Resource identifiedSubjectData = resolver.resolve(identifiedSubjectDataUrl);
             return new SubjectContents(subjectData.adaptTo(JsonObject.class).toString(),
@@ -274,6 +283,10 @@ public class ExportTask implements Runnable
         } catch (LoginException e) {
             LOGGER.warn("Failed to get service session: {}", e.getMessage(), e);
             return null;
+        } finally {
+            if (mustPopResolver) {
+                this.rrp.pop();
+            }
         }
     }
 

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
@@ -48,7 +48,7 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 public class ExportTask implements Runnable
 {

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/NightlyExport.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/NightlyExport.java
@@ -29,6 +29,8 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+
 @Component(immediate = true)
 public class NightlyExport
 {
@@ -38,6 +40,9 @@ public class NightlyExport
     /** Provides access to resources. */
     @Reference
     private ResourceResolverFactory resolverFactory;
+
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     /** The scheduler for rescheduling jobs. */
     @Reference
@@ -52,7 +57,7 @@ public class NightlyExport
         options.name("NightlyExport");
         options.canRunConcurrently(true);
 
-        final Runnable exportJob = new ExportTask(this.resolverFactory, "nightly");
+        final Runnable exportJob = new ExportTask(this.resolverFactory, this.rrp, "nightly");
 
         try {
             this.scheduler.schedule(exportJob, options);

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/NightlyExport.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/NightlyExport.java
@@ -29,7 +29,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 @Component(immediate = true)
 public class NightlyExport

--- a/modules/clarity-integration/pom.xml
+++ b/modules/clarity-integration/pom.xml
@@ -84,7 +84,7 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>cards-utils</artifactId>
+      <artifactId>cards-resolver-provider</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportEndpoint.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportEndpoint.java
@@ -39,7 +39,7 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 
 import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 @Component(service = { Servlet.class })
 @SlingServletResourceTypes(

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
@@ -51,7 +51,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 /**
  * Query the Clarity server every so often to obtain all of the visits & patients that have appeared throughout the day.

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/NightlyClarityImport.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/NightlyClarityImport.java
@@ -38,7 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 @Component(configurationPolicy = ConfigurationPolicy.REQUIRE, immediate = true)
 @Designate(ocd = ClarityImportConfigDefinition.class)

--- a/modules/data-entry/pom.xml
+++ b/modules/data-entry/pom.xml
@@ -126,6 +126,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>cards-resolver-provider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>cards-permissions</artifactId>
       <version>${project.version}</version>
       <scope>runtime</scope>

--- a/modules/data-entry/src/main/java/io/uhndata/cards/spi/AbstractNodeUtils.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/spi/AbstractNodeUtils.java
@@ -26,7 +26,7 @@ import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.sling.api.resource.ResourceResolver;
 
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 /**
  * Some utilities for working with JCR nodes.

--- a/modules/data-entry/src/main/java/io/uhndata/cards/spi/AbstractNodeUtils.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/spi/AbstractNodeUtils.java
@@ -25,7 +25,8 @@ import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ResourceResolverFactory;
+
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Some utilities for working with JCR nodes.
@@ -175,13 +176,13 @@ public abstract class AbstractNodeUtils
      * @param rrf the resource resolver factory service, may be {@code null}
      * @return the current session, or {@code null} if a session may not be obtained
      */
-    protected Session getSession(final ResourceResolverFactory rrf)
+    protected Session getSession(final ThreadResourceResolverProvider rrp)
     {
-        if (rrf == null) {
+        if (rrp == null) {
             return null;
         }
 
-        final ResourceResolver rr = rrf.getThreadResourceResolver();
+        final ResourceResolver rr = rrp.getThreadResourceResolver();
         if (rr == null) {
             return null;
         }

--- a/modules/data-model/forms/impl/pom.xml
+++ b/modules/data-model/forms/impl/pom.xml
@@ -108,6 +108,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>cards-resolver-provider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>cards-dataentry</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/AnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/AnswersEditor.java
@@ -84,9 +84,10 @@ public abstract class AnswersEditor extends DefaultEditor
      * @param resolver the resource resolver which can provide access to JCR sessions
      * @param questionnaireUtils for working with questionnaire data
      * @param formUtils for working with form data
+     * @param serviceSession a session with access to all questionnaires. Can be null
      */
     public AnswersEditor(final NodeBuilder nodeBuilder, final ResourceResolver resolver,
-        final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils)
+        final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils, final Session serviceSession)
     {
         this.currentNodeBuilder = nodeBuilder;
         this.questionnaireUtils = questionnaireUtils;
@@ -97,6 +98,7 @@ public abstract class AnswersEditor extends DefaultEditor
         this.resolver = resolver;
         if (this.resolver != null) {
             this.currentSession = this.resolver.adaptTo(Session.class);
+            this.serviceSession = serviceSession;
             this.isFormNode = this.isFormNode(nodeBuilder);
         }
     }
@@ -147,7 +149,9 @@ public abstract class AnswersEditor extends DefaultEditor
     {
         final String questionnaireId = this.currentNodeBuilder.getProperty("questionnaire").getValue(Type.REFERENCE);
         try {
-            return this.currentSession.getNodeByIdentifier(questionnaireId);
+            return this.serviceSession == null
+                ? this.currentSession.getNodeByIdentifier(questionnaireId)
+                : this.serviceSession.getNodeByIdentifier(questionnaireId);
         } catch (RepositoryException e) {
             return null;
         }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/AnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/AnswersEditor.java
@@ -48,8 +48,6 @@ import io.uhndata.cards.forms.api.FormUtils;
 import io.uhndata.cards.forms.api.QuestionnaireUtils;
 
 /**
- *
- *
  * @version $Id$
  */
 public abstract class AnswersEditor extends DefaultEditor
@@ -249,8 +247,7 @@ public abstract class AnswersEditor extends DefaultEditor
         final Map<String, List<NodeBuilder>> childNodesByReference, final NodeBuilder nodeBuilder)
     {
         Map<QuestionTree, NodeBuilder> result = new HashMap<>();
-        for (Map.Entry<String, QuestionTree> childQuestion
-            : questionTree.getChildren().entrySet()) {
+        for (Map.Entry<String, QuestionTree> childQuestion : questionTree.getChildren().entrySet()) {
             QuestionTree childTree = childQuestion.getValue();
             try {
                 Node childQuestionNode = childTree.getNode();
@@ -306,8 +303,6 @@ public abstract class AnswersEditor extends DefaultEditor
         }
         return result;
     }
-
-
 
     protected abstract static class AbstractAnswerChangeTracker extends DefaultEditor
     {

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.jackrabbit.oak.api.Type;
@@ -60,11 +61,13 @@ public class ComputedAnswersEditor extends AnswersEditor
      * @param questionnaireUtils for working with questionnaire data
      * @param formUtils for working with form data
      * @param expressionUtils for evaluating the computed questions
+     * @param serviceSession a session with access to all questionnaires. Can be null
      */
     public ComputedAnswersEditor(final NodeBuilder nodeBuilder, final ResourceResolver resolver,
-        final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils, final ExpressionUtils expressionUtils)
+        final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils, final ExpressionUtils expressionUtils,
+        final Session serviceSession)
     {
-        super(nodeBuilder, resolver, questionnaireUtils, formUtils);
+        super(nodeBuilder, resolver, questionnaireUtils, formUtils, serviceSession);
         this.expressionUtils = expressionUtils;
     }
 
@@ -84,7 +87,7 @@ public class ComputedAnswersEditor extends AnswersEditor
     protected ComputedAnswersEditor getNewEditor(String name)
     {
         return new ComputedAnswersEditor(this.currentNodeBuilder.getChildNode(name),
-            this.resolver, this.questionnaireUtils, this.formUtils, this.expressionUtils);
+            this.resolver, this.questionnaireUtils, this.formUtils, this.expressionUtils, this.serviceSession);
     }
 
     @Override

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.jackrabbit.oak.api.Type;
@@ -33,7 +34,6 @@ import org.apache.jackrabbit.oak.spi.commit.Editor;
 import org.apache.jackrabbit.oak.spi.state.ChildNodeEntry;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
-import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,17 +57,17 @@ public class ComputedAnswersEditor extends AnswersEditor
      * Simple constructor.
      *
      * @param nodeBuilder the builder for the current node
-     * @param resolver the resource resolver which can provide access to JCR sessions
+     * @param currentSession the current user session
+     * @param rrf the resource resolver factory which can provide access to JCR sessions
      * @param questionnaireUtils for working with questionnaire data
      * @param formUtils for working with form data
      * @param expressionUtils for evaluating the computed questions
-     * @param rrf a resource resolver factory used to obtain access to service sessions. Can be null
      */
-    public ComputedAnswersEditor(final NodeBuilder nodeBuilder, final ResourceResolver resolver,
-        final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils, final ExpressionUtils expressionUtils,
-        final ResourceResolverFactory rrf)
+    public ComputedAnswersEditor(final NodeBuilder nodeBuilder, final Session currentSession,
+        final ResourceResolverFactory rrf, final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils,
+        final ExpressionUtils expressionUtils)
     {
-        super(nodeBuilder, resolver, questionnaireUtils, formUtils, rrf);
+        super(nodeBuilder, currentSession, rrf, questionnaireUtils, formUtils);
         this.expressionUtils = expressionUtils;
     }
 
@@ -93,7 +93,7 @@ public class ComputedAnswersEditor extends AnswersEditor
     protected ComputedAnswersEditor getNewEditor(String name)
     {
         return new ComputedAnswersEditor(this.currentNodeBuilder.getChildNode(name),
-            this.resolver, this.questionnaireUtils, this.formUtils, this.expressionUtils, this.rrf);
+            this.currentSession, this.rrf, this.questionnaireUtils, this.formUtils, this.expressionUtils);
     }
 
     @Override

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
@@ -33,7 +33,7 @@ import org.apache.jackrabbit.oak.spi.commit.Editor;
 import org.apache.jackrabbit.oak.spi.state.ChildNodeEntry;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
-import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,15 +56,15 @@ public class ComputedAnswersEditor extends AnswersEditor
      * Simple constructor.
      *
      * @param nodeBuilder the builder for the current node
-     * @param rrf the resource resolver factory which can provide access to JCR sessions
+     * @param resolver the resource resolver which can provide access to JCR sessions
      * @param questionnaireUtils for working with questionnaire data
      * @param formUtils for working with form data
      * @param expressionUtils for evaluating the computed questions
      */
-    public ComputedAnswersEditor(final NodeBuilder nodeBuilder, final ResourceResolverFactory rrf,
+    public ComputedAnswersEditor(final NodeBuilder nodeBuilder, final ResourceResolver resolver,
         final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils, final ExpressionUtils expressionUtils)
     {
-        super(nodeBuilder, rrf, questionnaireUtils, formUtils, "computedAnswers");
+        super(nodeBuilder, resolver, questionnaireUtils, formUtils);
         this.expressionUtils = expressionUtils;
     }
 
@@ -84,7 +84,7 @@ public class ComputedAnswersEditor extends AnswersEditor
     protected ComputedAnswersEditor getNewEditor(String name)
     {
         return new ComputedAnswersEditor(this.currentNodeBuilder.getChildNode(name),
-            this.rrf, this.questionnaireUtils, this.formUtils, this.expressionUtils);
+            this.resolver, this.questionnaireUtils, this.formUtils, this.expressionUtils);
     }
 
     @Override
@@ -217,12 +217,12 @@ public class ComputedAnswersEditor extends AnswersEditor
     {
         final Map<String, Object> currentAnswers = new HashMap<>();
         if (currentNode.exists()) {
-            if (this.formUtils.isAnswerSection(currentNode) || this.formUtils.isForm(currentNode)) {
+            if (this.isAnswerSection(currentNode) || this.formUtils.isForm(currentNode)) {
                 // Found a section: Recursively get all of this section's answers
                 for (ChildNodeEntry childNode : currentNode.getChildNodeEntries()) {
                     currentAnswers.putAll(getNodeAnswers(childNode.getNodeState()));
                 }
-            } else if (this.formUtils.isAnswer(currentNode)) {
+            } else if (this.isAnswer(currentNode)) {
                 String questionName = this.questionnaireUtils.getQuestionName(this.formUtils.getQuestion(currentNode));
                 Object value = this.formUtils.getValue(currentNode);
                 if (questionName != null && value != null && !currentAnswers.containsKey(questionName)) {

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditorProvider.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditorProvider.java
@@ -16,6 +16,8 @@
  */
 package io.uhndata.cards.forms.internal;
 
+import javax.jcr.Session;
+
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.commit.Editor;
@@ -68,8 +70,10 @@ public class ComputedAnswersEditorProvider implements EditorProvider
         final ResourceResolver resolver = this.rrp.getThreadResourceResolver();
         if (resolver != null && !("true".equals(computedAnswersDisabled))) {
             // Each ComputedEditor maintains a state, so a new instance must be returned each time
-            return new ComputedAnswersEditor(builder, resolver, this.questionnaireUtils, this.formUtils,
-                this.expressionUtils, this.rrf);
+            return new ComputedAnswersEditor(builder, resolver.adaptTo(Session.class), this.rrf,
+                this.questionnaireUtils,
+                this.formUtils,
+                this.expressionUtils);
         }
         return null;
     }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditorProvider.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditorProvider.java
@@ -16,17 +16,12 @@
  */
 package io.uhndata.cards.forms.internal;
 
-import java.util.Collections;
-
-import javax.jcr.Session;
-
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.commit.Editor;
 import org.apache.jackrabbit.oak.spi.commit.EditorProvider;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
-import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
@@ -70,23 +65,11 @@ public class ComputedAnswersEditorProvider implements EditorProvider
     {
         String computedAnswersDisabled = System.getenv("COMPUTED_ANSWERS_DISABLED");
 
-        Session serviceSession = null;
-        if (this.rrf != null)
-        {
-            try {
-                ResourceResolver serviceResolver = this.rrf.getServiceResourceResolver(
-                    Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "computedAnswers"));
-                serviceSession = serviceResolver.adaptTo(Session.class);
-            } catch (LoginException e) {
-                // Do nothing, just leave null
-            }
-        }
-
         final ResourceResolver resolver = this.rrp.getThreadResourceResolver();
         if (resolver != null && !("true".equals(computedAnswersDisabled))) {
             // Each ComputedEditor maintains a state, so a new instance must be returned each time
             return new ComputedAnswersEditor(builder, resolver, this.questionnaireUtils, this.formUtils,
-                this.expressionUtils, serviceSession);
+                this.expressionUtils, this.rrf);
         }
         return null;
     }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditorProvider.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditorProvider.java
@@ -35,7 +35,7 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 import io.uhndata.cards.forms.api.ExpressionUtils;
 import io.uhndata.cards.forms.api.FormUtils;
 import io.uhndata.cards.forms.api.QuestionnaireUtils;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 /**
  * A {@link EditorProvider} returning {@link ComputedAnswersEditor}.

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormRelatedSubjectsEditorProvider.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormRelatedSubjectsEditorProvider.java
@@ -29,7 +29,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 /**
  * A {@link EditorProvider} returning {@link FormRelatedSubjectsEditor}.

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormUtilsImpl.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormUtilsImpl.java
@@ -51,9 +51,9 @@ import org.osgi.service.component.annotations.Reference;
 
 import io.uhndata.cards.forms.api.FormUtils;
 import io.uhndata.cards.forms.api.QuestionnaireUtils;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 import io.uhndata.cards.spi.AbstractNodeUtils;
 import io.uhndata.cards.subjects.api.SubjectUtils;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Basic utilities for working with Form data.

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormUtilsImpl.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormUtilsImpl.java
@@ -46,17 +46,14 @@ import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import io.uhndata.cards.forms.api.FormUtils;
 import io.uhndata.cards.forms.api.QuestionnaireUtils;
 import io.uhndata.cards.spi.AbstractNodeUtils;
 import io.uhndata.cards.subjects.api.SubjectUtils;
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Basic utilities for working with Form data.
@@ -66,9 +63,8 @@ import io.uhndata.cards.subjects.api.SubjectUtils;
 @Component
 public final class FormUtilsImpl extends AbstractNodeUtils implements FormUtils
 {
-    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
-        policyOption = ReferencePolicyOption.GREEDY)
-    private ResourceResolverFactory rrf;
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     @Reference
     private QuestionnaireUtils questionnaires;
@@ -93,7 +89,7 @@ public final class FormUtilsImpl extends AbstractNodeUtils implements FormUtils
     @Override
     public boolean isForm(final NodeState node)
     {
-        return isNodeType(node, FORM_NODETYPE, getSession(this.rrf));
+        return isNodeType(node, FORM_NODETYPE, getSession(this.rrp));
     }
 
     @Override
@@ -202,7 +198,7 @@ public final class FormUtilsImpl extends AbstractNodeUtils implements FormUtils
     @Override
     public boolean isAnswerSection(final NodeState node)
     {
-        return isNodeType(node, ANSWER_SECTION_NODETYPE, getSession(this.rrf));
+        return isNodeType(node, ANSWER_SECTION_NODETYPE, getSession(this.rrp));
     }
 
     @Override
@@ -264,7 +260,7 @@ public final class FormUtilsImpl extends AbstractNodeUtils implements FormUtils
     @Override
     public boolean isAnswer(final NodeState node)
     {
-        return isNodeType(node, ANSWER_NODETYPE, getSession(this.rrf));
+        return isNodeType(node, ANSWER_NODETYPE, getSession(this.rrp));
     }
 
     @Override

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/QuestionnaireUtilsImpl.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/QuestionnaireUtilsImpl.java
@@ -20,27 +20,23 @@ import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import io.uhndata.cards.forms.api.QuestionnaireUtils;
 import io.uhndata.cards.spi.AbstractNodeUtils;
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 @Component
 public final class QuestionnaireUtilsImpl extends AbstractNodeUtils implements QuestionnaireUtils
 {
-    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
-        policyOption = ReferencePolicyOption.GREEDY)
-    private ResourceResolverFactory rrf;
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     @Override
     public Node getQuestionnaire(final String identifier)
     {
-        final Node result = getNodeByIdentifier(identifier, getSession(this.rrf));
+        final Node result = getNodeByIdentifier(identifier, getSession(this.rrp));
         return isQuestionnaire(result) ? result : null;
     }
 
@@ -81,7 +77,7 @@ public final class QuestionnaireUtilsImpl extends AbstractNodeUtils implements Q
     @Override
     public Node getSection(final String identifier)
     {
-        final Node result = getNodeByIdentifier(identifier, getSession(this.rrf));
+        final Node result = getNodeByIdentifier(identifier, getSession(this.rrp));
         return isSection(result) ? result : null;
     }
 
@@ -140,7 +136,7 @@ public final class QuestionnaireUtilsImpl extends AbstractNodeUtils implements Q
     @Override
     public Node getQuestion(final String identifier)
     {
-        final Node result = getNodeByIdentifier(identifier, getSession(this.rrf));
+        final Node result = getNodeByIdentifier(identifier, getSession(this.rrp));
         return isQuestion(result) ? result : null;
     }
 

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/QuestionnaireUtilsImpl.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/QuestionnaireUtilsImpl.java
@@ -24,8 +24,8 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 import io.uhndata.cards.forms.api.QuestionnaireUtils;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 import io.uhndata.cards.spi.AbstractNodeUtils;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 @Component
 public final class QuestionnaireUtilsImpl extends AbstractNodeUtils implements QuestionnaireUtils

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
@@ -34,6 +34,7 @@ import org.apache.jackrabbit.oak.spi.commit.Editor;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,13 +61,13 @@ public class ReferenceAnswersEditor extends AnswersEditor
      * @param questionnaireUtils for working with questionnaire data
      * @param formUtils for working with form data
      * @param subjectUtils for working with subject data
-     * @param serviceSession a session with access to all questionnaires. Can be null
+     * @param rrf a resource resolver factory used to obtain access to service sessions. Can be null
      */
     public ReferenceAnswersEditor(final NodeBuilder nodeBuilder, final ResourceResolver resolver,
         final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils, SubjectUtils subjectUtils,
-        Session serviceSession)
+        ResourceResolverFactory rrf)
     {
-        super(nodeBuilder, resolver, questionnaireUtils, formUtils, serviceSession);
+        super(nodeBuilder, resolver, questionnaireUtils, formUtils, rrf);
         this.subjectUtils = subjectUtils;
     }
 
@@ -74,6 +75,12 @@ public class ReferenceAnswersEditor extends AnswersEditor
     protected Logger getLogger()
     {
         return LOGGER;
+    }
+
+    @Override
+    protected String getServiceName()
+    {
+        return "referenceAnswers";
     }
 
     @Override
@@ -86,7 +93,7 @@ public class ReferenceAnswersEditor extends AnswersEditor
     protected ReferenceAnswersEditor getNewEditor(String name)
     {
         return new ReferenceAnswersEditor(this.currentNodeBuilder.getChildNode(name),
-            this.resolver, this.questionnaireUtils, this.formUtils, this.subjectUtils, this.serviceSession);
+            this.resolver, this.questionnaireUtils, this.formUtils, this.subjectUtils, this.rrf);
     }
 
     @Override
@@ -167,11 +174,11 @@ public class ReferenceAnswersEditor extends AnswersEditor
 
     private Object getAnswer(NodeState form, String questionPath)
     {
-        Node subject = this.getSubject(form);
+        Node subject = this.formUtils.getSubject(form);
         try {
             Collection<Node> answers =
-                this.formUtils.findAllSubjectRelatedAnswers(subject, this.currentSession.getNode(questionPath),
-                    EnumSet.allOf(FormUtils.SearchType.class));
+                this.formUtils.findAllSubjectRelatedAnswers(subject, this.resolver.adaptTo(Session.class)
+                    .getNode(questionPath), EnumSet.allOf(FormUtils.SearchType.class));
             if (!answers.isEmpty()) {
                 Object value = this.formUtils.getValue(answers.iterator().next());
                 if (value != null) {
@@ -232,32 +239,6 @@ public class ReferenceAnswersEditor extends AnswersEditor
         ReferenceAnswerNodeTypes(final Node questionNode) throws RepositoryException
         {
             super(questionNode, "cards:ReferenceAnswer", "cards/ReferenceAnswer");
-        }
-    }
-
-    // Ideally, formUtils would be used for getSubject.
-    // However, formUtils uses a ResourceResolverFactory not a ThreadResourceResolverProvider
-    // so is not reliable in this use case
-    private Node getSubject(final NodeState form)
-    {
-        String identifier = form.getProperty(FormUtils.SUBJECT_PROPERTY).getValue(Type.STRING);
-        try {
-            final Node result = this.currentSession.getNodeByIdentifier(identifier);
-            return this.isNodeType(result, SubjectUtils.SUBJECT_NODETYPE) ? result : null;
-        } catch (RepositoryException e) {
-            // SHould not happen
-            return null;
-        }
-    }
-    protected boolean isNodeType(final Node node, final String targetNodeType)
-    {
-        if (node == null) {
-            return false;
-        }
-        try {
-            return node.isNodeType(targetNodeType);
-        } catch (final RepositoryException e) {
-            return false;
         }
     }
 }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
@@ -59,11 +60,13 @@ public class ReferenceAnswersEditor extends AnswersEditor
      * @param questionnaireUtils for working with questionnaire data
      * @param formUtils for working with form data
      * @param subjectUtils for working with subject data
+     * @param serviceSession a session with access to all questionnaires. Can be null
      */
     public ReferenceAnswersEditor(final NodeBuilder nodeBuilder, final ResourceResolver resolver,
-        final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils, SubjectUtils subjectUtils)
+        final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils, SubjectUtils subjectUtils,
+        Session serviceSession)
     {
-        super(nodeBuilder, resolver, questionnaireUtils, formUtils);
+        super(nodeBuilder, resolver, questionnaireUtils, formUtils, serviceSession);
         this.subjectUtils = subjectUtils;
     }
 
@@ -83,7 +86,7 @@ public class ReferenceAnswersEditor extends AnswersEditor
     protected ReferenceAnswersEditor getNewEditor(String name)
     {
         return new ReferenceAnswersEditor(this.currentNodeBuilder.getChildNode(name),
-            this.resolver, this.questionnaireUtils, this.formUtils, this.subjectUtils);
+            this.resolver, this.questionnaireUtils, this.formUtils, this.subjectUtils, this.serviceSession);
     }
 
     @Override

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
@@ -33,7 +33,6 @@ import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.spi.commit.Editor;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
-import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,17 +56,17 @@ public class ReferenceAnswersEditor extends AnswersEditor
      * Simple constructor.
      *
      * @param nodeBuilder the builder for the current node
-     * @param resolver the resource resolver factory which can provide access to JCR sessions
+     * @param currentSession the current user session
+     * @param rrf the resource resolver factory which can provide access to JCR sessions
      * @param questionnaireUtils for working with questionnaire data
      * @param formUtils for working with form data
      * @param subjectUtils for working with subject data
-     * @param rrf a resource resolver factory used to obtain access to service sessions. Can be null
      */
-    public ReferenceAnswersEditor(final NodeBuilder nodeBuilder, final ResourceResolver resolver,
-        final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils, SubjectUtils subjectUtils,
-        ResourceResolverFactory rrf)
+    public ReferenceAnswersEditor(final NodeBuilder nodeBuilder, final Session currentSession,
+        final ResourceResolverFactory rrf, final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils,
+        final SubjectUtils subjectUtils)
     {
-        super(nodeBuilder, resolver, questionnaireUtils, formUtils, rrf);
+        super(nodeBuilder, currentSession, rrf, questionnaireUtils, formUtils);
         this.subjectUtils = subjectUtils;
     }
 
@@ -92,8 +91,8 @@ public class ReferenceAnswersEditor extends AnswersEditor
     @Override
     protected ReferenceAnswersEditor getNewEditor(String name)
     {
-        return new ReferenceAnswersEditor(this.currentNodeBuilder.getChildNode(name),
-            this.resolver, this.questionnaireUtils, this.formUtils, this.subjectUtils, this.rrf);
+        return new ReferenceAnswersEditor(this.currentNodeBuilder.getChildNode(name), this.currentSession,
+            this.rrf, this.questionnaireUtils, this.formUtils, this.subjectUtils);
     }
 
     @Override
@@ -177,8 +176,8 @@ public class ReferenceAnswersEditor extends AnswersEditor
         Node subject = this.formUtils.getSubject(form);
         try {
             Collection<Node> answers =
-                this.formUtils.findAllSubjectRelatedAnswers(subject, this.resolver.adaptTo(Session.class)
-                    .getNode(questionPath), EnumSet.allOf(FormUtils.SearchType.class));
+                this.formUtils.findAllSubjectRelatedAnswers(subject, this.serviceSession.getNode(questionPath),
+                    EnumSet.allOf(FormUtils.SearchType.class));
             if (!answers.isEmpty()) {
                 Object value = this.formUtils.getValue(answers.iterator().next());
                 if (value != null) {

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditorProvider.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditorProvider.java
@@ -16,6 +16,8 @@
  */
 package io.uhndata.cards.forms.internal;
 
+import javax.jcr.Session;
+
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.commit.Editor;
@@ -66,8 +68,8 @@ public class ReferenceAnswersEditorProvider implements EditorProvider
         final ResourceResolver resolver = this.rrp.getThreadResourceResolver();
         if (resolver != null) {
             // Each ReferenceEditor maintains a state, so a new instance must be returned each time
-            return new ReferenceAnswersEditor(builder, resolver, this.questionnaireUtils, this.formUtils,
-                this.subjectUtils, null);
+            return new ReferenceAnswersEditor(builder, resolver.adaptTo(Session.class), this.rrf,
+                this.questionnaireUtils, this.formUtils, this.subjectUtils);
         }
         return null;
     }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditorProvider.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditorProvider.java
@@ -34,8 +34,8 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import io.uhndata.cards.forms.api.FormUtils;
 import io.uhndata.cards.forms.api.QuestionnaireUtils;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 import io.uhndata.cards.subjects.api.SubjectUtils;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * A {@link EditorProvider} returning {@link ReferenceAnswersEditor}.

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditorProvider.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditorProvider.java
@@ -59,7 +59,7 @@ public class ReferenceAnswersEditorProvider implements EditorProvider
         if (resolver != null) {
             // Each ReferenceEditor maintains a state, so a new instance must be returned each time
             return new ReferenceAnswersEditor(builder, resolver, this.questionnaireUtils, this.formUtils,
-                this.subjectUtils);
+                this.subjectUtils, null);
         }
         return null;
     }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditorProvider.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditorProvider.java
@@ -23,8 +23,12 @@ import org.apache.jackrabbit.oak.spi.commit.EditorProvider;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import io.uhndata.cards.forms.api.FormUtils;
 import io.uhndata.cards.forms.api.QuestionnaireUtils;
@@ -39,6 +43,10 @@ import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 @Component(service = EditorProvider.class, immediate = true)
 public class ReferenceAnswersEditorProvider implements EditorProvider
 {
+    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
+        policyOption = ReferencePolicyOption.GREEDY)
+    private ResourceResolverFactory rrf;
+
     @Reference
     private ThreadResourceResolverProvider rrp;
 

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/labels/ResourceLabelProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/labels/ResourceLabelProcessor.java
@@ -31,11 +31,11 @@ import javax.json.JsonObjectBuilder;
 import javax.json.JsonValue;
 
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 import io.uhndata.cards.serialize.spi.ResourceJsonProcessor;
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Fills in the human-readable question answer for resource questions with the value of the resource node property
@@ -48,7 +48,7 @@ public class ResourceLabelProcessor extends AbstractResourceLabelProcessor imple
 {
     /** Provides access to resources. */
     @Reference
-    private ResourceResolverFactory resolverFactory;
+    private ThreadResourceResolverProvider rrp;
 
     @Override
     public int getPriority()
@@ -74,7 +74,7 @@ public class ResourceLabelProcessor extends AbstractResourceLabelProcessor imple
         try {
             // Find the property of the resource that should be used as the label
             String labelPropertyName = getLabelPropertyName(question);
-            ResourceResolver resolver = this.resolverFactory.getThreadResourceResolver();
+            ResourceResolver resolver = this.rrp.getThreadResourceResolver();
             if (resolver == null) {
                 return null;
             }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/labels/ResourceLabelProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/labels/ResourceLabelProcessor.java
@@ -34,8 +34,8 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 import io.uhndata.cards.serialize.spi.ResourceJsonProcessor;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Fills in the human-readable question answer for resource questions with the value of the resource node property

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/labels/ResourceOptionsLabelProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/labels/ResourceOptionsLabelProcessor.java
@@ -33,11 +33,11 @@ import javax.json.JsonValue;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 import io.uhndata.cards.serialize.spi.ResourceJsonProcessor;
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Adds a label to Answer Option nodes for resource questions in a questionnaire's JSON.
@@ -49,7 +49,7 @@ public class ResourceOptionsLabelProcessor extends AbstractResourceLabelProcesso
 {
     /** Provides access to resources. */
     @Reference
-    private ResourceResolverFactory resolverFactory;
+    private ThreadResourceResolverProvider rrp;
 
     @Override
     public boolean canProcess(Resource resource)
@@ -99,7 +99,7 @@ public class ResourceOptionsLabelProcessor extends AbstractResourceLabelProcesso
                 valueLabelMap.put(valueProp.getString(), valueProp.getString());
             }
 
-            ResourceResolver resolver = this.resolverFactory.getThreadResourceResolver();
+            ResourceResolver resolver = this.rrp.getThreadResourceResolver();
             if (resolver != null) {
                 // Populate the labels in the map
                 for (String value : new LinkedHashSet<>(valueLabelMap.keySet())) {

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/labels/ResourceOptionsLabelProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/labels/ResourceOptionsLabelProcessor.java
@@ -36,8 +36,8 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 import io.uhndata.cards.serialize.spi.ResourceJsonProcessor;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Adds a label to Answer Option nodes for resource questions in a questionnaire's JSON.

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/labels/ResourceOptionsLabelProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/labels/ResourceOptionsLabelProcessor.java
@@ -80,8 +80,8 @@ public class ResourceOptionsLabelProcessor extends AbstractResourceLabelProcesso
      * Basic method to get the answer label associated with the resource answer option.
      *
      * @param node the AnswerOption node being serialized
-     * @return the label for that AmswerOption, obtained from the label property (indicated by the parent question)
-     *     of resource it refers to
+     * @return the label for that AmswerOption, obtained from the label property (indicated by the parent question) of
+     *         resource it refers to
      */
     private JsonValue getAnswerOptionLabel(final Node node, final String labelPropertyName)
     {

--- a/modules/data-model/subjects/impl/pom.xml
+++ b/modules/data-model/subjects/impl/pom.xml
@@ -94,6 +94,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>cards-resolver-provider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>cards-dataentry</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectTypeUtilsImpl.java
+++ b/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectTypeUtilsImpl.java
@@ -21,15 +21,12 @@ import javax.jcr.RepositoryException;
 
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import io.uhndata.cards.spi.AbstractNodeUtils;
 import io.uhndata.cards.subjects.api.SubjectTypeUtils;
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Basic utilities for working with SubjectType data.
@@ -39,16 +36,15 @@ import io.uhndata.cards.subjects.api.SubjectTypeUtils;
 @Component
 public final class SubjectTypeUtilsImpl extends AbstractNodeUtils implements SubjectTypeUtils
 {
-    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
-        policyOption = ReferencePolicyOption.GREEDY)
-    private ResourceResolverFactory rrf;
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     // Subject methods
 
     @Override
     public Node getSubjectType(final String identifier)
     {
-        final Node result = getNodeByIdentifier(identifier, getSession(this.rrf));
+        final Node result = getNodeByIdentifier(identifier, getSession(this.rrp));
         return isSubjectType(result) ? result : null;
     }
 
@@ -67,7 +63,7 @@ public final class SubjectTypeUtilsImpl extends AbstractNodeUtils implements Sub
     @Override
     public boolean isSubjectType(final NodeState node)
     {
-        return isNodeType(node, SUBJECT_TYPE_NODETYPE, getSession(this.rrf));
+        return isNodeType(node, SUBJECT_TYPE_NODETYPE, getSession(this.rrp));
     }
 
     @Override

--- a/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectTypeUtilsImpl.java
+++ b/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectTypeUtilsImpl.java
@@ -24,9 +24,9 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 import io.uhndata.cards.spi.AbstractNodeUtils;
 import io.uhndata.cards.subjects.api.SubjectTypeUtils;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Basic utilities for working with SubjectType data.

--- a/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectUtilsImpl.java
+++ b/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectUtilsImpl.java
@@ -24,9 +24,9 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 import io.uhndata.cards.spi.AbstractNodeUtils;
 import io.uhndata.cards.subjects.api.SubjectUtils;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Basic utilities for working with Subject data.

--- a/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectUtilsImpl.java
+++ b/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectUtilsImpl.java
@@ -21,15 +21,12 @@ import javax.jcr.RepositoryException;
 
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import io.uhndata.cards.spi.AbstractNodeUtils;
 import io.uhndata.cards.subjects.api.SubjectUtils;
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Basic utilities for working with Subject data.
@@ -39,16 +36,15 @@ import io.uhndata.cards.subjects.api.SubjectUtils;
 @Component
 public final class SubjectUtilsImpl extends AbstractNodeUtils implements SubjectUtils
 {
-    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
-        policyOption = ReferencePolicyOption.GREEDY)
-    private ResourceResolverFactory rrf;
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     // Subject methods
 
     @Override
     public Node getSubject(final String identifier)
     {
-        final Node result = getNodeByIdentifier(identifier, getSession(this.rrf));
+        final Node result = getNodeByIdentifier(identifier, getSession(this.rrp));
         return isSubject(result) ? result : null;
     }
 
@@ -67,7 +63,7 @@ public final class SubjectUtilsImpl extends AbstractNodeUtils implements Subject
     @Override
     public boolean isSubject(final NodeState node)
     {
-        return isNodeType(node, SUBJECT_NODETYPE, getSession(this.rrf));
+        return isNodeType(node, SUBJECT_NODETYPE, getSession(this.rrp));
     }
 
     @Override

--- a/modules/form-completion-status/pom.xml
+++ b/modules/form-completion-status/pom.xml
@@ -67,6 +67,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cards-resolver-provider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/modules/form-completion-status/src/main/java/io/uhndata/cards/formcompletionstatus/AnswerCompletionStatusEditorProvider.java
+++ b/modules/form-completion-status/src/main/java/io/uhndata/cards/formcompletionstatus/AnswerCompletionStatusEditorProvider.java
@@ -36,7 +36,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 
 import io.uhndata.cards.formcompletionstatus.spi.AnswerValidator;
 import io.uhndata.cards.forms.api.FormUtils;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 /**
  * A {@link EditorProvider} returning {@link AnswerCompletionStatusEditor}.

--- a/modules/patient-portal/pom.xml
+++ b/modules/patient-portal/pom.xml
@@ -129,6 +129,11 @@
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cards-resolver-provider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>io.uhndata.cards</groupId>
       <artifactId>cards-dataentry</artifactId>
       <version>${project.version}</version>

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
@@ -104,8 +104,10 @@ abstract class AbstractEmailNotification
         final Map<String, Object> parameters =
             Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "EmailNotifications");
         long emailsSent = 0;
+        boolean mustPopResolver = false;
         try (ResourceResolver resolver = this.resolverFactory.getServiceResourceResolver(parameters)) {
             this.resolverProvider.push(resolver);
+            mustPopResolver = true;
             final Session session = resolver.adaptTo(Session.class);
             NodeIterator appointmentResults = AppointmentUtils.getAppointmentsForDay(session,
                 dateToQuery, clinicId);
@@ -145,7 +147,9 @@ abstract class AbstractEmailNotification
         } catch (LoginException | RepositoryException e) {
             LOGGER.warn("Failed to results.next().getPath()");
         } finally {
-            this.resolverProvider.pop();
+            if (mustPopResolver) {
+                this.resolverProvider.pop();
+            }
         }
         return emailsSent;
     }

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
@@ -45,7 +45,7 @@ import io.uhndata.cards.emailnotifications.EmailTemplate;
 import io.uhndata.cards.emailnotifications.EmailUtils;
 import io.uhndata.cards.forms.api.FormUtils;
 import io.uhndata.cards.patients.api.PatientAccessConfiguration;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 import jakarta.mail.MessagingException;
 
 abstract class AbstractEmailNotification

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentEmailNotificationsFactory.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentEmailNotificationsFactory.java
@@ -36,7 +36,7 @@ import io.uhndata.cards.auth.token.TokenManager;
 import io.uhndata.cards.forms.api.FormUtils;
 import io.uhndata.cards.metrics.Metrics;
 import io.uhndata.cards.patients.api.PatientAccessConfiguration;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 @Designate(ocd = AppointmentEmailNotificationsFactory.Config.class, factory = true)
 @Component(configurationPolicy = ConfigurationPolicy.REQUIRE)

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/GeneralNotificationsTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/GeneralNotificationsTask.java
@@ -38,7 +38,7 @@ import io.uhndata.cards.emailnotifications.EmailTemplate;
 import io.uhndata.cards.forms.api.FormUtils;
 import io.uhndata.cards.metrics.Metrics;
 import io.uhndata.cards.patients.api.PatientAccessConfiguration;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 public class GeneralNotificationsTask extends AbstractEmailNotification implements Runnable
 {

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/PatientAccessConfigurationImpl.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/PatientAccessConfigurationImpl.java
@@ -31,8 +31,8 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import io.uhndata.cards.patients.api.PatientAccessConfiguration;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 import io.uhndata.cards.spi.AbstractNodeUtils;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Basic utilities for grabbing patient authentication config details.

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
@@ -45,9 +45,9 @@ import org.slf4j.LoggerFactory;
 
 import io.uhndata.cards.forms.api.FormUtils;
 import io.uhndata.cards.forms.api.QuestionnaireUtils;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 import io.uhndata.cards.subjects.api.SubjectTypeUtils;
 import io.uhndata.cards.subjects.api.SubjectUtils;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Change listener looking for new or modified forms related to a Visit subject. Initially, when a new Visit Information

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
@@ -117,6 +117,7 @@ public class VisitChangeListener implements ResourceChangeListener
     private void handleEvent(final ResourceChange event)
     {
         // Acquire a service session with the right privileges for accessing visits and their forms
+        boolean mustPopResolver = false;
         try (ResourceResolver localResolver = this.resolverFactory
             .getServiceResourceResolver(Map.of(ResourceResolverFactory.SUBSERVICE, "VisitFormsPreparation"))) {
             // Get the information needed from the triggering form
@@ -130,6 +131,7 @@ public class VisitChangeListener implements ResourceChangeListener
                 return;
             }
             this.rrp.push(localResolver);
+            mustPopResolver = true;
             final Node questionnaire = this.formUtils.getQuestionnaire(form);
             final Node subject = this.formUtils.getSubject(form);
 
@@ -144,11 +146,14 @@ public class VisitChangeListener implements ResourceChangeListener
                     handleVisitDataForm(subject, session);
                 }
             }
-            this.rrp.pop();
         } catch (final LoginException e) {
             LOGGER.warn("Failed to get service session: {}", e.getMessage(), e);
         } catch (final RepositoryException e) {
             LOGGER.error(e.getMessage(), e);
+        } finally {
+            if (mustPopResolver) {
+                this.rrp.pop();
+            }
         }
     }
 

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
@@ -432,8 +432,8 @@ public class VisitChangeListener implements ResourceChangeListener
     }
 
     /**
-     * Remove any questionnaires from the questionnaire set which are in the provided list of questionnaires
-     * if they are within the questionnaire set's frequency range.
+     * Remove any questionnaires from the questionnaire set which are in the provided list of questionnaires if they are
+     * within the questionnaire set's frequency range.
      *
      * @param visitInformation the set of data about the visit that triggered this event
      * @param visitDate the data of the visit being checked
@@ -727,11 +727,16 @@ public class VisitChangeListener implements ResourceChangeListener
     {
         // Conflict with any questionnaire
         private static final String CONFLICT_ANY = "any";
+
         // Only conflict with questionnaires included in the map of conflicts
         private static final String CONFLICT_ANY_LISTED = "anyListed";
+
         private final Map<String, Integer> conflicts;
+
         private final Map<String, QuestionnaireRef> members;
+
         private boolean ignoreClinic;
+
         private String conflictMode;
 
         QuestionnaireSetInfo()
@@ -757,7 +762,7 @@ public class VisitChangeListener implements ResourceChangeListener
                 int frequencyPeriod = 0;
                 if (CONFLICT_ANY.equals(this.conflictMode)) {
                     frequencyPeriod = this.members.values().stream()
-                        .map(ref -> ref.getFrequency())
+                        .map(QuestionnaireRef::getFrequency)
                         .max(Integer::compare).get();
                 } else if (this.conflicts.containsKey(questionnaireIdentifier)) {
                     frequencyPeriod = this.conflicts.get(questionnaireIdentifier);

--- a/modules/permissions-ownership/pom.xml
+++ b/modules/permissions-ownership/pom.xml
@@ -47,6 +47,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cards-resolver-provider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>javax.jcr</groupId>
       <artifactId>jcr</artifactId>
     </dependency>

--- a/modules/permissions-ownership/src/main/java/io/uhndata/cards/permissions/internal/ownership/OwnerRestrictionFactory.java
+++ b/modules/permissions-ownership/src/main/java/io/uhndata/cards/permissions/internal/ownership/OwnerRestrictionFactory.java
@@ -23,14 +23,11 @@ import javax.jcr.Session;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionPattern;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import io.uhndata.cards.permissions.spi.RestrictionFactory;
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Factory for {@link OwnerRestrictionPattern}.
@@ -44,25 +41,18 @@ public class OwnerRestrictionFactory implements RestrictionFactory
     public static final String NAME = "cards:owner";
 
     /**
-     * This is needed to get access to the current session, which knows the currently logged in user. The reference
-     * configuration is set to lazily resolve the service, since the RRF is only available after the repository is
-     * initialized, but the repository initialization scripts reference the owner restriction, which would lead to a
-     * circular dependency. By allowing the RRF to be null when this class is instantiated, the repoinit statements can
-     * be processed correctly, and the RRF is only needed when actually evaluating permissions, which only happens when
-     * the repository is ready.
+     * This is needed to get access to the current session, which knows the currently logged in user.
      */
-    @Reference(fieldOption = FieldOption.REPLACE,
-        cardinality = ReferenceCardinality.OPTIONAL,
-        policyOption = ReferencePolicyOption.GREEDY)
-    private ResourceResolverFactory rrf;
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     @Override
     public RestrictionPattern forValue(PropertyState value)
     {
         // The value is ignored, the owner is set in the Form node itself
         Session session = null;
-        if (this.rrf != null && this.rrf.getThreadResourceResolver() != null) {
-            session = this.rrf.getThreadResourceResolver().adaptTo(Session.class);
+        if (this.rrp.getThreadResourceResolver() != null) {
+            session = this.rrp.getThreadResourceResolver().adaptTo(Session.class);
         }
         return new OwnerRestrictionPattern(session);
     }

--- a/modules/permissions-ownership/src/main/java/io/uhndata/cards/permissions/internal/ownership/OwnerRestrictionFactory.java
+++ b/modules/permissions-ownership/src/main/java/io/uhndata/cards/permissions/internal/ownership/OwnerRestrictionFactory.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 import io.uhndata.cards.permissions.spi.RestrictionFactory;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 /**
  * Factory for {@link OwnerRestrictionPattern}.

--- a/modules/permissions/pom.xml
+++ b/modules/permissions/pom.xml
@@ -41,6 +41,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cards-utils</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>javax.jcr</groupId>
       <artifactId>jcr</artifactId>
     </dependency>

--- a/modules/permissions/pom.xml
+++ b/modules/permissions/pom.xml
@@ -42,7 +42,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>cards-utils</artifactId>
+      <artifactId>cards-resolver-provider</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/CreatedByRestrictionFactory.java
+++ b/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/CreatedByRestrictionFactory.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 import io.uhndata.cards.permissions.spi.RestrictionFactory;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 /**
  * Factory for {@link CreatedByRestrictionPattern}.

--- a/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/CreatedByRestrictionFactory.java
+++ b/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/CreatedByRestrictionFactory.java
@@ -23,14 +23,11 @@ import javax.jcr.Session;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionPattern;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import io.uhndata.cards.permissions.spi.RestrictionFactory;
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Factory for {@link CreatedByRestrictionPattern}.
@@ -46,17 +43,15 @@ public class CreatedByRestrictionFactory implements RestrictionFactory
     /**
      * This is needed to get access to the current session.
      */
-    @Reference(fieldOption = FieldOption.REPLACE,
-        cardinality = ReferenceCardinality.OPTIONAL,
-        policyOption = ReferencePolicyOption.GREEDY)
-    private ResourceResolverFactory rrf;
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     @Override
     public RestrictionPattern forValue(PropertyState value)
     {
         Session session = null;
-        if (this.rrf != null && this.rrf.getThreadResourceResolver() != null) {
-            session = this.rrf.getThreadResourceResolver().adaptTo(Session.class);
+        if (this.rrp.getThreadResourceResolver() != null) {
+            session = this.rrp.getThreadResourceResolver().adaptTo(Session.class);
         }
         return new CreatedByRestrictionPattern(session);
     }

--- a/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/QuestionRestrictionFactory.java
+++ b/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/QuestionRestrictionFactory.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 import io.uhndata.cards.permissions.spi.RestrictionFactory;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 /**
  * Factory for {@link QuestionRestrictionPattern}.

--- a/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/QuestionRestrictionFactory.java
+++ b/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/QuestionRestrictionFactory.java
@@ -23,14 +23,11 @@ import javax.jcr.Session;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionPattern;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import io.uhndata.cards.permissions.spi.RestrictionFactory;
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Factory for {@link QuestionRestrictionPattern}.
@@ -43,16 +40,15 @@ public class QuestionRestrictionFactory implements RestrictionFactory
     /** @see #getName */
     public static final String NAME = "cards:question";
 
-    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
-        policyOption = ReferencePolicyOption.GREEDY)
-    private ResourceResolverFactory rrf;
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     @Override
     public RestrictionPattern forValue(final PropertyState value)
     {
         Session session = null;
-        if (this.rrf != null && this.rrf.getThreadResourceResolver() != null) {
-            session = this.rrf.getThreadResourceResolver().adaptTo(Session.class);
+        if (this.rrp.getThreadResourceResolver() != null) {
+            session = this.rrp.getThreadResourceResolver().adaptTo(Session.class);
         }
         return new QuestionRestrictionPattern(value.getValue(Type.STRINGS), session);
     }

--- a/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/QuestionnaireRestrictionFactory.java
+++ b/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/QuestionnaireRestrictionFactory.java
@@ -30,7 +30,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 import io.uhndata.cards.permissions.spi.RestrictionFactory;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 /**
  * Factory for {@link QuestionnaireRestrictionPattern}.

--- a/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/QuestionnaireRestrictionFactory.java
+++ b/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/QuestionnaireRestrictionFactory.java
@@ -26,14 +26,11 @@ import javax.jcr.Session;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionPattern;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import io.uhndata.cards.permissions.spi.RestrictionFactory;
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Factory for {@link QuestionnaireRestrictionPattern}.
@@ -46,16 +43,15 @@ public class QuestionnaireRestrictionFactory implements RestrictionFactory
     /** @see #getName */
     public static final String NAME = "cards:questionnaire";
 
-    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
-        policyOption = ReferencePolicyOption.GREEDY)
-    private ResourceResolverFactory rrf;
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     @Override
     public RestrictionPattern forValue(final PropertyState value)
     {
         Session session = null;
-        if (this.rrf != null && this.rrf.getThreadResourceResolver() != null) {
-            session = this.rrf.getThreadResourceResolver().adaptTo(Session.class);
+        if (this.rrp.getThreadResourceResolver() != null) {
+            session = this.rrp.getThreadResourceResolver().adaptTo(Session.class);
         }
 
         // Sling repoinit parser does not currently allow spaces in a restriction value

--- a/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/SectionRestrictionFactory.java
+++ b/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/SectionRestrictionFactory.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 import io.uhndata.cards.permissions.spi.RestrictionFactory;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 /**
  * Factory for {@link SectionRestrictionPattern}.

--- a/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/SectionRestrictionFactory.java
+++ b/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/SectionRestrictionFactory.java
@@ -23,14 +23,11 @@ import javax.jcr.Session;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionPattern;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import io.uhndata.cards.permissions.spi.RestrictionFactory;
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Factory for {@link SectionRestrictionPattern}.
@@ -43,16 +40,15 @@ public class SectionRestrictionFactory implements RestrictionFactory
     /** @see #getName */
     public static final String NAME = "cards:section";
 
-    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
-        policyOption = ReferencePolicyOption.GREEDY)
-    private ResourceResolverFactory rrf;
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     @Override
     public RestrictionPattern forValue(final PropertyState value)
     {
         Session session = null;
-        if (this.rrf != null && this.rrf.getThreadResourceResolver() != null) {
-            session = this.rrf.getThreadResourceResolver().adaptTo(Session.class);
+        if (this.rrp.getThreadResourceResolver() != null) {
+            session = this.rrp.getThreadResourceResolver().adaptTo(Session.class);
         }
         return new SectionRestrictionPattern(value.getValue(Type.STRINGS), session);
     }

--- a/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/SessionSubjectRestrictionFactory.java
+++ b/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/SessionSubjectRestrictionFactory.java
@@ -23,14 +23,11 @@ import javax.jcr.Session;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionPattern;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import io.uhndata.cards.permissions.spi.RestrictionFactory;
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Factory for {@link SessionSubjectRestrictionPattern}.
@@ -46,17 +43,15 @@ public class SessionSubjectRestrictionFactory implements RestrictionFactory
     /**
      * This is needed to get access to the current session, which knows if there is a subject bound to it.
      */
-    @Reference(fieldOption = FieldOption.REPLACE,
-        cardinality = ReferenceCardinality.OPTIONAL,
-        policyOption = ReferencePolicyOption.GREEDY)
-    private ResourceResolverFactory rrf;
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     @Override
     public RestrictionPattern forValue(PropertyState value)
     {
         Session session = null;
-        if (this.rrf != null && this.rrf.getThreadResourceResolver() != null) {
-            session = this.rrf.getThreadResourceResolver().adaptTo(Session.class);
+        if (this.rrp.getThreadResourceResolver() != null) {
+            session = this.rrp.getThreadResourceResolver().adaptTo(Session.class);
         }
         return new SessionSubjectRestrictionPattern(session);
     }

--- a/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/SessionSubjectRestrictionFactory.java
+++ b/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/SessionSubjectRestrictionFactory.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 import io.uhndata.cards.permissions.spi.RestrictionFactory;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 /**
  * Factory for {@link SessionSubjectRestrictionPattern}.

--- a/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/SubjectRestrictionFactory.java
+++ b/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/SubjectRestrictionFactory.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 import io.uhndata.cards.permissions.spi.RestrictionFactory;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 /**
  * Factory for {@link SubjectRestrictionPattern}.

--- a/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/SubjectRestrictionFactory.java
+++ b/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/SubjectRestrictionFactory.java
@@ -23,14 +23,11 @@ import javax.jcr.Session;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionPattern;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import io.uhndata.cards.permissions.spi.RestrictionFactory;
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Factory for {@link SubjectRestrictionPattern}.
@@ -43,17 +40,15 @@ public class SubjectRestrictionFactory implements RestrictionFactory
     /** @see #getName */
     public static final String NAME = "cards:subject";
 
-    @Reference(fieldOption = FieldOption.REPLACE,
-        cardinality = ReferenceCardinality.OPTIONAL,
-        policyOption = ReferencePolicyOption.GREEDY)
-    private ResourceResolverFactory rrf;
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     @Override
     public RestrictionPattern forValue(PropertyState value)
     {
         Session session = null;
-        if (this.rrf != null && this.rrf.getThreadResourceResolver() != null) {
-            session = this.rrf.getThreadResourceResolver().adaptTo(Session.class);
+        if (this.rrp.getThreadResourceResolver() != null) {
+            session = this.rrp.getThreadResourceResolver().adaptTo(Session.class);
         }
         return new SubjectRestrictionPattern(value.getValue(Type.STRING), session);
     }

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -32,6 +32,7 @@
 
   <modules>
     <module>startup-customization</module>
+    <module>resolver-provider</module>
     <module>form-completion-status</module>
     <module>commons</module>
     <module>ui-extension</module>

--- a/modules/resolver-provider/pom.xml
+++ b/modules/resolver-provider/pom.xml
@@ -26,18 +26,12 @@
     <version>0.9-SNAPSHOT</version>
   </parent>
 
-  <artifactId>cards-scheduled-csv-export</artifactId>
+  <artifactId>cards-resolver-provider</artifactId>
   <packaging>bundle</packaging>
-  <name>CARDS - Scheduled CSV Export</name>
+  <name>CARDS - Thread Resource Resolver Provider utility service</name>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.sling</groupId>
-        <artifactId>slingfeature-maven-plugin</artifactId>
-      </plugin>
-
-      <!-- This is an OSGi bundle -->
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
@@ -48,50 +42,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.sling</groupId>
-      <artifactId>org.apache.sling.commons.scheduler</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.sling</groupId>
-      <artifactId>org.apache.sling.servlets.annotations</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component.annotations</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.service.component</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.service.metatype.annotations</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>cards-utils</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>cards-resolver-provider</artifactId>
-      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/modules/resolver-provider/src/main/java/io/uhndata/cards/resolverProvider/ThreadResourceResolverProvider.java
+++ b/modules/resolver-provider/src/main/java/io/uhndata/cards/resolverProvider/ThreadResourceResolverProvider.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.uhndata.cards.utils;
+package io.uhndata.cards.resolverProvider;
 
 import org.apache.sling.api.resource.ResourceResolver;
 

--- a/modules/resolver-provider/src/main/java/io/uhndata/cards/resolverProvider/internal/ThreadResourceResolverProviderImpl.java
+++ b/modules/resolver-provider/src/main/java/io/uhndata/cards/resolverProvider/internal/ThreadResourceResolverProviderImpl.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.uhndata.cards.utils.internal;
+package io.uhndata.cards.resolverProvider.internal;
 
 import java.util.Stack;
 
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 /**
  * Thread-inheritable implementation for {@link ThreadResourceResolverProvider}.

--- a/modules/scheduled-csv-export/src/main/java/io/uhndata/cards/scheduledcsvexport/ExportEndpoint.java
+++ b/modules/scheduled-csv-export/src/main/java/io/uhndata/cards/scheduledcsvexport/ExportEndpoint.java
@@ -35,6 +35,8 @@ import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+
 @Component(service = { Servlet.class })
 @SlingServletResourceTypes(
     resourceTypes = { "cards/SubjectsHomepage" },
@@ -48,6 +50,9 @@ public class ExportEndpoint extends SlingSafeMethodsServlet
 
     @Reference
     private ResourceResolverFactory resolverFactory;
+
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     @Reference
     private volatile List<ExportConfig> configs;
@@ -81,7 +86,7 @@ public class ExportEndpoint extends SlingSafeMethodsServlet
             return;
         }
 
-        final Runnable exportJob = new ExportTask(this.resolverFactory, config.frequency_in_days(),
+        final Runnable exportJob = new ExportTask(this.resolverFactory, this.rrp, config.frequency_in_days(),
             config.questionnaires_to_be_exported(), config.save_path(), config.enable_label());
         final Thread thread = new Thread(exportJob);
         thread.start();

--- a/modules/scheduled-csv-export/src/main/java/io/uhndata/cards/scheduledcsvexport/ExportEndpoint.java
+++ b/modules/scheduled-csv-export/src/main/java/io/uhndata/cards/scheduledcsvexport/ExportEndpoint.java
@@ -35,7 +35,7 @@ import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 @Component(service = { Servlet.class })
 @SlingServletResourceTypes(

--- a/modules/scheduled-csv-export/src/main/java/io/uhndata/cards/scheduledcsvexport/ExportTask.java
+++ b/modules/scheduled-csv-export/src/main/java/io/uhndata/cards/scheduledcsvexport/ExportTask.java
@@ -36,8 +36,8 @@ import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 import io.uhndata.cards.serialize.CSVString;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 public class ExportTask implements Runnable
 {

--- a/modules/scheduled-csv-export/src/main/java/io/uhndata/cards/scheduledcsvexport/ScheduledExport.java
+++ b/modules/scheduled-csv-export/src/main/java/io/uhndata/cards/scheduledcsvexport/ScheduledExport.java
@@ -32,6 +32,8 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+
 @Component(immediate = true)
 public class ScheduledExport
 {
@@ -41,6 +43,9 @@ public class ScheduledExport
 
     @Reference
     private ResourceResolverFactory resolverFactory;
+
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     @Reference
     private Scheduler scheduler;
@@ -70,7 +75,7 @@ public class ScheduledExport
 
         final Runnable csvExportJob;
         csvExportJob =
-            new ExportTask(this.resolverFactory, configDef.frequency_in_days(),
+            new ExportTask(this.resolverFactory, this.rrp, configDef.frequency_in_days(),
                 configDef.questionnaires_to_be_exported(), configDef.save_path(), configDef.enable_label());
         try {
             this.scheduler.schedule(csvExportJob, options);

--- a/modules/scheduled-csv-export/src/main/java/io/uhndata/cards/scheduledcsvexport/ScheduledExport.java
+++ b/modules/scheduled-csv-export/src/main/java/io/uhndata/cards/scheduledcsvexport/ScheduledExport.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 @Component(immediate = true)
 public class ScheduledExport

--- a/modules/vocabularies/pom.xml
+++ b/modules/vocabularies/pom.xml
@@ -72,6 +72,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cards-utils</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>javax.jcr</groupId>
       <artifactId>jcr</artifactId>
     </dependency>

--- a/modules/vocabularies/pom.xml
+++ b/modules/vocabularies/pom.xml
@@ -73,7 +73,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>cards-utils</artifactId>
+      <artifactId>cards-resolver-provider</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/modules/vocabularies/src/main/java/io/uhndata/cards/vocabularies/internal/DefaultBioPortalApiKeyManager.java
+++ b/modules/vocabularies/src/main/java/io/uhndata/cards/vocabularies/internal/DefaultBioPortalApiKeyManager.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 import io.uhndata.cards.vocabularies.BioPortalApiKeyManager;
 
 /**

--- a/modules/vocabularies/src/main/java/io/uhndata/cards/vocabularies/internal/DefaultBioPortalApiKeyManager.java
+++ b/modules/vocabularies/src/main/java/io/uhndata/cards/vocabularies/internal/DefaultBioPortalApiKeyManager.java
@@ -22,15 +22,12 @@ import javax.jcr.Node;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 import io.uhndata.cards.vocabularies.BioPortalApiKeyManager;
 
 /**
@@ -46,9 +43,8 @@ public class DefaultBioPortalApiKeyManager implements BioPortalApiKeyManager
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultBioPortalApiKeyManager.class);
 
-    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
-        policyOption = ReferencePolicyOption.GREEDY)
-    private ResourceResolverFactory rrf;
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     @Override
     public String getAPIKey()
@@ -77,7 +73,7 @@ public class DefaultBioPortalApiKeyManager implements BioPortalApiKeyManager
         String apiKey = "";
 
         try {
-            Resource res = this.rrf.getThreadResourceResolver().resolve(resourcePath);
+            Resource res = this.rrp.getThreadResourceResolver().resolve(resourcePath);
             if (!res.isResourceType(Resource.RESOURCE_TYPE_NON_EXISTING)) {
                 Node keyNode = res.adaptTo(Node.class);
                 apiKey = keyNode.getProperty("key").getString();

--- a/modules/webhook-backup/pom.xml
+++ b/modules/webhook-backup/pom.xml
@@ -42,6 +42,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cards-resolver-provider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>javax.json</groupId>
       <artifactId>javax.json-api</artifactId>
     </dependency>

--- a/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/NightlyWebhookBackup.java
+++ b/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/NightlyWebhookBackup.java
@@ -29,6 +29,8 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+
 @Component(immediate = true)
 public class NightlyWebhookBackup
 {
@@ -38,6 +40,9 @@ public class NightlyWebhookBackup
     /** Provides access to resources. */
     @Reference
     private ResourceResolverFactory resolverFactory;
+
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     /** The scheduler for rescheduling jobs. */
     @Reference
@@ -52,7 +57,7 @@ public class NightlyWebhookBackup
         options.name("NightlyWebhookBackup");
         options.canRunConcurrently(true);
 
-        final Runnable webhookBackupJob = new WebhookBackupTask(this.resolverFactory, "nightly");
+        final Runnable webhookBackupJob = new WebhookBackupTask(this.resolverFactory, this.rrp, "nightly");
 
         try {
             this.scheduler.schedule(webhookBackupJob, options);

--- a/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/NightlyWebhookBackup.java
+++ b/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/NightlyWebhookBackup.java
@@ -29,7 +29,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 @Component(immediate = true)
 public class NightlyWebhookBackup

--- a/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupEndpoint.java
+++ b/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupEndpoint.java
@@ -35,7 +35,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 @Component(service = { Servlet.class })
 @SlingServletResourceTypes(

--- a/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupEndpoint.java
+++ b/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupEndpoint.java
@@ -35,6 +35,8 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+
 @Component(service = { Servlet.class })
 @SlingServletResourceTypes(
     resourceTypes = { "cards/SubjectsHomepage" },
@@ -48,15 +50,18 @@ public class WebhookBackupEndpoint extends SlingSafeMethodsServlet
     @Reference
     private ResourceResolverFactory resolverFactory;
 
+    @Reference
+    private ThreadResourceResolverProvider rrp;
+
     @Override
     public void doGet(final SlingHttpServletRequest request, final SlingHttpServletResponse response) throws IOException
     {
         final Writer out = response.getWriter();
 
-        //Ensure that this can only be run when logged in as admin
+        // Ensure that this can only be run when logged in as admin
         final String remoteUser = request.getRemoteUser();
         if (remoteUser == null || !"admin".equals(remoteUser)) {
-            //admin login required
+            // admin login required
             response.setStatus(403);
             out.write("Only admin can perform this operation.");
             return;
@@ -69,8 +74,8 @@ public class WebhookBackupEndpoint extends SlingSafeMethodsServlet
             : (dateLowerBound != null && dateUpperBound == null) ? "manualAfter" : "manualToday";
 
         final Runnable exportJob = ("manualToday".equals(exportRunMode))
-            ? new WebhookBackupTask(this.resolverFactory, exportRunMode)
-            : new WebhookBackupTask(this.resolverFactory, exportRunMode, dateLowerBound, dateUpperBound);
+            ? new WebhookBackupTask(this.resolverFactory, this.rrp, exportRunMode)
+            : new WebhookBackupTask(this.resolverFactory, this.rrp, exportRunMode, dateLowerBound, dateUpperBound);
         final Thread thread = new Thread(exportJob);
         thread.start();
         out.write("Webhook Backup export started");

--- a/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupEndpoint.java
+++ b/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupEndpoint.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 public class WebhookBackupEndpoint extends SlingSafeMethodsServlet
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(WebhookBackupEndpoint.class);
+
     private static final long serialVersionUID = -6489305069446929017L;
 
     @Reference

--- a/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupTask.java
+++ b/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupTask.java
@@ -52,15 +52,14 @@ public class WebhookBackupTask implements Runnable
     /** Provides access to resources. */
     private final ResourceResolverFactory resolverFactory;
     private final String exportRunMode;
+
     private final LocalDateTime exportLowerBound;
+
     private final LocalDateTime exportUpperBound;
 
     WebhookBackupTask(final ResourceResolverFactory resolverFactory, final String exportRunMode)
     {
-        this.resolverFactory = resolverFactory;
-        this.exportRunMode = exportRunMode;
-        this.exportLowerBound = null;
-        this.exportUpperBound = null;
+        this(resolverFactory, exportRunMode, null, null);
     }
 
     WebhookBackupTask(final ResourceResolverFactory resolverFactory, final String exportRunMode,

--- a/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupTask.java
+++ b/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupTask.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import io.uhndata.cards.httprequests.HttpRequests;
 import io.uhndata.cards.httprequests.HttpResponse;
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 public class WebhookBackupTask implements Runnable
 {
@@ -51,21 +52,27 @@ public class WebhookBackupTask implements Runnable
 
     /** Provides access to resources. */
     private final ResourceResolverFactory resolverFactory;
+
+    private final ThreadResourceResolverProvider rrp;
+
     private final String exportRunMode;
 
     private final LocalDateTime exportLowerBound;
 
     private final LocalDateTime exportUpperBound;
 
-    WebhookBackupTask(final ResourceResolverFactory resolverFactory, final String exportRunMode)
+    WebhookBackupTask(final ResourceResolverFactory resolverFactory, final ThreadResourceResolverProvider rrp,
+        final String exportRunMode)
     {
-        this(resolverFactory, exportRunMode, null, null);
+        this(resolverFactory, rrp, exportRunMode, null, null);
     }
 
-    WebhookBackupTask(final ResourceResolverFactory resolverFactory, final String exportRunMode,
+    WebhookBackupTask(final ResourceResolverFactory resolverFactory, final ThreadResourceResolverProvider rrp,
+        final String exportRunMode,
         final LocalDateTime exportLowerBound, final LocalDateTime exportUpperBound)
     {
         this.resolverFactory = resolverFactory;
+        this.rrp = rrp;
         this.exportRunMode = exportRunMode;
         this.exportLowerBound = exportLowerBound;
         this.exportUpperBound = exportUpperBound;
@@ -207,24 +214,38 @@ public class WebhookBackupTask implements Runnable
 
     private String getFormAsJson(String formPath) throws IOException
     {
+        boolean mustPopResolver = false;
         String formDataUrl = String.format("%s.deep", formPath);
         try (ResourceResolver resolver = this.resolverFactory.getServiceResourceResolver(null)) {
+            this.rrp.push(resolver);
+            mustPopResolver = true;
             Resource formData = resolver.resolve(formDataUrl);
             return formData.adaptTo(JsonObject.class).toString();
         } catch (LoginException e) {
             LOGGER.warn("LoginException in getFormAsJson: {}", e);
             throw new IOException("getFormAsJson LoginException");
+        } finally {
+            if (mustPopResolver) {
+                this.rrp.pop();
+            }
         }
     }
 
     private String getSubjectAsJson(String subjectPath) throws IOException
     {
+        boolean mustPopResolver = false;
         try (ResourceResolver resolver = this.resolverFactory.getServiceResourceResolver(null)) {
+            this.rrp.push(resolver);
+            mustPopResolver = true;
             Resource subjectData = resolver.resolve(subjectPath);
             return subjectData.adaptTo(JsonObject.class).toString();
         } catch (LoginException e) {
             LOGGER.warn("LoginException in getFormAsJson: {}", e);
             throw new IOException("getSubjectAsJson LoginException");
+        } finally {
+            if (mustPopResolver) {
+                this.rrp.pop();
+            }
         }
     }
 

--- a/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupTask.java
+++ b/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupTask.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import io.uhndata.cards.httprequests.HttpRequests;
 import io.uhndata.cards.httprequests.HttpResponse;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 public class WebhookBackupTask implements Runnable
 {

--- a/proms-resources/backend/pom.xml
+++ b/proms-resources/backend/pom.xml
@@ -113,6 +113,11 @@
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cards-resolver-provider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>io.uhndata.cards</groupId>
       <artifactId>cards-dataentry</artifactId>
       <version>${project.version}</version>

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportEndpoint.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportEndpoint.java
@@ -35,7 +35,7 @@ import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 @Component(service = { Servlet.class })
 @SlingServletResourceTypes(

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportTask.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportTask.java
@@ -57,7 +57,7 @@ import io.uhndata.cards.utils.ThreadResourceResolverProvider;
  *
  * @version $Id$
  */
-@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling"})
+@SuppressWarnings({ "checkstyle:ClassDataAbstractionCoupling" })
 public class ImportTask implements Runnable
 {
     /** Default log. */
@@ -119,12 +119,12 @@ public class ImportTask implements Runnable
         this.vaultToken = vaultToken;
         this.clinicNames = clinicNames;
         // Parse the query dates
-        this.queryDates = new LinkedList<Calendar>();
+        this.queryDates = new LinkedList<>();
         final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
-        for (int i = 0; i < queryDates.length; i++) {
+        for (String queryDate : queryDates) {
             try {
                 final Calendar date = Calendar.getInstance();
-                date.setTime(formatter.parse(queryDates[i]));
+                date.setTime(formatter.parse(queryDate));
                 this.queryDates.add(date);
             } catch (ParseException e) {
                 LOGGER.error("Query date invalid: {}", e.getMessage(), e);
@@ -142,8 +142,8 @@ public class ImportTask implements Runnable
         final String token = loginWithJWT();
         long importedAppointmentsCount = 0;
         // Iterate over every clinic name
-        for (int i = 0; i < this.clinicNames.length; i++) {
-            importedAppointmentsCount += getUpcomingAppointments(token, this.daysToQuery, this.clinicNames[i]);
+        for (String clinicName : this.clinicNames) {
+            importedAppointmentsCount += getUpcomingAppointments(token, this.daysToQuery, clinicName);
         }
         // Update the performance counter
         Metrics.increment(this.resolverFactory,

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportTask.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ImportTask.java
@@ -48,7 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.uhndata.cards.metrics.Metrics;
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 /**
  * Query the Torch server provided for patients with appointments in the coming few days (default: 3), and stores them

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/NightlyImport.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/NightlyImport.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.uhndata.cards.utils.ThreadResourceResolverProvider;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 @Component(immediate = true)
 public class NightlyImport


### PR DESCRIPTION
Convert ReferenceAnswersEditor and ComputedAnswersEditor over to ThreadResourceResolverProvider
- Allows these editors to run in the backend when ResourceResolverProvider does not have an effective session
- Required re-implementation of some FormUtil and SubjectUtil funtions as said util functions use the regular ResourceResolverFactory

Testing:
Running in PREMs runmode, create a visit form with Clinic, provider, a recognizable location and status. Save the form, wait a few seconds and verify that a new OED or OAIP form is automatically created with the location referenced in the new form.

Create a new patient + visit with a visit information form. Only fill out location so forms are not automatically created. Manually create a new OED or OAIP form for this visit. Observe that the location field is copied over to the hospital named below field.

Reference test forms can be found in [CARDS-1103](https://github.com/data-team-uhn/cards/pull/1116)

Verify that computed questions work correctly in the backend (tests are available in [CARDS-1800](https://github.com/data-team-uhn/cards/pull/1066)

[CARDS-1103]: https://phenotips.atlassian.net/browse/CARDS-1103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CARDS-1800]: https://phenotips.atlassian.net/browse/CARDS-1800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ