### PR TITLE
CARDS-2016: Fix broken email alerts for worrisome submitted answers

### DIFF
--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentUtils.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentUtils.java
@@ -179,33 +179,6 @@ public final class AppointmentUtils
         return clinicId;
     }
 
-    private static boolean isValidClinicNameChar(char c)
-    {
-        /*
-         * Python's string.ascii_letters + Python's string.digits + Blank spaces + Underscores
-         */
-        final String allowedChars = ""
-            + "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-            + "0123456789"
-            + " "
-            + "_";
-
-        if (allowedChars.indexOf(c) >= 0) {
-            return true;
-        }
-        return false;
-    }
-
-    private static boolean isValidClinicName(String clinicName)
-    {
-        for (int i = 0; i < clinicName.length(); i++) {
-            if (!isValidClinicNameChar(clinicName.charAt(i))) {
-                return false;
-            }
-        }
-        return true;
-    }
-
     /**
      * Returns the cards:QuestionnaireSet JCR Resource associated with the formRelatedSubject or null if no such
      * associated Resource can be found.
@@ -219,22 +192,17 @@ public final class AppointmentUtils
     public static Node getValidClinicNode(FormUtils formUtils, Node formRelatedSubject,
         String clinicIdLink, String clinicsJcrPath)
     {
-        String clinicId = getQuestionAnswerForSubject(
+        String clinicNodePath = getQuestionAnswerForSubject(
             formUtils,
             formRelatedSubject,
             clinicIdLink,
             TEXT_ANSWER,
             EMPTY);
 
-        if (EMPTY.equals(clinicId)) {
+        if (EMPTY.equals(clinicNodePath)) {
             return null;
         }
 
-        if (!isValidClinicName(clinicId)) {
-            return null;
-        }
-
-        String clinicNodePath = clinicsJcrPath.replaceAll("/$", "") + "/" + clinicId;
         try {
             return formRelatedSubject.getSession().getNode(clinicNodePath);
         } catch (RepositoryException e) {

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/EmailAlertEventListener.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/EmailAlertEventListener.java
@@ -54,7 +54,7 @@ public final class EmailAlertEventListener implements EventListener
 
     private String linkingSubjectType;
 
-    private String alertingQuestionUUID;
+    private String alertingQuestionPath;
 
     private String triggerOperator;
 
@@ -79,7 +79,7 @@ public final class EmailAlertEventListener implements EventListener
         this.alertName = listenerParams.get("alertName");
         this.submittedFlagUUID = listenerParams.get("submittedFlagUUID");
         this.linkingSubjectType = listenerParams.get("linkingSubjectType");
-        this.alertingQuestionUUID = listenerParams.get("alertingQuestionUUID");
+        this.alertingQuestionPath = listenerParams.get("alertingQuestionPath");
         this.triggerOperator = listenerParams.get("triggerOperator");
         this.triggerOperand = listenerParams.get("triggerOperand");
         this.alertDescription = listenerParams.get("alertDescription");
@@ -157,7 +157,7 @@ public final class EmailAlertEventListener implements EventListener
                  * button whose setting caused this event to occur.
                  */
                 Collection<Node> answers = this.formUtils.findAllSubjectRelatedAnswers(formRelatedSubject,
-                    session.getNode(this.alertingQuestionUUID),
+                    session.getNode(this.alertingQuestionPath),
                     EnumSet.of(FormUtils.SearchType.SUBJECT_FORMS, FormUtils.SearchType.DESCENDANTS_FORMS));
 
                 for (Node answer : answers) {

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/EmailAlertEventListener.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/EmailAlertEventListener.java
@@ -202,13 +202,13 @@ public final class EmailAlertEventListener implements EventListener
                 case "=":
                     return this.triggerOperand.equals(String.valueOf(value));
                 case ">":
-                    return Double.parseDouble(this.triggerOperand) > ((Number) value).doubleValue();
+                    return ((Number) value).doubleValue() > Double.parseDouble(this.triggerOperand);
                 case ">=":
-                    return Double.parseDouble(this.triggerOperand) >= ((Number) value).doubleValue();
+                    return ((Number) value).doubleValue() >= Double.parseDouble(this.triggerOperand);
                 case "<":
-                    return Double.parseDouble(this.triggerOperand) < ((Number) value).doubleValue();
+                    return ((Number) value).doubleValue() < Double.parseDouble(this.triggerOperand);
                 case "<=":
-                    return Double.parseDouble(this.triggerOperand) <= ((Number) value).doubleValue();
+                    return ((Number) value).doubleValue() <= Double.parseDouble(this.triggerOperand);
                 case "is not empty":
                     return value != null && !String.valueOf(value).isEmpty();
                 case "is empty":

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/EmailAlertEventListener.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/EmailAlertEventListener.java
@@ -68,6 +68,8 @@ public final class EmailAlertEventListener implements EventListener
 
     private String clinicEmailProperty;
 
+    private String emailFromAddress;
+
     private EmailTemplate template;
 
     public EmailAlertEventListener(ResourceResolverFactory rrf, FormUtils formUtils,
@@ -86,9 +88,10 @@ public final class EmailAlertEventListener implements EventListener
         this.clinicIdLink = listenerParams.get("clinicIdLink");
         this.clinicsJcrPath = listenerParams.get("clinicsJcrPath");
         this.clinicEmailProperty = listenerParams.get("clinicEmailProperty");
+        this.emailFromAddress = listenerParams.get("emailFromAddress");
 
         this.template = EmailTemplate.builder().withSubject("DATAPRO Alert: " + this.alertName)
-            .withSender(this.alertDescription, this.alertName).build();
+            .withSender(this.emailFromAddress, this.alertName).build();
     }
 
     private String getModifedValueNodePath(Event thisEvent) throws RepositoryException

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/EmailFormAlerts.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/EmailFormAlerts.java
@@ -93,7 +93,7 @@ public final class EmailFormAlerts
 
         @AttributeDefinition(name = "Clinic ID Link", description = "Response associated with the"
             + " subject of Linking Subject Type that associates it with a clinic")
-        String clinicIdLink() default "/Questionnaires/Visit information/surveys";
+        String clinicIdLink() default "/Questionnaires/Visit information/clinic";
 
         @AttributeDefinition(name = "Clinics JCR Path")
         String clinicsJcrPath() default "/Survey";

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/EmailFormAlerts.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/EmailFormAlerts.java
@@ -121,19 +121,11 @@ public final class EmailFormAlerts
                 return;
             }
 
-            // Get the UUID associated with config.alertingQuestionPath()
-            final String alertingQuestionUUID = this.resolver.getResource(
-                config.alertingQuestionPath()).getValueMap().get("jcr:uuid", "");
-
-            if ("".equals(alertingQuestionUUID)) {
-                return;
-            }
-
             Map<String, String> listenerParams = new HashMap<>();
             listenerParams.put("alertName", config.name());
             listenerParams.put("submittedFlagUUID", submittedFlagUUID);
             listenerParams.put("linkingSubjectType", config.linkingSubjectType());
-            listenerParams.put("alertingQuestionUUID", alertingQuestionUUID);
+            listenerParams.put("alertingQuestionPath", config.alertingQuestionPath());
             listenerParams.put("triggerOperator", config.triggerOperator());
             listenerParams.put("triggerOperand", config.triggerOperand());
             listenerParams.put("alertDescription", config.alertDescription());

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/EmailFormAlerts.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/EmailFormAlerts.java
@@ -101,6 +101,9 @@ public final class EmailFormAlerts
         @AttributeDefinition(name = "Clinic Email Property",
             description = "Property of the Clinic definition where the emergency contact is stored")
         String clinicEmailProperty() default "emergencyContact";
+
+        @AttributeDefinition(name = "From Email", description = "The email address which this email originates from")
+        String emailFromAddress() default "";
     }
 
     @Activate
@@ -132,6 +135,7 @@ public final class EmailFormAlerts
             listenerParams.put("clinicIdLink", config.clinicIdLink());
             listenerParams.put("clinicsJcrPath", config.clinicsJcrPath());
             listenerParams.put("clinicEmailProperty", config.clinicEmailProperty());
+            listenerParams.put("emailFromAddress", config.emailFromAddress());
             EventListener myEventListener = new EmailAlertEventListener(
                 this.resolverFactory, this.formUtils, this.mailService, listenerParams);
 


### PR DESCRIPTION
This PR addresses the bug described by CARDS-2016 where email alerts were not being generated whenever a survey with a worrisome answer was submitted.

Testing
---------

1. Build this (`CARDS-2016`) branch including the (development) Docker image with `mvn clean install -Pdocker`
2. Ensure that you have built a `cards/postfix-docker` image (see https://github.com/data-team-uhn/cards/tree/dev/Utilities/Development/EmailServer)
3. `mkdir ~/mail_test`
4. `cd compose-cluster`
5. Ensure that you have stopped all running Docker containers
6. Clean up any dangling Docker volumes (`docker volume prune -f`)
7. Clean up any old configurations (`./cleanup.sh`)
8. `python3 generate_compose_yaml.py --cards_project cards4proms --dev_docker_image --composum --oak_filesystem --server_address datapro.uhn.ca --smtps --smtps_test_container --smtps_test_mail_path ~/mail_test && docker-compose build && docker-compose up -d`
9. Configure GNOME Evolution to read mail from this `~/mail_test` directory. See the instructions from _step 5_ in https://github.com/data-team-uhn/cards/blob/dev/Utilities/Development/EmailServer/README.md#using-with-start_cardssh.
10. Visit http://localhost:8080 and login as `admin`:`admin`.
11. Visit http://localhost:8080/system/console/configMgr and configure a new _Email Alerts_ module with the default settings plus an `emailFromAddress` of `noreply@datapro.uhn.ca`
12. Create a new _Patient_ Subject and corresponding _Patient information_ Form. Fill it with random values.
13. Create a new _Visit_ Subject associated with the newly created _Patient_ Subject and a corresponding _Visit information_ Form. Set the _Clinic_ to `3542-CPH-Mood Disorders/Psychopharmacology` and the _Time_ to sometime tomorrow. Leave everything else blank and save the Form.
14. Visit the _Dashboard_ - a new _Patient Health Questionnaire-9_ Form should be created. Edit it, choosing _Nearly every day_ or _Extremely difficult_ for all answers. Save the Form.
15. Visit http://localhost:8080/bin/browser.html and edit the `/Survey/ClinicMapping/481110456` and `/Survey/ClinicMapping/853703519` nodes adding a new property of `emergencyContact` with a value of `emergency@test.com`.
16. Go back to editing the _Visit information_ Form, set _Surveys completed_ and _Surveys submitted_ to _Yes_ and save the Form.
17. Click the _Send / Receive_ button in GNOME evolution. An alert email should be present.