### PR TITLE
CARDS-1998: When generating a new form from the backend, generate blank answers for all questions

### DIFF
--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/PauseResumeFormEditorProvider.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/PauseResumeFormEditorProvider.java
@@ -39,7 +39,7 @@ import io.uhndata.cards.subjects.api.SubjectUtils;
  *
  * @version $Id$
  */
-@Component
+@Component(property = "service.ranking:Integer=10")
 public class PauseResumeFormEditorProvider implements EditorProvider
 {
     @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,

--- a/modules/data-entry/src/main/features/feature.json
+++ b/modules/data-entry/src/main/features/feature.json
@@ -76,6 +76,7 @@
     },
     "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~cards-data-entry":{
       "user.mapping":[
+        "io.uhndata.cards.data-model-forms-impl:createMissingAnswers=[cards-answer-editor]",
         "io.uhndata.cards.data-model-forms-impl:computedAnswers=[cards-answer-editor]",
         "io.uhndata.cards.data-model-forms-impl:referenceAnswers=[cards-answer-editor]",
         "io.uhndata.cards.data-model-forms-impl:maxFormsOfTypePerSubjectValidator=[sling-readall]",

--- a/modules/data-model/forms/api/src/main/java/io/uhndata/cards/forms/api/QuestionnaireUtils.java
+++ b/modules/data-model/forms/api/src/main/java/io/uhndata/cards/forms/api/QuestionnaireUtils.java
@@ -85,6 +85,15 @@ public interface QuestionnaireUtils
     boolean isSection(Node node);
 
     /**
+     * Check if the given node is a conditional Section node.
+     *
+     * @param node the node to check, a JCR Node, may be {@code null}
+     * @return {@code true} if the node is not {@code null} and is of type {@code cards:Section} and has a condition,
+     *         {@code false} otherwise
+     */
+    boolean isConditionalSection(Node node);
+
+    /**
      * Retrieve the Section with the given UUID.
      *
      * @param identifier an UUID that references a section.

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
@@ -137,12 +137,8 @@ public class ComputedAnswersEditor extends AnswersEditor
 
         // There are missing computed questions, let's create them!
         if (computedQuestionsTree != null) {
-            FormGenerator generator = new FormGenerator(this.questionnaireUtils, this.formUtils,
-                this.currentSession.getUserID());
-            generator.createMissingNodes(questionnaireNode, this.currentNodeBuilder);
-
-            Map<Node, NodeBuilder> questionAndAnswers
-                = computedQuestionsTree.getQuestionAndAnswers(this.currentNodeBuilder);
+            Map<Node, NodeBuilder> questionAndAnswers =
+                computedQuestionsTree.getQuestionAndAnswers(this.currentNodeBuilder);
             // Try to determine the right order in which answers should be computed, so that the answers that depend on
             // other computed answers are evaluated after all their dependencies have been evaluated
             final Set<String> questionNames = questionAndAnswers.keySet().stream()

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
@@ -97,13 +97,6 @@ public class ComputedAnswersEditor extends AnswersEditor
     }
 
     @Override
-    protected ComputedAnswerNodeTypes getNewAnswerNodeTypes(Node node)
-        throws RepositoryException
-    {
-        return new ComputedAnswerNodeTypes(node);
-    }
-
-    @Override
     protected boolean isQuestionNodeMatchingType(Node node)
     {
         return this.questionnaireUtils.isComputedQuestion(node);
@@ -171,13 +164,7 @@ public class ComputedAnswersEditor extends AnswersEditor
     {
         final Node question = entry.getKey();
         final NodeBuilder answer = entry.getValue();
-        Type<?> resultType = Type.STRING;
-        try {
-            ComputedAnswerNodeTypes types = new ComputedAnswerNodeTypes(question);
-            resultType = types.getDataType();
-        } catch (RepositoryException e) {
-            LOGGER.error("Error typing value for question. " + e.getMessage());
-        }
+        Type<?> resultType = getAnswerType(question);
         Object result = this.expressionUtils.evaluate(question, answersByQuestionName, resultType);
 
         if (result == null || (result instanceof String && "null".equals(result))) {
@@ -268,14 +255,6 @@ public class ComputedAnswersEditor extends AnswersEditor
                 }
             }
             return false;
-        }
-    }
-
-    private final class ComputedAnswerNodeTypes extends AnswerNodeTypes
-    {
-        ComputedAnswerNodeTypes(final Node questionNode) throws RepositoryException
-        {
-            super(questionNode, "cards:ComputedAnswer", "cards/ComputedAnswer");
         }
     }
 }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
@@ -137,30 +137,31 @@ public class ComputedAnswersEditor extends AnswersEditor
 
         // There are missing computed questions, let's create them!
         if (computedQuestionsTree != null) {
-            // Create the missing structure, i.e. AnswerSection and Answer nodes
-            final Map<QuestionTree, NodeBuilder> answersToCompute =
-                createMissingNodes(computedQuestionsTree, this.currentNodeBuilder);
+            FormGenerator generator = new FormGenerator(this.questionnaireUtils, this.formUtils,
+                this.currentSession.getUserID());
+            generator.createMissingNodes(questionnaireNode, this.currentNodeBuilder);
 
+            Map<Node, NodeBuilder> questionAndAnswers
+                = computedQuestionsTree.getQuestionAndAnswers(this.currentNodeBuilder);
             // Try to determine the right order in which answers should be computed, so that the answers that depend on
             // other computed answers are evaluated after all their dependencies have been evaluated
-            final Set<String> questionNames = answersToCompute.keySet().stream()
-                .map(QuestionTree::getNode)
+            final Set<String> questionNames = questionAndAnswers.keySet().stream()
                 .map(this.questionnaireUtils::getQuestionName)
                 .collect(Collectors.toSet());
             final Map<String, Set<String>> computedAnswerDependencies =
-                answersToCompute.keySet().stream().map(question -> {
-                    Set<String> dependencies = this.expressionUtils.getDependencies(question.getNode());
+                questionAndAnswers.keySet().stream().map(question -> {
+                    Set<String> dependencies = this.expressionUtils.getDependencies(question);
                     dependencies.retainAll(questionNames);
-                    return Pair.of(this.questionnaireUtils.getQuestionName(question.getNode()), dependencies);
+                    return Pair.of(this.questionnaireUtils.getQuestionName(question), dependencies);
                 }).collect(Collectors.toConcurrentMap(Pair::getKey, Pair::getValue));
             final List<String> orderedAnswersToCompute = sortDependencies(computedAnswerDependencies);
 
             // We have the right order, compute all the missing answers
             orderedAnswersToCompute.stream()
                 // Get the right answer node
-                .map(questionName -> answersToCompute.entrySet().stream()
+                .map(questionName -> questionAndAnswers.entrySet().stream()
                     .filter(
-                        entry -> questionName.equals(this.questionnaireUtils.getQuestionName(entry.getKey().getNode())))
+                        entry -> questionName.equals(this.questionnaireUtils.getQuestionName(entry.getKey())))
                     .findFirst().get())
                 // Evaluate it
                 .forEachOrdered(entry -> {
@@ -169,19 +170,19 @@ public class ComputedAnswersEditor extends AnswersEditor
         }
     }
 
-    private void computeAnswer(final Map.Entry<QuestionTree, NodeBuilder> entry,
+    private void computeAnswer(final Map.Entry<Node, NodeBuilder> entry,
         final Map<String, Object> answersByQuestionName)
     {
-        final QuestionTree question = entry.getKey();
+        final Node question = entry.getKey();
         final NodeBuilder answer = entry.getValue();
         Type<?> resultType = Type.STRING;
         try {
-            ComputedAnswerNodeTypes types = new ComputedAnswerNodeTypes(question.getNode());
+            ComputedAnswerNodeTypes types = new ComputedAnswerNodeTypes(question);
             resultType = types.getDataType();
         } catch (RepositoryException e) {
             LOGGER.error("Error typing value for question. " + e.getMessage());
         }
-        Object result = this.expressionUtils.evaluate(question.getNode(), answersByQuestionName, resultType);
+        Object result = this.expressionUtils.evaluate(question, answersByQuestionName, resultType);
 
         if (result == null || (result instanceof String && "null".equals(result))) {
             answer.removeProperty(FormUtils.VALUE_PROPERTY);
@@ -193,7 +194,7 @@ public class ComputedAnswersEditor extends AnswersEditor
             answer.setProperty(FormUtils.VALUE_PROPERTY, result, untypedResultType);
         }
         // Update the computed value in the map of existing answers
-        String questionName = this.questionnaireUtils.getQuestionName(question.getNode());
+        String questionName = this.questionnaireUtils.getQuestionName(question);
         if (answersByQuestionName.containsKey(questionName)) {
             // Question has multiple answers. Ignore this answer, just keep previous.
             // TODO: Implement better recurrent section handling

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditorProvider.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditorProvider.java
@@ -42,7 +42,7 @@ import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
  *
  * @version $Id$
  */
-@Component
+@Component(property = "service.ranking:Integer=60")
 public class ComputedAnswersEditorProvider implements EditorProvider
 {
     @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/CreateMissingAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/CreateMissingAnswersEditor.java
@@ -132,7 +132,7 @@ public class CreateMissingAnswersEditor extends DefaultEditor
         }
 
         final FormGenerator generator = new FormGenerator(this.questionnaireUtils, this.formUtils,
-            this.currentSession.getUserID());
+            this.currentSession);
         generator.createMissingNodes(questionnaireNode, this.currentNodeBuilder);
     }
 }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/CreateMissingAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/CreateMissingAnswersEditor.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.forms.internal;
+
+import java.util.Map;
+
+import javax.jcr.Node;
+import javax.jcr.Session;
+
+import org.apache.jackrabbit.oak.spi.commit.DefaultEditor;
+import org.apache.jackrabbit.oak.spi.commit.Editor;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.uhndata.cards.forms.api.FormUtils;
+import io.uhndata.cards.forms.api.QuestionnaireUtils;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
+
+/**
+ * An {@link Editor} that creates any missing answers and answer sections, following the questionnaire as a template.
+ *
+ * @version $Id$
+ */
+public class CreateMissingAnswersEditor extends DefaultEditor
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(CreateMissingAnswersEditor.class);
+
+    // This holds the builder for the current node. The methods called for editing specific properties don't receive the
+    // actual parent node of those properties, so we must manually keep track of the current node.
+    private final NodeBuilder currentNodeBuilder;
+
+    private final ResourceResolverFactory rrf;
+
+    private final ThreadResourceResolverProvider rrp;
+
+    /** The current user session. */
+    private final Session currentSession;
+
+    private final QuestionnaireUtils questionnaireUtils;
+
+    private final FormUtils formUtils;
+
+    private final boolean isFormNode;
+
+    /**
+     * Simple constructor.
+     *
+     * @param nodeBuilder the builder for the current node
+     * @param currentSession the current user session
+     * @param rrf the resource resolver factory which can provide access to JCR sessions
+     * @param rrp for sharing the resource resolver with other components
+     * @param questionnaireUtils for working with questionnaire data
+     * @param formUtils for working with form data
+     */
+    public CreateMissingAnswersEditor(final NodeBuilder nodeBuilder, final Session currentSession,
+        final ResourceResolverFactory rrf, final ThreadResourceResolverProvider rrp,
+        final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils)
+    {
+        this.currentNodeBuilder = nodeBuilder;
+        this.questionnaireUtils = questionnaireUtils;
+        this.formUtils = formUtils;
+        this.currentSession = currentSession;
+        this.rrf = rrf;
+        this.rrp = rrp;
+        this.isFormNode = this.formUtils.isForm(nodeBuilder);
+    }
+
+    @Override
+    public Editor childNodeAdded(final String name, final NodeState after)
+    {
+        if (this.isFormNode) {
+            // No need to descend further down, we already know that this is a form that has changes
+            return null;
+        } else {
+            return new CreateMissingAnswersEditor(this.currentNodeBuilder.getChildNode(name), this.currentSession,
+                this.rrf, this.rrp, this.questionnaireUtils, this.formUtils);
+        }
+    }
+
+    @Override
+    public Editor childNodeChanged(final String name, final NodeState before, final NodeState after)
+    {
+        return childNodeAdded(name, after);
+    }
+
+    @Override
+    public void enter(final NodeState before, final NodeState after)
+    {
+        if (!this.isFormNode) {
+            return;
+        }
+
+        boolean mustPopResolver = false;
+        try (ResourceResolver serviceResolver =
+            this.rrf.getServiceResourceResolver(Map.of(ResourceResolverFactory.SUBSERVICE, "createMissingAnswers"))) {
+            this.rrp.push(serviceResolver);
+            mustPopResolver = true;
+            createMissingNodes();
+        } catch (final LoginException e) {
+            // Should not happen
+        } finally {
+            if (mustPopResolver) {
+                this.rrp.pop();
+            }
+        }
+    }
+
+    private void createMissingNodes()
+    {
+        final Node questionnaireNode = this.formUtils.getQuestionnaire(this.currentNodeBuilder);
+        if (questionnaireNode == null) {
+            return;
+        }
+
+        final FormGenerator generator = new FormGenerator(this.questionnaireUtils, this.formUtils,
+            this.currentSession.getUserID());
+        generator.createMissingNodes(questionnaireNode, this.currentNodeBuilder);
+    }
+}

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/CreateMissingAnswersEditorProvider.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/CreateMissingAnswersEditorProvider.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.forms.internal;
+
+import javax.jcr.Session;
+
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
+import org.apache.jackrabbit.oak.spi.commit.Editor;
+import org.apache.jackrabbit.oak.spi.commit.EditorProvider;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.FieldOption;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import io.uhndata.cards.forms.api.FormUtils;
+import io.uhndata.cards.forms.api.QuestionnaireUtils;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
+
+/**
+ * A {@link EditorProvider} returning {@link ReferenceAnswersEditor}.
+ *
+ * @version $Id$
+ */
+@Component(property = "service.ranking:Integer=50")
+public class CreateMissingAnswersEditorProvider implements EditorProvider
+{
+    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
+        policyOption = ReferencePolicyOption.GREEDY)
+    private ResourceResolverFactory rrf;
+
+    @Reference
+    private ThreadResourceResolverProvider rrp;
+
+    @Reference
+    private QuestionnaireUtils questionnaireUtils;
+
+    @Reference
+    private FormUtils formUtils;
+
+    @Override
+    public Editor getRootEditor(final NodeState before, final NodeState after, final NodeBuilder builder,
+        final CommitInfo info)
+        throws CommitFailedException
+    {
+        final ResourceResolver resolver = this.rrp.getThreadResourceResolver();
+        if (resolver != null) {
+            // Each ReferenceEditor maintains a state, so a new instance must be returned each time
+            return new CreateMissingAnswersEditor(builder, resolver.adaptTo(Session.class), this.rrf, this.rrp,
+                this.questionnaireUtils, this.formUtils);
+        }
+        return null;
+    }
+}

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormGenerator.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormGenerator.java
@@ -164,7 +164,6 @@ public class FormGenerator
 
         private Type<?> dataType;
 
-        @SuppressWarnings("checkstyle:CyclomaticComplexity")
         AnswerNodeTypes(final Node questionNode) throws RepositoryException
         {
             final String dataTypeString = questionNode.getProperty("dataType").getString();
@@ -191,9 +190,6 @@ public class FormGenerator
                             ? Type.LONG
                             : Type.DATE;
                     break;
-                case "time":
-                case "vocabulary":
-                case "text":
                 default:
                     this.dataType = Type.STRING;
             }
@@ -214,5 +210,4 @@ public class FormGenerator
             return this.dataType;
         }
     }
-
 }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormGenerator.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormGenerator.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.forms.internal;
+
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+
+import io.uhndata.cards.forms.api.FormUtils;
+import io.uhndata.cards.forms.api.QuestionnaireUtils;
+
+/**
+ *
+ *
+ * @version $Id$
+ */
+public class FormGenerator
+{
+    protected final QuestionnaireUtils questionnaireUtils;
+
+    protected final FormUtils formUtils;
+
+    protected final String userID;
+
+    /**
+     * Simple constructor.
+     *
+     * @param questionnaireUtils for working with questionnaire data
+     * @param formUtils for working with form data
+     * @param userID the user that should be recorded as ccreating any missing nodes
+     */
+    public FormGenerator(final QuestionnaireUtils questionnaireUtils, final FormUtils formUtils,
+        final String userID)
+    {
+        this.questionnaireUtils = questionnaireUtils;
+        this.formUtils = formUtils;
+        this.userID = userID;
+    }
+
+    public NodeBuilder createMissingNodes(final Node questionnaireNode, final NodeBuilder formNode)
+    {
+        // If the current node has a primarytype, it has already been created
+        boolean nodeNeedsInitialization = !formNode.hasProperty("jcr:primaryType");
+
+        if (this.questionnaireUtils.isSection(questionnaireNode)) {
+            if (nodeNeedsInitialization) {
+                initializeSection(questionnaireNode, formNode);
+            }
+            createMissingChildren(questionnaireNode, formNode);
+        } else if (this.questionnaireUtils.isQuestionnaire(questionnaireNode)) {
+            createMissingChildren(questionnaireNode, formNode);
+        } else {
+            if (nodeNeedsInitialization) {
+                initializeAnswer(questionnaireNode, formNode);
+            }
+        }
+
+        return formNode;
+    }
+
+    public void createMissingNodes(final Node questionnaireNode, final List<NodeBuilder> formNodes)
+    {
+        for (NodeBuilder node: formNodes) {
+            createMissingNodes(questionnaireNode, node);
+        }
+    }
+
+    private void createMissingChildren(Node questionnaireNode, NodeBuilder formNode)
+    {
+        Map<String, NodeBuilder> childFormNodes = new HashMap<>();
+        for (String childNodeName : formNode.getChildNodeNames()) {
+            NodeBuilder childNode = formNode.getChildNode(childNodeName);
+            if (this.formUtils.isAnswerSection(childNode)) {
+                childFormNodes.put(this.formUtils.getSectionIdentifier(childNode), childNode);
+            } else if (this.formUtils.isAnswer(childNode)) {
+                childFormNodes.put(this.formUtils.getQuestionIdentifier(childNode), childNode);
+            }
+        }
+
+        try {
+            for (NodeIterator i = questionnaireNode.getNodes(); i.hasNext();) {
+                Node questionnaireChild = i.nextNode();
+
+                NodeBuilder childNode;
+                if (childFormNodes.containsKey(questionnaireNode.getIdentifier())) {
+                    childNode = childFormNodes.get(questionnaireNode.getIdentifier());
+                } else {
+                    childNode = formNode.setChildNode(UUID.randomUUID().toString());
+                }
+
+                createMissingNodes(questionnaireChild, childNode);
+                // TODO: Handle recurrent sections properly
+                // if (childQuestionNode.hasProperty("recurrent")
+                // && childQuestionNode.getProperty("recurrent").getBoolean()
+                // && childQuestionNode.hasProperty("initialNumberOfInstances")) {
+                // expectedNumberOfInstances = (int) childQuestionNode.getProperty("initialNumberOfInstances")
+                //     .getLong();
+
+            }
+        } catch (RepositoryException e) {
+            // Could not iterate through children
+        }
+    }
+
+    private void initializeSection(Node sectionNode, NodeBuilder answerSectionNode)
+    {
+        try {
+            // Section must be created before primary type
+            answerSectionNode.setProperty(FormUtils.SECTION_PROPERTY, sectionNode.getIdentifier(),
+                Type.REFERENCE);
+            answerSectionNode.setProperty("jcr:primaryType", FormUtils.ANSWER_SECTION_NODETYPE, Type.NAME);
+            answerSectionNode.setProperty("sling:resourceSuperType", "cards/Resource", Type.STRING);
+            answerSectionNode.setProperty("sling:resourceType", FormUtils.ANSWER_SECTION_RESOURCE, Type.STRING);
+            answerSectionNode.setProperty("statusFlags", Collections.emptyList(), Type.STRINGS);
+        } catch (RepositoryException e) {
+            // Could not retrieve section UUID
+        }
+    }
+
+    private void initializeAnswer(Node questionNode, NodeBuilder answerNode)
+    {
+        try {
+            AnswerNodeTypes types = new AnswerNodeTypes(questionNode);
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+            answerNode.setProperty("jcr:created", dateFormat.format(new Date()), Type.DATE);
+            answerNode.setProperty("jcr:createdBy", this.userID, Type.NAME);
+            answerNode.setProperty(FormUtils.QUESTION_PROPERTY, questionNode.getIdentifier(),
+                Type.REFERENCE);
+            answerNode.setProperty("jcr:primaryType", types.getPrimaryType(), Type.NAME);
+            answerNode.setProperty("sling:resourceSuperType", FormUtils.ANSWER_RESOURCE, Type.STRING);
+            answerNode.setProperty("sling:resourceType", types.getResourceType(), Type.STRING);
+            answerNode.setProperty("statusFlags", Collections.emptyList(), Type.STRINGS);
+        } catch (RepositoryException e) {
+            // Could not retrieve answer type or question UUID
+        }
+    }
+
+    protected static class AnswerNodeTypes
+    {
+        private String primaryType;
+
+        private String resourceType;
+
+        private Type<?> dataType;
+
+        @SuppressWarnings("checkstyle:CyclomaticComplexity")
+        AnswerNodeTypes(final Node questionNode) throws RepositoryException
+        {
+            final String dataTypeString = questionNode.getProperty("dataType").getString();
+            final String capitalizedType = StringUtils.capitalize(dataTypeString);
+            this.primaryType = "cards:" + capitalizedType + "Answer";
+            this.resourceType = "cards/" + capitalizedType + "Answer";
+            switch (dataTypeString) {
+                case "long":
+                    this.dataType = Type.LONG;
+                    break;
+                case "double":
+                    this.dataType = Type.DOUBLE;
+                    break;
+                case "decimal":
+                    this.dataType = Type.DECIMAL;
+                    break;
+                case "boolean":
+                    // Long, not boolean
+                    this.dataType = Type.LONG;
+                    break;
+                case "date":
+                    this.dataType = (questionNode.hasProperty("dateFormat") && "yyyy".equals(
+                        questionNode.getProperty("dateFormat").getString().toLowerCase()))
+                            ? Type.LONG
+                            : Type.DATE;
+                    break;
+                case "time":
+                case "vocabulary":
+                case "text":
+                default:
+                    this.dataType = Type.STRING;
+            }
+        }
+
+        public String getPrimaryType()
+        {
+            return this.primaryType;
+        }
+
+        public String getResourceType()
+        {
+            return this.resourceType;
+        }
+
+        public Type<?> getDataType()
+        {
+            return this.dataType;
+        }
+    }
+
+}

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormGenerator.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormGenerator.java
@@ -110,7 +110,8 @@ public class FormGenerator
                 final Node questionnaireChild = i.nextNode();
 
                 if (!this.questionnaireUtils.isSection(questionnaireChild)
-                    && !this.questionnaireUtils.isQuestion(questionnaireChild)) {
+                    && !this.questionnaireUtils.isQuestion(questionnaireChild)
+                    || this.questionnaireUtils.isConditionalSection(questionnaireChild)) {
                     continue;
                 }
 

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormGenerator.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormGenerator.java
@@ -97,6 +97,11 @@ public class FormGenerator
             for (NodeIterator i = questionnaireNode.getNodes(); i.hasNext();) {
                 Node questionnaireChild = i.nextNode();
 
+                if (!this.questionnaireUtils.isSection(questionnaireChild)
+                    && !this.questionnaireUtils.isQuestion(questionnaireChild)) {
+                    continue;
+                }
+
                 NodeBuilder childNode;
                 if (childFormNodes.containsKey(questionnaireNode.getIdentifier())) {
                     childNode = childFormNodes.get(questionnaireNode.getIdentifier());

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormGenerator.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormGenerator.java
@@ -115,8 +115,8 @@ public class FormGenerator
                 }
 
                 NodeBuilder childNode;
-                if (childFormNodes.containsKey(questionnaireNode.getIdentifier())) {
-                    childNode = childFormNodes.get(questionnaireNode.getIdentifier());
+                if (childFormNodes.containsKey(questionnaireChild.getIdentifier())) {
+                    childNode = childFormNodes.get(questionnaireChild.getIdentifier());
                 } else {
                     childNode = formNode.setChildNode(UUID.randomUUID().toString());
                 }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormGenerator.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormGenerator.java
@@ -20,7 +20,6 @@ import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -36,8 +35,6 @@ import io.uhndata.cards.forms.api.FormUtils;
 import io.uhndata.cards.forms.api.QuestionnaireUtils;
 
 /**
- *
- *
  * @version $Id$
  */
 public class FormGenerator
@@ -82,13 +79,6 @@ public class FormGenerator
         }
 
         return formNode;
-    }
-
-    public void createMissingNodes(final Node questionnaireNode, final List<NodeBuilder> formNodes)
-    {
-        for (NodeBuilder node: formNodes) {
-            createMissingNodes(questionnaireNode, node);
-        }
     }
 
     private void createMissingChildren(Node questionnaireNode, NodeBuilder formNode)

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormRelatedSubjectsEditorProvider.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormRelatedSubjectsEditorProvider.java
@@ -27,7 +27,6 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ServiceScope;
 
 import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
@@ -36,7 +35,7 @@ import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
  *
  * @version $Id$
  */
-@Component(service = EditorProvider.class, scope = ServiceScope.SINGLETON, immediate = true)
+@Component(property = "service.ranking:Integer=50")
 public class FormRelatedSubjectsEditorProvider implements EditorProvider
 {
     @Reference

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/QuestionMatrixEditorProvider.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/QuestionMatrixEditorProvider.java
@@ -23,14 +23,13 @@ import org.apache.jackrabbit.oak.spi.commit.EditorProvider;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ServiceScope;
 
 /**
  * A {@link EditorProvider} returning {@link QuestionMatrixEditor}.
  *
  * @version $Id$
  */
-@Component(service = EditorProvider.class, scope = ServiceScope.SINGLETON, immediate = true)
+@Component(property = "service.ranking:Integer=10")
 public class QuestionMatrixEditorProvider implements EditorProvider
 {
     @Override

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/QuestionnaireUtilsImpl.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/QuestionnaireUtilsImpl.java
@@ -17,6 +17,7 @@
 package io.uhndata.cards.forms.internal;
 
 import javax.jcr.Node;
+import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
 
 import org.apache.commons.lang3.StringUtils;
@@ -85,6 +86,25 @@ public final class QuestionnaireUtilsImpl extends AbstractNodeUtils implements Q
     public boolean isSection(final Node node)
     {
         return isNodeType(node, SECTION_NODETYPE);
+    }
+
+    @Override
+    public boolean isConditionalSection(final Node node)
+    {
+        if (isSection(node)) {
+            try {
+                final NodeIterator children = node.getNodes();
+                while (children.hasNext()) {
+                    final Node child = children.nextNode();
+                    if (child.isNodeType("cards:Conditional") || child.isNodeType("cards:ConditionalGroup")) {
+                        return true;
+                    }
+                }
+            } catch (final RepositoryException e) {
+                // Not expected
+            }
+        }
+        return false;
     }
 
     @Override

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
@@ -95,13 +95,6 @@ public class ReferenceAnswersEditor extends AnswersEditor
     }
 
     @Override
-    protected ReferenceAnswerNodeTypes getNewAnswerNodeTypes(Node node)
-        throws RepositoryException
-    {
-        return new ReferenceAnswerNodeTypes(node);
-    }
-
-    @Override
     protected boolean isQuestionNodeMatchingType(Node node)
     {
         return this.questionnaireUtils.isReferenceQuestion(node);
@@ -142,14 +135,7 @@ public class ReferenceAnswersEditor extends AnswersEditor
                     }
 
                     NodeBuilder answer = entry.getValue();
-                    Type<?> resultType = Type.STRING;
-                    try {
-                        ReferenceAnswerNodeTypes types = new ReferenceAnswerNodeTypes(question);
-                        resultType = types.getDataType();
-                    } catch (RepositoryException e) {
-                        LOGGER.warn("Error typing value for question. " + e.getMessage());
-                    }
-
+                    Type<?> resultType = getAnswerType(question);
                     Object result = getAnswer(form, referencedQuestion);
 
                     if (result == null) {
@@ -162,7 +148,6 @@ public class ReferenceAnswersEditor extends AnswersEditor
                             (Type<Object>) (result instanceof List ? resultType.getArrayType() : resultType);
                         answer.setProperty(FormUtils.VALUE_PROPERTY, result, untypedResultType);
                     }
-
                 });
         }
     }
@@ -226,14 +211,6 @@ public class ReferenceAnswersEditor extends AnswersEditor
                 }
             }
             return false;
-        }
-    }
-
-    private final class ReferenceAnswerNodeTypes extends AnswerNodeTypes
-    {
-        ReferenceAnswerNodeTypes(final Node questionNode) throws RepositoryException
-        {
-            super(questionNode, "cards:ReferenceAnswer", "cards/ReferenceAnswer");
         }
     }
 }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
@@ -221,7 +221,7 @@ public class ReferenceAnswersEditor extends AnswersEditor
                 Node questionNode = ReferenceAnswersEditor.this.questionnaireUtils.getQuestion(questionId);
                 try {
                     if (questionNode != null && questionNode.hasProperty("entryMode")
-                        && "refernce".equals(questionNode.getProperty("entryMode").getString())) {
+                        && "reference".equals(questionNode.getProperty("entryMode").getString())) {
                         return true;
                     }
                 } catch (RepositoryException e) {

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
@@ -129,10 +129,6 @@ public class ReferenceAnswersEditor extends AnswersEditor
 
         // There are missing reference questions, let's create them!
         if (unansweredQuestionsTree != null) {
-            FormGenerator generator = new FormGenerator(this.questionnaireUtils, this.formUtils,
-                this.currentSession.getUserID());
-            generator.createMissingNodes(questionnaireNode, this.currentNodeBuilder);
-
             // Retrieve all the referenced answers
             unansweredQuestionsTree.getQuestionAndAnswers(this.currentNodeBuilder)
                 .entrySet().stream().forEach(entry -> {

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
@@ -22,7 +22,6 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Map;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
@@ -125,49 +124,50 @@ public class ReferenceAnswersEditor extends AnswersEditor
         if (questionnaireNode == null) {
             return;
         }
-        final QuestionTree referenceQuestionsTree =
+        final QuestionTree unansweredQuestionsTree =
             getUnansweredMatchingQuestions(questionnaireNode);
 
         // There are missing reference questions, let's create them!
-        if (referenceQuestionsTree != null) {
-            // Create the missing structure, i.e. AnswerSection and Answer nodes
-            final Map<QuestionTree, NodeBuilder> answersToFinish =
-                createMissingNodes(referenceQuestionsTree, this.currentNodeBuilder);
+        if (unansweredQuestionsTree != null) {
+            FormGenerator generator = new FormGenerator(this.questionnaireUtils, this.formUtils,
+                this.currentSession.getUserID());
+            generator.createMissingNodes(questionnaireNode, this.currentNodeBuilder);
 
             // Retrieve all the referenced answers
-            answersToFinish.entrySet().stream().forEach(entry -> {
-                Node question = entry.getKey().getNode();
-                final String referencedQuestion;
-                try {
-                    referencedQuestion = question.getProperty("question").getString();
-                } catch (final RepositoryException e) {
-                    LOGGER.warn("Skipping referenced question due to missing property");
-                    return;
-                }
+            unansweredQuestionsTree.getQuestionAndAnswers(this.currentNodeBuilder)
+                .entrySet().stream().forEach(entry -> {
+                    Node question = entry.getKey();
+                    final String referencedQuestion;
+                    try {
+                        referencedQuestion = question.getProperty("question").getString();
+                    } catch (final RepositoryException e) {
+                        LOGGER.warn("Skipping referenced question due to missing property");
+                        return;
+                    }
 
-                NodeBuilder answer = entry.getValue();
-                Type<?> resultType = Type.STRING;
-                try {
-                    ReferenceAnswerNodeTypes types = new ReferenceAnswerNodeTypes(question);
-                    resultType = types.getDataType();
-                } catch (RepositoryException e) {
-                    LOGGER.warn("Error typing value for question. " + e.getMessage());
-                }
+                    NodeBuilder answer = entry.getValue();
+                    Type<?> resultType = Type.STRING;
+                    try {
+                        ReferenceAnswerNodeTypes types = new ReferenceAnswerNodeTypes(question);
+                        resultType = types.getDataType();
+                    } catch (RepositoryException e) {
+                        LOGGER.warn("Error typing value for question. " + e.getMessage());
+                    }
 
-                Object result = getAnswer(form, referencedQuestion);
+                    Object result = getAnswer(form, referencedQuestion);
 
-                if (result == null) {
-                    answer.removeProperty(FormUtils.VALUE_PROPERTY);
-                } else {
-                    // Type erasure makes the actual type irrelevant, there's only one real implementation method
-                    // The implementation can extract the right type from the type object
-                    @SuppressWarnings("unchecked")
-                    Type<Object> untypedResultType =
-                        (Type<Object>) (result instanceof List ? resultType.getArrayType() : resultType);
-                    answer.setProperty(FormUtils.VALUE_PROPERTY, result, untypedResultType);
-                }
+                    if (result == null) {
+                        answer.removeProperty(FormUtils.VALUE_PROPERTY);
+                    } else {
+                        // Type erasure makes the actual type irrelevant, there's only one real implementation method
+                        // The implementation can extract the right type from the type object
+                        @SuppressWarnings("unchecked")
+                        Type<Object> untypedResultType =
+                            (Type<Object>) (result instanceof List ? resultType.getArrayType() : resultType);
+                        answer.setProperty(FormUtils.VALUE_PROPERTY, result, untypedResultType);
+                    }
 
-            });
+                });
         }
     }
 

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditorProvider.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditorProvider.java
@@ -42,7 +42,7 @@ import io.uhndata.cards.subjects.api.SubjectUtils;
  *
  * @version $Id$
  */
-@Component(service = EditorProvider.class, immediate = true)
+@Component(property = "service.ranking:Integer=60")
 public class ReferenceAnswersEditorProvider implements EditorProvider
 {
     @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,

--- a/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectFullIdentifierEditorProvider.java
+++ b/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectFullIdentifierEditorProvider.java
@@ -30,15 +30,13 @@ import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
-import org.osgi.service.component.annotations.ServiceScope;
 
 /**
  * A {@link EditorProvider} returning {@link SubjectFullIdentifierEditor}.
  *
  * @version $Id$
  */
-@Component(name = "SubjectFullIdentifierEditorProvider", service = EditorProvider.class,
-    scope = ServiceScope.SINGLETON, immediate = true)
+@Component(property = "service.ranking:Integer=50")
 public class SubjectFullIdentifierEditorProvider implements EditorProvider
 {
     @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,

--- a/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectParentEditorProvider.java
+++ b/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectParentEditorProvider.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.Component;
  *
  * @version $Id$
  */
-@Component(immediate = true)
+@Component(property = "service.ranking:Integer=0")
 public class SubjectParentEditorProvider implements EditorProvider
 {
     @Override

--- a/modules/form-completion-status/src/main/java/io/uhndata/cards/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/io/uhndata/cards/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -16,7 +16,6 @@
  */
 package io.uhndata.cards.formcompletionstatus;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -63,50 +62,35 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     // actual parent node of those properties, so we must manually keep track of the current node.
     private final NodeBuilder currentNodeBuilder;
 
-    private final NodeBuilder form;
-
     private final Session session;
 
     private final FormUtils formUtils;
 
+    private final boolean isFormNode;
+
     // Validators list to be called in sequence, in ascending order of their priority, and each can add or remove flags.
     private final List<AnswerValidator> allValidators;
 
-    // This holds a list of NodeBuilders with the first item corresponding to the root of the JCR tree
-    // and the last item corresponding to the current node. By keeping this list, one is capable of
-    // moving up the tree and setting status flags of ancestor nodes based on the status flags of a
-    // descendant node.
-    private final List<NodeBuilder> currentNodeBuilderPath;
-
-    private final boolean newNode;
+    private final boolean newForm;
 
     /**
      * Simple constructor.
      *
-     * @param nodeBuilder a list of NodeBuilder objects starting from the root of the JCR tree and moving down towards
-     *            the current node.
-     * @param form the form node found up the tree, if any; may be {@code null} if no form node has been encountered so
-     *            far
-     * @param newNode is this a newly created answer, or an existing answer being updated
+     * @param currentNodeBuilder the NodeBuilder to process
+     * @param newNode is this a newly created node, or an existing node being updated
      * @param session the current JCR session
      * @param formUtils for working with form data
      * @param allValidators all available AnswerValidator services
      */
-    public AnswerCompletionStatusEditor(final List<NodeBuilder> nodeBuilder, final NodeBuilder form,
-        final boolean newNode, final Session session, final FormUtils formUtils,
-        final List<AnswerValidator> allValidators)
+    public AnswerCompletionStatusEditor(final NodeBuilder currentNodeBuilder, final boolean newNode,
+        final Session session, final FormUtils formUtils, final List<AnswerValidator> allValidators)
     {
-        this.currentNodeBuilderPath = nodeBuilder;
-        this.currentNodeBuilder = nodeBuilder.get(nodeBuilder.size() - 1);
-        this.newNode = newNode;
+        this.currentNodeBuilder = currentNodeBuilder;
+        this.newForm = newNode;
         this.session = session;
         this.formUtils = formUtils;
         this.allValidators = allValidators;
-        if (this.formUtils.isForm(this.currentNodeBuilder)) {
-            this.form = this.currentNodeBuilder;
-        } else {
-            this.form = form;
-        }
+        this.isFormNode = this.formUtils.isForm(currentNodeBuilder);
     }
 
     // When something changes in a node deep in the content tree, the editor is invoked starting with the root node,
@@ -117,94 +101,100 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
     public Editor childNodeAdded(final String name, final NodeState after)
         throws CommitFailedException
     {
-        final List<NodeBuilder> tmpList = new ArrayList<>(this.currentNodeBuilderPath);
-        tmpList.add(this.currentNodeBuilder.getChildNode(name));
-        return new AnswerCompletionStatusEditor(tmpList, this.form, true, this.session, this.formUtils,
-            this.allValidators);
+        if (this.isFormNode) {
+            return null;
+        }
+        return new AnswerCompletionStatusEditor(this.currentNodeBuilder.getChildNode(name), true, this.session,
+            this.formUtils, this.allValidators);
     }
 
     @Override
     public Editor childNodeChanged(final String name, final NodeState before, final NodeState after)
         throws CommitFailedException
     {
-        final List<NodeBuilder> tmpList = new ArrayList<>(this.currentNodeBuilderPath);
-        tmpList.add(this.currentNodeBuilder.getChildNode(name));
-        return new AnswerCompletionStatusEditor(tmpList, this.form, false, this.session, this.formUtils,
-            this.allValidators);
+        if (this.isFormNode) {
+            return null;
+        }
+        return new AnswerCompletionStatusEditor(this.currentNodeBuilder.getChildNode(name), false, this.session,
+            this.formUtils, this.allValidators);
     }
 
     @Override
-    public void leave(final NodeState before, final NodeState after)
+    public void enter(final NodeState before, final NodeState after)
         throws CommitFailedException
     {
-        if (this.formUtils.isAnswer(this.currentNodeBuilder)) {
-            validateAnswer();
-        } else if (this.formUtils.isForm(this.currentNodeBuilder)
-            || this.formUtils.isAnswerSection(this.currentNodeBuilder)) {
+        if (this.isFormNode) {
+            processNode(this.currentNodeBuilder);
+        }
+    }
 
+    private void processNode(final NodeBuilder node)
+    {
+        summarizeChildren(node);
+        summarizeNode(node);
+    }
+
+    private void summarizeChildren(final NodeBuilder node)
+    {
+        node.getChildNodeNames().iterator().forEachRemaining(name -> processNode(node.getChildNode(name)));
+    }
+
+    private void summarizeNode(final NodeBuilder node)
+    {
+        if (this.formUtils.isAnswer(node)) {
+            validateAnswer(node);
+        } else if (this.formUtils.isForm(node)
+            || this.formUtils.isAnswerSection(node)) {
             try {
-                summarize();
+                summarize(node);
             } catch (final RepositoryException e) {
                 // This is not a fatal error, the form status is not required for a functional application
                 LOGGER.warn("Unexpected exception while checking the completion status of form {}",
-                    this.currentNodeBuilder.getString("jcr:uuid"));
+                    this.currentNodeBuilder.getString("jcr:uuid"), e);
             }
         }
     }
 
     /**
-     * Validate the current node, which must be an answer.
+     * Validate an answer node.
+     *
+     * @param answerNode the {@code cards:Answer} node to validate
      */
-    public void validateAnswer()
+    public void validateAnswer(final NodeBuilder answerNode)
     {
-        final Node questionNode = this.formUtils.getQuestion(this.currentNodeBuilder);
+        final Node questionNode = this.formUtils.getQuestion(answerNode);
 
         if (questionNode != null) {
             // populate the flags map with the old flags all set to false
             final Map<String, Boolean> flags = new HashMap<>();
-            if (this.currentNodeBuilder.hasProperty(STATUS_FLAGS)) {
-                this.currentNodeBuilder.getProperty(STATUS_FLAGS).getValue(Type.STRINGS)
+            if (answerNode.hasProperty(STATUS_FLAGS)) {
+                answerNode.getProperty(STATUS_FLAGS).getValue(Type.STRINGS)
                     .forEach(flag -> flags.put(flag, Boolean.FALSE));
             }
             // call each validator
             this.allValidators.forEach(validator -> {
-                validator.validate(this.currentNodeBuilder, questionNode, this.newNode, flags);
+                validator.validate(answerNode, questionNode, this.newForm, flags);
             });
             // Write these statusFlags to the JCR repo
-            this.currentNodeBuilder.setProperty(STATUS_FLAGS, flags.keySet(), Type.STRINGS);
+            answerNode.setProperty(STATUS_FLAGS, flags.keySet(), Type.STRINGS);
         }
     }
 
     /**
-     * Checks if a NodeBuilder represents an empty Form and returns true if that is the case. Otherwise, this method
-     * returns false.
-     */
-    private boolean isEmptyForm(final NodeBuilder n)
-    {
-        if (this.formUtils.isForm(n)) {
-            if (!(n.getChildNodeNames().iterator().hasNext())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Gather all status flags from all the (satisfied) descendants of the current node and store them as the status
-     * flags of the current node.
+     * Gather all status flags from all the (satisfied) descendants of a node and store them as the status flags of the
+     * node.
      *
+     * @param node the node to summarize, either a {@code cards:Form} or a {@code cards:AnswerSection} node
      * @throws RepositoryException if accessing the repository fails
      */
-    private void summarize() throws RepositoryException
+    private void summarize(final NodeBuilder node) throws RepositoryException
     {
-        this.currentNodeBuilder.getChildNodeNames().iterator();
-        isEmptyForm(this.currentNodeBuilder);
-        final Set<String> flags = StreamSupport.stream(this.currentNodeBuilder.getChildNodeNames().spliterator(), false)
-            .map(childName -> this.currentNodeBuilder.getChildNode(childName))
+        final Set<String> flags = StreamSupport.stream(node.getChildNodeNames().spliterator(), false)
+            .map(childName -> node.getChildNode(childName))
             .filter(child -> {
                 try {
                     return !(this.formUtils.isAnswerSection(child)
-                        && !ConditionalSectionUtils.isConditionSatisfied(this.session, child, this.form));
+                        && !ConditionalSectionUtils.isConditionSatisfied(this.session, child, this.currentNodeBuilder));
                 } catch (final RepositoryException e) {
                     return true;
                 }
@@ -223,8 +213,11 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
                 });
         // Set the flags in selectedNodeBuilder accordingly
         final Set<String> statusFlags = new TreeSet<>();
-        if (this.currentNodeBuilder.hasProperty(STATUS_FLAGS)) {
-            this.currentNodeBuilder.getProperty(STATUS_FLAGS).getValue(Type.STRINGS).forEach(statusFlags::add);
+        if (node.hasProperty(STATUS_FLAGS)) {
+            node.getProperty(STATUS_FLAGS).getValue(Type.STRINGS).forEach(statusFlags::add);
+        }
+        if (isEmptyForm()) {
+            flags.add(STATUS_FLAG_INCOMPLETE);
         }
         if (flags.contains(STATUS_FLAG_INVALID)) {
             statusFlags.add(STATUS_FLAG_INVALID);
@@ -243,6 +236,18 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
             statusFlags.remove(STATUS_FLAG_DRAFT);
         }
         // Write these statusFlags to the JCR repo
-        this.currentNodeBuilder.setProperty(STATUS_FLAGS, statusFlags, Type.STRINGS);
+        node.setProperty(STATUS_FLAGS, statusFlags, Type.STRINGS);
+    }
+
+    /**
+     * Checks if a NodeBuilder represents an empty Form and returns true if that is the case. Otherwise, this method
+     * returns false.
+     */
+    private boolean isEmptyForm()
+    {
+        if (!(this.currentNodeBuilder.getChildNodeNames().iterator().hasNext())) {
+            return true;
+        }
+        return false;
     }
 }

--- a/modules/form-completion-status/src/main/java/io/uhndata/cards/formcompletionstatus/AnswerCompletionStatusEditorProvider.java
+++ b/modules/form-completion-status/src/main/java/io/uhndata/cards/formcompletionstatus/AnswerCompletionStatusEditorProvider.java
@@ -16,7 +16,6 @@
  */
 package io.uhndata.cards.formcompletionstatus;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.jcr.Session;
@@ -64,12 +63,9 @@ public class AnswerCompletionStatusEditorProvider implements EditorProvider
     {
         final ResourceResolver resolver = this.rrp.getThreadResourceResolver();
         if (resolver != null) {
-            this.allValidators.sort((o1, o2) -> o1.getPriority() - o2.getPriority());
+            this.allValidators.sort(null);
             // Each AnswerCompletionStatusEditor maintains a state, so a new instance must be returned each time
-            final List<NodeBuilder> tmpList = new ArrayList<>();
-            tmpList.add(builder);
-            return new AnswerCompletionStatusEditor(tmpList, null, false, resolver.adaptTo(Session.class),
-                this.formUtils,
+            return new AnswerCompletionStatusEditor(builder, false, resolver.adaptTo(Session.class), this.formUtils,
                 this.allValidators);
         }
         return null;

--- a/modules/form-completion-status/src/main/java/io/uhndata/cards/formcompletionstatus/AnswerCompletionStatusEditorProvider.java
+++ b/modules/form-completion-status/src/main/java/io/uhndata/cards/formcompletionstatus/AnswerCompletionStatusEditorProvider.java
@@ -43,7 +43,7 @@ import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
  *
  * @version $Id$
  */
-@Component(immediate = true)
+@Component(property = "service.ranking:Integer=100")
 public class AnswerCompletionStatusEditorProvider implements EditorProvider
 {
     @Reference

--- a/modules/form-completion-status/src/main/java/io/uhndata/cards/formcompletionstatus/ConditionalSectionUtils.java
+++ b/modules/form-completion-status/src/main/java/io/uhndata/cards/formcompletionstatus/ConditionalSectionUtils.java
@@ -610,17 +610,33 @@ public final class ConditionalSectionUtils
         final NodeBuilder answerSection, final NodeBuilder form) throws RepositoryException
     {
         final Node sectionNode = getSectionNode(resourceSession, answerSection);
-        if (sectionNode != null && sectionNode.hasNode("condition")) {
-            final Node conditionNode = sectionNode.getNode("condition");
+        if (sectionNode != null) {
+            final Node conditionNode = findCondition(sectionNode);
             /*
              * Recursively go through all children of the condition node and determine if this condition node evaluates
              * to True or False.
              */
-            if (!evaluateConditionNodeRecursive(conditionNode, sectionNode, form)) {
+            if (conditionNode != null && !evaluateConditionNodeRecursive(conditionNode, sectionNode, form)) {
                 return false;
             }
         }
         return true;
+    }
+
+    private static Node findCondition(final Node section)
+    {
+        try {
+            final NodeIterator children = section.getNodes();
+            while (children.hasNext()) {
+                final Node child = children.nextNode();
+                if (child.isNodeType("cards:Conditional") || child.isNodeType("cards:ConditionalGroup")) {
+                    return child;
+                }
+            }
+        } catch (final RepositoryException e) {
+            // Not expected
+        }
+        return null;
     }
 
     private static long toLong(Object o)

--- a/modules/form-completion-status/src/main/java/io/uhndata/cards/formcompletionstatus/spi/AnswerValidator.java
+++ b/modules/form-completion-status/src/main/java/io/uhndata/cards/formcompletionstatus/spi/AnswerValidator.java
@@ -34,7 +34,7 @@ import io.uhndata.cards.forms.api.FormUtils;
  *
  * @version $Id$
  */
-public interface AnswerValidator
+public interface AnswerValidator extends Comparable<AnswerValidator>
 {
     /**
      * JCR node property name for the answer value.
@@ -85,5 +85,11 @@ public interface AnswerValidator
         if (flags.getOrDefault(flag, Boolean.TRUE) == Boolean.FALSE) {
             flags.remove(flag);
         }
+    }
+
+    @Override
+    default int compareTo(AnswerValidator o)
+    {
+        return this.getPriority() - o.getPriority();
     }
 }

--- a/modules/permissions-ownership/src/main/java/io/uhndata/cards/permissions/internal/ownership/OwnerSetterEditorProvider.java
+++ b/modules/permissions-ownership/src/main/java/io/uhndata/cards/permissions/internal/ownership/OwnerSetterEditorProvider.java
@@ -29,7 +29,7 @@ import org.osgi.service.component.annotations.Component;
  *
  * @version $Id$
  */
-@Component(service = EditorProvider.class)
+@Component(property = "service.ranking:Integer=0")
 public class OwnerSetterEditorProvider implements EditorProvider
 {
     @Override

--- a/modules/versioning/src/main/java/io/uhndata/cards/versioning/LastModifiedEditorProvider.java
+++ b/modules/versioning/src/main/java/io/uhndata/cards/versioning/LastModifiedEditorProvider.java
@@ -35,7 +35,7 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
  *
  * @version $Id$
  */
-@Component
+@Component(property = "service.ranking:Integer=70")
 public class LastModifiedEditorProvider implements EditorProvider
 {
     @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,


### PR DESCRIPTION
With this, everything should be working fine in prems mode, either with manually created visits, or with imported visits.

To test in standalone mode:
- manually create  Patient Information and Visit Information forms
- check that these forms are correctly marked as complete and there are no duplicate answers
- check that the right data forms are auto-created
- check that the reference and computed answers have the right value (in the JSON or Composum, since they are hidden in the UI) 
- generate a token, access the patient portal with it, make sure the survey goes to the welcome screen
- fill in the survey as the patient, make sure it is correctly marked as incomplete when leaving unanswered questions, and correctly completed when all answers are entered
- make sure to test CPESIC too, since it has conditional sections

To test clarity import:
- build with `-Pdocker`
- run in `compose-cluster`: `python3 generate_compose_yaml.py --mssql --cards_project cards4prems --oak_filesystem --dev_docker_image --smtps --smtps_test_container --smtps_test_mail_path ~/cardsmail --composum --adminer` (you can use a different path than `~/cardsmail` if that one is not working correctly)
- run `python3 generate_test_sql.py -n 10 ./importTestSql.new.sql` in `compose-cluster/mssql`
- start docker with `docker-compose up`
- at http://localhost:1435/ import the generated sample data file from `compose-cluster/mssql/importTestSql.new.sql`
- at http://localhost:8080/system/console/configMgr change the default frequency for `Clarity import filter - CPESIC percentage` to `1.0`
- open http://localhost:8080/Subjects.importClarity
- check as above that the forms are imported correctly, and at least one of them can be filled in and submitted by a patient with a token

Question 1: the following behavior is new: when creating a new form with no mandatory questions (like Visit Information), the form is no longer created as a Draft/Incomplete, since all 0 mandatory questions have been answered. Should this revert to the old behavior, new forms are always incomplete? If we force that new forms are incomplete, the CSV import will start creating only draft forms.

Question 2: the following behavior might also be changed: as I remember, CSV imported forms were never marked as incomplete, since the agreement was that data imported is considered complete, even if mandatory questions are not answered, but the new code always computes flags correctly; do we want to revert to the old convention that imported data is considered complete?