### PR TITLE
CARDS-1938: Implement the /Forms.count API endpoint

### DIFF
--- a/modules/data-entry/src/main/features/feature.json
+++ b/modules/data-entry/src/main/features/feature.json
@@ -70,7 +70,7 @@
     "org.apache.sling.jcr.repoinit.RepositoryInitializer~forms":{
       "service.ranking:Integer":150,
       "scripts":[
-        "create path (cards:dataQuery) /query \n\n # Allow all users to query; the actual results will obey their access rights \n set ACL for everyone \n   allow  jcr:read  on /query \n end \n\n create path (cards:QuestionnairesHomepage) /Questionnaires \n create path (cards:FormsHomepage) /Forms \n create path (cards:SubjectsHomepage) /Subjects \n create path (cards:SubjectTypesHomepage) /SubjectTypes ",
+        "create path (cards:dataQuery) /query \n\n # Allow all users to query; the actual results will obey their access rights \n set ACL for everyone \n   allow  jcr:read  on /query \n end \n\n create path (cards:QuestionnairesHomepage) /Questionnaires \n create path (cards:FormsHomepage) /Forms \n create path (cards:FormsQueryCacheHomepage) /FormsQueryCache \n create path (cards:SubjectsHomepage) /Subjects \n create path (cards:SubjectTypesHomepage) /SubjectTypes ",
         "create service user cards-answer-editor \n set ACL on /Questionnaires \n   allow jcr:read for cards-answer-editor \n end"
       ]
     },

--- a/modules/data-entry/src/main/features/feature.json
+++ b/modules/data-entry/src/main/features/feature.json
@@ -70,7 +70,7 @@
     "org.apache.sling.jcr.repoinit.RepositoryInitializer~forms":{
       "service.ranking:Integer":150,
       "scripts":[
-        "create path (cards:dataQuery) /query \n\n # Allow all users to query; the actual results will obey their access rights \n set ACL for everyone \n   allow  jcr:read  on /query \n end \n\n create path (cards:QuestionnairesHomepage) /Questionnaires \n create path (cards:FormsHomepage) /Forms \n create path (cards:FormsQueryCacheHomepage) /FormsQueryCache \n create path (cards:SubjectsHomepage) /Subjects \n create path (cards:SubjectTypesHomepage) /SubjectTypes ",
+        "create path (cards:dataQuery) /query \n\n # Allow all users to query; the actual results will obey their access rights \n set ACL for everyone \n   allow  jcr:read  on /query \n end \n\n create path (cards:QuestionnairesHomepage) /Questionnaires \n create path (cards:FormsHomepage) /Forms \n create path (cards:QueryCacheHomepage) /QueryCache \n create path (cards:SubjectsHomepage) /Subjects \n create path (cards:SubjectTypesHomepage) /SubjectTypes ",
         "create service user cards-answer-editor \n set ACL on /Questionnaires \n   allow jcr:read for cards-answer-editor \n end"
       ]
     },

--- a/modules/data-entry/src/main/java/io/uhndata/cards/CountServlet.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/CountServlet.java
@@ -198,6 +198,12 @@ public class CountServlet extends PaginationServlet
                 LOGGER.error("Failed to set node property: {}", e.getMessage(), e);
             }
         }));
+
+        Map<String, String> fieldParameters = getSanitizedFieldParameters(request);
+        if (!fieldParameters.isEmpty() && !fieldParameters.get(FIELDNAME).isBlank()) {
+            node.setProperty(fieldParameters.get(FIELDNAME) + fieldParameters.get(FIELDCOMPARATOR),
+                    fieldParameters.get(FIELDVALUE));
+        }
     }
 
     /**

--- a/modules/data-entry/src/main/java/io/uhndata/cards/CountServlet.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/CountServlet.java
@@ -190,6 +190,7 @@ public class CountServlet extends PaginationServlet
      * @param query the query to execute
      * @param request the current request
      * @return a long-typed number of the number of Resources with the specified parameters
+     * @throws IOException if failed or interrupted I/O operation
      */
     private long getCount(final Query query, final SlingHttpServletRequest request,
                           final SlingHttpServletResponse response) throws IOException

--- a/modules/data-entry/src/main/java/io/uhndata/cards/CountServlet.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/CountServlet.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.uhndata.cards;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryManager;
+import javax.jcr.query.QueryResult;
+import javax.json.Json;
+import javax.json.stream.JsonGenerator;
+import javax.servlet.Servlet;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A servlet that counts the number of resources that meet specified filters.
+ * <p>
+ * This servlet supports the following parameters:
+ * </p>
+ * <ul>
+ * <li><code>filter</code>: a (lucene-like) search term, such as {@code germline}, {@code cancer OR tumor},
+ * {@code (*blastoma OR *noma OR tumor*) recurrent}; no filter set by default</li>
+ * <li><code>includeallstatus</code>: if true, incomplete forms will be included. Otherwise, they will be excluded
+ * unless searched for directly using {@code fieldname="statusFlags"}
+ * </ul>
+ *
+ * @version $Id$
+ */
+@Component(service = { Servlet.class })
+@SlingServletResourceTypes(
+        resourceTypes = { "cards/ResourceHomepage" },
+        selectors = { "count" })
+public class CountServlet extends PaginationServlet
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(CountServlet.class);
+
+    private static final long serialVersionUID = -6068156942302219324L;
+
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+
+    @Override
+    public void doGet(final SlingHttpServletRequest request, final SlingHttpServletResponse response)
+            throws IOException, IllegalArgumentException
+    {
+        try {
+            final ResourceResolver resolver = request.getResourceResolver();
+            final Session session = resolver.adaptTo(Session.class);
+
+            // Parse the request to build a list of filters
+            final Map<FilterType, List<Filter>> filters = parseFiltersFromRequest(request);
+
+            // Check for special cases in request and return zero results if any
+            if (checkForSpecialEmptyFilter(request, filters, response)) {
+                // Write the empty response
+                writeEmptyResponse(response);
+                return;
+            }
+
+            // Get a QueryManager object
+            final QueryManager queryManager = session.getWorkspace().getQueryManager();
+
+            // Create the Query object
+            Query filterQuery = queryManager.createQuery(createQuery(request, session, filters), "JCR-SQL2");
+
+            // Get the results and write the response
+            writeResponse(request, response, filterQuery, filters, session);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to execute query: {}", e.getMessage(), e);
+            return;
+        }
+    }
+
+    /**
+     * Write an empty results response.
+     *
+     * @param response the HTTP response
+     * @throws IOException if failed or interrupted I/O operation
+     * @throws RepositoryException if accessing the repository fails
+     */
+    protected void writeEmptyResponse(final SlingHttpServletResponse response) throws IOException, RepositoryException
+    {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        // The writer doesn't need to be explicitly closed since the auto-closed jsonGen will also close the writer
+        final Writer out = response.getWriter();
+        try (JsonGenerator jsonGen = Json.createGenerator(out)) {
+            jsonGen.writeStartObject();
+            jsonGen.write("count", "0");
+            jsonGen.writeEnd().flush();
+        }
+    }
+
+    /**
+     * Write the response.
+     *
+     * @param request the current request
+     * @param response the HTTP response
+     * @param query the query to execute
+     * @throws IOException if failed or interrupted I/O operation
+     * @throws RepositoryException if accessing the repository fails
+     */
+    private void writeResponse(final SlingHttpServletRequest request, final SlingHttpServletResponse response,
+                               final Query query, final Map<FilterType, List<Filter>> filters, Session session)
+            throws IOException, RepositoryException
+    {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        // The writer doesn't need to be explicitly closed since the auto-closed jsonGen will also close the writer
+        final Writer out = response.getWriter();
+        try (JsonGenerator jsonGen = Json.createGenerator(out)) {
+            jsonGen.writeStartObject();
+            long count = getCount(query, request);
+            jsonGen.write("count", count);
+            createFormsQueryCacheNode(session, count, filters.get(FilterType.CHILD));
+            try {
+                session.save();
+            } catch (final RepositoryException e) {
+                LOGGER.error("Failed to commit formsQueryCache: {}", e.getMessage(), e);
+            }
+            jsonGen.writeEnd().flush();
+        }
+    }
+
+    /**
+     * Creates a <code>FormsQueryCache</code> node that represents the current FormsQueryCache instance with identified
+     * filters.
+     *
+     * @param session the current session
+     * @param count the number of Resources that meet the conditions specified in the request
+     * @param filters a list of filters
+     * @throws RepositoryException if accessing the repository fails
+     */
+    private void createFormsQueryCacheNode(final Session session, final long count, final List<Filter> filters)
+            throws RepositoryException
+    {
+        Node node = session.getNode("/FormsQueryCache").addNode(UUID.randomUUID().toString(), "cards:FormsQueryCache");
+        node.setProperty("countType", "=");
+        node.setProperty("count", count);
+        node.setProperty("time", DATE_FORMAT.format(new Date()));
+        for (Filter filter : filters) {
+            node.setProperty(filter.getName() + filter.getComparator(), filter.getValue());
+        }
+    }
+
+    /**
+     * Counts the number of Resources that meet the conditions specified in the query.
+     *
+     * @param query the query to execute
+     * @param request the current request
+     * @return a long-typed number of the number of Resources with the specified parameters
+     */
+    private long getCount(final Query query, final SlingHttpServletRequest request)
+    {
+        long count = 0;
+
+        // Execute the query
+        try {
+            final QueryResult filterResult = query.execute();
+            final Iterator<Resource> results =
+                    new ResourceIterator(request.getResourceResolver(), filterResult.getNodes());
+
+            while (results.hasNext()) {
+                count++;
+                results.next();
+            }
+        } catch (RepositoryException e) {
+            //
+        }
+
+        return count;
+    }
+
+}

--- a/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
@@ -99,7 +99,7 @@ public class PaginationServlet extends SlingSafeMethodsServlet
     /**
      * Various supported filter types.
      */
-    private enum FilterType
+    protected enum FilterType
     {
         /** Regular filters on child node values. */
         CHILD("child", "filternames", null, false),
@@ -133,7 +133,7 @@ public class PaginationServlet extends SlingSafeMethodsServlet
      * A parsed filter, gathering together the field, comparator, value to compare against, type of the value, and
      * source name that the field belongs to.
      */
-    private static final class Filter
+    protected static final class Filter
     {
         /**
          * The field name, may be the jcr:uuid of a question being answered, or a special value like the subject,
@@ -171,6 +171,21 @@ public class PaginationServlet extends SlingSafeMethodsServlet
             this.value = value;
             this.type = type;
             this.comparator = comparator;
+        }
+
+        String getName()
+        {
+            return this.name;
+        }
+
+        String getValue()
+        {
+            return this.value;
+        }
+
+        String getComparator()
+        {
+            return this.comparator;
         }
     }
 
@@ -219,7 +234,7 @@ public class PaginationServlet extends SlingSafeMethodsServlet
      * @return {@code true} if any mandatory special property has an "is empty" filter, {@code false} otherwise
      * @throws RepositoryException if accessing the repository fails
      */
-    private boolean checkForSpecialEmptyFilter(final SlingHttpServletRequest request,
+    protected boolean checkForSpecialEmptyFilter(final SlingHttpServletRequest request,
         final Map<FilterType, List<Filter>> filters, final SlingHttpServletResponse response)
         throws RepositoryException
     {
@@ -314,7 +329,7 @@ public class PaginationServlet extends SlingSafeMethodsServlet
      * @return a query that takes into account the requested filters
      * @throws RepositoryException if accessing the repository fails
      */
-    private String createQuery(final SlingHttpServletRequest request, Session session,
+    protected String createQuery(final SlingHttpServletRequest request, Session session,
         final Map<FilterType, List<Filter>> filters) throws RepositoryException
     {
         // If we want this query to be fast, we need to use the exact nodetype requested.
@@ -388,7 +403,7 @@ public class PaginationServlet extends SlingSafeMethodsServlet
      *         only some types of filters, depending on which filters are specified in the request
      * @throws IllegalArgumentException when the number of request parameters are not equal
      */
-    private Map<FilterType, List<Filter>> parseFiltersFromRequest(final SlingHttpServletRequest request)
+    protected Map<FilterType, List<Filter>> parseFiltersFromRequest(final SlingHttpServletRequest request)
         throws IllegalArgumentException
     {
         final Map<FilterType, List<Filter>> result = new HashMap<>();

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -62,25 +62,25 @@
   - showTotalRows (BOOLEAN) = 'true'
 
 //-----------------------------------------------------------------------------
-[cards:FormsQueryCache] > sling:Folder, mix:referenceable, mix:versionable, mix:lastModified
+[cards:QueryCache] > nt:unstructured
   // Attributes
 
-  // We can use forms in a query.
+  // We can query the cache for saved counts.
   query
 
   // Properties
 
   // Hardcode the resource type.
-  - sling:resourceType (STRING) = "cards/FormsQueryCache" mandatory autocreated protected
+  - sling:resourceType (STRING) = "cards/QueryCache" mandatory autocreated protected
 
-  // Hardcode the resource supertype: each form is a resource.
+  // Hardcode the resource supertype: each queryCache is a resource.
   - sling:resourceSuperType (STRING) = "cards/Resource" mandatory autocreated protected
 
   // Children
 
 //-----------------------------------------------------------------------------
-// The homepage for the FormsQueryCache space.
-[cards:FormsQueryCacheHomepage] > sling:Folder
+// The homepage for the QueryCache space.
+[cards:QueryCacheHomepage] > sling:Folder
   // Attributes:
 
   // We can use this homepage in a query.
@@ -89,12 +89,10 @@
   // Properties:
 
   // Hardcode the resource type.
-  - sling:resourceType (STRING) = "cards/FormsQueryCacheHomepage" mandatory autocreated protected
+  - sling:resourceType (STRING) = "cards/QueryCacheHomepage" mandatory autocreated protected
 
-  // Hardcode the resource supertype: the FormsQueryCacheHomepage is a resource homepage.
+  // Hardcode the resource supertype: the QueryCacheHomepage is a resource homepage.
   - sling:resourceSuperType (STRING) = "cards/ResourceHomepage" mandatory autocreated protected
 
-  // Set a default title.
-  - title (String) = "Data" mandatory autocreated
-
   // Children
+  + * (cards:QueryCache)

--- a/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
+++ b/modules/data-entry/src/main/resources/SLING-INF/nodetypes/dataentry.cnd
@@ -60,3 +60,41 @@
   // Whether to show the total number of results.
   // Can be set to 'false' in case of performance issues.
   - showTotalRows (BOOLEAN) = 'true'
+
+//-----------------------------------------------------------------------------
+[cards:FormsQueryCache] > sling:Folder, mix:referenceable, mix:versionable, mix:lastModified
+  // Attributes
+
+  // We can use forms in a query.
+  query
+
+  // Properties
+
+  // Hardcode the resource type.
+  - sling:resourceType (STRING) = "cards/FormsQueryCache" mandatory autocreated protected
+
+  // Hardcode the resource supertype: each form is a resource.
+  - sling:resourceSuperType (STRING) = "cards/Resource" mandatory autocreated protected
+
+  // Children
+
+//-----------------------------------------------------------------------------
+// The homepage for the FormsQueryCache space.
+[cards:FormsQueryCacheHomepage] > sling:Folder
+  // Attributes:
+
+  // We can use this homepage in a query.
+  query
+
+  // Properties:
+
+  // Hardcode the resource type.
+  - sling:resourceType (STRING) = "cards/FormsQueryCacheHomepage" mandatory autocreated protected
+
+  // Hardcode the resource supertype: the FormsQueryCacheHomepage is a resource homepage.
+  - sling:resourceSuperType (STRING) = "cards/ResourceHomepage" mandatory autocreated protected
+
+  // Set a default title.
+  - title (String) = "Data" mandatory autocreated
+
+  // Children


### PR DESCRIPTION
[CARDS-1938](https://phenotips.atlassian.net/browse/CARDS-1938)

To test:
1. Build this CARDS-1938 branch with mvn clean install.
2. Start CARDS with ./start_cards.sh --dev --test .
3. Login to http://localhost:8080 as admin:admin and create several same and different forms from a couple of patients.
4. With http://localhost:8080/Forms.count?descending=true&includeallstatus=true&req=2&filternames=cards%3ACreatedDate&filtercomparators=%3D&filtervalues=2022-11-28T00%3A00%3A00-05%3A00&filtertypes=createddate test the number of forms created by you this day.
5. With http://localhost:8080/Forms.count?descending=true&includeallstatus=true&req=2&filternames=cards%3AQuestionnaire&filtercomparators=%3D&filtervalues={questionnaire_uuid}&filtertypes=questionnaire&filternames={answer_uuid}&filtercomparators=%3D&filtervalues={desirable_value}&filtertypes={answer_type}&filternodetypes=cards%2FAnswer test the number of forms with specific answer value
6. With http://localhost:8080/Forms.count?descending=true&includeallstatus=true&req=2&filternames=cards%3ASubject&filtercomparators=%3D&filtervalues={subject_uuid}&filtertypes=relatedSubjects test the number of forms of specific patient

[CARDS-1938]: https://phenotips.atlassian.net/browse/CARDS-1938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ