### PR TITLE
CARDS-1978: As a patient filling out a paginated survey, I am presented with all the questions I must fill out before reaching the buttons to advance to the next page

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -508,17 +508,15 @@ function Form (props) {
         {/* FormPagination must be called regardless of whether paginationEnabled is true or false,
             because it is what populates the contents of the form.
             However, it should only be displayed to the user in edit mode when paginationEnabled is true. */}
-        <Grid item xs={12} className={paginationEnabled ? classes.formFooter : classes.hiddenFooter} id="cards-resource-footer">
-          <FormPagination
-              saveInProgress={saveInProgress}
-              lastSaveStatus={lastSaveStatus}
-              paginationEnabled={paginationEnabled}
-              questionnaireData={data.questionnaire}
-              setPagesCallback={setPages}
-              onDone={() => { setEndReached(true) }}
-              doneLabel={doneLabel}
-          />
-        </Grid>
+        <FormPagination
+          saveInProgress={saveInProgress}
+          lastSaveStatus={lastSaveStatus}
+          enabled={paginationEnabled}
+          questionnaireData={data.questionnaire}
+          setPagesCallback={setPages}
+          onDone={() => { setEndReached(true) }}
+          doneLabel={doneLabel}
+        />
         { !paginationEnabled && !disableButton &&
         <Grid item xs={false} className={classes.formBottom}>
           <div className={classes.mainPageAction}>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -508,15 +508,17 @@ function Form (props) {
         {/* FormPagination must be called regardless of whether paginationEnabled is true or false,
             because it is what populates the contents of the form.
             However, it should only be displayed to the user in edit mode when paginationEnabled is true. */}
-        <FormPagination
-          saveInProgress={saveInProgress}
-          lastSaveStatus={lastSaveStatus}
-          enabled={paginationEnabled}
-          questionnaireData={data.questionnaire}
-          setPagesCallback={setPages}
-          onDone={() => { setEndReached(true) }}
-          doneLabel={doneLabel}
-        />
+        <Grid item xs={12} className={paginationEnabled ? classes.formFooter : classes.hiddenFooter} id="cards-resource-footer">
+          <FormPagination
+              saveInProgress={saveInProgress}
+              lastSaveStatus={lastSaveStatus}
+              enabled={paginationEnabled}
+              questionnaireData={data.questionnaire}
+              setPagesCallback={setPages}
+              onDone={() => { setEndReached(true) }}
+              doneLabel={doneLabel}
+          />
+        </Grid>
         { !paginationEnabled && !disableButton &&
         <Grid item xs={false} className={classes.formBottom}>
           <div className={classes.mainPageAction}>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -200,9 +200,9 @@ function FormPagination (props) {
           activeStep={activePage + (lastSaveStatus && savedLastPage ? 1 : 0)}
           // Change the color of the back bar
           LinearProgressProps={{ 
-              classes: { barColorPrimary: classes.formStepperTopBar,
-                         bar2Buffer: classes.completedProgressBar,
-                         dashed: classes.bufferProgressBar
+              classes: {
+                         bar2Buffer: classes.formStepperBufferBar,
+                         dashed: classes.formStepperBackgroundBar
                        },
               variant: "buffer",
               valueBuffer: (activePage + 1) / (lastValidPage() + 1) * 100

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -21,13 +21,11 @@ import React, { useState, useEffect } from "react";
 
 import {
   Button,
-  MobileStepper,
-  useMediaQuery
+  MobileStepper
 } from "@mui/material";
 
 import withStyles from '@mui/styles/withStyles';
 
-import { useTheme } from '@mui/material/styles';
 import PropTypes from "prop-types";
 import { SECTION_TYPES, ENTRY_TYPES } from "./FormEntry";
 import QuestionnaireStyle from "./QuestionnaireStyle";
@@ -62,9 +60,6 @@ function FormPagination (props) {
   let questionIndex = 0;
   let pagesResults = {};
   let pagesArray = [];
-
-  const theme = useTheme();
-  const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
 
   useEffect(() => {
     setPagesCallback(null);
@@ -149,16 +144,18 @@ function FormPagination (props) {
     setActivePage(nextPage);
   }
 
-  if (saveInProgress && pendingSubmission) {
-    setPendingSubmission(false);
-    if (activePage === lastValidPage() && direction === DIRECTION_NEXT) {
-      setSavedLastPage(true);
-      onDone && onDone();
-    } else {
-      setSavedLastPage(false);
-      handlePageChange();
+  useEffect(() => {
+    if (saveInProgress && pendingSubmission) {
+      setPendingSubmission(false);
+      if (activePage === lastValidPage() && direction === DIRECTION_NEXT) {
+        setSavedLastPage(true);
+        onDone && onDone();
+      } else {
+        setSavedLastPage(false);
+        handlePageChange();
+      }
     }
-  }
+  }, [saveInProgress, pendingSubmission]);
 
   let saveButton =
     <Button
@@ -187,7 +184,7 @@ function FormPagination (props) {
       // Change the color of the back bar
       LinearProgressProps={isBack ? {classes: {barColorPrimary: classes.formStepperTopBar}}: null}
       // Hide the backround of the front bar to segment of back bar
-      className={`${classes.formStepper} ${isBack && classes.formStepperBottom} ${!fullScreen && classes.formStepperFullScreen}`}
+      className={`${classes.formStepper} ${isBack ? classes.formStepperTop : classes.formStepperBottom}`}
       classes={isBack ? null : {progress:classes.formStepperBottomBackground}}
       // base 0 to base 1, plus 1 for the "current page" region
       steps={lastValidPage() + 2}
@@ -214,10 +211,10 @@ function FormPagination (props) {
     paginationEnabled ?
     lastValidPage() > 0 ?
       <React.Fragment>
-        {/* Back bar to show a different colored current page section*/}
-        {stepper(false)}
         {/* Front bar to color completed pages differently from current page */}
         {stepper(true)}
+        {/* Back bar to show a different colored current page section*/}
+        {stepper(false)}
       </React.Fragment>
     :
       saveButton

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -21,8 +21,7 @@ import React, { useState, useEffect } from "react";
 
 import {
   Button,
-  Grid,
-  LinearProgress
+  MobileStepper
 } from "@mui/material";
 
 import withStyles from '@mui/styles/withStyles';
@@ -163,7 +162,7 @@ function FormPagination (props) {
       type="submit"
       variant="contained"
       disabled={saveInProgress}
-      className={classes.saveButton}
+      className={classes.paginationButton}
       onClick={handleNext}
     >
       {
@@ -183,7 +182,7 @@ function FormPagination (props) {
       disabled={(activePage === 0 && !pendingSubmission)
         || saveInProgress
         || lastSaveStatus === false}
-      className={classes.backButton}
+      className={classes.paginationButton}
       onClick={handleBack}
     >
       Back
@@ -194,29 +193,28 @@ function FormPagination (props) {
     ?
       lastValidPage() > 0
       ?
-        <Grid container
-          spacing={0}
-          direction="row"
-          justifyContent="space-between"
-          alignItems="center"
-          id="cards-resource-footer"
-          className={classes.formFooter}
-        >
-          <Grid item xs={2}>
-            { backButton }
-          </Grid>
-          <Grid item xs={8}>
-            <LinearProgress
-              classes={{bar2Buffer: classes.topProgressBar, dashed: classes.bottomProgressBar}}
-              variant="buffer"
-              valueBuffer={(activePage + 1) / (lastValidPage() + 1) * 100}
-              value={(activePage + (lastSaveStatus && savedLastPage ? 1 : 0)) / (lastValidPage() + 1) * 100}
-            />
-          </Grid>
-          <Grid item xs={2}>
-            { saveButton }
-          </Grid>
-        </Grid>
+        <MobileStepper
+          variant="progress"
+          // Offset back bar 1 to create a "current page" region.
+          // If the final page has been saved, progress the front bar to complete
+          activeStep={activePage + (lastSaveStatus && savedLastPage ? 1 : 0)}
+          // Change the color of the back bar
+          LinearProgressProps={{ 
+              classes: { barColorPrimary: classes.formStepperTopBar,
+                         bar2Buffer: classes.completedProgressBar,
+                         dashed: classes.bufferProgressBar
+                       },
+              variant: "buffer",
+              valueBuffer: (activePage + 1) / (lastValidPage() + 1) * 100
+          }}
+          // Hide the backround of the front bar to segment of back bar
+          className={classes.formStepper}
+          classes={{progress: classes.formStepperBottomBackground}}
+          // base 0 to base 1, plus 1 for the "current page" region
+          steps={lastValidPage() + 2}
+          nextButton={saveButton}
+          backButton={backButton}
+        />
       :
         saveButton
     : null

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
@@ -105,13 +105,15 @@ function QuestionnairePreview (props) {
         }
         </FormUpdateProvider>
       </FormProvider>
-      <FormPagination
-        enabled={paginationEnabled}
-        questionnaireData={data}
-        setPagesCallback={setPages}
-        enableSave={false}
-        onDone={close}
-      />
+      <Grid item xs={12} className={classes.formFooter} id="cards-resource-footer">
+        <FormPagination
+            enabled={paginationEnabled}
+            questionnaireData={data}
+            setPagesCallback={setPages}
+            enableSave={false}
+            onDone={close}
+        />
+      </Grid>
     </Grid>
     {!paginationEnabled &&
       <MainActionButton

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
@@ -105,15 +105,13 @@ function QuestionnairePreview (props) {
         }
         </FormUpdateProvider>
       </FormProvider>
-      <Grid item xs={12} className={classes.formFooter} id="cards-resource-footer">
-        <FormPagination
-            paginationEnabled={paginationEnabled}
-            questionnaireData={data}
-            setPagesCallback={setPages}
-            enableSave={false}
-            onDone={close}
-        />
-      </Grid>
+      <FormPagination
+        enabled={paginationEnabled}
+        questionnaireData={data}
+        setPagesCallback={setPages}
+        enableSave={false}
+        onDone={close}
+      />
     </Grid>
     {!paginationEnabled &&
       <MainActionButton

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -449,10 +449,10 @@ const questionnaireStyle = theme => ({
         backgroundColor: theme.palette.secondary.main,
     },
     bufferProgressBar: {
-      backgroundColor: theme.palette.primary.light,
-      opacity: "0.5",
-      animation: "none",
-      backgroundImage: "none",
+        backgroundColor: theme.palette.primary.light,
+        opacity: "0.5",
+        animation: "none",
+        backgroundImage: "none",
     },
     actionsMenu: {
         border: "1px solid " + theme.palette.divider,

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -426,36 +426,25 @@ const questionnaireStyle = theme => ({
         marginLeft: theme.spacing(0)
     },
     formFooter: {
-        position: "relative",
-        maxHeight: "68px",
-        "& .MuiMobileStepper-progress" : {
-          width: "100%",
-        },
+        padding: theme.spacing(2),
+        paddingLeft: theme.spacing(5),
+        backgroundColor: "transparent",
     },
-    hiddenFooter: {
-        display: "none",
-    },
-    formStepper: {
-        position: "relative",
-    },
-    formStepperTop: {
-        bottom: theme.spacing(2),
-    },
-    formStepperBottom: {
-        background: "transparent",
-        position: "absolute",
-        top: theme.spacing(4),
-        left: theme.spacing(4),
-    },
-    formStepperBottomBackground: {
-        background: "transparent",
-    },
-    formStepperTopBar: {
+    topProgressBar: {
         backgroundColor: theme.palette.secondary.main,
     },
-    paginationButton: {
+    saveButton: {
+        margin: theme.spacing(1),
+    },
+    backButton: {
         float: "right",
         margin: theme.spacing(1),
+    },
+    bottomProgressBar: {
+      backgroundColor: theme.palette.primary.light,
+      opacity: "0.5",
+      animation: "none",
+      backgroundImage: "none",
     },
     actionsMenu: {
         border: "1px solid " + theme.palette.divider,

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -426,26 +426,22 @@ const questionnaireStyle = theme => ({
         marginLeft: theme.spacing(0)
     },
     formFooter: {
-        position: "sticky",
         bottom: theme.spacing(0),
         zIndex: 1000,
         maxHeight: "68px",
-        marginTop: theme.spacing(5),
     },
     hiddenFooter: {
         display: "none",
     },
     formStepper: {
-        position: "fixed",
-        bottom: theme.spacing(2),
-        right: theme.spacing(5),
-        left: theme.spacing(5),
+        position: "relative",
     },
-    formStepperFullScreen: {
-        left: theme.spacing(37.5),
+    formStepperTop: {
+        bottom: "16px",
     },
     formStepperBottom: {
         background: "transparent",
+        bottom: "84px",
     },
     formStepperBottomBackground: {
         background: "transparent",

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -438,17 +438,14 @@ const questionnaireStyle = theme => ({
           width: "100%",
         },
     },
-    formStepperBottomBackground: {
-        background: "transparent",
-    },
     paginationButton: {
         float: "right",
         margin: theme.spacing(1),
     },
-    completedProgressBar: {
+    formStepperBufferBar: {
         backgroundColor: theme.palette.secondary.main,
     },
-    bufferProgressBar: {
+    formStepperBackgroundBar: {
         backgroundColor: theme.palette.primary.light,
         opacity: "0.5",
         animation: "none",

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -426,8 +426,6 @@ const questionnaireStyle = theme => ({
         marginLeft: theme.spacing(0)
     },
     formFooter: {
-        bottom: theme.spacing(0),
-        zIndex: 1000,
         position: "relative",
         maxHeight: "68px",
         "& .MuiMobileStepper-progress" : {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -441,7 +441,7 @@ const questionnaireStyle = theme => ({
         position: "relative",
     },
     formStepperTop: {
-        bottom: "16px",
+        bottom: theme.spacing(2),
     },
     formStepperBottom: {
         background: "transparent",

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -428,6 +428,7 @@ const questionnaireStyle = theme => ({
     formFooter: {
         bottom: theme.spacing(0),
         zIndex: 1000,
+        position: "relative",
         maxHeight: "68px",
         "& .MuiMobileStepper-progress" : {
           width: "100%",
@@ -444,7 +445,9 @@ const questionnaireStyle = theme => ({
     },
     formStepperBottom: {
         background: "transparent",
-        bottom: "84px",
+        position: "absolute",
+        top: theme.spacing(4),
+        left: theme.spacing(4),
     },
     formStepperBottomBackground: {
         background: "transparent",

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -427,16 +427,16 @@ const questionnaireStyle = theme => ({
     },
     formFooter: {
         position: "relative",
-        maxHeight: "68px",
-        "& .MuiMobileStepper-progress" : {
-          width: "100%",
-        },
     },
     hiddenFooter: {
         display: "none",
     },
     formStepper: {
         position: "relative",
+        margin: theme.spacing(0, -2),
+        "& .MuiMobileStepper-progress" : {
+          width: "100%",
+        },
     },
     formStepperBottomBackground: {
         background: "transparent",

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -429,6 +429,9 @@ const questionnaireStyle = theme => ({
         bottom: theme.spacing(0),
         zIndex: 1000,
         maxHeight: "68px",
+        "& .MuiMobileStepper-progress" : {
+          width: "100%",
+        },
     },
     hiddenFooter: {
         display: "none",

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -426,21 +426,29 @@ const questionnaireStyle = theme => ({
         marginLeft: theme.spacing(0)
     },
     formFooter: {
-        padding: theme.spacing(2),
-        paddingLeft: theme.spacing(5),
-        backgroundColor: "transparent",
+        position: "relative",
+        maxHeight: "68px",
+        "& .MuiMobileStepper-progress" : {
+          width: "100%",
+        },
     },
-    topProgressBar: {
-        backgroundColor: theme.palette.secondary.main,
+    hiddenFooter: {
+        display: "none",
     },
-    saveButton: {
-        margin: theme.spacing(1),
+    formStepper: {
+        position: "relative",
     },
-    backButton: {
+    formStepperBottomBackground: {
+        background: "transparent",
+    },
+    paginationButton: {
         float: "right",
         margin: theme.spacing(1),
     },
-    bottomProgressBar: {
+    completedProgressBar: {
+        backgroundColor: theme.palette.secondary.main,
+    },
+    bufferProgressBar: {
       backgroundColor: theme.palette.primary.light,
       opacity: "0.5",
       animation: "none",

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -52,9 +52,6 @@ import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js"
 const useStyles = makeStyles(theme => ({
   mainContainer: {
     margin: theme.spacing(2),
-    "& #cards-resource-footer .MuiMobileStepper-progress" : {
-      width: "100%",
-    },
   },
   screen : {
     alignItems: "center",

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -52,6 +52,14 @@ import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js"
 const useStyles = makeStyles(theme => ({
   mainContainer: {
     margin: theme.spacing(2),
+    "& #cards-resource-footer > .MuiMobileStepper-root" : {
+      bottom: theme.spacing(3),
+      left: 0,
+      right: theme.spacing(1),
+    },
+    "& #cards-resource-footer .MuiMobileStepper-progress" : {
+      width: "100%",
+    },
   },
   screen : {
     alignItems: "center",

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -52,11 +52,6 @@ import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js"
 const useStyles = makeStyles(theme => ({
   mainContainer: {
     margin: theme.spacing(2),
-    "& #cards-resource-footer > .MuiMobileStepper-root" : {
-      bottom: theme.spacing(3),
-      left: 0,
-      right: theme.spacing(1),
-    },
     "& #cards-resource-footer .MuiMobileStepper-progress" : {
       width: "100%",
     },


### PR DESCRIPTION
[CARDS-1978](https://phenotips.atlassian.net/browse/CARDS-1978):  in the patient UI, the pagination controls of paginated surveys should be displayed at the bottom of the page content, and reachable when scrolling all the way down, not sticking to the bottom of the screen & always visible.