### PR TITLE
CARDS-2060: Weak SSL ciphers should be disabled in the proxy container whenever the proxy container is operating as an SSL-terminating reverse proxy

### DIFF
--- a/Utilities/Development/scan_nmap_ssl_xml_for_weak_ciphers.py
+++ b/Utilities/Development/scan_nmap_ssl_xml_for_weak_ciphers.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+"""
+
+"""
+Checks the results of an SSL cipher scan done by:
+
+nmap --script ssl-enum-ciphers -p 443 localhost -oX ssl_scan.xml
+
+"""
+
+import sys
+import defusedxml.ElementTree as ET
+
+WEAK_CIPHERS = []
+WEAK_CIPHERS.append("TLS_RSA_WITH_AES_128_CBC_SHA")
+WEAK_CIPHERS.append("TLS_DHE_RSA_WITH_AES_128_CBC_SHA")
+WEAK_CIPHERS.append("TLS_RSA_WITH_AES_256_CBC_SHA")
+WEAK_CIPHERS.append("TLS_DHE_RSA_WITH_AES_256_CBC_SHA")
+WEAK_CIPHERS.append("TLS_RSA_WITH_AES_128_CBC_SHA256")
+WEAK_CIPHERS.append("TLS_RSA_WITH_AES_256_CBC_SHA256")
+WEAK_CIPHERS.append("TLS_DHE_RSA_WITH_AES_128_CBC_SHA256")
+WEAK_CIPHERS.append("TLS_DHE_RSA_WITH_AES_256_CBC_SHA256")
+WEAK_CIPHERS.append("TLS_RSA_WITH_CAMELLIA_128_CBC_SHA")
+WEAK_CIPHERS.append("TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA")
+WEAK_CIPHERS.append("TLS_RSA_WITH_CAMELLIA_256_CBC_SHA")
+WEAK_CIPHERS.append("TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA")
+WEAK_CIPHERS.append("TLS_RSA_WITH_AES_128_GCM_SHA256")
+WEAK_CIPHERS.append("TLS_RSA_WITH_AES_256_GCM_SHA384")
+WEAK_CIPHERS.append("TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256")
+WEAK_CIPHERS.append("TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256")
+WEAK_CIPHERS.append("TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256")
+WEAK_CIPHERS.append("TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256")
+WEAK_CIPHERS.append("TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA")
+WEAK_CIPHERS.append("TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA")
+WEAK_CIPHERS.append("TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256")
+WEAK_CIPHERS.append("TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384")
+WEAK_CIPHERS.append("TLS_ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256")
+WEAK_CIPHERS.append("TLS_ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384")
+
+XML_FILE = sys.argv[1]
+
+with open(XML_FILE, 'r') as f_xml:
+  xml_tree = ET.fromstring(f_xml.read())
+
+for elem in xml_tree.findall(".//elem"):
+  if 'key' in elem.attrib:
+    if elem.attrib['key'] == 'name':
+      cipher_name = elem.text
+      print("Checking cipher: {}".format(cipher_name))
+      if cipher_name in WEAK_CIPHERS:
+        raise Exception("FAIL: The server allows the weak cipher: {}".format(cipher_name))
+
+print("PASS: The server does not allow any weak ciphers.")

--- a/compose-cluster/proxy/apache_common_conf/apache_ssl.conf
+++ b/compose-cluster/proxy/apache_common_conf/apache_ssl.conf
@@ -17,7 +17,13 @@
 
 SSLEngine on
 SSLProtocol all -TLSv1.1 -TLSv1 -SSLv2 -SSLv3
-SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:!RC4+RSA:!RC4:+HIGH:!MEDIUM:!LOW
+
+# Settings taken from https://httpd.apache.org/docs/trunk/ssl/ssl_howto.html
+# with removal of ECDHE-RSA-AES256-SHA384 and ECDHE-RSA-AES128-SHA256
+SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256
+SSLHonorCipherOrder on
+SSLCompression off
+SSLSessionTickets off
 
 SSLCertificateFile /etc/cert/certificate.crt
 SSLCertificateKeyFile /etc/cert/certificatekey.key


### PR DESCRIPTION
This PR implements CARDS-2060 by only allowing SSL ciphers that are considered by the security scanning team to not be _weak_.

Testing Instructions
--------------------------

- Before starting the tests, please ensure that you have `nmap` installed. On Debian/Ubuntu, `nmap` can be installed with `sudo apt install nmap`.

1. Build the latest `dev` branch (including a Docker image) with `mvn clean install -Pdocker`.
2. `cd compose-cluster`
3. `python3 generate_compose_yaml.py --dev_docker_image --ssl_proxy --self_signed_ssl_proxy --oak_filesystem --web_port_admin 443 --web_port_user 444`
4. `docker-compose build && docker-compose up -d`
5. `nmap --script ssl-enum-ciphers -p 443 localhost -oX ~/ssl_scan_dev_443.xml`
6. `nmap --script ssl-enum-ciphers -p 444 localhost -oX ~/ssl_scan_dev_444.xml`
7. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`
8. `cd ..` (switch back to the root of the git repository)
9. Build _this_ (`CARDS-2060`) branch (including a Docker image) with `mvn clean install -Pdocker`.
10. `cd compose-cluster`
11. `python3 generate_compose_yaml.py --dev_docker_image --ssl_proxy --self_signed_ssl_proxy --oak_filesystem --web_port_admin 443 --web_port_user 444`
12. `docker-compose build && docker-compose up -d`
13. `nmap --script ssl-enum-ciphers -p 443 localhost -oX ~/ssl_scan_cards-2060_443.xml`
14. `nmap --script ssl-enum-ciphers -p 444 localhost -oX ~/ssl_scan_cards-2060_444.xml`
15. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`
16. `cd ../Utilities/Development`
17. `python3 scan_nmap_ssl_xml_for_weak_ciphers.py ~/ssl_scan_dev_443.xml` - this should result in a **failed** test.
18. `python3 scan_nmap_ssl_xml_for_weak_ciphers.py ~/ssl_scan_dev_444.xml` - this should result in a **failed** test.
19. `python3 scan_nmap_ssl_xml_for_weak_ciphers.py ~/ssl_scan_cards-2060_443.xml` - this should result in a **passed** test.
20. `python3 scan_nmap_ssl_xml_for_weak_ciphers.py ~/ssl_scan_cards-2060_444.xml` - this should result in a **passed** test.