### PR TITLE
[misc] Add support for enabling debug mode in generate_compose_yaml

### DIFF
--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -45,6 +45,7 @@ argparser.add_argument('--demo', help='Enable the Demo Banner, Upgrade Marker Fl
 argparser.add_argument('--demo_banner', help='Enable only the Demo Banner', action='store_true')
 argparser.add_argument('--dev_docker_image', help='Indicate that the CARDS Docker image being used was built for development, not production.', action='store_true')
 argparser.add_argument('--composum', help='Enable Composum for the CARDS admin account', action='store_true')
+argparser.add_argument('--debug', help='Debug the CARDS instance on port 5005', action='store_true')
 argparser.add_argument('--adminer', help='Add an Adminer Docker container for database interaction via web browser', action='store_true')
 argparser.add_argument('--adminer_port', help='If --adminer is specified, bind it to this localhost port [default: 1435]', default=1435, type=int)
 argparser.add_argument('--enable_backup_server', help='Add a cards/backup_recorder service to the cluster', action='store_true')
@@ -481,14 +482,22 @@ if not (args.oak_filesystem or args.external_mongo):
   # internal MongoDB setup will also use a significant amount of memory.
   yaml_obj['services']['cardsinitial']['environment'].append("CARDS_JAVA_MEMORY_LIMIT_MB={}".format(getCardsJavaMemoryLimitMB()))
 
+yaml_obj['services']['cardsinitial']['ports'] = []
+
 if args.sling_admin_port:
-  yaml_obj['services']['cardsinitial']['ports'] = ["127.0.0.1:{}:8080".format(args.sling_admin_port)]
+  yaml_obj['services']['cardsinitial']['ports'].append("127.0.0.1:{}:8080".format(args.sling_admin_port))
+
+if args.debug:
+  yaml_obj['services']['cardsinitial']['ports'].append("127.0.0.1:5005:5005")
 
 if args.cards_project:
   yaml_obj['services']['cardsinitial']['environment'].append("CARDS_PROJECT={}".format(args.cards_project))
 
 if args.composum:
   yaml_obj['services']['cardsinitial']['environment'].append("DEV=true")
+
+if args.debug:
+  yaml_obj['services']['cardsinitial']['environment'].append("DEBUG=true")
 
 if args.demo:
   yaml_obj['services']['cardsinitial']['environment'].append("DEMO=true")

--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -282,6 +282,18 @@ def getCardsJavaMemoryLimitMB():
   # Floor down to the nearest integer MB
   return math.floor(cards_java_memory_limit_mb)
 
+def newListIfEmpty(yaml_object, *keys):
+  # Descend down the yaml_object through the keys
+  list_parent_object = yaml_object
+  for key in keys[0:-1]:
+    list_parent_object = list_parent_object[key]
+  list_name = keys[-1]
+  if list_name in list_parent_object.keys():
+    if type(list_parent_object[list_name]) is list:
+      return list_parent_object[list_name]
+  list_parent_object[list_name] = []
+  return list_parent_object[list_name]
+
 OUTPUT_FILENAME = "docker-compose.yml"
 
 yaml_obj = {}
@@ -482,13 +494,11 @@ if not (args.oak_filesystem or args.external_mongo):
   # internal MongoDB setup will also use a significant amount of memory.
   yaml_obj['services']['cardsinitial']['environment'].append("CARDS_JAVA_MEMORY_LIMIT_MB={}".format(getCardsJavaMemoryLimitMB()))
 
-yaml_obj['services']['cardsinitial']['ports'] = []
-
 if args.sling_admin_port:
-  yaml_obj['services']['cardsinitial']['ports'].append("127.0.0.1:{}:8080".format(args.sling_admin_port))
+  newListIfEmpty(yaml_obj, 'services', 'cardsinitial', 'ports').append("127.0.0.1:{}:8080".format(args.sling_admin_port))
 
 if args.debug:
-  yaml_obj['services']['cardsinitial']['ports'].append("127.0.0.1:5005:5005")
+  newListIfEmpty(yaml_obj, 'services', 'cardsinitial', 'ports').append("127.0.0.1:5005:5005")
 
 if args.cards_project:
   yaml_obj['services']['cardsinitial']['environment'].append("CARDS_PROJECT={}".format(args.cards_project))


### PR DESCRIPTION
Question: in the absence of `--debug` and `--sling_admin_port`, this ends up in the yaml file:

```
    ports: []
```

It doesn't seem to break anything, can you confirm it's OK?