### PR TITLE
CARDS-1969: Users should not be allowed to upload HTML or JavaScript files

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/FileQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FileQuestion.jsx
@@ -254,7 +254,7 @@ function FileQuestion(props) {
     }).catch((errorObj) => {
       // Backend did not allow this file to be uploaded
       console.log(errorObj);
-      setError("File could not be uploaded" + (errorObj.statusText ? ": " + errorObj.statusText : ""));
+      setError("You are not allowed to upload this file");
     });
   };
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FileQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FileQuestion.jsx
@@ -252,9 +252,9 @@ function FileQuestion(props) {
       allowResave();
       onAfterUpload && onAfterUpload(file);
     }).catch((errorObj) => {
-      // Is the user logged out? Or did something else happen?
+      // Backend did not allow this file to be uploaded
       console.log(errorObj);
-      setError(String(errorObj));
+      setError("File could not be uploaded" + (errorObj.statusText ? ": " + errorObj.statusText : ""));
     });
   };
 

--- a/modules/utils/pom.xml
+++ b/modules/utils/pom.xml
@@ -70,6 +70,10 @@
       <artifactId>org.apache.sling.scripting.sightly.runtime</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.servlets.post</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.json</groupId>
       <artifactId>javax.json-api</artifactId>
     </dependency>

--- a/modules/utils/src/main/java/io/uhndata/cards/utils/internal/DenyScriptsSlingPostProcessor.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/utils/internal/DenyScriptsSlingPostProcessor.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.utils.internal;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.servlets.post.Modification;
+import org.apache.sling.servlets.post.SlingPostProcessor;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * For security purposes, deny uploading HTML or JavaScript files for anybody other than the admin.
+ *
+ * @version $Id$
+ */
+@Component
+public class DenyScriptsSlingPostProcessor implements SlingPostProcessor
+{
+    @Override
+    public void process(SlingHttpServletRequest request, List<Modification> changes) throws Exception
+    {
+        if ("admin".equalsIgnoreCase(request.getRemoteUser())) {
+            return;
+        }
+
+        ResourceResolver rr = request.getResourceResolver();
+        for (Modification m : changes) {
+            final Resource r = rr.getResource(m.getSource());
+            if (r == null || r.getResourceMetadata() == null) {
+                continue;
+            }
+            final String contentType = r.getResourceMetadata().getContentType();
+            if (contentType == null) {
+                continue;
+            }
+            if (contentType.toLowerCase(Locale.ROOT).contains("script")) {
+                throw new Exception("Script files are not allowed");
+            }
+            if (contentType.toLowerCase(Locale.ROOT).contains("html")) {
+                throw new Exception("HTML files are not allowed");
+            }
+        }
+    }
+}


### PR DESCRIPTION
To test [CARDS-1969](https://phenotips.atlassian.net/browse/CARDS-1969):

- start in lfs mode
- prepare a `.js` and a `.html` file
- as admin, create a new Somatic Variants form, try to upload these files, make sure it succeeds
- create a new non-admin user, log in with it
- create a new somatic variants form, try to upload these files, check that the upload does not succeed
- try to upload csv and pdf files, check that the upload does work