### PR TITLE
CARDS-1990: Patient survey header is too narrow when the survey title is short

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Header.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Header.jsx
@@ -66,6 +66,7 @@ const useStyles = makeStyles(theme => ({
   fullSize : {
     paddingTop: theme.spacing(5),
     maxWidth: "780px",
+    width: `calc(100% - ${theme.spacing(5)})`,
     margin: "auto",
     "&.MuiToolbar-root > .MuiTypography-root" : {
       zoom: 1.2,


### PR DESCRIPTION
See [CARDS-1990](https://phenotips.atlassian.net/browse/CARDS-1990) on Jira.

The problem was introduced by #1241. The CPESIC survey title appears crammed in the middle of the row.

Before this fix:

![image](https://user-images.githubusercontent.com/651980/211381000-ee2ed084-1bbb-424e-b60b-983e3081c352.png)


After this fix:

![image](https://user-images.githubusercontent.com/651980/211380900-4b524ec5-bb7c-42ba-a453-cfb60e15953d.png)


[CARDS-1990]: https://phenotips.atlassian.net/browse/CARDS-1990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ