### PR TITLE
CARDS-1949: As an admin using the questionnaire designer, I can access contextual help / detailed descriptions of the questionnaire items' fields

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/AnswerOptions.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/AnswerOptions.jsx
@@ -107,7 +107,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 let AnswerOptions = (props) => {
-  const { objectKey, value, data, path, saveButtonRef, hints, onHelpClick } = props;
+  const { objectKey, value, data, path, saveButtonRef, hint } = props;
   const classes = useStyles();
   let [ options, setOptions ] = useState(extractSortedOptions(data));
   let [ deletedOptions, setDeletedOptions ] = useState([]);
@@ -380,7 +380,7 @@ let AnswerOptions = (props) => {
   }
 
   return (
-    <EditorInput name={objectKey} hasHint={Boolean(hints?.[objectKey])} onHelpClick={onHelpClick}>
+    <EditorInput name={objectKey} hint={hint}>
       { deletedOptions.map((value, index) =>
         <input type='hidden' name={`${value['@path']}@Delete`} value="0" key={value['@path']} />
       )}
@@ -522,8 +522,7 @@ let AnswerOptions = (props) => {
 
 AnswerOptions.propTypes = {
   data: PropTypes.object.isRequired,
-  hints: PropTypes.object,
-  onHelpClick: PropTypes.func
+  hint: PropTypes.string,
 };
 
 export default AnswerOptions;

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/AnswerOptions.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/AnswerOptions.jsx
@@ -107,7 +107,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 let AnswerOptions = (props) => {
-  const { objectKey, value, data, path, saveButtonRef } = props;
+  const { objectKey, value, data, path, saveButtonRef, hints, onHelpClick } = props;
   const classes = useStyles();
   let [ options, setOptions ] = useState(extractSortedOptions(data));
   let [ deletedOptions, setDeletedOptions ] = useState([]);
@@ -380,7 +380,7 @@ let AnswerOptions = (props) => {
   }
 
   return (
-    <EditorInput name={objectKey}>
+    <EditorInput name={objectKey} hasHint={Boolean(hints?.[objectKey])} onHelpClick={onHelpClick}>
       { deletedOptions.map((value, index) =>
         <input type='hidden' name={`${value['@path']}@Delete`} value="0" key={value['@path']} />
       )}
@@ -521,7 +521,9 @@ let AnswerOptions = (props) => {
 }
 
 AnswerOptions.propTypes = {
-  data: PropTypes.object.isRequired
+  data: PropTypes.object.isRequired,
+  hints: PropTypes.object,
+  onHelpClick: PropTypes.func
 };
 
 export default AnswerOptions;

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/BooleanInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/BooleanInput.jsx
@@ -35,11 +35,11 @@ import ValueComponentManager from "../questionnaireEditor/ValueComponentManager"
 // Boolean Input field used by Edit dialog component
 
 let BooleanInput = (props) => {
-  let { objectKey, data, hints, onHelpClick } = props;
+  let { objectKey, data, hint } = props;
   let [ checked, setChecked ] = useState(data?.[objectKey] == true);
 
   return (
-    <EditorInput name={objectKey} hasHint={Boolean(hints?.[objectKey])} onHelpClick={onHelpClick}>
+    <EditorInput name={objectKey} hint={hint}>
       <Switch
         color="secondary"
         edge="start"
@@ -56,8 +56,7 @@ let BooleanInput = (props) => {
 BooleanInput.propTypes = {
   objectKey: PropTypes.string.isRequired,
   data: PropTypes.object.isRequired,
-  hints: PropTypes.object,
-  onHelpClick: PropTypes.func
+  hint: PropTypes.string,
 };
 
 const StyledBooleanInput = withStyles(QuestionnaireStyle)(BooleanInput);

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/BooleanInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/BooleanInput.jsx
@@ -35,11 +35,11 @@ import ValueComponentManager from "../questionnaireEditor/ValueComponentManager"
 // Boolean Input field used by Edit dialog component
 
 let BooleanInput = (props) => {
-  let { objectKey, data } = props;
+  let { objectKey, data, hints, onHelpClick } = props;
   let [ checked, setChecked ] = useState(data?.[objectKey] == true);
 
   return (
-    <EditorInput name={objectKey}>
+    <EditorInput name={objectKey} hasHint={Boolean(hints?.[objectKey])} onHelpClick={onHelpClick}>
       <Switch
         color="secondary"
         edge="start"
@@ -55,7 +55,9 @@ let BooleanInput = (props) => {
 
 BooleanInput.propTypes = {
   objectKey: PropTypes.string.isRequired,
-  data: PropTypes.object.isRequired
+  data: PropTypes.object.isRequired,
+  hints: PropTypes.object,
+  onHelpClick: PropTypes.func
 };
 
 const StyledBooleanInput = withStyles(QuestionnaireStyle)(BooleanInput);

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ConditionalValueInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ConditionalValueInput.jsx
@@ -74,7 +74,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 let ConditionalValueInput = (props) => {
-  let { objectKey, value, data, saveButtonRef, hints, onHelpClick } = props;
+  let { objectKey, value, data, saveButtonRef, hint } = props;
 
   let [ values, setValues ] = useState(data[objectKey]?.value || []);
   let [ isReference, setReference ] = useState(data[objectKey] ? data[objectKey].isReference : (objectKey == 'operandA'));
@@ -191,7 +191,7 @@ let ConditionalValueInput = (props) => {
   );
 
   return (
-    <EditorInput name={objectKey} hasHint={Boolean(hints?.[objectKey])} onHelpClick={onHelpClick}>
+    <EditorInput name={objectKey} hint={hint}>
 
       {/* Is this a variable name or a value? */}
       <ToggleButtonGroup
@@ -274,8 +274,7 @@ let ConditionalValueInput = (props) => {
 ConditionalValueInput.propTypes = {
   objectKey: PropTypes.string.isRequired,
   data: PropTypes.object.isRequired,
-  hints: PropTypes.object,
-  onHelpClick: PropTypes.func
+  hint: PropTypes.string,
 };
 
 export default ConditionalValueInput;

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ConditionalValueInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ConditionalValueInput.jsx
@@ -74,7 +74,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 let ConditionalValueInput = (props) => {
-  let { objectKey, value, data, saveButtonRef } = props;
+  let { objectKey, value, data, saveButtonRef, hints, onHelpClick } = props;
 
   let [ values, setValues ] = useState(data[objectKey]?.value || []);
   let [ isReference, setReference ] = useState(data[objectKey] ? data[objectKey].isReference : (objectKey == 'operandA'));
@@ -191,7 +191,7 @@ let ConditionalValueInput = (props) => {
   );
 
   return (
-    <EditorInput name={objectKey}>
+    <EditorInput name={objectKey} hasHint={Boolean(hints?.[objectKey])} onHelpClick={onHelpClick}>
 
       {/* Is this a variable name or a value? */}
       <ToggleButtonGroup
@@ -274,6 +274,8 @@ let ConditionalValueInput = (props) => {
 ConditionalValueInput.propTypes = {
   objectKey: PropTypes.string.isRequired,
   data: PropTypes.object.isRequired,
+  hints: PropTypes.object,
+  onHelpClick: PropTypes.func
 };
 
 export default ConditionalValueInput;

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditDialog.jsx
@@ -32,7 +32,6 @@ import {
 
 import Fields from './Fields';
 import { camelCaseToWords } from './LabeledField';
-import FormattedText from "../components/FormattedText.jsx";
 import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
 
 // Dialog for editing or creating questions or sections
@@ -55,7 +54,13 @@ let EditDialog = (props) => {
   let [ variableNameError, setVariableNameError ] = useState('');
 
   let json = model ? require(`./${model}`) : require(`./${type}.json`);
-  let hints = require(`./${type}-hints.json`);
+  let hints = null;
+  try {
+    hints = require(`./${type}-hints.json`);
+  } catch (e) {
+    console.log(`Failed to locate hints file ${type}-hints.json`)
+  }
+  
 
   let formattedType = camelCaseToWords(type);
 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditDialog.jsx
@@ -21,17 +21,21 @@ import React, { useState, useContext } from "react";
 import PropTypes from 'prop-types';
 import {
   Button,
+  Card,
+  CardContent,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   Grid,
+  Popover,
   TextField,
   Typography,
 } from "@mui/material";
 
 import Fields from './Fields';
 import { camelCaseToWords } from './LabeledField';
+import FormattedText from "../components/FormattedText.jsx";
 import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
 
 // Dialog for editing or creating questions or sections
@@ -52,8 +56,12 @@ let EditDialog = (props) => {
   let [ primaryType, setPrimaryType ] = useState(`cards:${type}`);
   let [ error, setError ] = useState('');
   let [ variableNameError, setVariableNameError ] = useState('');
+  // Variables holding the anchor and the content of the help info icon
+  let [ helpText, setHelpText ] = useState('');
+  let [ helpAnchorEl, setHelpAnchorEl ] = useState(null);
 
   let json = model ? require(`./${model}`) : require(`./${type}.json`);
+  let hints = require(`./${type}-hints.json`);
 
   let formattedType = camelCaseToWords(type);
 
@@ -186,6 +194,16 @@ let EditDialog = (props) => {
     }
   }
 
+  let onHelpClick = (event, key) => {
+    setHelpAnchorEl(event?.currentTarget);
+    setHelpText(hints?.[key]);
+  }
+
+  let handlePopoverClose = () => {
+    setHelpAnchorEl(null);
+    setHelpText('');
+  }
+
   return (
     <form action={data?.['@path']} method='POST' onSubmit={saveData} onChange={() => setLastSaveStatus(undefined) } key={id}>
        <Dialog disablePortal id='editDialog' open={open} onClose={() => { setOpen(false); onCancel && onCancel();} } fullWidth maxWidth='md'>
@@ -198,10 +216,12 @@ let EditDialog = (props) => {
               <Grid item>{targetIdField()}</Grid>
               <Fields
                 data={dialogData}
+                hints={hints}
                 JSON={json[0]}
                 edit={true}
                 path={data["@path"] + (targetExists ? "" : `/${targetId}`)}
                 saveButtontRef={saveButtonRef}
+                onHelpClick={onHelpClick}
                />
             </Grid>
           </DialogContent>
@@ -226,7 +246,28 @@ let EditDialog = (props) => {
             </Button>
           </DialogActions>
        </Dialog>
-    </form>
+       <Popover
+         open={Boolean(helpAnchorEl) && Boolean(helpText)}
+         anchorEl={helpAnchorEl}
+         onClose={() => {
+           handlePopoverClose();
+         }}
+         anchorOrigin={{
+           vertical: 'bottom',
+           horizontal: 'center',
+         }}
+         transformOrigin={{
+           vertical: 'top',
+           horizontal: 'center',
+         }}
+       >
+         <Card>
+           <CardContent>
+             <FormattedText>{helpText}</FormattedText>
+           </CardContent>
+         </Card>
+       </Popover>
+     </form>
   );
 };
 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditDialog.jsx
@@ -21,14 +21,11 @@ import React, { useState, useContext } from "react";
 import PropTypes from 'prop-types';
 import {
   Button,
-  Card,
-  CardContent,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   Grid,
-  Popover,
   TextField,
   Typography,
 } from "@mui/material";
@@ -56,9 +53,6 @@ let EditDialog = (props) => {
   let [ primaryType, setPrimaryType ] = useState(`cards:${type}`);
   let [ error, setError ] = useState('');
   let [ variableNameError, setVariableNameError ] = useState('');
-  // Variables holding the anchor and the content of the help info icon
-  let [ helpText, setHelpText ] = useState('');
-  let [ helpAnchorEl, setHelpAnchorEl ] = useState(null);
 
   let json = model ? require(`./${model}`) : require(`./${type}.json`);
   let hints = require(`./${type}-hints.json`);
@@ -194,16 +188,6 @@ let EditDialog = (props) => {
     }
   }
 
-  let onHelpClick = (event, key) => {
-    setHelpAnchorEl(event?.currentTarget);
-    setHelpText(hints?.[key]);
-  }
-
-  let handlePopoverClose = () => {
-    setHelpAnchorEl(null);
-    setHelpText('');
-  }
-
   return (
     <form action={data?.['@path']} method='POST' onSubmit={saveData} onChange={() => setLastSaveStatus(undefined) } key={id}>
        <Dialog disablePortal id='editDialog' open={open} onClose={() => { setOpen(false); onCancel && onCancel();} } fullWidth maxWidth='md'>
@@ -221,7 +205,6 @@ let EditDialog = (props) => {
                 edit={true}
                 path={data["@path"] + (targetExists ? "" : `/${targetId}`)}
                 saveButtontRef={saveButtonRef}
-                onHelpClick={onHelpClick}
                />
             </Grid>
           </DialogContent>
@@ -246,28 +229,7 @@ let EditDialog = (props) => {
             </Button>
           </DialogActions>
        </Dialog>
-       <Popover
-         open={Boolean(helpAnchorEl) && Boolean(helpText)}
-         anchorEl={helpAnchorEl}
-         onClose={() => {
-           handlePopoverClose();
-         }}
-         anchorOrigin={{
-           vertical: 'bottom',
-           horizontal: 'center',
-         }}
-         transformOrigin={{
-           vertical: 'top',
-           horizontal: 'center',
-         }}
-       >
-         <Card>
-           <CardContent>
-             <FormattedText>{helpText}</FormattedText>
-           </CardContent>
-         </Card>
-       </Popover>
-     </form>
+    </form>
   );
 };
 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditorInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditorInput.jsx
@@ -22,22 +22,28 @@ import makeStyles from '@mui/styles/makeStyles';
 import PropTypes from 'prop-types';
 import {
   Grid,
-  IconButton,
+  Tooltip,
   Typography
 } from "@mui/material";
 
 import Info from "@mui/icons-material/Info";
 
 import { camelCaseToWords } from "./LabeledField";
+import FormattedText from "../components/FormattedText.jsx";
 
 let EditorInput = (props) => {
-  let { children, name, hasHint, onHelpClick } = props;
+  let { children, name, hint } = props;
 
   const classes = makeStyles((theme) => ({
     labelContainer: {
       /* Match the input padding so the text of the label would appear aligned with the text of the input */
       /* To do: switch to a vertical layout in the future to avoid most alignment issues  */
       paddingTop: theme.spacing(1.75) + " !important",
+      /* Align the optional hint icon within the label */
+      "& .MuiTypography-root" : {
+         display: "flex",
+         alignItems: "flex-end",
+      },
     },
   }))();
 
@@ -47,16 +53,11 @@ let EditorInput = (props) => {
       <Grid item xs={4} className={classes.labelContainer}>
         <Typography variant="subtitle2">
           {camelCaseToWords(name?.concat(':')) || ''}
-          { hasHint &&
-              <IconButton
-                size="small"
-                color="primary"
-                onClick={(e) => {e.preventDefault(); e.stopPropagation(); onHelpClick && onHelpClick(e, name);}}
-                className={classes.infoButton}
-            >
+          { name && hint &&
+            <Tooltip title={<FormattedText>{hint}</FormattedText>} enterTouchDelay={200}>
               <Info color="primary" />
-            </IconButton>
-        }
+            </Tooltip>
+          }
         </Typography>
       </Grid>
       <Grid item xs={8}>
@@ -70,8 +71,7 @@ let EditorInput = (props) => {
 EditorInput.propTypes = {
   children: PropTypes.node.isRequired,
   name: PropTypes.string.isRequired,
-  hasHint: PropTypes.bool,
-  onHelpClick: PropTypes.func
+  hint: PropTypes.string,
 };
 
 export default EditorInput

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditorInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditorInput.jsx
@@ -54,7 +54,9 @@ let EditorInput = (props) => {
         <Typography variant="subtitle2">
           {camelCaseToWords(name?.concat(':')) || ''}
           { name && hint &&
-            <Tooltip title={<FormattedText>{hint}</FormattedText>} enterTouchDelay={200}>
+            <Tooltip enterTouchDelay={200} title={
+              <FormattedText variant="caption">{hint}</FormattedText>
+            }>
               <Info color="primary" />
             </Tooltip>
           }

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditorInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditorInput.jsx
@@ -22,13 +22,16 @@ import makeStyles from '@mui/styles/makeStyles';
 import PropTypes from 'prop-types';
 import {
   Grid,
+  IconButton,
   Typography
 } from "@mui/material";
+
+import Info from "@mui/icons-material/Info";
 
 import { camelCaseToWords } from "./LabeledField";
 
 let EditorInput = (props) => {
-  let { children, name } = props;
+  let { children, name, hasHint, onHelpClick } = props;
 
   const classes = makeStyles((theme) => ({
     labelContainer: {
@@ -44,6 +47,16 @@ let EditorInput = (props) => {
       <Grid item xs={4} className={classes.labelContainer}>
         <Typography variant="subtitle2">
           {camelCaseToWords(name?.concat(':')) || ''}
+          { hasHint &&
+              <IconButton
+                size="small"
+                color="primary"
+                onClick={(e) => {e.preventDefault(); e.stopPropagation(); onHelpClick && onHelpClick(e, name);}}
+                className={classes.infoButton}
+            >
+              <Info color="primary" />
+            </IconButton>
+        }
         </Typography>
       </Grid>
       <Grid item xs={8}>
@@ -56,7 +69,9 @@ let EditorInput = (props) => {
 
 EditorInput.propTypes = {
   children: PropTypes.node.isRequired,
-  name: PropTypes.string.isRequired
+  name: PropTypes.string.isRequired,
+  hasHint: PropTypes.bool,
+  onHelpClick: PropTypes.func
 };
 
 export default EditorInput

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Fields.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Fields.jsx
@@ -40,7 +40,7 @@ import LabeledField from "./LabeledField";
 import { FieldsProvider } from "./FieldsContext.jsx";
 
 let Fields = (props) => {
-  let { data, hints, JSON, edit, classes, condensed, onHelpClick, ...rest } = props;
+  let { data, hints, JSON, edit, classes, condensed, ...rest } = props;
 
   /**
    * Method responsible for displaying a question from the questionnaire
@@ -58,7 +58,7 @@ let Fields = (props) => {
           objectKey={key}
           value={value}
           data={data}
-          onHelpClick={onHelpClick}
+          hint={hints?.[key]}
           hints={hints}
           {...rest}
           />
@@ -104,9 +104,8 @@ Fields.propTypes = {
   JSON: PropTypes.object.isRequired,
   edit: PropTypes.bool.isRequired,
   condensed: PropTypes.bool,
-  hints: PropTypes.object,
   onChange: PropTypes.func,
-  onHelpClick: PropTypes.func
+  hints: PropTypes.object,
 };
 
 export default withStyles(QuestionnaireStyle)(Fields);

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Fields.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Fields.jsx
@@ -40,7 +40,7 @@ import LabeledField from "./LabeledField";
 import { FieldsProvider } from "./FieldsContext.jsx";
 
 let Fields = (props) => {
-  let { data, JSON, edit, classes, condensed, ...rest } = props;
+  let { data, hints, JSON, edit, classes, condensed, onHelpClick, ...rest } = props;
 
   /**
    * Method responsible for displaying a question from the questionnaire
@@ -58,6 +58,8 @@ let Fields = (props) => {
           objectKey={key}
           value={value}
           data={data}
+          onHelpClick={onHelpClick}
+          hints={hints}
           {...rest}
           />
     );
@@ -102,7 +104,9 @@ Fields.propTypes = {
   JSON: PropTypes.object.isRequired,
   edit: PropTypes.bool.isRequired,
   condensed: PropTypes.bool,
-  onChange: PropTypes.func
+  hints: PropTypes.object,
+  onChange: PropTypes.func,
+  onHelpClick: PropTypes.func
 };
 
 export default withStyles(QuestionnaireStyle)(Fields);

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ListInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ListInput.jsx
@@ -29,7 +29,7 @@ import ValueComponentManager from "./ValueComponentManager";
 import { useFieldsWriterContext } from "./FieldsContext";
 
 let ListInput = (props) => {
-  let { objectKey, data, value: type, hints, onHelpClick } = props;
+  let { objectKey, data, value: type, hint } = props;
   let [ value, setValue ] = React.useState(Array.isArray(data[objectKey]) ? data[objectKey] : data[objectKey] ? [data[objectKey]] : []);
   const [ options, setOptions ] = React.useState([]);
   const changeFieldsContext = useFieldsWriterContext();
@@ -82,7 +82,7 @@ let ListInput = (props) => {
   };
 
   return (
-    <EditorInput name={objectKey} hasHint={Boolean(hints?.[objectKey])}  onHelpClick={onHelpClick}>
+    <EditorInput name={objectKey} hint={hint}>
       <input type="hidden" name={objectKey + "@TypeHint"} value={type.saveType + '[]'} />
       {
         // Maps each selected object to a reference type for submitting
@@ -120,8 +120,7 @@ let ListInput = (props) => {
 ListInput.propTypes = {
   objectKey: PropTypes.string.isRequired,
   data: PropTypes.object.isRequired,
-  hints: PropTypes.objects,
-  onHelpClick: PropTypes.func
+  hint: PropTypes.string,
 };
 
 var StyledListInput = withStyles(QuestionnaireStyle)(ListInput);

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ListInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ListInput.jsx
@@ -29,7 +29,7 @@ import ValueComponentManager from "./ValueComponentManager";
 import { useFieldsWriterContext } from "./FieldsContext";
 
 let ListInput = (props) => {
-  let { objectKey, data, value: type } = props;
+  let { objectKey, data, value: type, hints, onHelpClick } = props;
   let [ value, setValue ] = React.useState(Array.isArray(data[objectKey]) ? data[objectKey] : data[objectKey] ? [data[objectKey]] : []);
   const [ options, setOptions ] = React.useState([]);
   const changeFieldsContext = useFieldsWriterContext();
@@ -82,7 +82,7 @@ let ListInput = (props) => {
   };
 
   return (
-    <EditorInput name={objectKey}>
+    <EditorInput name={objectKey} hasHint={Boolean(hints?.[objectKey])}  onHelpClick={onHelpClick}>
       <input type="hidden" name={objectKey + "@TypeHint"} value={type.saveType + '[]'} />
       {
         // Maps each selected object to a reference type for submitting
@@ -119,7 +119,9 @@ let ListInput = (props) => {
 
 ListInput.propTypes = {
   objectKey: PropTypes.string.isRequired,
-  data: PropTypes.object.isRequired
+  data: PropTypes.object.isRequired,
+  hints: PropTypes.objects,
+  onHelpClick: PropTypes.func
 };
 
 var StyledListInput = withStyles(QuestionnaireStyle)(ListInput);

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/MarkdownTextField.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/MarkdownTextField.jsx
@@ -30,11 +30,11 @@ import FormattedText from "../components/FormattedText.jsx";
 
 // Markdown Text Input field used by Edit dialog component
 let MarkdownTextField = (props) => {
-  let { objectKey, data, onChange, hints, onHelpClick, classes } = props;
+  let { objectKey, data, onChange, hint, classes } = props;
   const [value, setValue] = useState(data[objectKey] || '');
 
   return (
-    <EditorInput name={objectKey} hasHint={Boolean(hints?.[objectKey])}  onHelpClick={onHelpClick}>
+    <EditorInput name={objectKey} hint={hint}>
       <MarkdownText value={value} onChange={value => {setValue(value); onChange && onChange(value);}} />
       <input type="hidden" name={objectKey} value={value} />
     </EditorInput>
@@ -45,8 +45,7 @@ MarkdownTextField.propTypes = {
   objectKey: PropTypes.string.isRequired,
   data: PropTypes.object.isRequired,
   onChange: PropTypes.func,
-  hints: PropTypes.object,
-  onHelpClick: PropTypes.func
+  hint: PropTypes.string,
 };
 
 const StyledMarkdownTextField = withStyles(QuestionnaireStyle)(MarkdownTextField);

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/MarkdownTextField.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/MarkdownTextField.jsx
@@ -30,11 +30,11 @@ import FormattedText from "../components/FormattedText.jsx";
 
 // Markdown Text Input field used by Edit dialog component
 let MarkdownTextField = (props) => {
-  let { objectKey, data, onChange, classes } = props;
+  let { objectKey, data, onChange, hints, onHelpClick, classes } = props;
   const [value, setValue] = useState(data[objectKey] || '');
 
   return (
-    <EditorInput name={objectKey}>
+    <EditorInput name={objectKey} hasHint={Boolean(hints?.[objectKey])}  onHelpClick={onHelpClick}>
       <MarkdownText value={value} onChange={value => {setValue(value); onChange && onChange(value);}} />
       <input type="hidden" name={objectKey} value={value} />
     </EditorInput>
@@ -44,7 +44,9 @@ let MarkdownTextField = (props) => {
 MarkdownTextField.propTypes = {
   objectKey: PropTypes.string.isRequired,
   data: PropTypes.object.isRequired,
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  hints: PropTypes.object,
+  onHelpClick: PropTypes.func
 };
 
 const StyledMarkdownTextField = withStyles(QuestionnaireStyle)(MarkdownTextField);

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/NumberInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/NumberInput.jsx
@@ -35,7 +35,7 @@ import ValueComponentManager from "./ValueComponentManager";
 // Number Input field used by Edit dialog component
 
 let NumberInput = (props) => {
-  let { objectKey, data, hints, onHelpClick } = props;
+  let { objectKey, data, hint } = props;
   const type = props.value?.charAt(0).toUpperCase() + props.value?.slice(1).toLowerCase();
   const defaultValue = type === "Long" ? 0 : '';
   const isMax = type === "Long" && objectKey.startsWith('max');
@@ -43,7 +43,7 @@ let NumberInput = (props) => {
   let [ value, setValue ] = useState(typeof data[objectKey] != 'undefined' ? data[objectKey] : defaultValue);
 
   return (
-    <EditorInput name={objectKey} hasHint={Boolean(hints?.[objectKey])} onHelpClick={onHelpClick}>
+    <EditorInput name={objectKey} hint={hint}>
       <TextField
         variant="standard"
         fullWidth
@@ -69,8 +69,7 @@ let NumberInput = (props) => {
 NumberInput.propTypes = {
   objectKey: PropTypes.string.isRequired,
   data: PropTypes.object.isRequired,
-  hints: PropTypes.object,
-  onHelpClick: PropTypes.func
+  hint: PropTypes.string,
 };
 
 const StyledNumberInput = withStyles(QuestionnaireStyle)(NumberInput);

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/NumberInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/NumberInput.jsx
@@ -35,7 +35,7 @@ import ValueComponentManager from "./ValueComponentManager";
 // Number Input field used by Edit dialog component
 
 let NumberInput = (props) => {
-  let { objectKey, data } = props;
+  let { objectKey, data, hints, onHelpClick } = props;
   const type = props.value?.charAt(0).toUpperCase() + props.value?.slice(1).toLowerCase();
   const defaultValue = type === "Long" ? 0 : '';
   const isMax = type === "Long" && objectKey.startsWith('max');
@@ -43,7 +43,7 @@ let NumberInput = (props) => {
   let [ value, setValue ] = useState(typeof data[objectKey] != 'undefined' ? data[objectKey] : defaultValue);
 
   return (
-    <EditorInput name={objectKey}>
+    <EditorInput name={objectKey} hasHint={Boolean(hints?.[objectKey])} onHelpClick={onHelpClick}>
       <TextField
         variant="standard"
         fullWidth
@@ -68,7 +68,9 @@ let NumberInput = (props) => {
 
 NumberInput.propTypes = {
   objectKey: PropTypes.string.isRequired,
-  data: PropTypes.object.isRequired
+  data: PropTypes.object.isRequired,
+  hints: PropTypes.object,
+  onHelpClick: PropTypes.func
 };
 
 const StyledNumberInput = withStyles(QuestionnaireStyle)(NumberInput);

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ObjectInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ObjectInput.jsx
@@ -36,13 +36,13 @@ import QuestionComponentManager from "../questionnaireEditor/QuestionComponentMa
 // Object Input field used by Edit dialog component
 
 let ObjectInput = (props) => {
-  let { objectKey, value, data, onChange, ...rest } = props;
+  let { objectKey, value, data, hints, onHelpClick, onChange, ...rest } = props;
   const defaultValue = data[objectKey] || (Object.keys(value || {})[0] || '');
   let [ selectedValue, setSelectedValue ] = useState(defaultValue);
 
   return (
     <>
-    <EditorInput name={objectKey}>
+    <EditorInput name={objectKey} hasHint={Boolean(hints?.[objectKey])} onHelpClick={onHelpClick}>
       <Select
         variant="standard"
         id={objectKey}
@@ -60,7 +60,7 @@ let ObjectInput = (props) => {
       </Select>
     </EditorInput>
     { typeof(value) === 'object' && selectedValue != '' && typeof (value[selectedValue]) === 'object' ?
-        <Fields data={data} JSON={value[selectedValue]} edit={true} {...rest} />
+        <Fields data={data} JSON={value[selectedValue]} edit={true} hints={hints} onHelpClick={onHelpClick} {...rest} />
       :
       (selectedValue != '') && <Typography color="secondary" variant="subtitle2">Unsupported: {selectedValue}</Typography>
     }
@@ -71,7 +71,9 @@ let ObjectInput = (props) => {
 ObjectInput.propTypes = {
   objectKey: PropTypes.string.isRequired,
   value: PropTypes.object.isRequired,
-  data: PropTypes.object.isRequired
+  data: PropTypes.object.isRequired,
+  hints: PropTypes.object,
+  onHelpClick: PropTypes.func
 };
 
 const StyledObjectInput = withStyles(QuestionnaireStyle)(ObjectInput);

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ObjectInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ObjectInput.jsx
@@ -36,13 +36,13 @@ import QuestionComponentManager from "../questionnaireEditor/QuestionComponentMa
 // Object Input field used by Edit dialog component
 
 let ObjectInput = (props) => {
-  let { objectKey, value, data, hints, onHelpClick, onChange, ...rest } = props;
+  let { objectKey, value, data, hint, hints, onChange, ...rest } = props;
   const defaultValue = data[objectKey] || (Object.keys(value || {})[0] || '');
   let [ selectedValue, setSelectedValue ] = useState(defaultValue);
 
   return (
     <>
-    <EditorInput name={objectKey} hasHint={Boolean(hints?.[objectKey])} onHelpClick={onHelpClick}>
+    <EditorInput name={objectKey} hint={hint}>
       <Select
         variant="standard"
         id={objectKey}
@@ -60,7 +60,7 @@ let ObjectInput = (props) => {
       </Select>
     </EditorInput>
     { typeof(value) === 'object' && selectedValue != '' && typeof (value[selectedValue]) === 'object' ?
-        <Fields data={data} JSON={value[selectedValue]} edit={true} hints={hints} onHelpClick={onHelpClick} {...rest} />
+        <Fields data={data} JSON={value[selectedValue]} edit={true} hints={hints} {...rest} />
       :
       (selectedValue != '') && <Typography color="secondary" variant="subtitle2">Unsupported: {selectedValue}</Typography>
     }
@@ -72,8 +72,8 @@ ObjectInput.propTypes = {
   objectKey: PropTypes.string.isRequired,
   value: PropTypes.object.isRequired,
   data: PropTypes.object.isRequired,
+  hint: PropTypes.string,
   hints: PropTypes.object,
-  onHelpClick: PropTypes.func
 };
 
 const StyledObjectInput = withStyles(QuestionnaireStyle)(ObjectInput);

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question-hints.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question-hints.json
@@ -3,3 +3,4 @@
   "expression": "Used with the **computed** entry mode. Supports javascript syntax. Example: `return 2 * @{age:-0}`, where `age` is the id of a question in the same form, `:-` is an optional marker for a default value, and `0` is the optional default value.",
   "question": "Used with the **reference** entry mode. Example: `/Questionnaires/Demographics/name`"
 }
+

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question-hints.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question-hints.json
@@ -1,6 +1,6 @@
 {
   "entryMode": "Specifies the source of the value for this question: manually entered by the **user**, **computed** using a specified expression and answers to other questions, or copied over from another **reference** answer to a question specified by a path.",
-  "expression": "Used with the **computed** entry mode. Supports javascript syntax.\n\nExample:\n\n```return 2 * @{age:-0}```\n\n where `age` is the id of a question in the same form, `:-` is an optional marker for a default value, and `0` is the optional default value.",
+  "expression": "Supports javascript syntax, with special placeholder variables being populated with answers to other questions in the form.\n\nExample:\n\n```return @{laps} * @{lapLength:-100}```\n\n where `laps` and `lapLength` are the names of questions in the same form, `:-` is an optional marker for a default value, and `100` is the optional default value.",
   "question": "Used with the **reference** entry mode. Example: `/Questionnaires/Demographics/name`"
 }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question-hints.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question-hints.json
@@ -1,5 +1,5 @@
 {
-  "entryMode": "Specifies the source of the value for this question: manually entered by the **user**, **computed** using a specified expression, or copied over from another **reference** answer to a question specified by a path.",
+  "entryMode": "Specifies the source of the value for this question: manually entered by the **user**, **computed** using a specified expression and answers to other questions, or copied over from another **reference** answer to a question specified by a path.",
   "expression": "Used with the **computed** entry mode. Supports javascript syntax.\n\nExample:\n\n```return 2 * @{age:-0}```\n\n where `age` is the id of a question in the same form, `:-` is an optional marker for a default value, and `0` is the optional default value.",
   "question": "Used with the **reference** entry mode. Example: `/Questionnaires/Demographics/name`"
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question-hints.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question-hints.json
@@ -1,6 +1,6 @@
 {
   "entryMode": "Specifies the source of the value for this question: manually entered by the **user**, **computed** using a specified expression, or copied over from another **reference** answer to a question specified by a path.",
-  "expression": "Used with the **computed** entry mode. Supports javascript syntax. Example: `return 2 * @{age:-0}`, where `age` is the id of a question in the same form, `:-` is an optional marker for a default value, and `0` is the optional default value.",
+  "expression": "Used with the **computed** entry mode. Supports javascript syntax.\n\nExample:\n\n```return 2 * @{age:-0}```\n\n where `age` is the id of a question in the same form, `:-` is an optional marker for a default value, and `0` is the optional default value.",
   "question": "Used with the **reference** entry mode. Example: `/Questionnaires/Demographics/name`"
 }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question-hints.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question-hints.json
@@ -1,0 +1,5 @@
+{
+  "entryMode": "Specifies the source of the value for this question: manually entered by the **user**, **computed** using a specified expression, or copied over from another **reference** answer to a question specified by a path.",
+  "expression": "Used with the **computed** entry mode. Supports javascript syntax. Example: `return 2 * @{age:-0}`, where `age` is the id of a question in the same form, `:-` is an optional marker for a default value, and `0` is the optional default value.",
+  "question": "Used with the **reference** entry mode. Example: `/Questionnaires/Demographics/name`"
+}

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question-hints.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question-hints.json
@@ -1,5 +1,5 @@
 {
-  "entryMode": "Specifies the source of the value for this question: manually entered by the **user**, **computed** using a specified expression and answers to other questions, or copied over from another **reference** answer to a question specified by a path.",
+  "entryMode": "Specifies the source of the value for this question:  \n* manually entered by the **user**,\n* **computed** using a specified expression and answers to other questions, or\n* copied over from another **reference** answer to a question specified by a path.",
   "expression": "Supports javascript syntax, with special placeholder variables being populated with answers to other questions in the form.\n\nExample:\n\n```return @{laps} * @{lapLength:-100}```\n\n where `laps` and `lapLength` are the names of questions in the same form, `:-` is an optional marker for a default value, and `100` is the optional default value.",
   "question": "Path to a question, either in this or a different questionnaire. Example: `/Questionnaires/Demographics/name`"
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question-hints.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question-hints.json
@@ -1,6 +1,6 @@
 {
   "entryMode": "Specifies the source of the value for this question: manually entered by the **user**, **computed** using a specified expression and answers to other questions, or copied over from another **reference** answer to a question specified by a path.",
   "expression": "Supports javascript syntax, with special placeholder variables being populated with answers to other questions in the form.\n\nExample:\n\n```return @{laps} * @{lapLength:-100}```\n\n where `laps` and `lapLength` are the names of questions in the same form, `:-` is an optional marker for a default value, and `100` is the optional default value.",
-  "question": "Used with the **reference** entry mode. Example: `/Questionnaires/Demographics/name`"
+  "question": "Path to a question, either in this or a different questionnaire. Example: `/Questionnaires/Demographics/name`"
 }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Questionnaire-hints.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Questionnaire-hints.json
@@ -1,3 +1,4 @@
 {
   "maxPerSubject" : "The maximum number of forms of this type allowed for a specific subject"
 }
+

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Questionnaire-hints.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Questionnaire-hints.json
@@ -1,0 +1,3 @@
+{
+  "maxPerSubject" : "The maximum number of forms of this type allowed for a specific subject"
+}

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReferenceInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReferenceInput.jsx
@@ -36,7 +36,7 @@ let SUBJECT_TYPE_URL = "/SubjectTypes.paginate?offset=0&limit=100&req=0";
 
 // Reference Input field used by Edit dialog component
 let ReferenceInput = (props) => {
-  const { classes, objectKey, data, value } = props;
+  const { classes, objectKey, data, value, hints, onHelpClick } = props;
   const fieldsReader = useFieldsReaderContext();
   const fieldsWriter = useFieldsWriterContext();
 
@@ -263,7 +263,7 @@ let ReferenceInput = (props) => {
   }
 
   return (
-    <EditorInput name={objectKey}>
+    <EditorInput name={objectKey} hasHint={Boolean(hints?.[objectKey])}  onHelpClick={onHelpClick}>
       <input type="hidden" name={objectKey + "@TypeHint"} value='Reference' />
       {hiddenInput}
       <Select
@@ -282,7 +282,9 @@ let ReferenceInput = (props) => {
 
 ReferenceInput.propTypes = {
   objectKey: PropTypes.string.isRequired,
-  data: PropTypes.object.isRequired
+  data: PropTypes.object.isRequired,
+  hints: PropTypes.object,
+  onHelpClick: PropTypes.func
 };
 
 const StyledReferenceInput = withStyles(LiveTableStyle)(ReferenceInput);

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReferenceInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReferenceInput.jsx
@@ -36,7 +36,7 @@ let SUBJECT_TYPE_URL = "/SubjectTypes.paginate?offset=0&limit=100&req=0";
 
 // Reference Input field used by Edit dialog component
 let ReferenceInput = (props) => {
-  const { classes, objectKey, data, value, hints, onHelpClick } = props;
+  const { classes, objectKey, data, value, hint } = props;
   const fieldsReader = useFieldsReaderContext();
   const fieldsWriter = useFieldsWriterContext();
 
@@ -263,7 +263,7 @@ let ReferenceInput = (props) => {
   }
 
   return (
-    <EditorInput name={objectKey} hasHint={Boolean(hints?.[objectKey])}  onHelpClick={onHelpClick}>
+    <EditorInput name={objectKey} hint={hint}>
       <input type="hidden" name={objectKey + "@TypeHint"} value='Reference' />
       {hiddenInput}
       <Select
@@ -283,8 +283,7 @@ let ReferenceInput = (props) => {
 ReferenceInput.propTypes = {
   objectKey: PropTypes.string.isRequired,
   data: PropTypes.object.isRequired,
-  hints: PropTypes.object,
-  onHelpClick: PropTypes.func
+  hint: PropTypes.string,
 };
 
 const StyledReferenceInput = withStyles(LiveTableStyle)(ReferenceInput);

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/TextInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/TextInput.jsx
@@ -31,10 +31,10 @@ import ValueComponentManager from "../questionnaireEditor/ValueComponentManager"
 
 // Text Input field used by Edit dialog component
 let TextInput = (props) => {
-  let { objectKey, data, multiline, variant } = props;
+  let { objectKey, data, multiline, variant, hints, onHelpClick } = props;
 
   return (
-    <EditorInput name={objectKey}>
+    <EditorInput name={objectKey} hasHint={Boolean(hints?.[objectKey])} onHelpClick={onHelpClick}>
       <TextField
         variant="standard"
         name={objectKey}
@@ -51,7 +51,9 @@ let TextInput = (props) => {
 
 TextInput.propTypes = {
   objectKey: PropTypes.string.isRequired,
-  data: PropTypes.object.isRequired
+  data: PropTypes.object.isRequired,
+  hints: PropTypes.object,
+  onHelpClick: PropTypes.func
 };
 
 const StyledTextInput = withStyles(QuestionnaireStyle)(TextInput);

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/TextInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/TextInput.jsx
@@ -31,10 +31,10 @@ import ValueComponentManager from "../questionnaireEditor/ValueComponentManager"
 
 // Text Input field used by Edit dialog component
 let TextInput = (props) => {
-  let { objectKey, data, multiline, variant, hints, onHelpClick } = props;
+  let { objectKey, data, multiline, variant, hint } = props;
 
   return (
-    <EditorInput name={objectKey} hasHint={Boolean(hints?.[objectKey])} onHelpClick={onHelpClick}>
+    <EditorInput name={objectKey} hint={hint}>
       <TextField
         variant="standard"
         name={objectKey}
@@ -52,8 +52,7 @@ let TextInput = (props) => {
 TextInput.propTypes = {
   objectKey: PropTypes.string.isRequired,
   data: PropTypes.object.isRequired,
-  hints: PropTypes.object,
-  onHelpClick: PropTypes.func
+  hint: PropTypes.string,
 };
 
 const StyledTextInput = withStyles(QuestionnaireStyle)(TextInput);


### PR DESCRIPTION
[CARDS-1949](https://phenotips.atlassian.net/browse/CARDS-1949) As an admin using the questionnaire designer, I can access contextual help / detailed descriptions of the questionnaire items' fields
To test go to the questionnaire editor and edit questionnaire and question. Observe the info icon and hover or tap on it to see the description. 