### PR TITLE
CARDS-1966: Display the link to Terms of Use on the patient portal error page

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/index.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/index.jsx
@@ -88,13 +88,15 @@ function PatientPortalHomepage (props) {
     let appName = document.querySelector('meta[name="title"]')?.content;
     let message = surveyInstructions?.welcomeMessage?.replaceAll("APP_NAME", appName) || '';
     message = `${message}\n\n### To fill out surveys, please follow the personalized link that was emailed to you.`;
-    return (
+    return (<>
       <ErrorPage
         sx={{maxWidth: 500, margin: "0 auto"}}
         title=""
         message={message}
         messageColor="textPrimary"
-      />)
+      />
+      <Footer/>
+    </>)
   }
 
   if (!subject) {


### PR DESCRIPTION
To test, start `prems` and navigate to http://localhost:8080/Survey.html. Note the Terms of Use link at the bottom of the page.