### PR TITLE
CARDS-2052 + CARDS-2053: UI fixes for reference resource questions

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/AutocreatedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/AutocreatedQuestion.jsx
@@ -41,7 +41,7 @@ let AutocreatedQuestion = (props) => {
   const [isFormatted, changeIsFormatted] = useState(false);
 
 
-  // If we are in edit mode, upon lading the pre-filled answers, place them
+  // If we are in edit mode, upon loading the pre-filled answers, place them
   // in the form context where they can be accessed by computed answers
   const changeFormContext = useFormWriterContext();
 
@@ -49,7 +49,6 @@ let AutocreatedQuestion = (props) => {
     if (isEdit) {
       let value = existingAnswer?.[1].value;
       if (typeof(value) != "undefined" && value != "") {
-        value = Array.of(value).flat();
         let answer = Array.of(value).flat().map(v => [v, v]);
         changeFormContext((oldContext) => ({...oldContext, [questionName]: answer}));
       }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/AutocreatedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/AutocreatedQuestion.jsx
@@ -27,6 +27,7 @@ import AnswerComponentManager from "./AnswerComponentManager";
 import Question from "./Question";
 import FormattedText from "../components/FormattedText";
 import QuestionnaireStyle from './QuestionnaireStyle';
+import { useFormWriterContext } from "./FormContext";
 
 // Component that displays an autocreated question of any type.
 //
@@ -38,6 +39,22 @@ let AutocreatedQuestion = (props) => {
 
   const [muiInputProps, changeMuiInputProps] = useState({});
   const [isFormatted, changeIsFormatted] = useState(false);
+
+
+  // If we are in edit mode, upon lading the pre-filled answers, place them
+  // in the form context where they can be accessed by computed answers
+  const changeFormContext = useFormWriterContext();
+
+  useEffect(() => {
+    if (isEdit) {
+      let value = existingAnswer?.[1].value;
+      if (typeof(value) != "undefined" && value != "") {
+        value = Array.of(value).flat();
+        let answer = Array.of(value).flat().map(v => [v, v]);
+        changeFormContext((oldContext) => ({...oldContext, [questionName]: answer}));
+      }
+    }
+  }, []);
 
   useEffect(() => {
     let formatted = (displayMode === "formatted" || displayMode === "summary");

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Question.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Question.jsx
@@ -69,6 +69,19 @@ function Question (props) {
     cardClasses.push(classes.focusedQuestionnaireItem);
   }
 
+  let labels = existingAnswer?.[1].displayedValue;
+  if (typeof(labels) == "undefined") {
+    labels = existingAnswer?.[1].value;
+  }
+  // Always turn value into an array for convenience
+  if (!Array.isArray(labels)) {
+    if (typeof(labels) == "undefined" || labels === "") {
+      labels = [];
+    } else {
+      labels = [labels];
+    }
+  }
+
   return (
     <Card
       id={questionDefinition["@path"]}
@@ -99,9 +112,9 @@ function Question (props) {
             </>
           }
           { !isEdit && !preventDefaultView ?
-            ( existingAnswer?.[1]["displayedValue"] ?
+            ( labels ?
               <List>
-                { Array.of(existingAnswer?.[1]["displayedValue"]).flat().map( (item, idx) => {
+                { labels.map( (item, idx) => {
                   return(
                     <ListItem key={existingAnswer[0] + idx}> {defaultDisplayFormatter ? defaultDisplayFormatter(item, idx) : item} </ListItem>
                   )})

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -50,14 +50,14 @@
           "reference": {
             "question": "string",
             "displayMode" : {
-              "input" : {},
+              "plain" : {},
               "formatted" : {},
               "hidden": {}
             }
           },
           "autocreated": {
             "displayMode" : {
-              "input" : {},
+              "plain" : {},
               "formatted" : {},
               "hidden": {}
             }

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -105,14 +105,14 @@
           "reference": {
             "question": "string",
             "displayMode" : {
-              "input" : {},
+              "plain" : {},
               "formatted" : {},
               "hidden": {}
             }
           },
           "autocreated": {
             "displayMode" : {
-              "input" : {},
+              "plain" : {},
               "formatted" : {},
               "hidden": {}
             }
@@ -167,14 +167,14 @@
           "reference": {
             "question": "string",
             "displayMode" : {
-              "input" : {},
+              "plain" : {},
               "formatted" : {},
               "hidden": {}
             }
           },
           "autocreated": {
             "displayMode" : {
-              "input" : {},
+              "plain" : {},
               "formatted" : {},
               "hidden": {}
             }
@@ -229,14 +229,14 @@
           "reference": {
             "question": "string",
             "displayMode" : {
-              "input" : {},
+              "plain" : {},
               "formatted" : {},
               "hidden": {}
             }
           },
           "autocreated": {
             "displayMode" : {
-              "input" : {},
+              "plain" : {},
               "formatted" : {},
               "hidden": {}
             }
@@ -277,14 +277,14 @@
           "reference": {
             "question": "string",
             "displayMode" : {
-              "input" : {},
+              "plain" : {},
               "formatted" : {},
               "hidden": {}
             }
           },
           "autocreated": {
             "displayMode" : {
-              "input" : {},
+              "plain" : {},
               "formatted" : {},
               "hidden": {}
             }
@@ -347,14 +347,14 @@
           "reference": {
             "question": "string",
             "displayMode" : {
-              "input" : {},
+              "plain" : {},
               "formatted" : {},
               "hidden": {}
             }
           },
           "autocreated": {
             "displayMode" : {
-              "input" : {},
+              "plain" : {},
               "formatted" : {},
               "hidden": {}
             }
@@ -397,14 +397,14 @@
           "reference": {
             "question": "string",
             "displayMode" : {
-              "input" : {},
+              "plain" : {},
               "formatted" : {},
               "hidden": {}
             }
           },
           "autocreated": {
             "displayMode" : {
-              "input" : {},
+              "plain" : {},
               "formatted" : {},
               "hidden": {}
             }
@@ -431,14 +431,14 @@
           "reference": {
             "question": "string",
             "displayMode" : {
-              "input" : {},
+              "plain" : {},
               "formatted" : {},
               "hidden": {}
             }
           },
           "autocreated": {
             "displayMode" : {
-              "input" : {},
+              "plain" : {},
               "formatted" : {},
               "hidden": {}
             }

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ReferenceTestCopied.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ReferenceTestCopied.xml
@@ -67,6 +67,11 @@ Then, verify that all the answers have been copied over successfully</value>
             <type>String</type>
         </property>
         <property>
+            <name>displayMode</name>
+            <value>plain</value>
+            <type>String</type>
+        </property>
+        <property>
             <name>question</name>
             <value>/Questionnaires/ReferenceTestUser/textQuestion</value>
             <type>String</type>
@@ -183,6 +188,11 @@ Then, verify that all the answers have been copied over successfully</value>
                 <type>String</type>
             </property>
             <property>
+                <name>displayMode</name>
+                <value>plain</value>
+                <type>String</type>
+            </property>
+            <property>
                 <name>question</name>
                 <value>/Questionnaires/ReferenceTestUser/section/sectionTextQuestion</value>
                 <type>String</type>
@@ -223,6 +233,11 @@ Then, verify that all the answers have been copied over successfully</value>
             <type>String</type>
         </property>
         <property>
+            <name>displayMode</name>
+            <value>plain</value>
+            <type>String</type>
+        </property>
+        <property>
             <name>question</name>
             <value>/Questionnaires/ReferenceTestUser/longQuestion</value>
             <type>String</type>
@@ -257,6 +272,11 @@ Then, verify that all the answers have been copied over successfully</value>
             <type>String</type>
         </property>
         <property>
+            <name>displayMode</name>
+            <value>plain</value>
+            <type>String</type>
+        </property>
+        <property>
             <name>question</name>
             <value>/Questionnaires/ReferenceTestUser/doubleQuestion</value>
             <type>String</type>
@@ -288,6 +308,11 @@ Then, verify that all the answers have been copied over successfully</value>
         <property>
             <name>entryMode</name>
             <value>reference</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>displayMode</name>
+            <value>plain</value>
             <type>String</type>
         </property>
         <property>


### PR DESCRIPTION
**Includes:**
* [CARDS-2052](https://phenotips.atlassian.net/browse/CARDS-2052) - _For resource questions with entryMode : reference, the path is displayed in edit mode as answer instead of the configured label_
* [CARDS-2053](https://phenotips.atlassian.net/browse/CARDS-2052) - _If displayedValue is missing for an answer for any reason, the value should be used when rendering the answer instead of rendering nothing_

**Testing:**
* In `--test` mode, test for regressions in Reference User Answers + Reference Copied Answers
* Test reference resource questions in #1301 in Visit information + Survey events forms.

[CARDS-2052]: https://phenotips.atlassian.net/browse/CARDS-2052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CARDS-2053]: https://phenotips.atlassian.net/browse/CARDS-2053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CARDS-1998]: https://phenotips.atlassian.net/browse/CARDS-1998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ