### PR TITLE
CARDS-1971: Misplaced reference question in form's markdown export

### DIFF
--- a/modules/data-entry/src/main/java/io/uhndata/cards/spi/AbstractNodeUtils.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/spi/AbstractNodeUtils.java
@@ -24,7 +24,8 @@ import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ResourceResolverFactory;
+
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Some utilities for working with JCR nodes.
@@ -143,13 +144,13 @@ public abstract class AbstractNodeUtils
      * @param rrf the resource resolver factory service, may be {@code null}
      * @return the current session, or {@code null} if a session may not be obtained
      */
-    protected Session getSession(final ResourceResolverFactory rrf)
+    protected Session getSession(final ThreadResourceResolverProvider rrp)
     {
-        if (rrf == null) {
+        if (rrp == null) {
             return null;
         }
 
-        final ResourceResolver rr = rrf.getThreadResourceResolver();
+        final ResourceResolver rr = rrp.getThreadResourceResolver();
         if (rr == null) {
             return null;
         }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/AnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/AnswersEditor.java
@@ -84,9 +84,10 @@ public abstract class AnswersEditor extends DefaultEditor
      * @param resolver the resource resolver which can provide access to JCR sessions
      * @param questionnaireUtils for working with questionnaire data
      * @param formUtils for working with form data
+     * @param serviceSession a session with access to all questionnaires. Can be null
      */
     public AnswersEditor(final NodeBuilder nodeBuilder, final ResourceResolver resolver,
-        final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils)
+        final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils, final Session serviceSession)
     {
         this.currentNodeBuilder = nodeBuilder;
         this.questionnaireUtils = questionnaireUtils;
@@ -97,6 +98,7 @@ public abstract class AnswersEditor extends DefaultEditor
         this.resolver = resolver;
         if (this.resolver != null) {
             this.currentSession = this.resolver.adaptTo(Session.class);
+            this.serviceSession = serviceSession;
             this.isFormNode = this.isFormNode(nodeBuilder);
         }
     }
@@ -147,7 +149,9 @@ public abstract class AnswersEditor extends DefaultEditor
     {
         final String questionnaireId = this.currentNodeBuilder.getProperty("questionnaire").getValue(Type.REFERENCE);
         try {
-            return this.currentSession.getNodeByIdentifier(questionnaireId);
+            return this.serviceSession == null
+                ? this.currentSession.getNodeByIdentifier(questionnaireId)
+                : this.serviceSession.getNodeByIdentifier(questionnaireId);
         } catch (RepositoryException e) {
             return null;
         }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.jackrabbit.oak.api.Type;
@@ -60,11 +61,13 @@ public class ComputedAnswersEditor extends AnswersEditor
      * @param questionnaireUtils for working with questionnaire data
      * @param formUtils for working with form data
      * @param expressionUtils for evaluating the computed questions
+     * @param serviceSession a session with access to all questionnaires. Can be null
      */
     public ComputedAnswersEditor(final NodeBuilder nodeBuilder, final ResourceResolver resolver,
-        final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils, final ExpressionUtils expressionUtils)
+        final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils, final ExpressionUtils expressionUtils,
+        final Session serviceSession)
     {
-        super(nodeBuilder, resolver, questionnaireUtils, formUtils);
+        super(nodeBuilder, resolver, questionnaireUtils, formUtils, serviceSession);
         this.expressionUtils = expressionUtils;
     }
 
@@ -84,7 +87,7 @@ public class ComputedAnswersEditor extends AnswersEditor
     protected ComputedAnswersEditor getNewEditor(String name)
     {
         return new ComputedAnswersEditor(this.currentNodeBuilder.getChildNode(name),
-            this.resolver, this.questionnaireUtils, this.formUtils, this.expressionUtils);
+            this.resolver, this.questionnaireUtils, this.formUtils, this.expressionUtils, this.serviceSession);
     }
 
     @Override

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
@@ -33,7 +33,7 @@ import org.apache.jackrabbit.oak.spi.commit.Editor;
 import org.apache.jackrabbit.oak.spi.state.ChildNodeEntry;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
-import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,15 +56,15 @@ public class ComputedAnswersEditor extends AnswersEditor
      * Simple constructor.
      *
      * @param nodeBuilder the builder for the current node
-     * @param rrf the resource resolver factory which can provide access to JCR sessions
+     * @param resolver the resource resolver which can provide access to JCR sessions
      * @param questionnaireUtils for working with questionnaire data
      * @param formUtils for working with form data
      * @param expressionUtils for evaluating the computed questions
      */
-    public ComputedAnswersEditor(final NodeBuilder nodeBuilder, final ResourceResolverFactory rrf,
+    public ComputedAnswersEditor(final NodeBuilder nodeBuilder, final ResourceResolver resolver,
         final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils, final ExpressionUtils expressionUtils)
     {
-        super(nodeBuilder, rrf, questionnaireUtils, formUtils, "computedAnswers");
+        super(nodeBuilder, resolver, questionnaireUtils, formUtils);
         this.expressionUtils = expressionUtils;
     }
 
@@ -84,7 +84,7 @@ public class ComputedAnswersEditor extends AnswersEditor
     protected ComputedAnswersEditor getNewEditor(String name)
     {
         return new ComputedAnswersEditor(this.currentNodeBuilder.getChildNode(name),
-            this.rrf, this.questionnaireUtils, this.formUtils, this.expressionUtils);
+            this.resolver, this.questionnaireUtils, this.formUtils, this.expressionUtils);
     }
 
     @Override
@@ -217,12 +217,12 @@ public class ComputedAnswersEditor extends AnswersEditor
     {
         final Map<String, Object> currentAnswers = new HashMap<>();
         if (currentNode.exists()) {
-            if (this.formUtils.isAnswerSection(currentNode) || this.formUtils.isForm(currentNode)) {
+            if (this.isAnswerSection(currentNode) || this.formUtils.isForm(currentNode)) {
                 // Found a section: Recursively get all of this section's answers
                 for (ChildNodeEntry childNode : currentNode.getChildNodeEntries()) {
                     currentAnswers.putAll(getNodeAnswers(childNode.getNodeState()));
                 }
-            } else if (this.formUtils.isAnswer(currentNode)) {
+            } else if (this.isAnswer(currentNode)) {
                 String questionName = this.questionnaireUtils.getQuestionName(this.formUtils.getQuestion(currentNode));
                 Object value = this.formUtils.getValue(currentNode);
                 if (questionName != null && value != null && !currentAnswers.containsKey(questionName)) {

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditorProvider.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditorProvider.java
@@ -16,17 +16,12 @@
  */
 package io.uhndata.cards.forms.internal;
 
-import java.util.Collections;
-
-import javax.jcr.Session;
-
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.commit.Editor;
 import org.apache.jackrabbit.oak.spi.commit.EditorProvider;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
-import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
@@ -70,23 +65,11 @@ public class ComputedAnswersEditorProvider implements EditorProvider
     {
         String computedAnswersDisabled = System.getenv("COMPUTED_ANSWERS_DISABLED");
 
-        Session serviceSession = null;
-        if (this.rrf != null)
-        {
-            try {
-                ResourceResolver serviceResolver = this.rrf.getServiceResourceResolver(
-                    Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "computedAnswers"));
-                serviceSession = serviceResolver.adaptTo(Session.class);
-            } catch (LoginException e) {
-                // Do nothing, just leave null
-            }
-        }
-
         final ResourceResolver resolver = this.rrp.getThreadResourceResolver();
         if (resolver != null && !("true".equals(computedAnswersDisabled))) {
             // Each ComputedEditor maintains a state, so a new instance must be returned each time
             return new ComputedAnswersEditor(builder, resolver, this.questionnaireUtils, this.formUtils,
-                this.expressionUtils, serviceSession);
+                this.expressionUtils, this.rrf);
         }
         return null;
     }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormUtilsImpl.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormUtilsImpl.java
@@ -37,17 +37,14 @@ import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import io.uhndata.cards.forms.api.FormUtils;
 import io.uhndata.cards.forms.api.QuestionnaireUtils;
 import io.uhndata.cards.spi.AbstractNodeUtils;
 import io.uhndata.cards.subjects.api.SubjectUtils;
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Basic utilities for working with Form data.
@@ -57,9 +54,8 @@ import io.uhndata.cards.subjects.api.SubjectUtils;
 @Component
 public final class FormUtilsImpl extends AbstractNodeUtils implements FormUtils
 {
-    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
-        policyOption = ReferencePolicyOption.GREEDY)
-    private ResourceResolverFactory rrf;
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     @Reference
     private QuestionnaireUtils questionnaires;
@@ -84,7 +80,7 @@ public final class FormUtilsImpl extends AbstractNodeUtils implements FormUtils
     @Override
     public boolean isForm(final NodeState node)
     {
-        return isNodeType(node, FORM_NODETYPE, getSession(this.rrf));
+        return isNodeType(node, FORM_NODETYPE, getSession(this.rrp));
     }
 
     @Override
@@ -170,7 +166,7 @@ public final class FormUtilsImpl extends AbstractNodeUtils implements FormUtils
     @Override
     public boolean isAnswerSection(final NodeState node)
     {
-        return isNodeType(node, ANSWER_SECTION_NODETYPE, getSession(this.rrf));
+        return isNodeType(node, ANSWER_SECTION_NODETYPE, getSession(this.rrp));
     }
 
     @Override
@@ -232,7 +228,7 @@ public final class FormUtilsImpl extends AbstractNodeUtils implements FormUtils
     @Override
     public boolean isAnswer(final NodeState node)
     {
-        return isNodeType(node, ANSWER_NODETYPE, getSession(this.rrf));
+        return isNodeType(node, ANSWER_NODETYPE, getSession(this.rrp));
     }
 
     @Override

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/QuestionnaireUtilsImpl.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/QuestionnaireUtilsImpl.java
@@ -20,27 +20,23 @@ import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import io.uhndata.cards.forms.api.QuestionnaireUtils;
 import io.uhndata.cards.spi.AbstractNodeUtils;
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 @Component
 public final class QuestionnaireUtilsImpl extends AbstractNodeUtils implements QuestionnaireUtils
 {
-    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
-        policyOption = ReferencePolicyOption.GREEDY)
-    private ResourceResolverFactory rrf;
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     @Override
     public Node getQuestionnaire(final String identifier)
     {
-        final Node result = getNodeByIdentifier(identifier, getSession(this.rrf));
+        final Node result = getNodeByIdentifier(identifier, getSession(this.rrp));
         return isQuestionnaire(result) ? result : null;
     }
 
@@ -81,7 +77,7 @@ public final class QuestionnaireUtilsImpl extends AbstractNodeUtils implements Q
     @Override
     public Node getSection(final String identifier)
     {
-        final Node result = getNodeByIdentifier(identifier, getSession(this.rrf));
+        final Node result = getNodeByIdentifier(identifier, getSession(this.rrp));
         return isSection(result) ? result : null;
     }
 
@@ -140,7 +136,7 @@ public final class QuestionnaireUtilsImpl extends AbstractNodeUtils implements Q
     @Override
     public Node getQuestion(final String identifier)
     {
-        final Node result = getNodeByIdentifier(identifier, getSession(this.rrf));
+        final Node result = getNodeByIdentifier(identifier, getSession(this.rrp));
         return isQuestion(result) ? result : null;
     }
 

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
@@ -34,6 +34,7 @@ import org.apache.jackrabbit.oak.spi.commit.Editor;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,13 +61,13 @@ public class ReferenceAnswersEditor extends AnswersEditor
      * @param questionnaireUtils for working with questionnaire data
      * @param formUtils for working with form data
      * @param subjectUtils for working with subject data
-     * @param serviceSession a session with access to all questionnaires. Can be null
+     * @param rrf a resource resolver factory used to obtain access to service sessions. Can be null
      */
     public ReferenceAnswersEditor(final NodeBuilder nodeBuilder, final ResourceResolver resolver,
         final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils, SubjectUtils subjectUtils,
-        Session serviceSession)
+        ResourceResolverFactory rrf)
     {
-        super(nodeBuilder, resolver, questionnaireUtils, formUtils, serviceSession);
+        super(nodeBuilder, resolver, questionnaireUtils, formUtils, rrf);
         this.subjectUtils = subjectUtils;
     }
 
@@ -74,6 +75,12 @@ public class ReferenceAnswersEditor extends AnswersEditor
     protected Logger getLogger()
     {
         return LOGGER;
+    }
+
+    @Override
+    protected String getServiceName()
+    {
+        return "referenceAnswers";
     }
 
     @Override
@@ -86,7 +93,7 @@ public class ReferenceAnswersEditor extends AnswersEditor
     protected ReferenceAnswersEditor getNewEditor(String name)
     {
         return new ReferenceAnswersEditor(this.currentNodeBuilder.getChildNode(name),
-            this.resolver, this.questionnaireUtils, this.formUtils, this.subjectUtils, this.serviceSession);
+            this.resolver, this.questionnaireUtils, this.formUtils, this.subjectUtils, this.rrf);
     }
 
     @Override
@@ -167,11 +174,11 @@ public class ReferenceAnswersEditor extends AnswersEditor
 
     private Object getAnswer(NodeState form, String questionPath)
     {
-        Node subject = this.getSubject(form);
+        Node subject = this.formUtils.getSubject(form);
         try {
             Collection<Node> answers =
-                this.formUtils.findAllSubjectRelatedAnswers(subject, this.currentSession.getNode(questionPath),
-                    EnumSet.allOf(FormUtils.SearchType.class));
+                this.formUtils.findAllSubjectRelatedAnswers(subject, this.resolver.adaptTo(Session.class)
+                    .getNode(questionPath), EnumSet.allOf(FormUtils.SearchType.class));
             if (!answers.isEmpty()) {
                 Object value = this.formUtils.getValue(answers.iterator().next());
                 if (value != null) {
@@ -232,32 +239,6 @@ public class ReferenceAnswersEditor extends AnswersEditor
         ReferenceAnswerNodeTypes(final Node questionNode) throws RepositoryException
         {
             super(questionNode, "cards:ReferenceAnswer", "cards/ReferenceAnswer");
-        }
-    }
-
-    // Ideally, formUtils would be used for getSubject.
-    // However, formUtils uses a ResourceResolverFactory not a ThreadResourceResolverProvider
-    // so is not reliable in this use case
-    private Node getSubject(final NodeState form)
-    {
-        String identifier = form.getProperty(FormUtils.SUBJECT_PROPERTY).getValue(Type.STRING);
-        try {
-            final Node result = this.currentSession.getNodeByIdentifier(identifier);
-            return this.isNodeType(result, SubjectUtils.SUBJECT_NODETYPE) ? result : null;
-        } catch (RepositoryException e) {
-            // SHould not happen
-            return null;
-        }
-    }
-    protected boolean isNodeType(final Node node, final String targetNodeType)
-    {
-        if (node == null) {
-            return false;
-        }
-        try {
-            return node.isNodeType(targetNodeType);
-        } catch (final RepositoryException e) {
-            return false;
         }
     }
 }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
@@ -59,11 +60,13 @@ public class ReferenceAnswersEditor extends AnswersEditor
      * @param questionnaireUtils for working with questionnaire data
      * @param formUtils for working with form data
      * @param subjectUtils for working with subject data
+     * @param serviceSession a session with access to all questionnaires. Can be null
      */
     public ReferenceAnswersEditor(final NodeBuilder nodeBuilder, final ResourceResolver resolver,
-        final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils, SubjectUtils subjectUtils)
+        final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils, SubjectUtils subjectUtils,
+        Session serviceSession)
     {
-        super(nodeBuilder, resolver, questionnaireUtils, formUtils);
+        super(nodeBuilder, resolver, questionnaireUtils, formUtils, serviceSession);
         this.subjectUtils = subjectUtils;
     }
 
@@ -83,7 +86,7 @@ public class ReferenceAnswersEditor extends AnswersEditor
     protected ReferenceAnswersEditor getNewEditor(String name)
     {
         return new ReferenceAnswersEditor(this.currentNodeBuilder.getChildNode(name),
-            this.resolver, this.questionnaireUtils, this.formUtils, this.subjectUtils);
+            this.resolver, this.questionnaireUtils, this.formUtils, this.subjectUtils, this.serviceSession);
     }
 
     @Override

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditorProvider.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditorProvider.java
@@ -59,7 +59,7 @@ public class ReferenceAnswersEditorProvider implements EditorProvider
         if (resolver != null) {
             // Each ReferenceEditor maintains a state, so a new instance must be returned each time
             return new ReferenceAnswersEditor(builder, resolver, this.questionnaireUtils, this.formUtils,
-                this.subjectUtils);
+                this.subjectUtils, null);
         }
         return null;
     }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditorProvider.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditorProvider.java
@@ -23,8 +23,12 @@ import org.apache.jackrabbit.oak.spi.commit.EditorProvider;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import io.uhndata.cards.forms.api.FormUtils;
 import io.uhndata.cards.forms.api.QuestionnaireUtils;
@@ -39,6 +43,10 @@ import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 @Component(service = EditorProvider.class, immediate = true)
 public class ReferenceAnswersEditorProvider implements EditorProvider
 {
+    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
+        policyOption = ReferencePolicyOption.GREEDY)
+    private ResourceResolverFactory rrf;
+
     @Reference
     private ThreadResourceResolverProvider rrp;
 

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/AbstractFormToStringSerializer.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/AbstractFormToStringSerializer.java
@@ -375,13 +375,11 @@ public abstract class AbstractFormToStringSerializer
 
         private String getDefinitionUuid(JsonObject json)
         {
-            final String uuid;
+            String uuid = "";
             if (json.containsKey(SECTION_KEY)) {
                 uuid = json.getJsonObject(SECTION_KEY).getString(UUID_KEY);
             } else if (json.containsKey(QUESTION_KEY)) {
                 uuid = json.getJsonObject(QUESTION_KEY).getString(UUID_KEY);
-            } else {
-                uuid = "";
             }
             return uuid;
         }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/AbstractFormToStringSerializer.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/AbstractFormToStringSerializer.java
@@ -355,9 +355,7 @@ public abstract class AbstractFormToStringSerializer
             this.definitionUuids = definition.values().stream()
                 .filter(value -> ValueType.OBJECT.equals(value.getValueType()))
                 .map(JsonValue::asJsonObject)
-                .filter(value -> value.containsKey(PRIMARY_TYPE_KEY)
-                    && ("cards:Section".equals(value.getString(PRIMARY_TYPE_KEY))
-                    || "cards:Question".equals(value.getString(PRIMARY_TYPE_KEY))))
+                .filter(value -> value.containsKey(UUID_KEY))
                 .map(value -> value.getString(UUID_KEY))
                 .collect(Collectors.toList());
         }

--- a/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectTypeUtilsImpl.java
+++ b/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectTypeUtilsImpl.java
@@ -21,15 +21,12 @@ import javax.jcr.RepositoryException;
 
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import io.uhndata.cards.spi.AbstractNodeUtils;
 import io.uhndata.cards.subjects.api.SubjectTypeUtils;
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Basic utilities for working with SubjectType data.
@@ -39,16 +36,15 @@ import io.uhndata.cards.subjects.api.SubjectTypeUtils;
 @Component
 public final class SubjectTypeUtilsImpl extends AbstractNodeUtils implements SubjectTypeUtils
 {
-    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
-        policyOption = ReferencePolicyOption.GREEDY)
-    private ResourceResolverFactory rrf;
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     // Subject methods
 
     @Override
     public Node getSubjectType(final String identifier)
     {
-        final Node result = getNodeByIdentifier(identifier, getSession(this.rrf));
+        final Node result = getNodeByIdentifier(identifier, getSession(this.rrp));
         return isSubjectType(result) ? result : null;
     }
 
@@ -67,7 +63,7 @@ public final class SubjectTypeUtilsImpl extends AbstractNodeUtils implements Sub
     @Override
     public boolean isSubjectType(final NodeState node)
     {
-        return isNodeType(node, SUBJECT_TYPE_NODETYPE, getSession(this.rrf));
+        return isNodeType(node, SUBJECT_TYPE_NODETYPE, getSession(this.rrp));
     }
 
     @Override

--- a/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectUtilsImpl.java
+++ b/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectUtilsImpl.java
@@ -21,15 +21,12 @@ import javax.jcr.RepositoryException;
 
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import io.uhndata.cards.spi.AbstractNodeUtils;
 import io.uhndata.cards.subjects.api.SubjectUtils;
+import io.uhndata.cards.utils.ThreadResourceResolverProvider;
 
 /**
  * Basic utilities for working with Subject data.
@@ -39,16 +36,15 @@ import io.uhndata.cards.subjects.api.SubjectUtils;
 @Component
 public final class SubjectUtilsImpl extends AbstractNodeUtils implements SubjectUtils
 {
-    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
-        policyOption = ReferencePolicyOption.GREEDY)
-    private ResourceResolverFactory rrf;
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     // Subject methods
 
     @Override
     public Node getSubject(final String identifier)
     {
-        final Node result = getNodeByIdentifier(identifier, getSession(this.rrf));
+        final Node result = getNodeByIdentifier(identifier, getSession(this.rrp));
         return isSubject(result) ? result : null;
     }
 
@@ -67,7 +63,7 @@ public final class SubjectUtilsImpl extends AbstractNodeUtils implements Subject
     @Override
     public boolean isSubject(final NodeState node)
     {
-        return isNodeType(node, SUBJECT_NODETYPE, getSession(this.rrf));
+        return isNodeType(node, SUBJECT_NODETYPE, getSession(this.rrp));
     }
 
     @Override


### PR DESCRIPTION
Modify form to string serialization to sort sections/question by questionnaire definition before serializing

Testing:
In runmode PREMs, create a new visit information form with `location` and all the required details to generate a form for the visit.
Fill out the entire visit and save
From more actions, select print preview
Verify that the location question is the first answer in the print preview