### PR TITLE
CARDS-2025 - As an admin, I can specify if a user answering a vocabulary question can add free-text answers and has access the vocabulary browser

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question-hints.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question-hints.json
@@ -1,6 +1,7 @@
 {
   "entryMode": "Specifies the source of the value for this question:  \n* manually entered by the **user**,\n* **computed** using a specified expression and answers to other questions, \n* copied over from another **reference** answer to a question specified by a path, or \n* **autocreated** by a backend script (the logic for populating autocreated answers cannot be configured from the user interface).",
   "expression": "Supports javascript syntax, with special placeholder variables being populated with answers to other questions in the form.\n\nExample:\n\n```return @{laps} * @{lapLength:-100}```\n\n where `laps` and `lapLength` are the names of questions in the same form, `:-` is an optional marker for a default value, and `100` is the optional default value.",
+  "enableUserEntry": "If enabled, the user is not restricted to using one of the suggested vocabulary terms, and may save their own text as the free-form answer to the vocabulary question.",
   "question": "Path to a question, either in this or a different questionnaire. Example: `/Questionnaires/Demographics/name`"
 }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question-hints.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question-hints.json
@@ -1,7 +1,7 @@
 {
   "entryMode": "Specifies the source of the value for this question:  \n* manually entered by the **user**,\n* **computed** using a specified expression and answers to other questions, \n* copied over from another **reference** answer to a question specified by a path, or \n* **autocreated** by a backend script (the logic for populating autocreated answers cannot be configured from the user interface).",
   "expression": "Supports javascript syntax, with special placeholder variables being populated with answers to other questions in the form.\n\nExample:\n\n```return @{laps} * @{lapLength:-100}```\n\n where `laps` and `lapLength` are the names of questions in the same form, `:-` is an optional marker for a default value, and `100` is the optional default value.",
-  "enableUserEntry": "If enabled, the user is not restricted to using one of the suggested vocabulary terms, and may save their own text as the free-form answer to the vocabulary question.",
+  "enableUserEntry": "If enabled, the user is not restricted to using one of the suggestions in the dropdown, and may save their own text as the free-form answer to the question.",
   "question": "Path to a question, either in this or a different questionnaire. Example: `/Questionnaires/Demographics/name`"
 }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -313,7 +313,10 @@
             "minAnswers": "long",
             "maxAnswers": "long",
             "displayMode": {
-              "input": {},
+              "input": {
+                "enableVocabularyBrowser" : "boolean",
+                "enableUserEntry" : "boolean"
+              },
               "list": {
                 "compact" : "boolean",
                 "answerOptions" : {
@@ -322,6 +325,8 @@
                 }
               },
               "list+input" : {
+                "enableVocabularyBrowser" : "boolean",
+                "enableUserEntry" : "boolean",
                 "compact" : "boolean",
                 "answerOptions" : {
                   "type": "textOptions",

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -370,7 +370,8 @@
             "maxAnswers": "long",
             "displayMode": {
               "input": {
-                "propertiesToSearch" : "string"
+                "propertiesToSearch" : "string",
+                "enableUserEntry" : "boolean"
               },
               "select" : {},
               "list": {
@@ -378,6 +379,7 @@
               },
               "list+input" : {
                 "propertiesToSearch" : "string",
+                "enableUserEntry" : "boolean",
                 "compact" : "boolean",
                 "answerOptions" : "textOptions"
               }

--- a/modules/data-entry/src/main/frontend/src/resourceQuery/ResourceQuery.jsx
+++ b/modules/data-entry/src/main/frontend/src/resourceQuery/ResourceQuery.jsx
@@ -73,8 +73,7 @@ export const MAX_RESULTS = 10;
 function ResourceQuery(props) {
   const { clearOnClick, onClick, focusAfterSelecting, disabled, variant, isNested, placeholder,
     value, questionDefinition, onChange, enableSelection, initialSelection, onRemoveOption, classes } = props;
-  const { maxAnswers, primaryType, labelProperty, propertiesToSearch } = questionDefinition;
-  const { enableUserEntry } = props;
+  const { maxAnswers, primaryType, labelProperty, propertiesToSearch, enableUserEntry } = questionDefinition;
   const { fetchSuggestions, formatSuggestionData, infoDisplayer } = props;
 
   const [suggestions, setSuggestions] = useState([]);
@@ -528,6 +527,7 @@ ResourceQuery.propTypes = {
       primaryType: PropTypes.string,
       labelProperty: PropTypes.string,
       propertiesToSearch: PropTypes.string,
+      enableUserEntry: PropTypes.bool,
     }).isRequired,
     onChange: PropTypes.func,
     enableSelection: PropTypes.bool,
@@ -541,7 +541,6 @@ ResourceQuery.propTypes = {
 ResourceQuery.defaultProps = {
   clearOnClick: true,
   focusAfterSelecting: true,
-  enableUserEntry: true,
   variant: 'default'
 };
 

--- a/modules/data-entry/src/main/frontend/src/vocabQuery/VocabularyQuery.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/VocabularyQuery.jsx
@@ -132,7 +132,7 @@ function VocabularyQuery(props) {
   return (
       <ResourceQuery
         {... props}
-        infoDisplayer={VocabularyBrowser}
+        infoDisplayer={questionDefinition?.enableVocabularyBrowser ? VocabularyBrowser : undefined}
         fetchSuggestions={fetchSuggestions}
         formatSuggestionData={formatSuggestionData}
       />

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ConceptRecognitionTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ConceptRecognitionTest.xml
@@ -79,6 +79,11 @@
 			<value>vocabulary</value>
 			<type>String</type>
 		</property>
+                <property>
+                        <name>enableVocabularyBrowser</name>
+                        <value>True</value>
+                        <type>Boolean</type>
+                </property>
 		<property>
 			<name>sourceVocabularies</name>
 			<values>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ResourceTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ResourceTest.xml
@@ -569,7 +569,7 @@
 		</property>
 		<property>
 			<name>description</name>
-			<value>Shows the **list+input** display mode with **multiple answers** for **Vocabulary** Questions. The vocabulary browser in **not** enabled.</value>
+			<value>Shows the **list+input** display mode with **multiple answers** for **Vocabulary** Questions. The vocabulary browser is **not** enabled.</value>
 			<type>String</type>
 		</property>
 		<property>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ResourceTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ResourceTest.xml
@@ -436,7 +436,7 @@
 		</property>
 		<property>
 			<name>description</name>
-			<value>Shows the **list+input** display mode with **single answer** for **Vocabulary** Questions</value>
+			<value>Shows the **list+input** display mode with **single answer** for **Vocabulary** Questions. The vocabulary browser is **not** enabled.</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -569,7 +569,7 @@
 		</property>
 		<property>
 			<name>description</name>
-			<value>Shows the **list+input** display mode with **multiple answers** for **Vocabulary** Questions</value>
+			<value>Shows the **list+input** display mode with **multiple answers** for **Vocabulary** Questions. The vocabulary browser in **not** enabled.</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -702,7 +702,7 @@
 		</property>
 		<property>
 			<name>description</name>
-			<value>Shows what the **Vocabulary** Question suggestion list looks like when there are **multiple source vocabulaies** and **one vocabulary cannot be accessed**</value>
+			<value>Shows what the **Vocabulary** Question suggestion list looks like when there are **multiple source vocabulaies** and **one vocabulary cannot be accessed**. The vocabulary browser is enabled.</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -720,6 +720,11 @@
 			<value>vocabulary</value>
 			<type>String</type>
 		</property>
+                <property>
+                        <name>enableVocabularyBrowser</name>
+                        <value>True</value>
+                        <type>Boolean</type>
+                </property>
 		<property>
 			<name>sourceVocabularies</name>
 			<values>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/VocabularyMultipleChoiceTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/VocabularyMultipleChoiceTest.xml
@@ -75,6 +75,11 @@
 			<value>vocabulary</value>
 			<type>String</type>
 		</property>
+                <property>
+                        <name>enableVocabularyBrowser</name>
+                        <value>True</value>
+                        <type>Boolean</type>
+                </property>
 		<property>
 			<name>sourceVocabularies</name>
 			<values>
@@ -208,6 +213,11 @@
 			<value>vocabulary</value>
 			<type>String</type>
 		</property>
+                <property>
+                        <name>enableVocabularyBrowser</name>
+                        <value>True</value>
+                        <type>Boolean</type>
+                </property>
 		<property>
 			<name>sourceVocabularies</name>
 			<values>
@@ -341,6 +351,11 @@
 			<value>vocabulary</value>
 			<type>String</type>
 		</property>
+                <property>
+                        <name>enableVocabularyBrowser</name>
+                        <value>True</value>
+                        <type>Boolean</type>
+                </property>
 		<property>
 			<name>sourceVocabularies</name>
 			<values>
@@ -398,6 +413,11 @@
 			<value>vocabulary</value>
 			<type>String</type>
 		</property>
+                <property>
+                        <name>enableVocabularyBrowser</name>
+                        <value>True</value>
+                        <type>Boolean</type>
+                </property>
 		<property>
 			<name>sourceVocabularies</name>
 			<values>


### PR DESCRIPTION
**Testing:**
`--test` mode, Resource Text questionnaire: enable/disable the 2 boolean properties newly added to vocabulary questions - **Enable user entry** and **Enable vocabulary browser**, and check how they affect the vocabulary questions. **Enable user entry** was also added to resource questions.

**Note:**
These changes are also included in #1284, so both issues can be tested on that branch.