### PR TITLE
CARDS-2042: Patient portal: add support for recording communication events related to patient surveys

### DIFF
--- a/modules/patient-portal/pom.xml
+++ b/modules/patient-portal/pom.xml
@@ -101,6 +101,10 @@
       <artifactId>org.osgi.service.component</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.event</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.json</groupId>
       <artifactId>javax.json-api</artifactId>
     </dependency>

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentEmailNotificationsFactory.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentEmailNotificationsFactory.java
@@ -26,6 +26,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.event.EventAdmin;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
@@ -53,6 +54,9 @@ public final class AppointmentEmailNotificationsFactory
     @Reference
     private ThreadResourceResolverProvider resolverProvider;
 
+    @Reference
+    private EventAdmin eventAdmin;
+
     /** The scheduler for rescheduling jobs. */
     @Reference
     private Scheduler scheduler;
@@ -78,6 +82,10 @@ public final class AppointmentEmailNotificationsFactory
     {
         @AttributeDefinition(name = "Name", description = "Name")
         String name();
+
+        @AttributeDefinition(name = "Notification Type",
+            description = "What type of email notification, e.g. Invitation")
+        String notificationType();
 
         @AttributeDefinition(name = "Metric Name", description = "Metric name description (eg. Reminder emails sent)")
         String metricName();
@@ -113,8 +121,9 @@ public final class AppointmentEmailNotificationsFactory
 
         // Instantiate the Runnable
         final Runnable notificationsJob = new GeneralNotificationsTask(this.resolverFactory, this.resolverProvider,
-            this.tokenManager, this.mailService, this.formUtils, this.patientAccessConfiguration, config.name(),
-            config.clinicId(), config.emailConfiguration(), config.daysToVisit());
+            this.eventAdmin, this.tokenManager, this.mailService, this.formUtils, this.patientAccessConfiguration,
+            config.name(), config.notificationType(), config.clinicId(), config.emailConfiguration(),
+            config.daysToVisit());
 
         try {
             this.scheduler.schedule(notificationsJob, notificationsOptions);

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/GeneralNotificationsTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/GeneralNotificationsTask.java
@@ -30,6 +30,7 @@ import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.commons.messaging.mail.MailService;
+import org.osgi.service.event.EventAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +46,8 @@ public class GeneralNotificationsTask extends AbstractEmailNotification implemen
     private static final Logger LOGGER = LoggerFactory.getLogger(GeneralNotificationsTask.class);
 
     private final String taskName;
+
+    private final String notificationType;
 
     private final String clinicId;
 
@@ -70,14 +73,15 @@ public class GeneralNotificationsTask extends AbstractEmailNotification implemen
      */
     @SuppressWarnings("checkstyle:ParameterNumber")
     public GeneralNotificationsTask(final ResourceResolverFactory resolverFactory,
-        final ThreadResourceResolverProvider resolverProvider,
+        final ThreadResourceResolverProvider resolverProvider, final EventAdmin eventAdmin,
         final TokenManager tokenManager, final MailService mailService,
-        final FormUtils formUtils,
-        final PatientAccessConfiguration patientAccessConfiguration, final String taskName,
-        final String clinicId, final String emailTemplatePath, final int daysToVisit)
+        final FormUtils formUtils, final PatientAccessConfiguration patientAccessConfiguration, final String taskName,
+        final String notificationType, final String clinicId, final String emailTemplatePath, final int daysToVisit)
     {
-        super(resolverFactory, resolverProvider, tokenManager, mailService, formUtils, patientAccessConfiguration);
+        super(resolverFactory, resolverProvider, tokenManager, mailService, formUtils, patientAccessConfiguration,
+            eventAdmin);
         this.taskName = taskName;
+        this.notificationType = notificationType;
         this.clinicId = clinicId;
         this.emailTemplatePath = emailTemplatePath;
         this.daysToVisit = daysToVisit;
@@ -91,6 +95,12 @@ public class GeneralNotificationsTask extends AbstractEmailNotification implemen
         }
         long emailsSent = sendNotification(this.daysToVisit, this.emailTemplate, this.clinicId);
         Metrics.increment(this.resolverFactory, this.taskName, emailsSent);
+    }
+
+    @Override
+    protected String getNotificationType()
+    {
+        return "Notification/Patient/Appointment/" + this.notificationType;
     }
 
     private EmailTemplate buildTemplate(final String configurationNodePath)

--- a/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/QuestionnaireRestrictionPattern.java
+++ b/modules/permissions/src/main/java/io/uhndata/cards/permissions/internal/QuestionnaireRestrictionPattern.java
@@ -68,7 +68,7 @@ public class QuestionnaireRestrictionPattern implements RestrictionPattern
                     return true;
                 }
             }
-        } catch (final RepositoryException e) {
+        } catch (final RepositoryException | NullPointerException e) {
             // Should not happen
         }
         return false;

--- a/prems-resources/backend/pom.xml
+++ b/prems-resources/backend/pom.xml
@@ -43,9 +43,37 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.uhndata.cards</groupId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cards-data-model-forms-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cards-data-model-subjects-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cards-patient-portal</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cards-resolver-provider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>cards-clarity-integration</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.jcr</groupId>
+      <artifactId>jcr</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.api</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-validator</groupId>
@@ -54,17 +82,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.service.metatype.annotations</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.service.cm</artifactId>
-      <version>1.6.1</version>
+      <artifactId>org.osgi.service.metatype.annotations</artifactId>
     </dependency>
     <dependency>
-    <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.framework</artifactId>
-      <version>1.9.0</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/prems-resources/backend/pom.xml
+++ b/prems-resources/backend/pom.xml
@@ -89,8 +89,16 @@
       <artifactId>org.osgi.service.metatype.annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.event</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/surveytracker/SurveyTracker.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/surveytracker/SurveyTracker.java
@@ -143,15 +143,15 @@ public class SurveyTracker implements ResourceChangeListener, EventHandler
             }
             final Node node = session.getNode(path);
             final Node surveyStatusQuestionnaire = session.getNode("/Questionnaires/Survey events");
-            if (isHasSurveysAnswer(node) && hasSurveys(node)) {
+            if (isAnswerForHasSurveys(node) && hasSurveys(node)) {
                 ensureSurveyStatusFormExists(surveyStatusQuestionnaire,
                     this.formUtils.getSubject(this.formUtils.getForm(node)), session);
                 // Also update the expiration date, since this cannot be copied from the visit
                 updateSurveyExpirationDate(this.formUtils.getAnswer(this.formUtils.getForm(node),
                     session.getNode("/Questionnaires/Visit information/time")), session);
-            } else if (isSubmittedAnswer(node) && isSubmitted(node)) {
+            } else if (isAnswerForSurveysSubmitted(node) && isSubmitted(node)) {
                 updateSurveySubmittedDate(node, session);
-            } else if (isDischargedAnswer(node)) {
+            } else if (isAnswerForDischargeTime(node)) {
                 updateSurveyExpirationDate(node, session);
             }
         } catch (final LoginException e) {
@@ -261,7 +261,7 @@ public class SurveyTracker implements ResourceChangeListener, EventHandler
      * @param answer the answer node to check
      * @return {@code true} if the answer is indeed for the target question
      */
-    private boolean isHasSurveysAnswer(final Node answer)
+    private boolean isAnswerForHasSurveys(final Node answer)
     {
         return isAnswerForQuestion(answer, "has_surveys");
     }
@@ -272,7 +272,7 @@ public class SurveyTracker implements ResourceChangeListener, EventHandler
      * @param answer the answer node to check
      * @return {@code true} if the answer is indeed for the target question
      */
-    private boolean isSubmittedAnswer(final Node answer)
+    private boolean isAnswerForSurveysSubmitted(final Node answer)
     {
         return isAnswerForQuestion(answer, "surveys_submitted");
     }
@@ -283,7 +283,7 @@ public class SurveyTracker implements ResourceChangeListener, EventHandler
      * @param answer the answer node to check
      * @return {@code true} if the answer is indeed for the target question
      */
-    private boolean isDischargedAnswer(final Node answer)
+    private boolean isAnswerForDischargeTime(final Node answer)
     {
         return isAnswerForQuestion(answer, "time");
     }

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -44,11 +44,13 @@
         // In certain environments, this script gets executed before the main forms repoinit does, so we must make sure the paths we reference are created.
         "create path (cards:QuestionnairesHomepage) /Questionnaires \n create path (cards:FormsHomepage) /Forms \n create path (cards:SubjectsHomepage) /Subjects \n create path (cards:SubjectTypesHomepage) /SubjectTypes \n create path (cards:Homepage) /content",
         // Access rights for the special "patient" user: do not allow access to PII
-        "create user patient \n set ACL for patient \n     deny jcr:all on /Questionnaires restriction(rep:itemNames,provider) \n     deny jcr:read on /Forms restriction(cards:question,/Questionnaires/Visit*information/provider) \n     deny jcr:all on /Forms restriction(cards:questionnaire,/Questionnaires/Patient*information) \n end",
+        "create user patient \n set ACL for patient \n     deny jcr:all on /Questionnaires restriction(rep:itemNames,provider) \n     deny jcr:read on /Forms restriction(cards:question,/Questionnaires/Visit*information/provider) \n     deny jcr:all on /Forms restriction(cards:questionnaire,/Questionnaires/Patient*information) \n     deny jcr:all on /Forms restriction(cards:questionnaire,/Questionnaires/Survey*events) \n end",
         // Deny access to the patient's name to the validation servlet, which would otherwise return it to the patient portal
         "create service user patient-validation \n set ACL for patient-validation \n   deny jcr:all on /Questionnaires restriction(rep:itemNames,last_name,first_name) \n     deny jcr:all on /Forms restriction(cards:question,/Questionnaires/Patient*information/last_name,/Questionnaires/Patient*information/first_name) \n end",
         // Service user for tracking the status of the surveys
         "create service user survey-tracker \n set ACL for survey-tracker \n   allow jcr:read on / \n     allow jcr:read,rep:write,jcr:versionManagement on /Forms \n end",
+        // Prevent the cleanup task from deleting the survey status form
+        "create service user patient-visit-backend \n set ACL for patient-visit-backend \n     deny jcr:all on /Forms restriction(cards:questionnaire,/Questionnaires/Survey*events) \n end",
         // This isn't actually used, but Patient.json references it; needs to be removed along with the torch import
         "create service user proms-import-backend"
       ]

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -60,6 +60,7 @@
     },
     "io.uhndata.cards.patients.emailnotifications.AppointmentEmailNotificationsFactory~CPES-InitialInvitationTask":{
       "name": "CPES-InitialNotificationsTask",
+      "notificationType": "Invitation",
       "metricName": "Initial Emails Sent",
       "clinicId": "/Survey/ClinicMapping/2075099",
       "emailConfiguration": "/apps/cards/clinics/CPES/mailTemplates/InitialInvitation",
@@ -67,6 +68,7 @@
     },
     "io.uhndata.cards.patients.emailnotifications.AppointmentEmailNotificationsFactory~CPES-Reminder1NotificationsTask":{
       "name": "CPES-Reminder1NotificationsTask",
+      "notificationType": "Reminder1",
       "metricName": "Reminder Emails Sent",
       "clinicId": "/Survey/ClinicMapping/2075099",
       "emailConfiguration": "/apps/cards/clinics/CPES/mailTemplates/ReminderNotification",
@@ -74,6 +76,7 @@
     },
     "io.uhndata.cards.patients.emailnotifications.AppointmentEmailNotificationsFactory~CPES-Reminder2NotificationsTask":{
       "name": "CPES-Reminder2NotificationsTask",
+      "notificationType": "Reminder2",
       "metricName": "Reminder Emails Sent",
       "clinicId": "/Survey/ClinicMapping/2075099",
       "emailConfiguration": "/apps/cards/clinics/CPES/mailTemplates/ReminderNotification",
@@ -81,6 +84,7 @@
     },
     "io.uhndata.cards.patients.emailnotifications.AppointmentEmailNotificationsFactory~UHN-IP-InitialInvitationTask":{
       "name": "UHN-IP-InitialInvitationsTask",
+      "notificationType": "Invitation",
       "metricName": "Initial Emails Sent",
       "clinicId": "/Survey/ClinicMapping/-1792626663",
       "emailConfiguration": "/apps/cards/clinics/UHN-IP/mailTemplates/InitialInvitation",
@@ -88,6 +92,7 @@
     },
     "io.uhndata.cards.patients.emailnotifications.AppointmentEmailNotificationsFactory~UHN-IP-Reminder1NotificationsTask":{
       "name": "UHN-IP-Reminder1NotificationsTask",
+      "notificationType": "Reminder1",
       "metricName": "Reminder Emails Sent",
       "clinicId": "/Survey/ClinicMapping/-1792626663",
       "emailConfiguration": "/apps/cards/clinics/UHN-IP/mailTemplates/ReminderNotification",
@@ -95,6 +100,7 @@
     },
     "io.uhndata.cards.patients.emailnotifications.AppointmentEmailNotificationsFactory~UHN-IP-Reminder2NotificationsTask":{
       "name": "UHN-IP-Reminder2NotificationsTask",
+      "notificationType": "Reminder2",
       "metricName": "Reminder Emails Sent",
       "clinicId": "/Survey/ClinicMapping/-1792626663",
       "emailConfiguration": "/apps/cards/clinics/UHN-IP/mailTemplates/ReminderNotification",
@@ -102,6 +108,7 @@
     },
     "io.uhndata.cards.patients.emailnotifications.AppointmentEmailNotificationsFactory~UHN-ED-InitialInvitationTask":{
       "name": "UHN-ED-InitialInvitationsTask",
+      "notificationType": "Invitation",
       "metricName": "Initial Emails Sent",
       "clinicId": "/Survey/ClinicMapping/-1792626799",
       "emailConfiguration": "/apps/cards/clinics/UHN-ED/mailTemplates/InitialInvitation",
@@ -109,6 +116,7 @@
     },
     "io.uhndata.cards.patients.emailnotifications.AppointmentEmailNotificationsFactory~UHN-ED-Reminder1NotificationsTask":{
       "name": "UHN-ED-Reminder1NotificationsTask",
+      "notificationType": "Reminder1",
       "metricName": "Reminder Emails Sent",
       "clinicId": "/Survey/ClinicMapping/-1792626799",
       "emailConfiguration": "/apps/cards/clinics/UHN-ED/mailTemplates/ReminderNotification",
@@ -116,6 +124,7 @@
     },
     "io.uhndata.cards.patients.emailnotifications.AppointmentEmailNotificationsFactory~UHN-ED-Reminder2NotificationsTask":{
       "name": "UHN-ED-Reminder2NotificationsTask",
+      "notificationType": "Reminder2",
       "metricName": "Reminder Emails Sent",
       "clinicId": "/Survey/ClinicMapping/-1792626799",
       "emailConfiguration": "/apps/cards/clinics/UHN-ED/mailTemplates/ReminderNotification",
@@ -123,6 +132,7 @@
     },
     "io.uhndata.cards.patients.emailnotifications.AppointmentEmailNotificationsFactory~UHN-EDIP-InitialInvitationTask":{
       "name": "UHN-EDIP-InitialInvitationsTask",
+      "notificationType": "Invitation",
       "metricName": "Initial Emails Sent",
       "clinicId": "/Survey/ClinicMapping/-432465800",
       "emailConfiguration": "/apps/cards/clinics/UHN-EDIP/mailTemplates/InitialInvitation",
@@ -130,6 +140,7 @@
     },
     "io.uhndata.cards.patients.emailnotifications.AppointmentEmailNotificationsFactory~UHN-EDIP-Reminder1NotificationsTask":{
       "name": "UHN-EDIP-Reminder1NotificationsTask",
+      "notificationType": "Reminder1",
       "metricName": "Reminder Emails Sent",
       "clinicId": "/Survey/ClinicMapping/-432465800",
       "emailConfiguration": "/apps/cards/clinics/UHN-EDIP/mailTemplates/ReminderNotification",
@@ -137,6 +148,7 @@
     },
     "io.uhndata.cards.patients.emailnotifications.AppointmentEmailNotificationsFactory~UHN-EDIP-Reminder2NotificationsTask":{
       "name": "UHN-EDIP-Reminder2NotificationsTask",
+      "notificationType": "Reminder2",
       "metricName": "Reminder Emails Sent",
       "clinicId": "/Survey/ClinicMapping/-432465800",
       "emailConfiguration": "/apps/cards/clinics/UHN-EDIP/mailTemplates/ReminderNotification",
@@ -144,6 +156,7 @@
     },
     "io.uhndata.cards.patients.emailnotifications.AppointmentEmailNotificationsFactory~UHN-Rehab-InitialInvitationTask":{
       "name": "UHN-Rehab-InitialInvitationsTask",
+      "notificationType": "Invitation",
       "metricName": "Initial Emails Sent",
       "clinicId": "/Survey/ClinicMapping/78840662",
       "emailConfiguration": "/apps/cards/clinics/UHN-Rehab/mailTemplates/InitialInvitation",
@@ -151,6 +164,7 @@
     },
     "io.uhndata.cards.patients.emailnotifications.AppointmentEmailNotificationsFactory~UHN-Rehab-Reminder1NotificationsTask":{
       "name": "UHN-Rehab-Reminder1NotificationsTask",
+      "notificationType": "Reminder1",
       "metricName": "Reminder Emails Sent",
       "clinicId": "/Survey/ClinicMapping/78840662",
       "emailConfiguration": "/apps/cards/clinics/UHN-Rehab/mailTemplates/ReminderNotification",
@@ -158,6 +172,7 @@
     },
     "io.uhndata.cards.patients.emailnotifications.AppointmentEmailNotificationsFactory~UHN-Rehab-Reminder2NotificationsTask":{
       "name": "UHN-Rehab-Reminder2NotificationsTask",
+      "notificationType": "Reminder2",
       "metricName": "Reminder Emails Sent",
       "clinicId": "/Survey/ClinicMapping/78840662",
       "emailConfiguration": "/apps/cards/clinics/UHN-Rehab/mailTemplates/ReminderNotification",

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -47,8 +47,15 @@
         "create user patient \n set ACL for patient \n     deny jcr:all on /Questionnaires restriction(rep:itemNames,provider) \n     deny jcr:read on /Forms restriction(cards:question,/Questionnaires/Visit*information/provider) \n     deny jcr:all on /Forms restriction(cards:questionnaire,/Questionnaires/Patient*information) \n end",
         // Deny access to the patient's name to the validation servlet, which would otherwise return it to the patient portal
         "create service user patient-validation \n set ACL for patient-validation \n   deny jcr:all on /Questionnaires restriction(rep:itemNames,last_name,first_name) \n     deny jcr:all on /Forms restriction(cards:question,/Questionnaires/Patient*information/last_name,/Questionnaires/Patient*information/first_name) \n end",
+        // Service user for tracking the status of the surveys
+        "create service user survey-tracker \n set ACL for survey-tracker \n   allow jcr:read on / \n     allow jcr:read,rep:write,jcr:versionManagement on /Forms \n end",
         // This isn't actually used, but Patient.json references it; needs to be removed along with the torch import
         "create service user proms-import-backend"
+      ]
+    },
+    "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~prems":{
+      "user.mapping":[
+        "io.uhndata.cards.prems-backend:SurveyTracker=[survey-tracker]"
       ]
     },
     "io.uhndata.cards.patients.emailnotifications.AppointmentEmailNotificationsFactory~CPES-InitialInvitationTask":{


### PR DESCRIPTION
Test on the **CARDS-2042-testing** branch!

To test:

- create and fill in patient information form with a valid email and consent to receive emails
- create a visit information form for a clinic set 3 days ago
- check that a Survey events form was created, with the right information
    - Hospital
    - Department
    - Discharged on
    - Assigned survey
    - Survey expires on
- change the visit date to 7 days ago, save, wait 1 minute
- check that the `Invitation email sent on` question  now has an answer
- change the visit date to 9 days ago, save, wait 1 minute
- check that the `First reminder email sent on` question  now has an answer
- change the visit date to 11 days ago, save, wait 1 minute
- check that the `Second reminder email sent on` question  now has an answer
- change the visit date to 60 days ago, save, wait 1 minute
- check that the data form (e.g. CPESIC) was deleted, but the Survey events form is still present

- generate a new visit information survey
- generate a token and fill in and submit the survey as a patient
- check that the `Patient responses received on` question now has an answer
