### PR TITLE
CARDS-2011 - Patient portal: add a configuration allowing to skip the review screen when patients fill in surveys

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -163,7 +163,7 @@ function QuestionnaireSet(props) {
 
   // If the `enableReviewScreen` state is not already defined, initialize it with the value passed via config
   useEffect(() => {
-    typeof(enableReviewScreen) != "undefined" && setEnableReviewScreen(config?.enableReviewScreen);
+    typeof(enableReviewScreen) == "undefined" && setEnableReviewScreen(config?.enableReviewScreen);
   }, [config?.enableReviewScreen]);
 
   // Determine the screen type (and style) based on the step number

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/SurveyInstructionsConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/SurveyInstructionsConfiguration.jsx
@@ -55,6 +55,7 @@ function SurveyInstructionsConfiguration() {
     welcomeMessage: ["welcomeMessage"],
     eventSelectionScreen: ["noEventsMessage", "eventSelectionMessage"],
     startScreen: [ "enableStartScreen", "eventLabel", "noSurveysMessage", "surveyIntro", "surveyDraftInfo" ],
+    reviewScreen: ["enableReviewScreen"],
     summaryScreen: [ "disclaimer", "summaryInstructions", "interpretationInstructions" ]
   };
 

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/index.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/index.jsx
@@ -82,7 +82,11 @@ function PatientPortalHomepage (props) {
   }
 
   return (<>
-    <QuestionnaireSet subject={subject} username={username} displayText={displayText} config={{...accessConfig, enableStartScreen: surveyInstructions?.enableStartScreen}} />
+    <QuestionnaireSet subject={subject} username={username} displayText={displayText} config={{
+      ...accessConfig,
+      enableStartScreen: surveyInstructions?.enableStartScreen,
+      enableReviewScreen: surveyInstructions?.enableReviewScreen
+    }} />
     <Footer />
   </>);
 }

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/index.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/index.jsx
@@ -84,8 +84,7 @@ function PatientPortalHomepage (props) {
   return (<>
     <QuestionnaireSet subject={subject} username={username} displayText={displayText} config={{
       ...accessConfig,
-      enableStartScreen: surveyInstructions?.enableStartScreen,
-      enableReviewScreen: surveyInstructions?.enableReviewScreen
+      ...surveyInstructions
     }} />
     <Footer />
   </>);

--- a/modules/patient-portal/src/main/resources/SLING-INF/nodetypes/patient-portal.cnd
+++ b/modules/patient-portal/src/main/resources/SLING-INF/nodetypes/patient-portal.cnd
@@ -107,6 +107,10 @@
   // An optional intro text about the survey to guide the patient
   - intro (string)
 
+  // An optional setting whether to show a review screen after survey completion
+  // Optional, defaults to the global setting
+  - enableReviewScreen (boolean)
+
   // An emergency contact for the clinic
   - emergencyContact (string)
 

--- a/modules/patient-portal/src/main/resources/SLING-INF/nodetypes/patient-portal.cnd
+++ b/modules/patient-portal/src/main/resources/SLING-INF/nodetypes/patient-portal.cnd
@@ -108,7 +108,7 @@
   - intro (string)
 
   // An optional setting whether to show a review screen after survey completion
-  // Optional, defaults to the global setting
+  // Optional, defaults to the global setting for the patient portal
   - enableReviewScreen (boolean)
 
   // An emergency contact for the clinic

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/CPES.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/CPES.xml
@@ -46,6 +46,11 @@ Do not include any other hospital stays in your answers.
         <value>any</value>
         <type>String</type>
     </property>
+    <property>
+        <name>enableReviewScreen</name>
+        <value>True</value>
+        <type>Boolean</type>
+    </property>
     <node>
         <name>CPESIC</name>
         <primaryNodeType>cards:QuestionnaireRef</primaryNodeType>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/SurveyInstructions.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/SurveyInstructions.xml
@@ -67,6 +67,11 @@ Completing this survey is voluntary, and your name and contact information will 
         <type>String</type>
     </property>
     <property>
+        <name>enableReviewScreen</name>
+        <value>True</value>
+        <type>Boolean</type>
+    </property>
+    <property>
         <name>disclaimer</name>
         <value></value>
         <type>String</type>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/SurveyInstructions.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/SurveyInstructions.xml
@@ -60,6 +60,11 @@ If routine service evaluations or research projects are undertaken, your respons
         <type>Boolean</type>
     </property>
     <property>
+        <name>enableReviewScreen</name>
+        <value>True</value>
+        <type>Boolean</type>
+    </property>
+    <property>
         <name>surveyIntro</name>
         <value>Tell us about your symptoms prior to your appointment.</value>
         <type>String</type>


### PR DESCRIPTION
**Summary of changes:**
* Added a new field to Survey instructions: `enableReviewScreen`
* To preserve existing functionality, this configuration was set to `true` for both PREMs and PROMs
* Added a new optional field `enableReviewScreen` to QuestionnaireSet resources , that can override the global setting
* To easily test the override, this field was set to `true` for CPES
* The Patient workflow (`QuestionnaireSet.jsx`) has been updated as follows: if `enableReviewScreen` is false, the submit button of the last survey is labeled "Submit my answers" (instead of review), and once clicked the final screen ("Thank you for your submission") is displayed

**Testing instructions:**
* **Regression testing:** in both `prems` & `proms`, without updating the configuration, check that nothing has changed from the perspective of the patient users (the review screen is invoked after completing the surveys)
* In `prems`, admin > survey instructions: uncheck **Enable review screen**
* Fill in a CPESIC survey as a patient, note how reviweing is still enabled
* Fill in **another** survey as a patient (ED or IP)
* Check that the review screen is skipped upon completion
* As admin, check that **Surveys completed** for the corresponding `Visit information` form is correctly set to `true`

**Reviewing the code:**
* Commit by commit is recommended