### PR TITLE
[Cleanup] JS console errors when rendering some dialogs

### DIFF
--- a/modules/commons/src/main/frontend/src/components/ErrorDialog.jsx
+++ b/modules/commons/src/main/frontend/src/components/ErrorDialog.jsx
@@ -32,7 +32,6 @@ import makeStyles from '@mui/styles/makeStyles';
 import CloseIcon from '@mui/icons-material/Close';
 
 // Component that renders an Error Dialog with a red title and a close button
-// the screen becomes more narrow than the specified width
 //
 // Props:
 // title: String specifying the title of the dialog. Defaults to "Error".

--- a/modules/commons/src/main/frontend/src/components/ErrorDialog.jsx
+++ b/modules/commons/src/main/frontend/src/components/ErrorDialog.jsx
@@ -1,0 +1,101 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React from "react";
+import PropTypes from "prop-types";
+
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  IconButton,
+} from "@mui/material";
+
+import makeStyles from '@mui/styles/makeStyles';
+
+import CloseIcon from '@mui/icons-material/Close';
+
+// Component that renders an Error Dialog with a red title and a close button
+// the screen becomes more narrow than the specified width
+//
+// Props:
+// title: String specifying the title of the dialog. Defaults to "Error".
+// children: the dialog contents
+// onClose: Callback for closing the dialog
+//
+// Sample usage:
+// <ErrorDialog
+//   title="Failed to save data"
+//   open={open}
+//   onClose={handleClose}
+//  >
+//    Saving failed due to an unknown error.
+// </ErrorDialog>
+//
+
+const useStyles = makeStyles(theme => ({
+  titleBar: {
+    color: theme.palette.error.main,
+    paddingRight: theme.spacing(5),
+  },
+  closeButton: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+  },
+}));
+
+const ErrorDialog = (props) => {
+  const { title, children, onClose, ...rest } = props;
+
+  const classes = useStyles();
+
+  return (
+    <Dialog onClose={onClose} {...rest}>
+      <DialogTitle className={classes.titleBar}>
+        {title}
+        <IconButton onClick={onClose} className={classes.closeButton} size="large">
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        {children}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+ErrorDialog.propTypes = {
+  title: PropTypes.string.isRequired,
+  maxWidth: PropTypes.oneOf(["xs", "sm", "md", "lg", "xl"]),
+  fullWidth: PropTypes.bool.isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]),
+  onClose: PropTypes.func,
+}
+
+ErrorDialog.defaultProps = {
+  title: "Error",
+  maxWidth: "xs",
+  fullWidth: true,
+};
+
+export default ErrorDialog;

--- a/modules/commons/src/main/frontend/src/components/ErrorDialog.jsx
+++ b/modules/commons/src/main/frontend/src/components/ErrorDialog.jsx
@@ -31,6 +31,19 @@ import makeStyles from '@mui/styles/makeStyles';
 
 import CloseIcon from '@mui/icons-material/Close';
 
+
+const useStyles = makeStyles(theme => ({
+  titleBar: {
+    color: theme.palette.error.main,
+    paddingRight: theme.spacing(5),
+  },
+  closeButton: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+  },
+}));
+
 // Component that renders an Error Dialog with a red title and a close button
 //
 // Props:
@@ -47,19 +60,6 @@ import CloseIcon from '@mui/icons-material/Close';
 //    Saving failed due to an unknown error.
 // </ErrorDialog>
 //
-
-const useStyles = makeStyles(theme => ({
-  titleBar: {
-    color: theme.palette.error.main,
-    paddingRight: theme.spacing(5),
-  },
-  closeButton: {
-    position: 'absolute',
-    right: theme.spacing(1),
-    top: theme.spacing(1),
-  },
-}));
-
 const ErrorDialog = (props) => {
   const { title, children, onClose, ...rest } = props;
 

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
@@ -168,7 +168,7 @@ function DeleteButton(props) {
       </ErrorDialog>
       <Dialog open={open} onClose={closeDialog}>
         <DialogTitle>
-        <Typography variant="h6">Delete {entryLabel ? entryLabel.concat(' ') : ''}{entryName}{deleteRecursive ? " and dependent items": null }</Typography>
+          Delete {entryLabel ? entryLabel.concat(' ') : ''}{entryName}{deleteRecursive ? " and dependent items": null }
         </DialogTitle>
         <DialogContent>
             <Typography variant="body1">{dialogMessage}</Typography>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
@@ -27,6 +27,7 @@ import { Delete, Close } from "@mui/icons-material";
 
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
+import ErrorDialog from "../components/ErrorDialog.jsx";
 
 /**
  * A component that renders an icon to open a dialog to delete an entry.
@@ -162,17 +163,9 @@ function DeleteButton(props) {
 
   return (
     <React.Fragment>
-      <Dialog open={errorOpen} onClose={closeError}>
-        <DialogTitle>
-          <Typography variant="h6" color="error" className={classes.dialogTitle}>Error</Typography>
-          <IconButton onClick={closeError} className={classes.closeButton} size="large">
-            <Close />
-          </IconButton>
-        </DialogTitle>
-        <DialogContent>
-            <Typography variant="body1">{errorMessage}</Typography>
-        </DialogContent>
-      </Dialog>
+      <ErrorDialog open={errorOpen} onClose={closeError}>
+        <Typography variant="body1">{errorMessage}</Typography>
+      </ErrorDialog>
       <Dialog open={open} onClose={closeDialog}>
         <DialogTitle>
         <Typography variant="h6">Delete {entryLabel ? entryLabel.concat(' ') : ''}{entryName}{deleteRecursive ? " and dependent items": null }</Typography>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -25,9 +25,6 @@ import {
   Button,
   Chip,
   CircularProgress,
-  Dialog,
-  DialogTitle,
-  DialogContent,
   Grid,
   IconButton,
   List,
@@ -37,7 +34,6 @@ import {
   Typography,
 } from "@mui/material";
 import withStyles from '@mui/styles/withStyles';
-import CloseIcon from "@mui/icons-material/Close";
 import EditIcon from '@mui/icons-material/Edit';
 import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import DoneIcon from "@mui/icons-material/Done";
@@ -51,6 +47,7 @@ import { SelectorDialog, parseToArray } from "./SubjectSelector";
 import { FormProvider } from "./FormContext";
 import { FormUpdateProvider } from "./FormUpdateContext";
 import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
+import ErrorDialog from "../components/ErrorDialog";
 import DeleteButton from "../dataHomepage/DeleteButton";
 import PrintButton from "../dataHomepage/PrintButton.jsx";
 import MainActionButton from "../components/MainActionButton.jsx";
@@ -535,21 +532,13 @@ function Form (props) {
         </Grid>
         }
       </Grid>
-      <Dialog open={errorDialogDisplayed} onClose={closeErrorDialog}>
-        <DialogTitle>
-          <Typography variant="h6" color="error" className={classes.dialogTitle}>Failed to save</Typography>
-          <IconButton onClick={closeErrorDialog} className={classes.closeButton} size="large">
-            <CloseIcon />
-          </IconButton>
-        </DialogTitle>
-        <DialogContent>
-            <Typography variant="h6">Your changes were not saved.</Typography>
-            <Typography variant="body1" paragraph>Server responded with response code {errorCode}: {errorMessage}</Typography>
-            {lastSaveTimestamp &&
-            <Typography variant="body1" paragraph>Time of the last successful save: {DateTime.fromISO(lastSaveTimestamp.toISOString()).toRelativeCalendar()}</Typography>
-            }
-        </DialogContent>
-      </Dialog>
+      <ErrorDialog title="Failed to save" open={errorDialogDisplayed} onClose={closeErrorDialog}>
+        <Typography variant="h6">Your changes were not saved.</Typography>
+        <Typography variant="body1" paragraph>Server responded with response code {errorCode}: {errorMessage}</Typography>
+        {lastSaveTimestamp &&
+          <Typography variant="body1" paragraph>Time of the last successful save: {DateTime.fromISO(lastSaveTimestamp.toISOString()).toRelativeCalendar()}</Typography>
+        }
+      </ErrorDialog>
     </form>
   );
 };

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
@@ -210,8 +210,8 @@ function PrintPreview(props) {
       >
         { (title || subtitle) &&
         <DialogTitle>
-          { title && <Typography variant="h4">{title}</Typography> }
-          { subtitle && <Typography variant="overline" color="textSecondary">{subtitle}</Typography> }
+          { title && <Typography component="div" variant="h4">{title}</Typography> }
+          { subtitle && <Typography component="div" variant="overline" color="textSecondary">{subtitle}</Typography> }
         </DialogTitle>
         }
         <DialogContent dividers>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -492,15 +492,6 @@ const questionnaireStyle = theme => ({
     NCRLoadingIndicator: {
         disable: "flex"
     },
-    closeButton: {
-        position: 'absolute',
-        right: theme.spacing(1),
-        top: theme.spacing(1),
-        color: theme.palette.grey[500]
-    },
-    dialogTitle: {
-        marginRight: theme.spacing(5)
-    },
     dialogContentWithTable: {
         padding: 0,
         "& .MuiPaper-root": {

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
@@ -207,7 +207,7 @@ function AdminConfigScreen(props) {
           { /* Confirmation dialog for resetting the changes */ }
           <Dialog className={classes.confirmationDialog} open={resetConfirmationPending}>
             <DialogTitle>
-              <Typography variant="h6" color="error" className={classes.dialogTitle}>Confirm configuration reset</Typography>
+              Confirm configuration reset
             </DialogTitle>
             <DialogContent>
               <FormattedText>

--- a/modules/login/src/main/frontend/src/login/signUpForm.js
+++ b/modules/login/src/main/frontend/src/login/signUpForm.js
@@ -19,19 +19,15 @@
 import React from 'react';
 import {
     Button,
-    Dialog,
-    DialogTitle,
-    DialogContent,
-    IconButton,
     TextField,
     Tooltip,
     Typography
 } from '@mui/material';
 import withStyles from '@mui/styles/withStyles';
-import { Close } from "@mui/icons-material";
 import { Formik } from "formik";
 import * as Yup from "yup";
 
+import ErrorDialog from "../components/ErrorDialog";
 import styles from "../styling/styles";
 
 class FormFields extends React.Component {
@@ -262,17 +258,9 @@ class SignUpForm extends React.Component {
     // Hooks only work inside functional components
     return (
       <React.Fragment>
-        <Dialog open={this.state.errorOpen} onClose={() => this.setState({errorOpen: false})}>
-          <DialogTitle>
-            <Typography variant="h6" color="error" className={classes.errorDialogTitle}>Error</Typography>
-            <IconButton size="large" onClick={() => this.setState({errorOpen: false})} className={classes.errorCloseButton}>
-              <Close />
-            </IconButton>
-          </DialogTitle>
-          <DialogContent>
-            <Typography variant="body1">{this.state.errorMsg}</Typography>
-          </DialogContent>
-        </Dialog>
+        <ErrorDialog open={this.state.errorOpen} onClose={() => this.setState({errorOpen: false})}>
+          <Typography variant="body1">{this.state.errorMsg}</Typography>
+        </ErrorDialog>
         <div className={classes.main}>
           <Formik
             render={props => <FormFieldsComponent {...props} />}

--- a/modules/login/src/main/frontend/src/login/signUpForm.js
+++ b/modules/login/src/main/frontend/src/login/signUpForm.js
@@ -19,6 +19,7 @@
 import React from 'react';
 import {
     Button,
+    Grid,
     TextField,
     Tooltip,
     Typography
@@ -118,12 +119,15 @@ class FormFields extends React.Component {
           required
 
         />
-        { !loginOnSuccess &&
-          <Button variant="outlined" size="small" onClick={handleReset} className={classes.submit + " " + classes.closeButton}>Close</Button>
-        }
-        {!isValid ?
-          // Render hover over and button
-          <React.Fragment>
+        <Grid container direction="row" justifyContent="flex-end" alignItems="center" className={classes.actions}>
+          { !loginOnSuccess &&
+            <Grid item>
+              <Button variant="outlined" size="small" onClick={handleReset} className={classes.submit + " " + classes.closeButton}>Close</Button>
+            </Grid>
+          }
+          <Grid item>
+          {!isValid ?
+            // Render tooltip and button
             <Tooltip title="You must fill in all fields.">
               <div>
                 { loginOnSuccess ?
@@ -132,13 +136,15 @@ class FormFields extends React.Component {
                 }
               </div>
             </Tooltip>
-          </React.Fragment> :
-          // Else just render the button
-          ( loginOnSuccess ?
-            <Button type="submit" variant="contained" color="primary" disabled={!isValid} className={classes.submit} fullWidth >Submit</Button> :
-            <Button type="submit" variant="contained" color="primary" disabled={!isValid} className={classes.submit + " " + classes.closeButton} size="small">Submit</Button>
-          )
-        }
+            :
+            // Else just render the button
+            ( loginOnSuccess ?
+              <Button type="submit" variant="contained" color="primary" disabled={!isValid} className={classes.submit} fullWidth >Submit</Button> :
+              <Button type="submit" variant="contained" color="primary" disabled={!isValid} className={classes.submit + " " + classes.closeButton} size="small">Submit</Button>
+            )
+          }
+          </Grid>
+        </Grid>
       </form>
     );
   }

--- a/modules/login/src/main/frontend/src/styling/styles.js
+++ b/modules/login/src/main/frontend/src/styling/styles.js
@@ -68,18 +68,6 @@ const styles = theme => ({
     marginLeft: theme.spacing(2),
     marginBottom: theme.spacing(2)
   },
-  dialogTitle: {
-    padding: theme.spacing(2,0,2,3)
-  },
-  errorDialogTitle: {
-    marginRight: theme.spacing(5)
-  },
-  errorCloseButton: {
-    position: 'absolute',
-    right: theme.spacing(1),
-    top: theme.spacing(1),
-    color: theme.palette.grey[500]
-  },
 });
 
 export default styles;

--- a/modules/principals/src/main/frontend/src/Userboard/Users/createuserdialogue.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Users/createuserdialogue.jsx
@@ -17,7 +17,7 @@
 
 import React from "react";
 import withStyles from '@mui/styles/withStyles';
-import { Grid, Dialog, DialogContent, Typography } from "@mui/material";
+import { Grid, Dialog, DialogTitle, DialogContent } from "@mui/material";
 import userboardStyle from '../userboardStyle.jsx';
 
 import SignUpForm from "../../login/signUpForm.js";
@@ -44,7 +44,7 @@ class CreateUserDialogue extends React.Component {
                 open={this.props.isOpen}
                 onClose={() => this.props.handleClose()}
             >
-                <Typography component="h2" variant="h5" className={classes.dialogTitle}>Create New User</Typography>
+                <DialogTitle>Register a new user</DialogTitle>
                 <DialogContent>
                   <Grid container>
                     <SignUpForm loginOnSuccess={false} handleSuccess={() => this.handleCreateUser()} handleExit={() => this.props.handleClose()}/>

--- a/modules/principals/src/main/frontend/src/Userboard/deleteprincipaldialogue.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/deleteprincipaldialogue.jsx
@@ -52,7 +52,7 @@ class DeletePrincipalDialogue extends React.Component {
                 onClose={() => this.props.handleClose()}
             >
                 <DialogTitle>
-                  <Typography variant="h6">Delete {this.props.name}</Typography>
+                  Delete {this.props.name}
                 </DialogTitle>
                 <DialogContent>
                     <Typography variant="body1">Are you sure you want to delete {this.props.type} {this.props.name}?</Typography>

--- a/modules/vocabularies/src/main/frontend/src/bioportalApiKey.jsx
+++ b/modules/vocabularies/src/main/frontend/src/bioportalApiKey.jsx
@@ -58,9 +58,6 @@ fetchWithReLogin(globalLoginDisplay, APIKEY_SERVLET_URL)
 }
 
 const useStyles = makeStyles(theme => ({
-  dialogTitle: {
-    marginRight: theme.spacing(5)
-  },
   vocabularyAction: {
     margin: theme.spacing(1)
   },

--- a/modules/vocabularies/src/main/frontend/src/vocabularyAction.jsx
+++ b/modules/vocabularies/src/main/frontend/src/vocabularyAction.jsx
@@ -198,7 +198,7 @@ export default function VocabularyAction(props) {
     <Dialog onClose={handleClose} open={displayPopup}>
 
       <DialogTitle>
-        <Typography variant="h4" className={classes.dialogTitle}>{vocabulary.name} ({vocabulary.acronym})</Typography>
+        {vocabulary.name} ({vocabulary.acronym})
       </DialogTitle>
 
       <DialogContent dividers>

--- a/modules/vocabularies/src/main/frontend/src/vocabularyActions.jsx
+++ b/modules/vocabularies/src/main/frontend/src/vocabularyActions.jsx
@@ -20,35 +20,17 @@
 import React, { useEffect, useContext } from "react";
 
 import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-  IconButton,
   Typography
 } from "@mui/material";
 
-import makeStyles from '@mui/styles/makeStyles';
-
-import CloseIcon from "@mui/icons-material/Close";
-
 import VocabularyDetails from "./vocabularyDetails"
 import VocabularyAction from "./vocabularyAction"
+import ErrorDialog from "./components/ErrorDialog";
 import { fetchWithReLogin, GlobalLoginContext } from "./login/loginDialogue.js";
 
 const vocabLinks = require('./vocabularyLinks.json');
 const Phase = require("./phaseCodes.json");
 
-const useStyles = makeStyles(theme => ({
-  closeButton: {
-    position: 'absolute',
-    right: theme.spacing(1),
-    top: theme.spacing(1),
-    color: theme.palette.grey[500]
-  },
-  title: {
-    marginRight: theme.spacing(5)
-  }
-}));
 
 /*
   This function keeps track of the state of the current vocabulary. It also keeps track of any error messages needed to be displayed.
@@ -62,8 +44,6 @@ export default function VocabularyActions(props) {
   const [errorMessage, setErrorMessage] = React.useState("");
 
   const [phase, setPhase] = React.useState(initPhase);
-
-  const classes = useStyles();
 
   const globalLoginDisplay = useContext(GlobalLoginContext);
 
@@ -144,22 +124,11 @@ export default function VocabularyActions(props) {
           vocabulary={vocabulary}
           type={props.type}
         />
-        <Dialog open={error} onClose={handleClose}>
-
-          <DialogTitle>
-            <Typography variant="h6" color="error" className={classes.title}>Failed to {action}</Typography>
-            <IconButton onClick={handleClose} className={classes.closeButton} size="large">
-              <CloseIcon />
-            </IconButton>
-          </DialogTitle>
-
-          <DialogContent dividers>
-            <Typography variant="h6">{vocabulary.name}</Typography>
-            <Typography variant="subtitle2" gutterBottom>Version: {vocabulary.version}</Typography>
-            <Typography paragraph color="error">{errorMessage}</Typography>
-          </DialogContent>
-
-        </Dialog>
+        <ErrorDialog title={`Failed to ${action}`} open={error} onClose={handleClose}>
+          <Typography variant="h6">{vocabulary.name}</Typography>
+          <Typography variant="subtitle2" gutterBottom>Version: {vocabulary.version}</Typography>
+          <Typography paragraph color="error">{errorMessage}</Typography>
+        </ErrorDialog>
       </React.Fragment>
   );
 }

--- a/modules/vocabularies/src/main/frontend/src/vocabularyDetails.jsx
+++ b/modules/vocabularies/src/main/frontend/src/vocabularyDetails.jsx
@@ -51,16 +51,6 @@ const useStyles = makeStyles(theme => ({
     borderRadius: 3,
     border: 0
   },
-  closeButton: {
-    position: "absolute",
-    right: theme.spacing(1),
-    top: theme.spacing(1),
-    marginLeft: theme.spacing(5),
-    color: theme.palette.grey[500],
-  },
-  dialogTitle: {
-    marginRight: theme.spacing(5)
-  },
   browseAction: {
     margin: theme.spacing(1),
     textTransform: "none",
@@ -97,7 +87,7 @@ export default function VocabularyDetails(props) {
       <Dialog onClose={handleClose} open={displayPopup}>
 
         <DialogTitle>
-          <Typography variant="h4" className={classes.dialogTitle}>{vocabulary.name} ({vocabulary.acronym})</Typography>
+          {vocabulary.name} ({vocabulary.acronym})
         </DialogTitle>
 
         <DialogContent dividers>


### PR DESCRIPTION
Affected dialogs include:
* Delete dialog from the delete button component (e.g. when deleting a questionnaire entry in the designer) + its error dialog which appears when the item to be deleted is already missing
* Vocabulary details dialog (admin > vocabularies > "About")
* Error dialog when a vocabulary action failed (e.g. click install on a vocabulary, but the browser is offline)
* Error dialog when user registration fails
* Error dialog when saving a form fails (open a form for editing, take the browser offline, then click the "Save" button)
* Print preview dialog
* Administration > any configuration screen > confirmation dialog to reset the config
* Administration > Dialog for confirming the deletion of a user or group

Additional changes:
* Removed unused DialogTitle-related styling from various files
* Used proper `<DialogTitle>` instead of Typography in the Administration > User registration
* Improved the styling of the action buttons in Administration > User registration

**Reviewing the code** commit by commit and ignoring whitespace changes is recommended.