### PR TITLE
CARDS-2042 / CARDS-2043: Create the Survey events questionnaire

### DIFF
--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Survey events.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Survey events.xml
@@ -1,0 +1,322 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>Survey events</name>
+	<primaryNodeType>cards:Questionnaire</primaryNodeType>
+	<property>
+		<name>title</name>
+		<value>Survey events</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>requiredSubjectTypes</name>
+		<values>
+			<value>/SubjectTypes/Patient/Visit</value>
+		</values>
+		<type>Reference</type>
+	</property>
+	<property>
+		<name>maxPerSubject</name>
+		<value>1</value>
+		<type>Long</type>
+	</property>
+	<node>
+		<name>hospital</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>text</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>text</name>
+			<value>Hospital</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>plain</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>entryMode</name>
+			<value>reference</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>question</name>
+			<value>/Questionnaires/Visit information/location</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>department</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>dataType</name>
+			<value>text</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>text</name>
+			<value>Department</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>plain</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>entryMode</name>
+			<value>reference</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>question</name>
+			<value>/Questionnaires/Visit information/provider</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>discharged_date</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>date</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>text</name>
+			<value>Discharged on</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>yyyy-MM-dd'T'HH:mm:ss.sssZ</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>plain</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>entryMode</name>
+			<value>reference</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>question</name>
+			<value>/Questionnaires/Visit information/time</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>assigned_survey</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>resource</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>text</name>
+			<value>Assigned survey</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>primaryType</name>
+			<value>cards:ClinicMapping</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>labelProperty</name>
+			<value>displayName</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>plain</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>entryMode</name>
+			<value>reference</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>question</name>
+			<value>/Questionnaires/Visit information/clinic</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>invitation_sent</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>date</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>text</name>
+			<value>Invitation email sent on</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>yyyy-MM-dd'T'HH:mm:ss.sssZ</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>plain</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>entryMode</name>
+			<value>autocreated</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>reminder1_sent</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>date</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>text</name>
+			<value>First reminder email sent on</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>yyyy-MM-dd'T'HH:mm:ss.sssZ</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>plain</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>entryMode</name>
+			<value>autocreated</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>reminder2_sent</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>date</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>text</name>
+			<value>Second reminder email sent on</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>yyyy-MM-dd'T'HH:mm:ss.sssZ</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>plain</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>entryMode</name>
+			<value>autocreated</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>responses_received</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>date</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>text</name>
+			<value>Patient responses received on</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>yyyy-MM-dd'T'HH:mm:ss.sssZ</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>plain</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>entryMode</name>
+			<value>autocreated</value>
+			<type>String</type>
+		</property>
+	</node>
+</node>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/ClinicMapping.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/ClinicMapping.xml
@@ -112,7 +112,7 @@
         </property>
         <property>
             <name>displayName</name>
-            <value>UHN Emergency to Inpatient</value>
+            <value>UHN Emergency and Inpatient</value>
             <type>String</type>
         </property>
         <property>
@@ -136,7 +136,7 @@
         </property>
         <property>
             <name>displayName</name>
-            <value>Toronto Rehab</value>
+            <value>UHN Rehab</value>
             <type>String</type>
         </property>
         <property>


### PR DESCRIPTION
**Scope:**
* See parent task [CARDS-2042](https://phenotips.atlassian.net/browse/CARDS-2042) for context.
* This PR is strictly about creating the questionnaire to be used for gathering data for CARDS-2042.

**Testing:**
* Create a `Visit information` form
* Create a `Survey events` form for the same visit
  * Note: all fields are of type `reference` or `autocreated`, so nothing can be edited
  * hospital, department, discharge date, and survey should be copied over from `Visit information`
  * The other 4 date fields are expected to be empty at this time; they will be filled in by the services implemented for the other subtasks of `CARDS-2042`
* After filling in one or more forms, test the csv export `/Questionnaire/Survey events.labels.csv`


[CARDS-2042]: https://phenotips.atlassian.net/browse/CARDS-2042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ