### PR TITLE
CARDS-1982: Add `autocreated` (read only) entry mode

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/AutocreatedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/AutocreatedQuestion.jsx
@@ -30,14 +30,10 @@ import QuestionnaireStyle from './QuestionnaireStyle';
 import { useFormWriterContext } from "./FormContext";
 
 
-// Component that displays a reference question of any type.
-//
-// Mandatory props:
-// text: the question to be displayed
-// dataType: the type of answer to be displayed
+// Component that displays an autocreated question of any type.
 //
 // Other options are passed to the <question> widget
-let ReadOnlyQuestion = (props) => {
+let AutocreatedQuestion = (props) => {
   const { existingAnswer, classes, pageActive, questionName} = props;
   const { unitOfMeasurement, displayMode } = {...props.questionDefinition, ...props};
 
@@ -97,7 +93,7 @@ let ReadOnlyQuestion = (props) => {
   )
 }
 
-ReadOnlyQuestion.propTypes = {
+AutocreatedQuestion.propTypes = {
   classes: PropTypes.object.isRequired,
   questionDefinition: PropTypes.shape({
     text: PropTypes.string.isRequired,
@@ -107,11 +103,11 @@ ReadOnlyQuestion.propTypes = {
   }).isRequired
 };
 
-const StyledReadOnlyQuestion = withStyles(QuestionnaireStyle)(ReadOnlyQuestion);
-export default StyledReadOnlyQuestion;
+const StyledAutocreatedQuestion = withStyles(QuestionnaireStyle)(AutocreatedQuestion);
+export default StyledAutocreatedQuestion;
 
 AnswerComponentManager.registerAnswerComponent((definition) => {
-  if (definition.entryMode === "readOnly") {
-    return [StyledReadOnlyQuestion, 80];
+  if (definition.entryMode === "autocreated") {
+    return [StyledAutocreatedQuestion, 80];
   }
 });

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ReadOnlyQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ReadOnlyQuestion.jsx
@@ -1,0 +1,117 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React, { useEffect, useState } from "react";
+import PropTypes from 'prop-types';
+import { InputAdornment, TextField } from "@mui/material";
+
+import withStyles from '@mui/styles/withStyles';
+
+import AnswerComponentManager from "./AnswerComponentManager";
+import Question from "./Question";
+import FormattedText from "../components/FormattedText";
+import QuestionnaireStyle from './QuestionnaireStyle';
+import { useFormWriterContext } from "./FormContext";
+
+
+// Component that displays a reference question of any type.
+//
+// Mandatory props:
+// text: the question to be displayed
+// dataType: the type of answer to be displayed
+//
+// Other options are passed to the <question> widget
+let ReadOnlyQuestion = (props) => {
+  const { existingAnswer, classes, pageActive, questionName} = props;
+  const { unitOfMeasurement, displayMode } = {...props.questionDefinition, ...props};
+
+  let initialValue = existingAnswer?.[1].value || "";
+  let answer = initialValue === "" ? [] : [["value", initialValue]];
+  const [muiInputProps, changeMuiInputProps] = useState({});
+  const [isFormatted, changeIsFormatted] = useState(false);
+
+  // Hooks must be pulled from the top level, so this cannot be moved to inside the useEffect()
+  const changeFormContext = useFormWriterContext();
+
+  // When the answers change, we inform the FormContext
+  useEffect(() => {
+    if (answer) {
+      changeFormContext((oldContext) => ({...oldContext, [questionName]: answer}));
+    }
+  }, [answer]);
+
+  useEffect(() => {
+    if (unitOfMeasurement) {
+      changeMuiInputProps(muiInputProps => ({ ...muiInputProps, endAdornment: <InputAdornment position="end">{unitOfMeasurement}</InputAdornment>}));
+    } else {
+      changeMuiInputProps(muiInputProps => ({ ...muiInputProps, endAdornment: undefined}));
+    }
+  }, [unitOfMeasurement])
+
+  useEffect(() => {
+    let formatted = (displayMode === "formatted" || displayMode === "summary");
+    if (formatted !== isFormatted) {
+      changeIsFormatted(formatted)
+    };
+  }, [displayMode])
+
+  return (
+    <Question
+      defaultDisplayFormatter={isFormatted ? (label, idx) => <FormattedText>{label}</FormattedText> : undefined}
+      currentAnswers={typeof(initialValue) !== "undefined" && initialValue !== "" ? 1 : 0}
+      {...props}
+      >
+      {
+        pageActive && <>
+          { isFormatted ? <FormattedText>
+              {initialValue + (unitOfMeasurement ? (" " + unitOfMeasurement) : '')}
+            </FormattedText>
+          :
+          <TextField
+            variant="standard"
+            disabled={true}
+            className={classes.textField + " " + classes.answerField}
+            value={initialValue}
+            InputProps={muiInputProps}
+          />
+          }
+        </>
+      }
+    </Question>
+  )
+}
+
+ReadOnlyQuestion.propTypes = {
+  classes: PropTypes.object.isRequired,
+  questionDefinition: PropTypes.shape({
+    text: PropTypes.string.isRequired,
+    description: PropTypes.string,
+    displayMode: PropTypes.oneOf(['input', 'formatted', 'hidden', 'summary']),
+    unitOfMeasurement: PropTypes.string
+  }).isRequired
+};
+
+const StyledReadOnlyQuestion = withStyles(QuestionnaireStyle)(ReadOnlyQuestion);
+export default StyledReadOnlyQuestion;
+
+AnswerComponentManager.registerAnswerComponent((definition) => {
+  if (definition.entryMode === "readOnly") {
+    return [StyledReadOnlyQuestion, 80];
+  }
+});

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ReferenceQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ReferenceQuestion.jsx
@@ -18,10 +18,10 @@
 //
 
 import AnswerComponentManager from "./AnswerComponentManager";
-import StyledReadOnlyQuestion from './ReadOnlyQuestion';
+import AutocreatedQuestion from './AutocreatedQuestion';
 
 AnswerComponentManager.registerAnswerComponent((definition) => {
   if (definition.entryMode === "reference") {
-    return [StyledReadOnlyQuestion, 80];
+    return [AutocreatedQuestion, 80];
   }
 });

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ReferenceQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ReferenceQuestion.jsx
@@ -17,101 +17,11 @@
 //  under the License.
 //
 
-import React, { useEffect, useState } from "react";
-import PropTypes from 'prop-types';
-import { InputAdornment, TextField } from "@mui/material";
-
-import withStyles from '@mui/styles/withStyles';
-
 import AnswerComponentManager from "./AnswerComponentManager";
-import Question from "./Question";
-import FormattedText from "../components/FormattedText";
-import QuestionnaireStyle from './QuestionnaireStyle';
-import { useFormWriterContext } from "./FormContext";
-
-
-// Component that displays a reference question of any type.
-//
-// Mandatory props:
-// text: the question to be displayed
-// dataType: the type of answer to be displayed
-//
-// Other options are passed to the <question> widget
-let ReferenceQuestion = (props) => {
-  const { existingAnswer, classes, pageActive, questionName} = props;
-  const { unitOfMeasurement, displayMode } = {...props.questionDefinition, ...props};
-
-  let initialValue = existingAnswer?.[1].value || "";
-  let answer = initialValue === "" ? [] : [["value", initialValue]];
-  const [muiInputProps, changeMuiInputProps] = useState({});
-  const [isFormatted, changeIsFormatted] = useState(false);
-
-  // Hooks must be pulled from the top level, so this cannot be moved to inside the useEffect()
-  const changeFormContext = useFormWriterContext();
-
-  // When the answers change, we inform the FormContext
-  useEffect(() => {
-    if (answer) {
-      changeFormContext((oldContext) => ({...oldContext, [questionName]: answer}));
-    }
-  }, [answer]);
-
-  useEffect(() => {
-    if (unitOfMeasurement) {
-      changeMuiInputProps(muiInputProps => ({ ...muiInputProps, endAdornment: <InputAdornment position="end">{unitOfMeasurement}</InputAdornment>}));
-    } else {
-      changeMuiInputProps(muiInputProps => ({ ...muiInputProps, endAdornment: undefined}));
-    }
-  }, [unitOfMeasurement])
-
-  useEffect(() => {
-    let formatted = (displayMode === "formatted" || displayMode === "summary");
-    if (formatted !== isFormatted) {
-      changeIsFormatted(formatted)
-    };
-  }, [displayMode])
-
-  return (
-    <Question
-      defaultDisplayFormatter={isFormatted ? (label, idx) => <FormattedText>{label}</FormattedText> : undefined}
-      currentAnswers={typeof(initialValue) !== "undefined" && initialValue !== "" ? 1 : 0}
-      {...props}
-      >
-      {
-        pageActive && <>
-          { isFormatted ? <FormattedText>
-              {initialValue + (unitOfMeasurement ? (" " + unitOfMeasurement) : '')}
-            </FormattedText>
-          :
-          <TextField
-            variant="standard"
-            disabled={true}
-            className={classes.textField + " " + classes.answerField}
-            value={initialValue}
-            InputProps={muiInputProps}
-          />
-          }
-        </>
-      }
-    </Question>
-  )
-}
-
-ReferenceQuestion.propTypes = {
-  classes: PropTypes.object.isRequired,
-  questionDefinition: PropTypes.shape({
-    text: PropTypes.string.isRequired,
-    description: PropTypes.string,
-    displayMode: PropTypes.oneOf(['input', 'formatted', 'hidden', 'summary']),
-    unitOfMeasurement: PropTypes.string
-  }).isRequired
-};
-
-const StyledReferenceQuestion = withStyles(QuestionnaireStyle)(ReferenceQuestion);
-export default StyledReferenceQuestion;
+import StyledReadOnlyQuestion from './ReadOnlyQuestion';
 
 AnswerComponentManager.registerAnswerComponent((definition) => {
   if (definition.entryMode === "reference") {
-    return [StyledReferenceQuestion, 80];
+    return [StyledReadOnlyQuestion, 80];
   }
 });

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question-hints.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question-hints.json
@@ -1,5 +1,5 @@
 {
-  "entryMode": "Specifies the source of the value for this question:  \n* manually entered by the **user**,\n* **computed** using a specified expression and answers to other questions, or\n* copied over from another **reference** answer to a question specified by a path.",
+  "entryMode": "Specifies the source of the value for this question:  \n* manually entered by the **user**,\n* **computed** using a specified expression and answers to other questions, \n* copied over from another **reference** answer to a question specified by a path, or \n* **autocreated** by a backend script (the logic for populating autocreated answers cannot be configured from the user interface).",
   "expression": "Supports javascript syntax, with special placeholder variables being populated with answers to other questions in the form.\n\nExample:\n\n```return @{laps} * @{lapLength:-100}```\n\n where `laps` and `lapLength` are the names of questions in the same form, `:-` is an optional marker for a default value, and `100` is the optional default value.",
   "question": "Path to a question, either in this or a different questionnaire. Example: `/Questionnaires/Demographics/name`"
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -54,6 +54,13 @@
               "formatted" : {},
               "hidden": {}
             }
+          },
+          "autocreated": {
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
           }
         }
       },
@@ -93,6 +100,13 @@
           },
           "reference": {
             "question": "string",
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
+          },
+          "autocreated": {
             "displayMode" : {
               "input" : {},
               "formatted" : {},
@@ -153,6 +167,13 @@
               "formatted" : {},
               "hidden": {}
             }
+          },
+          "autocreated": {
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
           }
         }
       },
@@ -208,6 +229,13 @@
               "formatted" : {},
               "hidden": {}
             }
+          },
+          "autocreated": {
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
           }
         }
       },
@@ -244,6 +272,13 @@
           },
           "reference": {
             "question": "string",
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
+          },
+          "autocreated": {
             "displayMode" : {
               "input" : {},
               "formatted" : {},
@@ -307,6 +342,13 @@
               "formatted" : {},
               "hidden": {}
             }
+          },
+          "autocreated": {
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
           }
         }
       },
@@ -348,6 +390,13 @@
               "formatted" : {},
               "hidden": {}
             }
+          },
+          "autocreated": {
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
           }
         }
       },
@@ -370,6 +419,13 @@
           },
           "reference": {
             "question": "string",
+            "displayMode" : {
+              "input" : {},
+              "formatted" : {},
+              "hidden": {}
+            }
+          },
+          "autocreated": {
             "displayMode" : {
               "input" : {},
               "formatted" : {},


### PR DESCRIPTION
- Rename referenceQuestion.jsx to ReadOnlyQuestion.jsx
- Create new ReferenceQustion.jsx that registers a readOnlyQuestion for reference entryModes

[CARDS-1973-test](https://github.com/data-team-uhn/cards/tree/CARDS-1973-test) branch is available with examples of readOnly questions (pause/resume form, ID and status).

Reference questions can be tested using `--test`

[CARDS-1973]: https://phenotips.atlassian.net/browse/CARDS-1973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CARDS-1973]: https://phenotips.atlassian.net/browse/CARDS-1973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ