### PR TITLE
[misc] The login form should never send data through the GET query string

### DIFF
--- a/modules/login/src/main/frontend/src/login/loginForm.js
+++ b/modules/login/src/main/frontend/src/login/loginForm.js
@@ -166,6 +166,7 @@ class SignIn extends React.Component {
             {this.state.failedLogin && <Alert severity="error">{this.state.failedLogin}</Alert>}
 
             <form
+              method="post"
               className={classes.form}
               onSubmit={(event)=> {
                 event.preventDefault();


### PR DESCRIPTION
No visible changes, but the HTML source should now have a `method=post` attribute on the login `<form>` element.