### PR TITLE
CARDS-2030: Add support for configuring the main theme colors (primary, secondary) in each app

### DIFF
--- a/modules/commons/src/main/frontend/src/themePalette.jsx
+++ b/modules/commons/src/main/frontend/src/themePalette.jsx
@@ -19,13 +19,16 @@
 import React from 'react';
 import { createTheme } from '@mui/material/styles';
 
+let primaryColor = document.querySelector('meta[name="primaryColor"]')?.content || "#003366";
+let secondaryColor = document.querySelector('meta[name="secondaryColor"]')?.content || "#f94900";
+
 const appTheme = createTheme({
   palette: {
     primary: {
-      main: '#003366',
+      main: primaryColor,
     },
     secondary: {
-      main: '#f94900',
+      main: secondaryColor,
     },
   }
 });

--- a/modules/commons/src/main/resources/SLING-INF/content/libs/cards/Resource/header.html
+++ b/modules/commons/src/main/resources/SLING-INF/content/libs/cards/Resource/header.html
@@ -34,6 +34,8 @@
     </sly>
     <sly data-sly-use.config="/libs/cards/conf/ThemeColor">
       <meta name="themeColor" content="${config['ThemeColor']}">
+      <meta name="primaryColor" content="${config['PrimaryColor']}">
+      <meta name="secondaryColor" content="${config['SecondaryColor']}">
     </sly>
     <sly data-sly-use.config="/libs/cards/conf/Media">
       <sly data-sly-repeat="${config.valueMap.entrySet.iterator}">

--- a/modules/commons/src/main/resources/SLING-INF/content/libs/sling/servlet/errorhandler/404.html
+++ b/modules/commons/src/main/resources/SLING-INF/content/libs/sling/servlet/errorhandler/404.html
@@ -36,6 +36,8 @@
     </sly>
     <sly data-sly-use.config="/libs/cards/conf/ThemeColor">
       <meta name="themeColor" content="${config['ThemeColor']}">
+      <meta name="primaryColor" content="${config['PrimaryColor']}">
+      <meta name="secondaryColor" content="${config['SecondaryColor']}">
     </sly>
     <sly data-sly-use.config="/libs/cards/conf/Media">
       <sly data-sly-repeat="${config.valueMap.entrySet.iterator}">

--- a/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/TokenExpired/html.html
+++ b/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/TokenExpired/html.html
@@ -36,6 +36,8 @@
     </sly>
     <sly data-sly-use.config="/libs/cards/conf/ThemeColor">
       <meta name="themeColor" content="${config['ThemeColor']}">
+      <meta name="primaryColor" content="${config['PrimaryColor']}">
+      <meta name="secondaryColor" content="${config['SecondaryColor']}">
     </sly>
     <sly data-sly-use.config="/libs/cards/conf/Media">
       <sly data-sly-repeat="${config.valueMap.entrySet.iterator}">

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/conf/ThemeColor.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/conf/ThemeColor.json
@@ -1,4 +1,6 @@
 {
   "jcr:primaryType": "nt:unstructured",
+  "PrimaryColor": "#106DB5",
+  "SecondaryColor": "#c6934b",
   "ThemeColor": "bronze"
 }


### PR DESCRIPTION
They can now be specified as `PrimaryColor` and `SecondaryColor` in `ThemeColor.json` for each project. If not specified, the default ones (midnight blue and orange red) are used.

The `prems` theme colors have been changed to match the logo colors. All other projects remain unchanged.