### PR TITLE
CARDS-1877: Reset to initial settings in administration pages is broken

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/MarkdownText.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/MarkdownText.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import withStyles from '@mui/styles/withStyles';
 
@@ -45,6 +45,10 @@ let MarkdownText = (props) => {
   let cmd = commands.getExtraCommands();
   cmd.push(commands.divider);
   cmd.push(infoButton);
+
+  useEffect(() => {
+    setValue(props.value || '');
+  }, [props.value]);
 
   return (
     <MDEditor className={classes.markdown} value={value} height={height} preview={preview} onChange={value => {setValue(value); onChange && onChange(value);}} extraCommands={cmd}/>

--- a/modules/downtime-warning-banner/src/main/frontend/src/DowntimeWarningConfiguration.jsx
+++ b/modules/downtime-warning-banner/src/main/frontend/src/DowntimeWarningConfiguration.jsx
@@ -65,7 +65,7 @@ function DowntimeWarningConfiguration() {
 
   useEffect(() => {
     // Determine if the end date is earlier than the start date
-    setDateRangeIsInvalid(fromDate && toDate && new Date(toDate).valueOf() < new Date(fromDate).valueOf());
+    setDateRangeIsInvalid(!!fromDate && !!toDate && new Date(toDate).valueOf() < new Date(fromDate).valueOf());
   }, [fromDate, toDate]);
 
   return (
@@ -75,7 +75,7 @@ function DowntimeWarningConfiguration() {
         configTemplate={{enabled: false, fromDate: "", toDate: ""}}
         onConfigFetched={readDowntimeWarningSettings}
         hasChanges={hasChanges}
-        configError={dateRangeIsInvalid ? "Invalid date range" : undefined}
+        configError={!!dateRangeIsInvalid ? "Invalid date range" : undefined}
         buildConfigData={buildConfigData}
         onConfigSaved={() => setHasChanges(false)}
       >

--- a/modules/downtime-warning-banner/src/main/frontend/src/DowntimeWarningConfiguration.jsx
+++ b/modules/downtime-warning-banner/src/main/frontend/src/DowntimeWarningConfiguration.jsx
@@ -68,10 +68,6 @@ function DowntimeWarningConfiguration() {
     setDateRangeIsInvalid(fromDate && toDate && new Date(toDate).valueOf() < new Date(fromDate).valueOf());
   }, [fromDate, toDate]);
 
-  useEffect(() => {
-    setHasChanges(true);
-  }, [enabled, fromDate, toDate]);
-
   return (
     <AdminConfigScreen
         title="Downtime Warning Banner Settings"
@@ -89,7 +85,7 @@ function DowntimeWarningConfiguration() {
                 control={
                   <Checkbox
                     checked={enabled}
-                    onChange={ event => setEnabled(event.target.checked) }
+                    onChange={ event => { setEnabled(event.target.checked); setHasChanges(true); } }
                     name="enabled"
                   />
                 }
@@ -103,7 +99,7 @@ function DowntimeWarningConfiguration() {
                 type="datetime-local"
                 InputLabelProps={{ shrink: true }}
                 className={classes.textField}
-                onChange={(event) => setFromDate(event.target.value) }
+                onChange={(event) => { setFromDate(event.target.value); setHasChanges(true); } }
                 onBlur={(event) => setFromDate(event.target.value) }
                 placeholder={dateFormat.toLowerCase()}
                 value={fromDate || ""}
@@ -116,7 +112,7 @@ function DowntimeWarningConfiguration() {
                 type="datetime-local"
                 InputLabelProps={{ shrink: true }}
                 className={classes.textField}
-                onChange={(event) => setToDate(event.target.value) }
+                onChange={(event) => { setToDate(event.target.value); setHasChanges(true); } }
                 onBlur={(event) => setToDate(event.target.value) }
                 placeholder={dateFormat.toLowerCase()}
                 value={toDate || ""}

--- a/modules/downtime-warning-banner/src/main/frontend/src/DowntimeWarningConfiguration.jsx
+++ b/modules/downtime-warning-banner/src/main/frontend/src/DowntimeWarningConfiguration.jsx
@@ -76,6 +76,7 @@ function DowntimeWarningConfiguration() {
     <AdminConfigScreen
         title="Downtime Warning Banner Settings"
         configPath="/apps/cards/config/DowntimeWarning"
+        configTemplate={{enabled: false, fromDate: "", toDate: ""}}
         onConfigFetched={readDowntimeWarningSettings}
         hasChanges={hasChanges}
         configError={dateRangeIsInvalid ? "Invalid date range" : undefined}

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
@@ -143,15 +143,15 @@ function AdminConfigScreen(props) {
     if (event) {
       // If the submit is user-initiated, grab values form the form
       buildConfigData?.(formData);
+      // Use the config template to Fill in any missing values
+      for (let key of Object.keys(configTemplate)) {
+        formData.get(key) == null && Array.of(configTemplate[key]).flat().forEach(v => formData.append(key, v));
+      }
     } else {
       // Otherwise just save the existing config
       // Use the template keys to avoid attempts to save reserved properties like "jcr:...", "sling:...", "@..."
       for (let key of Object.keys(configTemplate)) {
-        if (Array.isArray(config[key])) {
-          config[key].forEach(v => formData.append(key, v));
-        } else {
-          formData.append(key, config[key]);
-        }
+        Array.of(config[key]).flat().forEach(v => formData.append(key, v));
       }
     }
 

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
@@ -86,7 +86,8 @@ const useStyles = makeStyles(theme => ({
  * </AdminConfigScreen>
  *
  * @param {string} title  - the title of the administration screen, required
- * @param {string} configPath  - the path of the configuration node; will be used for loading and saving the data
+ * @param {string} configPath  - the path of the configuration node; will be used for loading and saving the data, required
+ * @param {object} configTemplate - what an empty config would look like; should list all the possible fields with empty values, required
  * @param {function} onConfigFetched  - handler to pass the loaded configuration json to the parent component
  * @param {boolean} hasChanges  - how the parent component notifies that the user changed the form values
  * @param {string} configError  - how the parent component notifies that there's a data sanity issue
@@ -97,7 +98,7 @@ const useStyles = makeStyles(theme => ({
  */
 
 function AdminConfigScreen(props) {
-  const { title, configPath, onConfigFetched, hasChanges, configError, buildConfigData, onConfigSaved, children } = props;
+  const { title, configPath, configTemplate, onConfigFetched, hasChanges, configError, buildConfigData, onConfigSaved, children } = props;
   const [ config, setConfig ] = useState();
   const [ configIsInitial, setConfigIsInitial ] = useState(true);
   const [ error, setError ] = useState();
@@ -115,8 +116,9 @@ function AdminConfigScreen(props) {
     fetchWithReLogin(globalContext, `${configPath}.json`)
       .then((response) => response.ok ? response.json() : Promise.reject(response))
       .then(json => {
-         setConfig(json);
-         onConfigFetched?.(json);
+         let conf = Object.assign({}, configTemplate, json);
+         setConfig(conf);
+         onConfigFetched?.(conf);
       })
       .catch(err => {
          setConfig(null);
@@ -138,7 +140,20 @@ function AdminConfigScreen(props) {
 
     // Build formData object.
     let formData = new URLSearchParams();
-    buildConfigData?.(formData);
+    if (event) {
+      // If the submit is user-initiated, grab values form the form
+      buildConfigData?.(formData);
+    } else {
+      // Otherwise just save the existing config
+      // Use the template keys to avoid attempts to save reserved properties like "jcr:...", "sling:...", "@..."
+      for (let key of Object.keys(configTemplate)) {
+        if (Array.isArray(config[key])) {
+          config[key].forEach(v => formData.append(key, v));
+        } else {
+          formData.append(key, config[key]);
+        }
+      }
+    }
 
     fetchWithReLogin(globalContext, configPath,
       {
@@ -234,7 +249,8 @@ function AdminConfigScreen(props) {
 
 AdminConfigScreen.propTypes = {
   title: PropTypes.string.isRequired,
-  configPath: PropTypes.string,
+  configPath: PropTypes.string.isRequired,
+  configTemplate: PropTypes.object.isRequired,
   onConfigFetched: PropTypes.func,
   hasChanges: PropTypes.bool,
   configError: PropTypes.string,

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
@@ -204,7 +204,7 @@ function AdminConfigScreen(props) {
               variant="contained"
               color="primary"
               size="small"
-              disabled={configError || !hasChanges}
+              disabled={!!configError || !hasChanges}
             >
               Save
             </Button>

--- a/modules/homepage/src/main/frontend/src/themePage/QuickSearchConfiguration.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/QuickSearchConfiguration.jsx
@@ -63,10 +63,6 @@ function QuickSearchConfiguration(props) {
     setAllowedResourceTypes(types);
   }
 
-  useEffect(() => {
-    setHasChanges(true);
-  }, [limit, showTotalRows]);
-
   return (
     <AdminConfigScreen
         title="Quick Search Settings"
@@ -89,7 +85,7 @@ function QuickSearchConfiguration(props) {
                 type="number"
                 label="Limit"
                 value={limit}
-                onChange={ event => setLimit(event.target.value) }
+                onChange={ event => { setLimit(event.target.value); setHasChanges(true); } }
                 style={{'width' : '250px'}}
                 helperText="How many results should be displayed"
               />
@@ -99,7 +95,7 @@ function QuickSearchConfiguration(props) {
                 control={
                   <Checkbox
                     checked={showTotalRows}
-                    onChange={ event => setShowTotalRows(event.target.checked) }
+                    onChange={ event => { setShowTotalRows(event.target.checked); setHasChanges(true); } }
                     name="showTotalRows"
                   />
                 }

--- a/modules/homepage/src/main/frontend/src/themePage/QuickSearchConfiguration.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/QuickSearchConfiguration.jsx
@@ -67,7 +67,7 @@ function QuickSearchConfiguration(props) {
     <AdminConfigScreen
         title="Quick Search Settings"
         configPath="/apps/cards/config/QuickSearch"
-        configTemplate={{limit: "", showTotalRows: false, allowedResourceTypes: []}}
+        configTemplate={{limit: "", showTotalRows: false, allowedResourceTypes: [""]}}
         onConfigFetched={readQuickSearchSettings}
         hasChanges={hasChanges}
         buildConfigData={buildConfigData}

--- a/modules/homepage/src/main/frontend/src/themePage/QuickSearchConfiguration.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/QuickSearchConfiguration.jsx
@@ -71,6 +71,7 @@ function QuickSearchConfiguration(props) {
     <AdminConfigScreen
         title="Quick Search Settings"
         configPath="/apps/cards/config/QuickSearch"
+        configTemplate={{limit: "", showTotalRows: false, allowedResourceTypes: []}}
         onConfigFetched={readQuickSearchSettings}
         hasChanges={hasChanges}
         buildConfigData={buildConfigData}

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/DashboardSettingsConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/DashboardSettingsConfiguration.jsx
@@ -72,6 +72,7 @@ function DashboardSettingsConfiguration() {
       <AdminConfigScreen
         title="Clinic dashboard"
         configPath={"/Survey/DashboardSettings"}
+        configTemplate={fields.reduce((t, k) => ({...t, [k.key] : ""}), {})}
         onConfigFetched={readDashboardSettings}
         hasChanges={hasChanges}
         buildConfigData={buildConfigData}

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/DashboardSettingsConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/DashboardSettingsConfiguration.jsx
@@ -51,10 +51,6 @@ function DashboardSettingsConfiguration() {
     type: "boolean"
   }];
 
-  useEffect(() => {
-    setHasChanges(true);
-  }, [enableTimeTabs, eventsLabel, eventTimeLabel]);
-
   let buildConfigData = (formData) => {
     formData.append('enableTimeTabs', enableTimeTabs);
     formData.append('eventsLabel', eventsLabel);
@@ -91,14 +87,14 @@ function DashboardSettingsConfiguration() {
                 type="text"
                 label={camelCaseToWords(field.key)}
                 value={field.value}
-                onChange={(event) => { field.setter(event.target.value); }}
+                onChange={(event) => { field.setter(event.target.value); setHasChanges(true); }}
               />
               :
               <FormControlLabel
                 control={
                   <Checkbox
                     checked={field.value}
-                    onChange={ event => field.setter(event.target.checked) }
+                    onChange={ event => { field.setter(event.target.checked); setHasChanges(true); } }
                     name={field.key}
                   />
                 }

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
@@ -107,6 +107,7 @@ function PatientAccessConfiguration() {
       <AdminConfigScreen
           title="Patient Access"
           configPath={PATIENT_ACCESS_CONFIG_PATH}
+          configTemplate={Object.keys(DEFAULT_PATIENT_ACCESS_CONFIG).reduce((t, k) => ({...t, [k] : ""}), {})}
           onConfigFetched={setPatientAccessConfig}
           hasChanges={hasChanges}
           buildConfigData={buildConfigData}

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
@@ -66,10 +66,6 @@ function PatientAccessConfiguration() {
     }
   }
 
-  useEffect(() => {
-    setHasChanges(true);
-  }, [patientAccessConfig]);
-
   let renderConfigCheckbox = (key, valueOverride) => (
       <ListItem>
         <FormControlLabel control={
@@ -77,7 +73,10 @@ function PatientAccessConfiguration() {
             name={key}
             checked={valueOverride || patientAccessConfig?.[key] || DEFAULT_PATIENT_ACCESS_CONFIG[key]}
             disabled={valueOverride}
-            onChange={event => setPatientAccessConfig({...patientAccessConfig, [key]: valueOverride || event.target.checked})}
+            onChange={event => {
+              setPatientAccessConfig({...patientAccessConfig, [key]: valueOverride || event.target.checked});
+              setHasChanges(true);
+            }}
           />}
           label={labels[key]}
         />
@@ -91,8 +90,8 @@ function PatientAccessConfiguration() {
           <TextField
             variant="standard"
             type="number"
-            onChange={event => setPatientAccessConfig({...patientAccessConfig, [key]: event.target.value})}
-            onBlur={event => setPatientAccessConfig({...patientAccessConfig, [key]: event.target.value})}
+            onChange={event => { setPatientAccessConfig({...patientAccessConfig, [key]: event.target.value}); setHasChanges(true); }}
+            onBlur={event => { setPatientAccessConfig({...patientAccessConfig, [key]: event.target.value}); setHasChanges(true); }}
             placeholder={DEFAULT_PATIENT_ACCESS_CONFIG[key] || ""}
             value={patientAccessConfig?.[key]}
             InputProps={{

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/SurveyInstructionsConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/SurveyInstructionsConfiguration.jsx
@@ -67,10 +67,6 @@ function SurveyInstructionsConfiguration() {
 
   let getUnsetValue = (key) => (key?.startsWith("enable") ? false : "");
 
-  useEffect(() => {
-    setHasChanges(true);
-  }, [surveyInstructions]);
-
   return (
       <AdminConfigScreen
         title="Patient Portal Survey Instructions"
@@ -91,14 +87,20 @@ function SurveyInstructionsConfiguration() {
                   { key == "welcomeMessage" ?
                       <WelcomeMessageConfiguration
                         welcomeMessage={surveyInstructions?.[key]}
-                        onChange={(text) => { setSurveyInstructions({...surveyInstructions, [key]: text}); }}
+                        onChange={(text) => {
+                          setSurveyInstructions({...surveyInstructions, [key]: text});
+                          setHasChanges(true);
+                        }}
                       />
                     :
                     key.startsWith("enable") ?
                       <FormControlLabel control={
                         <Checkbox
                           checked={!!(surveyInstructions?.[key])}
-                          onChange={event => setSurveyInstructions({...surveyInstructions, [key]: !!event.target.checked})}
+                          onChange={event => {
+                            setSurveyInstructions({...surveyInstructions, [key]: !!event.target.checked});
+                            setHasChanges(true);
+                          }}
                         />}
                         label={camelCaseToWords(key)}
                       />
@@ -114,7 +116,10 @@ function SurveyInstructionsConfiguration() {
                         label={camelCaseToWords(key)}
                         value={surveyInstructions?.[key] || ""}
                         placeholder={DEFAULT_INSTRUCTIONS[key] || ""}
-                        onChange={(event) => { setSurveyInstructions({...surveyInstructions, [key]: event.target.value}); }}
+                        onChange={(event) => {
+                           setSurveyInstructions({...surveyInstructions, [key]: event.target.value});
+                           setHasChanges(true);
+                        }}
                         fullWidth
                       />
                   }

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/SurveyInstructionsConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/SurveyInstructionsConfiguration.jsx
@@ -75,6 +75,7 @@ function SurveyInstructionsConfiguration() {
       <AdminConfigScreen
         title="Patient Portal Survey Instructions"
         configPath={SURVEY_INSTRUCTIONS_PATH}
+        configTemplate={Object.values(labels).flat().reduce((t, k) => ({...t, [k]: getUnsetValue(k)}), {})}
         onConfigFetched={setSurveyInstructions}
         hasChanges={hasChanges}
         buildConfigData={buildConfigData}

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/ToUConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/ToUConfiguration.jsx
@@ -58,10 +58,6 @@ function ToUConfiguration() {
     formData.append('text', text);
   }
 
-  useEffect(() => {
-    setHasChanges(true);
-  }, [title, version, text, acceptanceRequired]);
-
   return (
     <AdminConfigScreen
       title="Patient Portal Terms of Use"
@@ -85,7 +81,7 @@ function ToUConfiguration() {
                 type="text"
                 label="Title"
                 value={title}
-                onChange={(event) => { setTitle(event.target.value); }}
+                onChange={(event) => { setTitle(event.target.value); setHasChanges(true); }}
               />
             </ListItem>
             <ListItem key="version">
@@ -97,7 +93,7 @@ function ToUConfiguration() {
                 type="version"
                 label="Version"
                 value={version}
-                onChange={(event) => { setVersion(event.target.value); }}
+                onChange={(event) => { setVersion(event.target.value); setHasChanges(true); }}
                 style={{'width' : '250px'}}
               />
             </ListItem>
@@ -106,7 +102,7 @@ function ToUConfiguration() {
               <MarkdownText
                 value={text}
                 height={350}
-                onChange={value => { setText(value); }}
+                onChange={value => { setText(value); setHasChanges(true); }}
               />
             </ListItem>
             <ListItem key="acceptanceRequired">
@@ -114,7 +110,7 @@ function ToUConfiguration() {
                 control={
                   <Checkbox
                     checked={acceptanceRequired}
-                    onChange={(event) => { setAcceptanceRequired(event.target.checked); }}
+                    onChange={(event) => { setAcceptanceRequired(event.target.checked); setHasChanges(true); }}
                     name="acceptanceRequired"
                   />
                 }

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/ToUConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/ToUConfiguration.jsx
@@ -66,6 +66,7 @@ function ToUConfiguration() {
     <AdminConfigScreen
       title="Patient Portal Terms of Use"
       configPath="/Survey/TermsOfUse"
+      configTemplate={{"acceptanceRequired" : false, "title" : "", "version" : "", "text" : ""}}
       onConfigFetched={readToUData}
       hasChanges={hasChanges}
       buildConfigData={buildConfigData}


### PR DESCRIPTION
See [CARDS-1877](https://phenotips.atlassian.net/browse/CARDS-1877) on jira.

**Includes:**
* the fix from PR #1308 (the welcome message)
* a fix for the dates in Downtime Warning not being properly reset
* the save button is now disabled at the beginning when there are no changes to be saved

**Testing:** 
* Start `prems`
* Check all admin screens that have a reset button (because they target a single configuration, not a listing), highlighted in the screenshot below
* When testing the reset, always check in `/bin/browser` the values that were actually saved, do not rely only on what is in the form
![image](https://user-images.githubusercontent.com/651980/216691934-77dbf15c-d889-40e6-a19f-55439bf02bb2.png)

**Reviewing the code:**
* Commit by commit makes it easier to follow


[CARDS-1877]: https://phenotips.atlassian.net/browse/CARDS-1877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ