### PR TITLE
CARDS-2000 - Patient portal: "Sign out" in the header looks confusing to patients when only token auth is enabled and the patient has not actively signed in

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Header.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Header.jsx
@@ -78,7 +78,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 function Header (props) {
-  const { title, greeting, progress, subtitle, step } = props;
+  const { title, greeting, withSignout, progress, subtitle, step } = props;
 
   const classes = useStyles();
 
@@ -108,7 +108,9 @@ function Header (props) {
           </div>
           <Breadcrumbs separator = "·">
             {greeting && <span className={classes.greeting}>{ greeting }</span>}
-            <Link href="/system/sling/logout" underline="hover" onClick={(event) => {event.preventDefault(); window.location = "/system/sling/logout?resource=" + encodeURIComponent(window.location.pathname);}}>Sign out</Link>
+            {withSignout &&
+              <Link href="/system/sling/logout" underline="hover" onClick={(event) => {event.preventDefault(); window.location = "/system/sling/logout?resource=" + encodeURIComponent(window.location.pathname);}}>Sign out</Link>
+            }
           </Breadcrumbs>
         </Toolbar>
       </Collapse>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -679,6 +679,7 @@ function QuestionnaireSet(props) {
       <Header
         title={title}
         greeting={username}
+        withSignout={!!(config?.PIIAuthRequired)}
         progress={progress}
         subtitle={questionnaires[questionnaireIds[crtStep]]?.title}
         step={stepIndicator(crtStep, true)}

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/index.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/index.jsx
@@ -38,6 +38,20 @@ function PatientPortalHomepage (props) {
   const [ surveyInstructions, setSurveyInstructions ] = useState();
   const [ accessConfig, setAccessConfig ] = useState({});
 
+  // Sign the patient out when leaving the page
+  useEffect(() => {
+    window.addEventListener("beforeunload", signout, true);
+    // When component unmounts:
+    return (() => {
+      // cleanup event handler
+      window.removeEventListener("beforeunload", signout, true);
+    });
+  }, []);
+
+  let signout = () => {
+    fetch('/system/sling/logout');
+  }
+
   // Fetch saved settings for Patient Portal Survey Instructions
   useEffect(() => {
     fetch(`${SURVEY_INSTRUCTIONS_PATH}.json`)

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/index.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/index.jsx
@@ -38,20 +38,6 @@ function PatientPortalHomepage (props) {
   const [ surveyInstructions, setSurveyInstructions ] = useState();
   const [ accessConfig, setAccessConfig ] = useState({});
 
-  // Sign the patient out when leaving the page
-  useEffect(() => {
-    window.addEventListener("beforeunload", signout, true);
-    // When component unmounts:
-    return (() => {
-      // cleanup event handler
-      window.removeEventListener("beforeunload", signout, true);
-    });
-  }, []);
-
-  let signout = () => {
-    fetch('/system/sling/logout');
-  }
-
   // Fetch saved settings for Patient Portal Survey Instructions
   useEffect(() => {
     fetch(`${SURVEY_INSTRUCTIONS_PATH}.json`)


### PR DESCRIPTION
- Removed the "Sign out" link when the patient wasn't required to enter their mrn&dob in the identification form before proceeding
- ~When the patient closes the page, automatically send a call to logout~

**Testing:**
* check that Sign out is no longer displayed for PREMs
* check that the header layout looks ok without that link

**Regression testing:**
* ensure the PROMs workflow (where the patient must sign in with mrn&dob) is not affected
* ensure the Sign Out link is still displayed for PROMs 