### PR TITLE
CARDS-1962: Prems discharge events import exclusions, CARDS-1963: Prems long-form/short-form survey scheduling [PoC]

### DIFF
--- a/prems-resources/backend/pom.xml
+++ b/prems-resources/backend/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.uhndata.cards</groupId>
+    <artifactId>prems-resources</artifactId>
+    <version>0.9-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>prems-backend</artifactId>
+  <packaging>bundle</packaging>
+  <name>Prems Resources - Backend code</name>
+
+  <build>
+    <plugins>
+      <!-- This is an OSGi bundle -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.uhndata.cards</groupId>
+      <artifactId>cards-clarity-integration</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-validator</groupId>
+      <artifactId>commons-validator</artifactId>
+      <version>1.7</version>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.metatype.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
+      <version>1.6.1</version>
+    </dependency>
+    <dependency>
+    <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.framework</artifactId>
+      <version>1.9.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/FilterEmailConsent.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/FilterEmailConsent.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.prems.internal.importer;
+
+import java.util.Map;
+
+import org.apache.commons.validator.routines.EmailValidator;
+import org.osgi.service.component.annotations.Component;
+
+import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
+
+/**
+ * Clarity import processor that only allows visits for patients with a valid email address who have given consent to
+ * receiving emails.
+ *
+ * @version $Id$
+ */
+@Component()
+public class FilterEmailConsent implements ClarityDataProcessor
+{
+    @Override
+    public Map<String, String> processEntry(Map<String, String> input)
+    {
+        final String email = input.get("EMAIL_ADDRESS");
+        final Boolean consent = "Yes".equalsIgnoreCase(input.get("EMAIL_CONSENT_YN"));
+        if (consent && EmailValidator.getInstance().isValid(email)) {
+            return input;
+        }
+        return null;
+    }
+
+    @Override
+    public int getPriority()
+    {
+        return 0;
+    }
+}

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/SendCPESForDepartmentFrequency.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/SendCPESForDepartmentFrequency.java
@@ -45,15 +45,21 @@ public class SendCPESForDepartmentFrequency implements ClarityDataProcessor
             + " of the total visits registered for each department")
     public @interface SendCPESForDepartmentFrequencyConfigDefinition
     {
+        @AttributeDefinition(name = "Default Frequency", description = "For example \"0.04\".", defaultValue = "0.04")
+        double default_frequency();
+
         @AttributeDefinition(name = "Per Department Frequency", description = "For example \"Department name = 0.02\".")
         String[] frequency_per_department();
     }
+
+    private final double defaultFrequency;
 
     private final Map<String, Double> perDepartmentFrequency;
 
     @Activate
     public SendCPESForDepartmentFrequency(SendCPESForDepartmentFrequencyConfigDefinition configuration)
     {
+        this.defaultFrequency = configuration.default_frequency();
         this.perDepartmentFrequency = new HashMap<>(configuration.frequency_per_department().length);
         for (String clinic : configuration.frequency_per_department()) {
             String[] pieces = clinic.split("\\s*=\\s*");
@@ -68,7 +74,7 @@ public class SendCPESForDepartmentFrequency implements ClarityDataProcessor
     public Map<String, String> processEntry(Map<String, String> input)
     {
         final String department = input.get("DISCH_DEPT_NAME");
-        if (Math.random() < this.perDepartmentFrequency.getOrDefault(department, 0.0d)) {
+        if (Math.random() < this.perDepartmentFrequency.getOrDefault(department, this.defaultFrequency)) {
             input.put("CLINIC", "/Survey/ClinicMapping/2075099");
         }
         return input;

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/SendCPESForDepartmentFrequency.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/SendCPESForDepartmentFrequency.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.prems.internal.importer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
+
+/**
+ * Clarity import processor that sends the long-form CPESIC questionnaire to a small percentage of patients from each
+ * department. The percentage/department configuration is done through an OSGi service configuration.
+ *
+ * @version $Id$
+ */
+@Component()
+@Designate(ocd = SendCPESForDepartmentFrequency.SendCPESForDepartmentFrequencyConfigDefinition.class)
+public class SendCPESForDepartmentFrequency implements ClarityDataProcessor
+{
+    @ObjectClassDefinition(name = "Clarity import filter - CPESIC percentage",
+        description = "Configuration for the Clarity importer filter sending the CPESIC questionnaire to a percentage"
+            + " of the total visits registered for each department")
+    public @interface SendCPESForDepartmentFrequencyConfigDefinition
+    {
+        @AttributeDefinition(name = "Per Department Frequency", description = "For example \"Department name = 0.02\".")
+        String[] frequency_per_department();
+    }
+
+    private final Map<String, Double> perDepartmentFrequency;
+
+    @Activate
+    public SendCPESForDepartmentFrequency(SendCPESForDepartmentFrequencyConfigDefinition configuration)
+    {
+        this.perDepartmentFrequency = new HashMap<>(configuration.frequency_per_department().length);
+        for (String clinic : configuration.frequency_per_department()) {
+            String[] pieces = clinic.split("\\s*=\\s*");
+            if (pieces.length != 2) {
+                continue;
+            }
+            this.perDepartmentFrequency.put(pieces[0], Double.valueOf(pieces[1]));
+        }
+    }
+
+    @Override
+    public Map<String, String> processEntry(Map<String, String> input)
+    {
+        final String department = input.get("DISCH_DEPT_NAME");
+        if (Math.random() < this.perDepartmentFrequency.getOrDefault(department, 0.0d)) {
+            input.put("CLINIC", "/Survey/ClinicMapping/2075099");
+        }
+        return input;
+    }
+
+    @Override
+    public int getPriority()
+    {
+        return 100;
+    }
+}

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clarityMapping.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clarityMapping.xml
@@ -175,6 +175,25 @@
                 <type>String</type>
               </property>
             </node>
+            <node>
+              <name>00000004</name>
+              <primaryNodeType>cards:clarityQuestionMapping</primaryNodeType>
+              <property>
+                <name>column</name>
+                <value>CLINIC</value>
+                <type>String</type>
+              </property>
+              <property>
+                <name>question</name>
+                <value>/Questionnaires/Visit information/clinic</value>
+                <type>String</type>
+              </property>
+              <property>
+                <name>computed</name>
+                <value>True</value>
+                <type>Boolean</type>
+              </property>
+            </node>
           </node>
         </node>
       </node>

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -22,15 +22,19 @@
   "bundles":[
     {
       "id":"${project.groupId}:cards-patient-subject-type:${project.version}",
-      "start-order":"20"
+      "start-order": "20"
     },
     {
       "id":"${project.groupId}:cards-visit-subject-type:${project.version}",
-      "start-order":"21"
+      "start-order": "21"
+    },
+    {
+      "id":"${project.groupId}:prems-backend:${project.version}",
+      "start-order": "26"
     },
     {
       "id":"${project.groupId}:prems-resources-clinical-data:${project.version}",
-      "start-order":"26"
+      "start-order": "26"
     }
   ],
   "configurations":{

--- a/prems-resources/pom.xml
+++ b/prems-resources/pom.xml
@@ -32,6 +32,7 @@
   <description>A collection of questionnaires for Cards for PREMs.</description>
 
   <modules>
+    <module>backend</module>
     <module>clinical-data</module>
     <module>feature</module>
   </modules>


### PR DESCRIPTION
Started implementing exclusions, two basic filters for now:
- only consider patients who consented
- only send CPESIC to a small percentage of the events for each department

To test CPESIC survey distribution, do this before importing the test sql data:
* Go to http://localhost:8080/system/console/configMgr
* Search for "CPESIC"
* Add default frequency and/or department-specific percentages per instructions (see valid department names here: https://github.com/data-team-uhn/cards/blob/dev/compose-cluster/mssql/generate_test_sql.py#L82-L114)