### PR TITLE
[misc] Replace old-style for loop causing build failure on new CARDS clones

### DIFF
--- a/modules/data-entry/src/main/frontend/src/resourceQuery/QueryMatchingUtils.jsx
+++ b/modules/data-entry/src/main/frontend/src/resourceQuery/QueryMatchingUtils.jsx
@@ -67,13 +67,13 @@ export default class QueryMatchingUtils {
       while (uncoveredWords.length) {
         let maxWordsCovered = 0;
         let crtMax = null;
-        for (var item in matchList) {
+        Object.keys(matchList).forEach(item => {
           let crtCover = matchList[item].filter(w => uncoveredWords.includes(w));
           if (crtCover.length > maxWordsCovered) {
             maxWordsCovered = crtCover.length;
             crtMax = item;
           }
-        }
+        });
         if (crtMax) {
           setCover.push(crtMax);
           uncoveredWords = uncoveredWords.filter(w => !matchList[crtMax].includes(w));


### PR DESCRIPTION
Steps to replicate the bug:
* git clone cards
* mvn clean install => BUILD FAILURE

Steps to test the fix:
* git clone cards
* git checkout this branch
* mvn clean install => build should be successful
* start with --test
* ensure the HANCESTRO vocabulary is installed
* go to the `Resource / Vocabulary Test` questionnaire and check that vocabulary search works properly and results are found when the user input matches the synonyms or description (e.g. searching for "cauc" should find "European")