### PR TITLE
[misc] Make the "Your Experience" app name title case instead of uppercase

### DIFF
--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/TermsOfUse.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/TermsOfUse.xml
@@ -21,7 +21,7 @@
     <name>TermsOfUse</name>
     <property>
         <name>title</name>
-        <value>YOUR EXPERIENCE Terms of Use and Privacy Policy</value>
+        <value>Your Experience Terms of Use and Privacy Policy</value>
         <type>String</type>
     </property>
     <property>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/conf/AppName.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/conf/AppName.json
@@ -1,4 +1,4 @@
 {
   "jcr:primaryType": "nt:unstructured",
-  "AppName": "YOUR EXPERIENCE"
+  "AppName": "Your Experience"
 }


### PR DESCRIPTION
The appname is visible in places like the browser's title bar, the footer of the login page, the bottom of the sidebar.

Login page footer **before**:

![image](https://user-images.githubusercontent.com/651980/211842089-7a70cb1f-0acc-467f-8e67-45fc259ae29d.png)

Login page footer **after**:

![image](https://user-images.githubusercontent.com/651980/211842475-cc08bd48-e9e4-4e32-858c-8f081d78ee73.png)
