### PR TITLE
CARDS-2020: Implement a scheduled task that clears the patient's answer values from unsubmitted drafts that the patient hasn't updated for longer than `PatientAccess.draftLifetime` days

### DIFF
--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/DraftsAnswersCleanupScheduler.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/DraftsAnswersCleanupScheduler.java
@@ -36,7 +36,7 @@ import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
  * Schedule the cleanup of patient draft answers.
  *
  * @version $Id$
- * @since 0.9.2
+ * @since 0.9.6
  */
 @Component(immediate = true)
 public class DraftsAnswersCleanupScheduler

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/DraftsAnswersCleanupScheduler.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/DraftsAnswersCleanupScheduler.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.patients.internal;
+
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.commons.scheduler.ScheduleOptions;
+import org.apache.sling.commons.scheduler.Scheduler;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.uhndata.cards.patients.api.PatientAccessConfiguration;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
+
+/**
+ * Schedule the cleanup of patient draft answers.
+ *
+ * @version $Id$
+ * @since 0.9.2
+ */
+@Component(immediate = true)
+public class DraftsAnswersCleanupScheduler
+{
+    /** Default log. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(DraftsAnswersCleanupScheduler.class);
+
+    private static final String SCHEDULER_JOB_NAME = "DraftsAnswersCleanup";
+
+    /** Provides access to resources. */
+    @Reference
+    private ResourceResolverFactory resolverFactory;
+
+    /** For sharing the resource resolver with other services. */
+    @Reference
+    private ThreadResourceResolverProvider rrp;
+
+    /** Grab details on the number of days draft responses from patients are kept. */
+    @Reference
+    private PatientAccessConfiguration patientAccessConfiguration;
+
+    /** The scheduler for rescheduling jobs. */
+    @Reference
+    private Scheduler scheduler;
+
+    @Activate
+    protected void activate(final ComponentContext componentContext) throws Exception
+    {
+        try {
+            // Every night at midnight
+            final ScheduleOptions options = this.scheduler.EXPR("0 0 0 * * ? *");
+            options.name(SCHEDULER_JOB_NAME);
+            options.canRunConcurrently(false);
+
+            final Runnable cleanupJob = new DraftsAnswersCleanupTask(this.resolverFactory, this.rrp,
+                this.patientAccessConfiguration);
+            this.scheduler.schedule(cleanupJob, options);
+        } catch (final Exception e) {
+            LOGGER.error("DraftsAnswersCleanup failed to schedule: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/DraftsAnswersCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/DraftsAnswersCleanupTask.java
@@ -145,14 +145,14 @@ public class DraftsAnswersCleanupTask implements Runnable
             final Node child = children.nextNode();
             if (child.isNodeType("cards:AnswerSection")) {
                 deleteFormAnswers(child);
-            } else if (child.isNodeType("cards:Answer")) {
+            } else if (child.isNodeType("cards:Answer") && child.hasProperty("value")) {
                 // Only the answers added by the patient should be deleted.
                 // (entry mode: reference or autocreated)
                 final Node questionNode = child.getProperty("question").getNode();
                 if (questionNode != null && questionNode.hasProperty("entryMode")) {
                     final String entrymode = questionNode.getProperty("entryMode").getString();
                     if (!"reference".equals(entrymode) && !"autocreated".equals(entrymode)) {
-                        child.remove();
+                        child.getProperty("value").remove();
                     }
                 }
             }

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/DraftsAnswersCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/DraftsAnswersCleanupTask.java
@@ -108,7 +108,8 @@ public class DraftsAnswersCleanupTask implements Runnable
                     + "  visitInformation.questionnaire = '%1$s'"
                     // the data form was last modified by the patient before the allowed timeframe
                     + "  and dataForm.[jcr:lastModified] < '%2$s'"
-                    + "  and (lastmodifiedby = patient or lastmodifiedby = guest-patient)"
+                    + "  and"
+                    + " (dataForm.[jcr:lastModifiedBy] = 'patient' or dataForm.[jcr:lastModifiedBy] = 'guest-patient')"
                     // the visit is not submitted
                     + "  and submitted.question = '%3$s'"
                     + "  and (submitted.value <> 1 OR submitted.value IS NULL)"

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/DraftsAnswersCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/DraftsAnswersCleanupTask.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.patients.internal;
+
+import java.time.ZonedDateTime;
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.query.Query;
+
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.uhndata.cards.patients.api.PatientAccessConfiguration;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
+
+/**
+ * Periodically remove patient's answer values with a frequency specified by `PatientAccess.draftLifetime`
+ * that haven't been submitted by the patient.
+ *
+ * @version $Id$
+ * @since 0.9.2
+ */
+public class DraftsAnswersCleanupTask implements Runnable
+{
+
+    /** Default log. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(DraftsAnswersCleanupTask.class);
+
+    /** Provides access to resources. */
+    private final ResourceResolverFactory resolverFactory;
+
+    /** For sharing the resource resolver with other services. */
+    private final ThreadResourceResolverProvider rrp;
+
+    /** Grab details on the number of days draft responses from patients are kept. */
+    private final PatientAccessConfiguration patientAccessConfiguration;
+
+    /**
+     * @param resolverFactory a valid ResourceResolverFactory providing access to resources
+     * @param rrp sharing the resource resolver with other services
+     * @param patientAccessConfiguration details on the number of days draft responses from patients are kept
+     */
+    DraftsAnswersCleanupTask(final ResourceResolverFactory resolverFactory, final ThreadResourceResolverProvider rrp,
+        final PatientAccessConfiguration patientAccessConfiguration)
+    {
+        this.resolverFactory = resolverFactory;
+        this.rrp = rrp;
+        this.patientAccessConfiguration = patientAccessConfiguration;
+    }
+
+    @Override
+    public void run()
+    {
+        boolean mustPopResolver = false;
+        try (ResourceResolver resolver = this.resolverFactory
+            .getServiceResourceResolver(Map.of(ResourceResolverFactory.SUBSERVICE, "VisitFormsPreparation"))) {
+            this.rrp.push(resolver);
+            mustPopResolver = true;
+            final int draftLifetime = this.patientAccessConfiguration.getDraftLifetime();
+            // If draftLifetime is -1, do nothing
+            // (-1 means never delete; any cleanup that is necessary will be done by UnsubmittedFormsCleanupTask)
+            if (draftLifetime == -1) {
+                return;
+            }
+
+            // Gather the needed UUIDs to place in the query
+            final String visitInformationQuestionnaire =
+                (String) resolver.getResource("/Questionnaires/Visit information").getValueMap().get("jcr:uuid");
+            final String submitted = (String) resolver
+                .getResource("/Questionnaires/Visit information/surveys_submitted").getValueMap().get("jcr:uuid");
+
+            // Query:
+            final Iterator<Resource> resources = resolver.findResources(String.format(
+                // select the data forms
+                "select distinct dataForm.*"
+                    + "  from [cards:Form] as dataForm"
+                    // belonging to a visit
+                    + "  inner join [cards:Form] as visitInformation on visitInformation.subject = dataForm.subject"
+                    + "    inner join [cards:Answer] as submitted on isdescendantnode(submitted, visitInformation)"
+                    + " where"
+                    // link to the correct Visit Information questionnaire
+                    + "  visitInformation.questionnaire = '%1$s'"
+                    // the visit date is in the past
+                    + "  and dataForm.[jcr:lastModified] < '%2$s'"
+                    + "  and dataForm.[jcr:lastModifiedBy] = 'patient'"
+                    // the visit is not submitted
+                    + "  and submitted.question = '%3$s'"
+                    + "  and (submitted.value <> 1 OR submitted.value IS NULL)"
+                    // exclude the Visit Information form itself
+                    + "  and dataForm.questionnaire <> '%1$s'",
+                visitInformationQuestionnaire, ZonedDateTime.now().minusDays(draftLifetime), submitted),
+                Query.JCR_SQL2);
+            resources.forEachRemaining(form -> {
+                try {
+                    deleteFormAnswers(form.adaptTo(Node.class));
+                } catch (RepositoryException e) {
+                    LOGGER.warn("Failed to delete patient's answer values from unsubmitted drafts from the form {}: {}",
+                        form.getPath(), e.getMessage());
+                }
+            });
+            resolver.commit();
+        } catch (LoginException e) {
+            LOGGER.warn("Invalid setup, service rights not set up for drafts answer cleanup task");
+        } catch (PersistenceException e) {
+            LOGGER.warn("Failed to delete patient's answer values from unsubmitted drafts: {}", e.getMessage());
+        } finally {
+            if (mustPopResolver) {
+                this.rrp.pop();
+            }
+        }
+    }
+
+    private void deleteFormAnswers(final Node node)
+        throws RepositoryException
+    {
+        final NodeIterator children = node.getNodes();
+        while (children.hasNext()) {
+            final Node child = children.nextNode();
+            if (child.isNodeType("cards:AnswerSection")) {
+                deleteFormAnswers(child);
+            } else if (child.isNodeType("cards:Answer")) {
+                // Only the answers added by the patient should be deleted.
+                // (entry mode: reference or autocreated)
+                final Node questionNode = child.getProperty("question").getNode();
+                if (questionNode != null && questionNode.hasProperty("entryMode")) {
+                    final String entrymode = questionNode.getProperty("entryMode").getString();
+                    if (!"refernce".equals(entrymode) && !"autocreated".equals(entrymode)) {
+                        child.remove();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/DraftsAnswersCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/DraftsAnswersCleanupTask.java
@@ -40,11 +40,11 @@ import io.uhndata.cards.patients.api.PatientAccessConfiguration;
 import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 /**
- * Periodically remove patient's answer values with a frequency specified by `PatientAccess.draftLifetime`
+ * Periodically remove patient's answer values with a frequency specified by @{code PatientAccess.draftLifetime}
  * that haven't been submitted by the patient.
  *
  * @version $Id$
- * @since 0.9.2
+ * @since 0.9.6
  */
 public class DraftsAnswersCleanupTask implements Runnable
 {
@@ -106,9 +106,9 @@ public class DraftsAnswersCleanupTask implements Runnable
                     + " where"
                     // link to the correct Visit Information questionnaire
                     + "  visitInformation.questionnaire = '%1$s'"
-                    // the visit date is in the past
+                    // the data form was last modified by the patient before the allowed timeframe
                     + "  and dataForm.[jcr:lastModified] < '%2$s'"
-                    + "  and dataForm.[jcr:lastModifiedBy] = 'patient'"
+                    + "  and (lastmodifiedby = patient or lastmodifiedby = guest-patient)"
                     // the visit is not submitted
                     + "  and submitted.question = '%3$s'"
                     + "  and (submitted.value <> 1 OR submitted.value IS NULL)"
@@ -150,7 +150,7 @@ public class DraftsAnswersCleanupTask implements Runnable
                 final Node questionNode = child.getProperty("question").getNode();
                 if (questionNode != null && questionNode.hasProperty("entryMode")) {
                     final String entrymode = questionNode.getProperty("entryMode").getString();
-                    if (!"refernce".equals(entrymode) && !"autocreated".equals(entrymode)) {
+                    if (!"reference".equals(entrymode) && !"autocreated".equals(entrymode)) {
                         child.remove();
                     }
                 }

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/PatientAccessConfigurationImpl.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/PatientAccessConfigurationImpl.java
@@ -138,7 +138,8 @@ public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements
         try
         {
             Property lifetime = getConfig(DRAFT_LIFETIME_PROP);
-            return lifetime == null ? DRAFT_LIFETIME_DEFAULT : (int) lifetime.getLong();
+            int value = lifetime == null ? DRAFT_LIFETIME_DEFAULT : (int) lifetime.getLong();
+            return value < -1 ? DRAFT_LIFETIME_DEFAULT : value;
         } catch (RepositoryException e) {
             return DRAFT_LIFETIME_DEFAULT;
         }

--- a/modules/versioning/pom.xml
+++ b/modules/versioning/pom.xml
@@ -74,5 +74,10 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cards-resolver-provider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/modules/versioning/src/main/java/io/uhndata/cards/versioning/LastModifiedEditor.java
+++ b/modules/versioning/src/main/java/io/uhndata/cards/versioning/LastModifiedEditor.java
@@ -72,6 +72,12 @@ public class LastModifiedEditor extends DefaultEditor
         propertyAdded(after);
     }
 
+    @Override
+    public void propertyDeleted(PropertyState before) throws CommitFailedException
+    {
+        propertyAdded(before);
+    }
+
     // Called when a new property is added
     @Override
     public void propertyAdded(final PropertyState after)
@@ -100,6 +106,13 @@ public class LastModifiedEditor extends DefaultEditor
         return new LastModifiedEditor(this.currentNodeBuilder.getChildNode(name),
             this.currentResourceResolver,
             this.versionableAncestor);
+    }
+
+    @Override
+    public Editor childNodeDeleted(String name, NodeState before) throws CommitFailedException
+    {
+        handleAnswerChange();
+        return null;
     }
 
     private boolean isMixLastModified(NodeBuilder nodeBuilder)

--- a/modules/versioning/src/main/java/io/uhndata/cards/versioning/LastModifiedEditorProvider.java
+++ b/modules/versioning/src/main/java/io/uhndata/cards/versioning/LastModifiedEditorProvider.java
@@ -23,12 +23,10 @@ import org.apache.jackrabbit.oak.spi.commit.EditorProvider;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 /**
  * A {@link EditorProvider} returning {@link LastModifiedEditor}.
@@ -38,20 +36,17 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 @Component(property = "service.ranking:Integer=70")
 public class LastModifiedEditorProvider implements EditorProvider
 {
-    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
-        policyOption = ReferencePolicyOption.GREEDY)
-    private ResourceResolverFactory rrf;
+    @Reference
+    private ThreadResourceResolverProvider rrp;
 
     @Override
     public Editor getRootEditor(NodeState before, NodeState after, NodeBuilder builder, CommitInfo info)
         throws CommitFailedException
     {
-        if (this.rrf != null) {
-            final ResourceResolver myResolver = this.rrf.getThreadResourceResolver();
-            if (myResolver != null) {
-                // Each LastModifiedEditor maintains a state, so a new instance must be returned each time
-                return new LastModifiedEditor(builder, myResolver, null);
-            }
+        final ResourceResolver myResolver = this.rrp.getThreadResourceResolver();
+        if (myResolver != null) {
+            // Each LastModifiedEditor maintains a state, so a new instance must be returned each time
+            return new LastModifiedEditor(builder, myResolver, null);
         }
         return null;
     }


### PR DESCRIPTION
Includes: [CARDS-2020](https://phenotips.atlassian.net/browse/CARDS-2020), [CARDS-2076](https://phenotips.atlassian.net/browse/CARDS-2076), [CARDS-2077](https://phenotips.atlassian.net/browse/CARDS-2077).

To test **on branch `CARDS-2020-test`**:
- start in prems mode
- edit Administration/Patient Access/Patients can edit unsubmitted responses for = 1
- create two new visits for to different patients, generate tokens, fill them in as a patient, submit one but not the other
- wait a minute, as admin make sure that no answers have been deleted from the forms
- edit Administration/Patient Access/Patients can edit unsubmitted responses for = -1
- wait a minute, as admin make sure that no answers have been deleted from the forms
- edit Administration/Patient Access/Patients can edit unsubmitted responses for = 0
- wait a minute, as admin make sure that no answers have been deleted from the submitted form, but all answers have been deleted from the unsubmitted one

[CARDS-2020]: https://phenotips.atlassian.net/browse/CARDS-2020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CARDS-2076]: https://phenotips.atlassian.net/browse/CARDS-2076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CARDS-2077]: https://phenotips.atlassian.net/browse/CARDS-2077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ