### PR TITLE
CARDS-2017 / CARDS-2019 - Add a `draftLifetime` field to the `Patient Access` configuration

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
@@ -88,7 +88,7 @@ function PatientAccessConfiguration() {
       </ListItem>
     );
 
-  let renderConfigInput = (key, unit, placeholder) => (
+  let renderConfigInput = (key, unit, inputProps) => (
       <ListItem>
         <FormGroup className={classes.textField}>
           <FormLabel>{labels[key][0]}</FormLabel>
@@ -97,12 +97,13 @@ function PatientAccessConfiguration() {
             type="number"
             onChange={event => { setPatientAccessConfig({...patientAccessConfig, [key]: event.target.value}); setHasChanges(true); }}
             onBlur={event => { setPatientAccessConfig({...patientAccessConfig, [key]: event.target.value}); setHasChanges(true); }}
-            placeholder={placeholder || DEFAULT_PATIENT_ACCESS_CONFIG[key] || ""}
+            placeholder={DEFAULT_PATIENT_ACCESS_CONFIG[key] || ""}
             value={patientAccessConfig?.[key]}
             helperText={labels[key][1]}
             InputProps={{
               endAdornment: unit && <InputAdornment position="end">{unit}</InputAdornment>,
             }}
+            inputProps={inputProps}
           />
         </FormGroup>
       </ListItem>
@@ -122,7 +123,7 @@ function PatientAccessConfiguration() {
             { renderConfigCheckbox("tokenlessAuthEnabled") }
             { renderConfigCheckbox("PIIAuthRequired", patientAccessConfig?.tokenlessAuthEnabled) }
             { renderConfigInput("allowedPostVisitCompletionTime", "days") }
-            { renderConfigInput("draftLifetime", "days") }
+            { renderConfigInput("draftLifetime", "days", {min: -1, max: patientAccessConfig?.allowedPostVisitCompletionTime}) }
           </List>
       </AdminConfigScreen>
   );

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
@@ -35,16 +35,17 @@ export const DEFAULT_PATIENT_ACCESS_CONFIG = {
     tokenlessAuthEnabled: false,
     PIIAuthRequired: false,
     allowedPostVisitCompletionTime: "0",
-    draftLifetime: "0"
+    draftLifetime: "-1"
 };
 
 const useStyles = makeStyles(theme => ({
   textField: {
+    margin: theme.spacing(3, 0),
     "& .MuiFormLabel-root" : {
       color: theme.palette.text.primary,
     },
-    "& .MuiTextField-root" : {
-      maxWidth: "250px",
+    "& .MuiInputBase-root" : {
+      maxWidth: "150px",
     },
   },
 }));
@@ -55,11 +56,13 @@ function PatientAccessConfiguration() {
   const [ patientAccessConfig, setPatientAccessConfig ] = useState();
   const [ hasChanges, setHasChanges ] = useState(false);
 
+  // Boolean fields can have one label
+  // Text fields can have one label and one optional helper text
   const labels = {
     tokenlessAuthEnabled: "Patients can answer surveys without a personalized link",
     PIIAuthRequired: "Patients must confirm their identity by providing their date of birth and either MRN or HCN",
-    allowedPostVisitCompletionTime: "Patients can fill out surveys after the associated event for:",
-    draftLifetime: "Patients can edit unsubmitted responses for:"
+    allowedPostVisitCompletionTime: ["Patients can fill out surveys after the associated event for:"],
+    draftLifetime: ["Patients can edit unsubmitted responses for:", "-1 means that drafts are kept until the patient is no longer able to access their surveys"]
   };
 
   let buildConfigData = (formData) => {
@@ -88,14 +91,15 @@ function PatientAccessConfiguration() {
   let renderConfigInput = (key, unit, placeholder) => (
       <ListItem>
         <FormGroup className={classes.textField}>
-          <FormLabel>{labels[key]}</FormLabel>
+          <FormLabel>{labels[key][0]}</FormLabel>
           <TextField
-            variant="outlined"
+            variant="standard"
             type="number"
             onChange={event => { setPatientAccessConfig({...patientAccessConfig, [key]: event.target.value}); setHasChanges(true); }}
             onBlur={event => { setPatientAccessConfig({...patientAccessConfig, [key]: event.target.value}); setHasChanges(true); }}
             placeholder={placeholder || DEFAULT_PATIENT_ACCESS_CONFIG[key] || ""}
             value={patientAccessConfig?.[key]}
+            helperText={labels[key][1]}
             InputProps={{
               endAdornment: unit && <InputAdornment position="end">{unit}</InputAdornment>,
             }}
@@ -118,7 +122,7 @@ function PatientAccessConfiguration() {
             { renderConfigCheckbox("tokenlessAuthEnabled") }
             { renderConfigCheckbox("PIIAuthRequired", patientAccessConfig?.tokenlessAuthEnabled) }
             { renderConfigInput("allowedPostVisitCompletionTime", "days") }
-            { renderConfigInput("draftLifetime", "days", patientAccessConfig?.allowedPostVisitCompletionTime) }
+            { renderConfigInput("draftLifetime", "days") }
           </List>
       </AdminConfigScreen>
   );

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
@@ -79,7 +79,7 @@ function PatientAccessConfiguration() {
 
   let buildConfigData = (formData) => {
     for (let key of Object.keys(patientAccessConfig)) {
-      !key.startsWith("jcr:") && formData.append(key, patientAccessConfig[key] || DEFAULT_PATIENT_ACCESS_CONFIG[key]);
+      !key.startsWith("jcr:") && formData.append(key, patientAccessConfig[key]);
     }
   }
 
@@ -101,9 +101,9 @@ function PatientAccessConfiguration() {
     );
 
   let onInputValueChanged = (key, value) => {
-    setPatientAccessConfig({...patientAccessConfig, [key]: value});
+    setPatientAccessConfig(config => ({...config, [key]: (value || "")}));
     setHasChanges(true);
-    setError({...error, [key]: (LIMITS[key]?.min > value || LIMITS[key]?.max < value)});
+    setError(err => ({...err, [key]: (LIMITS[key]?.min > value || LIMITS[key]?.max < value)}));
   }
 
   let renderConfigInput = (key, unit) => (

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
@@ -67,7 +67,7 @@ function PatientAccessConfiguration() {
     allowedPostVisitCompletionTime: ["Patients can fill out surveys after the associated event for:"],
     draftLifetime: ["Patients can edit unsubmitted responses for:", "-1 means that drafts are kept until the patient is no longer able to access their surveys"]
   };
-  const errorText = `Value must be between 0 and ${patientAccessConfig?.allowedPostVisitCompletionTime}`;
+  const errorText = `Please use a value between 0 and ${patientAccessConfig?.allowedPostVisitCompletionTime}, or ${DEFAULT_PATIENT_ACCESS_CONFIG['draftLifetime']} to disable periodic draft deletion.`;
 
   let readPatientAccessConfigData = (json) => {
 	setDraftLifetime(json.draftLifetime);

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
@@ -34,7 +34,8 @@ export const PATIENT_ACCESS_CONFIG_PATH = "/Survey/PatientAccess";
 export const DEFAULT_PATIENT_ACCESS_CONFIG = {
     tokenlessAuthEnabled: false,
     PIIAuthRequired: false,
-    allowedPostVisitCompletionTime: "0"
+    allowedPostVisitCompletionTime: "0",
+    draftLifetime: "0"
 };
 
 const useStyles = makeStyles(theme => ({
@@ -57,7 +58,8 @@ function PatientAccessConfiguration() {
   const labels = {
     tokenlessAuthEnabled: "Patients can answer surveys without a personalized link",
     PIIAuthRequired: "Patients must confirm their identity by providing their date of birth and either MRN or HCN",
-    allowedPostVisitCompletionTime: "Patients can fill out surveys after the associated event for:"
+    allowedPostVisitCompletionTime: "Patients can fill out surveys after the associated event for:",
+    draftLifetime: "Patients can edit unsubmitted responses for:"
   };
 
   let buildConfigData = (formData) => {
@@ -83,16 +85,16 @@ function PatientAccessConfiguration() {
       </ListItem>
     );
 
-  let renderConfigInput = (key, unit) => (
+  let renderConfigInput = (key, unit, placeholder) => (
       <ListItem>
         <FormGroup className={classes.textField}>
           <FormLabel>{labels[key]}</FormLabel>
           <TextField
-            variant="standard"
+            variant="outlined"
             type="number"
             onChange={event => { setPatientAccessConfig({...patientAccessConfig, [key]: event.target.value}); setHasChanges(true); }}
             onBlur={event => { setPatientAccessConfig({...patientAccessConfig, [key]: event.target.value}); setHasChanges(true); }}
-            placeholder={DEFAULT_PATIENT_ACCESS_CONFIG[key] || ""}
+            placeholder={placeholder || DEFAULT_PATIENT_ACCESS_CONFIG[key] || ""}
             value={patientAccessConfig?.[key]}
             InputProps={{
               endAdornment: unit && <InputAdornment position="end">{unit}</InputAdornment>,
@@ -116,6 +118,7 @@ function PatientAccessConfiguration() {
             { renderConfigCheckbox("tokenlessAuthEnabled") }
             { renderConfigCheckbox("PIIAuthRequired", patientAccessConfig?.tokenlessAuthEnabled) }
             { renderConfigInput("allowedPostVisitCompletionTime", "days") }
+            { renderConfigInput("draftLifetime", "days", patientAccessConfig?.allowedPostVisitCompletionTime) }
           </List>
       </AdminConfigScreen>
   );

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
@@ -67,9 +67,9 @@ function PatientAccessConfiguration() {
     allowedPostVisitCompletionTime: ["Patients can fill out surveys after the associated event for:"],
     draftLifetime: ["Patients can edit unsubmitted responses for:", "-1 means that drafts are kept until the patient is no longer able to access their surveys"]
   };
-  const errorText = `Value must be between ${DEFAULT_PATIENT_ACCESS_CONFIG['draftLifetime']} and ${patientAccessConfig?.allowedPostVisitCompletionTime}`;
+  const errorText = `Value must be between 0 and ${patientAccessConfig?.allowedPostVisitCompletionTime}`;
 
-  let readpatientAccessConfigData = (json) => {
+  let readPatientAccessConfigData = (json) => {
 	setDraftLifetime(json.draftLifetime);
 	inputRef.current.value = json.draftLifetime;
 	setPatientAccessConfig(json);
@@ -153,7 +153,7 @@ function PatientAccessConfiguration() {
           title="Patient Access"
           configPath={PATIENT_ACCESS_CONFIG_PATH}
           configTemplate={Object.keys(DEFAULT_PATIENT_ACCESS_CONFIG).reduce((t, k) => ({...t, [k] : ""}), {})}
-          onConfigFetched={readpatientAccessConfigData}
+          onConfigFetched={readPatientAccessConfigData}
           hasChanges={hasChanges}
           buildConfigData={buildConfigData}
           onConfigSaved={() => setHasChanges(false)}

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/api/PatientAccessConfiguration.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/api/PatientAccessConfiguration.java
@@ -51,10 +51,10 @@ public interface PatientAccessConfiguration
     int getAllowedPostVisitCompletionTime();
 
     /**
-     * Get the configured amount of time, in days, that patient's draft response is kept in the database and the
-     * patient is allowed to continue filling it out. After the specified number of days, the draft would be
-     * deleted and the patient would have to start over. If a value is not specified for this setting, the draft
-     * lifetime should coincide with the authentication token's lifetime.
+     * Get the configured amount of time, in days, that patient's draft responses are kept in the database and the
+     * patient is allowed to continue filling them out. After the specified number of days, the draft responses would
+     * be deleted and the patient would have to start over. If a value is not specified for this setting, the draft
+     * will remain in the database until the patient no longer has access to it.
      *
      * @return A number of days
      */

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/api/PatientAccessConfiguration.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/api/PatientAccessConfiguration.java
@@ -53,8 +53,8 @@ public interface PatientAccessConfiguration
     /**
      * Get the configured amount of time, in days, that patient's draft responses are kept in the database and the
      * patient is allowed to continue filling them out. After the specified number of days, the draft responses would
-     * be deleted and the patient would have to start over. If a value is not specified for this setting, the draft
-     * will remain in the database until the patient no longer has access to it.
+     * be deleted and the patient would have to start over. If a value is not specified for this setting or if it is
+     * {@code -1}, the draft will remain in the database until the patient no longer has access to it.
      *
      * @return A number of days
      */

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/api/PatientAccessConfiguration.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/api/PatientAccessConfiguration.java
@@ -49,4 +49,14 @@ public interface PatientAccessConfiguration
      * @return A number of days
      */
     int getAllowedPostVisitCompletionTime();
+
+    /**
+     * Get the configured amount of time, in days, that patient's draft response is kept in the database and the
+     * patient is allowed to continue filling it out. After the specified number of days, the draft would be
+     * deleted and the patient would have to start over. If a value is not specified for this setting, the draft
+     * lifetime should coincide with the authentication token's lifetime.
+     *
+     * @return A number of days
+     */
+    int getDraftLifetime();
 }

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/PatientAccessConfigurationImpl.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/PatientAccessConfigurationImpl.java
@@ -67,7 +67,7 @@ public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements
     private static final int TOKEN_LIFETIME_DEFAULT = 0;
 
     /** The number of days a patient's draft response is kept for by default (used in case of errors). */
-    private static final int DRAFT_LIFETIME_DEFAULT = 0;
+    private static final int DRAFT_LIFETIME_DEFAULT = -1;
 
     @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
         policyOption = ReferencePolicyOption.GREEDY)
@@ -138,9 +138,6 @@ public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements
         try
         {
             Property lifetime = getConfig(DRAFT_LIFETIME_PROP);
-            if (lifetime == null) {
-                lifetime = getConfig(TOKEN_LIFETIME_PROP);
-            }
             return lifetime == null ? DRAFT_LIFETIME_DEFAULT : (int) lifetime.getLong();
         } catch (RepositoryException e) {
             return DRAFT_LIFETIME_DEFAULT;

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/PatientAccessConfigurationImpl.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/PatientAccessConfigurationImpl.java
@@ -54,6 +54,9 @@ public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements
     /** Property on config node for the number of days a token is valid for. */
     private static final String TOKEN_LIFETIME_PROP = "allowedPostVisitCompletionTime";
 
+    /** Property on config node for the number of days draft responses from patients are kept. */
+    private static final String DRAFT_LIFETIME_PROP = "draftLifetime";
+
     /** Whether or not tokenless auth is enabled by default (used in case of errors). */
     private static final Boolean TOKENLESS_AUTH_ENABLED_DEFAULT = false;
 
@@ -62,6 +65,9 @@ public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements
 
     /** The number of days a token is valid for by default (used in case of errors). */
     private static final int TOKEN_LIFETIME_DEFAULT = 0;
+
+    /** The number of days a patient's draft response is kept for by default (used in case of errors). */
+    private static final int DRAFT_LIFETIME_DEFAULT = 0;
 
     @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
         policyOption = ReferencePolicyOption.GREEDY)
@@ -123,6 +129,21 @@ public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements
             return lifetime == null ? TOKEN_LIFETIME_DEFAULT : (int) lifetime.getLong();
         } catch (RepositoryException e) {
             return TOKEN_LIFETIME_DEFAULT;
+        }
+    }
+
+    @Override
+    public int getDraftLifetime()
+    {
+        try
+        {
+            Property lifetime = getConfig(DRAFT_LIFETIME_PROP);
+            if (lifetime == null) {
+                lifetime = getConfig(TOKEN_LIFETIME_PROP);
+            }
+            return lifetime == null ? DRAFT_LIFETIME_DEFAULT : (int) lifetime.getLong();
+        } catch (RepositoryException e) {
+            return DRAFT_LIFETIME_DEFAULT;
         }
     }
 }


### PR DESCRIPTION
See parent task [CARDS-2017 - _As an admin, I can configure for how long the patients' draft responses are kept in the database_](https://phenotips.atlassian.net/browse/CARDS-2017) on jira for context.

**Status**
* This PR is a DRAFT because the branch is based on #1310, which addresses issues related to resetting to initial values, that were particularly prominent after the addition of the new configuration field to PatientAccess (in particular, resetting a config field to an empty value)
* The newly introduced configuration field will be leveraged by #1298

**Testing**
* The added configuration is not being used anywhere yet on this branch, so testing should focus exclusively on managing its value in the administration
* As admin, navigate to Administration > Patient access
  * Note the new field labeled "`Patients can edit unsubmitted responses for:"
  * Check that if unset, its placeholder is -1
  * Check if the helper text under the input is indeed helping
  * Test that it can be modified, saved and retrieved in the administration
