### PR TITLE
CARDS-2036: Unsubmitted forms for past visits are always deleted (amendment)

### DIFF
--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
@@ -73,10 +73,11 @@ public class UnsubmittedFormsCleanupTask implements Runnable
     @Override
     public void run()
     {
-        final boolean mustPopResolver = false;
+        boolean mustPopResolver = false;
         try (ResourceResolver resolver = this.resolverFactory
             .getServiceResourceResolver(Map.of(ResourceResolverFactory.SUBSERVICE, "VisitFormsPreparation"))) {
             this.rrp.push(resolver);
+            mustPopResolver = true;
             // Gather the needed UUIDs to place in the query
             final String visitInformationQuestionnaire =
                 (String) resolver.getResource("/Questionnaires/Visit information").getValueMap().get("jcr:uuid");


### PR DESCRIPTION
Bugfix: the resolver is never popped out of the thread.

This doesn't really affect anything, since the thread is destroyed anyway after the job finishes running, but we should clean up anyway.