### PR TITLE
CARDS-1965: Disable WebDAV

### DIFF
--- a/distribution/src/main/features/base.json
+++ b/distribution/src/main/features/base.json
@@ -254,12 +254,6 @@
             "request.log.enabled":true,
             "access.log.outputtype:Integer":"0"
         },
-        "org.apache.sling.jcr.davex.impl.servlets.SlingDavExServlet":{
-            "alias":"/server"
-        },
-        "org.apache.sling.jcr.webdav.impl.servlets.SimpleWebDavServlet":{
-            "dav.root":"/dav"
-        },
         "org.apache.sling.commons.log.LogManager.factory.config~access.log":{
             "org.apache.sling.commons.log.pattern":"%msg%n",
             "org.apache.sling.commons.log.names":[

--- a/distribution/src/main/features/oak/oak_base.json
+++ b/distribution/src/main/features/oak/oak_base.json
@@ -102,19 +102,11 @@
             "start-order":"15"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.jcr.davex:1.3.10",
-            "start-order":"15"
-        },
-        {
             "id":"org.apache.sling:org.apache.sling.jcr.jcr-wrapper:2.0.0",
             "start-order":"15"
         },
         {
             "id":"org.apache.sling:org.apache.sling.jcr.registration:1.0.6",
-            "start-order":"15"
-        },
-        {
-            "id":"org.apache.sling:org.apache.sling.jcr.webdav:2.3.8",
             "start-order":"15"
         },
         {


### PR DESCRIPTION
To test:
- start in proms mode
- run `curl -u admin:admin -X COPY -H "Destination: /Survey/Maad" http://localhost:8080/Survey/Mood`
- it should fail since `COPY` is now disabled
- make sure the normal UI still works: create a new form, fill it in, view it, check that it shows up on the dashboard, delete it
- make sure `/bin/browser.html` still works