### PR TITLE
[misc] Use a shaded outline istead of a shaded border for focused entries in forms and questionnaires

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -564,7 +564,7 @@ const questionnaireStyle = theme => ({
     },
     focusedQuestionnaireItem: {
       "&.MuiCard-root, > .MuiCard-root" : {
-        border: `2px solid ${theme.palette.primary.main}`,
+        outline: `2px solid ${theme.palette.primary.main}`,
       },
     },
     fileResourceAnswerList: {


### PR DESCRIPTION
The difference is only slightly noticeable by the user: while `border` takes up screen space, pushing the focused item down and to the side a little bit (2 pixels), the `outline` is displayed without any layout changes.

To test in forms, quick-search for something that matches an answer and click on a result. The matching item should be outlined.

To test in the questionnaire wizard, edit any questionnaire entry. The modified entry should appear as outlined.