### PR TITLE
CARDS-1977: On admin screens such as Questionnaires or SubjectTypes, the livetable data fails to load if the url ends in `/`

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -74,7 +74,10 @@ function LiveTable(props) {
     customUrl ?
       new URL(customUrl, window.location.origin)
     :
-      new URL(window.location.pathname.substring(window.location.pathname.lastIndexOf("/")) + ".paginate", window.location.origin)
+      new URL(
+        ((s) => s.substring(s.lastIndexOf("/")))(window.location.pathname.replace(/\/$/, "")).concat(".paginate"),
+        window.location.origin
+      )
   );
 
   const globalLoginDisplay = useContext(GlobalLoginContext);


### PR DESCRIPTION
See [task description](https://phenotips.atlassian.net/browse/CARDS-1977) for testing instructions.