### PR TITLE
CARDS-2043 - Create the Survey events questionnaire for recording the  information (amendment)

### DIFF
--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Survey events.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Survey events.xml
@@ -152,7 +152,6 @@
 			<value>1</value>
 			<type>Long</type>
 		</property>
-		
 		<property>
 			<name>maxAnswers</name>
 			<value>1</value>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Survey events.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Survey events.xml
@@ -41,6 +41,11 @@
 		<name>hospital</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
+			<name>minAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
 			<name>maxAnswers</name>
 			<value>1</value>
 			<type>Long</type>
@@ -143,6 +148,12 @@
 		<name>assigned_survey</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
+			<name>minAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		
+		<property>
 			<name>maxAnswers</name>
 			<value>1</value>
 			<type>Long</type>
@@ -184,8 +195,47 @@
 		</property>
 	</node>
 	<node>
+		<name>survey_expiry</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>date</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>text</name>
+			<value>Survey expires on</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>yyyy-MM-dd'T'HH:mm:ss.sssZ</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>plain</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>entryMode</name>
+			<value>autocreated</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
 		<name>invitation_sent</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>minAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
 		<property>
 			<name>maxAnswers</name>
 			<value>1</value>


### PR DESCRIPTION
See parent task [CARDS-2042](https://phenotips.atlassian.net/browse/CARDS-2042) for context.

**Summary of changes:**
* Added field for survey expiry date
* Made `hospital`, `assigned_survey`, `invitation_sent` mandatory (we will be exporting only "complete" forms, and we don't want to export before knowing what survey is being sent out and that the invitation was actually sent)

[CARDS-2042]: https://phenotips.atlassian.net/browse/CARDS-2042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ