### PR TITLE
CARDS-2064 - Add support for formatting in the question text

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Question.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Question.jsx
@@ -93,10 +93,9 @@ function Question (props) {
         // Note that we need to preserve the hierarchy in which we place children
         // so that pageActive changing does not cause children to lose state
         pageActive && <CardHeader
-          title={text}
-          titleTypographyProps={{ variant: 'h6' }}
-          subheader={<FormattedText variant="caption">{description}</FormattedText>}
-          subheaderTypographyProps={{ component: "div" }}
+          disableTypography
+          title={<FormattedText component="h6" variant="h6">{text}</FormattedText>}
+          subheader={<FormattedText component="div" variant="caption" color="textSecondary">{description}</FormattedText>}
           />
       }
       <CardContent className={isEdit ? classes.editModeAnswers : classes.viewModeAnswers}>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -34,6 +34,12 @@ const questionnaireStyle = theme => ({
     questionCard : {
       "& .MuiCardHeader-root" : {
         padding: theme.spacing(1, 3, 0, 3),
+        "& h6 ol" : {
+           paddingLeft: 0,
+        },
+        "& h6 li" : {
+           listStylePosition: "inside",
+        },
       },
       "& .MuiCardContent-root" : {
         paddingLeft: theme.spacing(3),

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -19,7 +19,7 @@
 
 import React, { useCallback, useState, useEffect } from "react";
 import PropTypes from "prop-types";
-import { Button, Collapse, Grid, IconButton, Tooltip, Typography } from "@mui/material";
+import { Button, Collapse, Grid, IconButton, Tooltip } from "@mui/material";
 import withStyles from '@mui/styles/withStyles';
 import Add from "@mui/icons-material/Add";
 import UnfoldLess from '@mui/icons-material/UnfoldLess';
@@ -69,9 +69,9 @@ function Section(props) {
   const headerVariant = "h5";
   const titleEl = sectionDefinition["label"] &&
     (idx =>
-      <Typography variant={headerVariant}>
+      <FormattedText component={headerVariant} variant={headerVariant}>
         {createTitle(sectionDefinition["label"], idx, isRecurrent)}
-      </Typography>
+      </FormattedText>
     );
   const descEl = sectionDefinition["description"] &&
     (() =>

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -8,7 +8,7 @@
          "defaultOrder" : 1
       }
     },
-    "text": "string",
+    "text": "markdown",
     "description": "markdown",
     "dataType": {
       "text" : {

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/QuestionnaireItemCard.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/QuestionnaireItemCard.jsx
@@ -29,7 +29,6 @@ import {
   IconButton,
   Popover,
   Tooltip,
-  Typography,
 } from "@mui/material";
 
 import makeStyles from '@mui/styles/makeStyles';
@@ -41,6 +40,8 @@ import MoreIcon from '@mui/icons-material/MoreHoriz';
 
 import EditDialog from "./EditDialog";
 import DeleteButton from "../dataHomepage/DeleteButton.jsx";
+
+import FormattedText from "../components/FormattedText.jsx";
 
 import { camelCaseToWords }  from "./LabeledField";
 
@@ -159,6 +160,7 @@ let QuestionnaireItemCard = (props) => {
   return (
     <Card variant="outlined" ref={highlight ? itemRef : undefined} className={cardClasses.join(" ")}>
       <CardHeader
+        disableTypography
         avatar={!plain && (avatar || type) ?
           <Avatar style={{backgroundColor: avatarColor || "black"}}>
             { avatar ? <Icon>{avatar}</Icon> : type?.charAt(0) }
@@ -167,7 +169,7 @@ let QuestionnaireItemCard = (props) => {
         }
         title={
           <>
-            { <Typography className={titleClasses.join(" ")} variant="h6">{titleText}</Typography> }
+            { <FormattedText className={titleClasses.join(" ")} variant="h6">{titleText}</FormattedText> }
             { moreInfo &&
               <Tooltip title="Properties">
                 <IconButton onClick={(event) => setMoreInfoAnchor(event.currentTarget)} size="large">

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Section.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Section.json
@@ -19,7 +19,7 @@
       "Section" : "Section.json",
       "Information" : "Information.json"
     },
-    "label": "string",
+    "label": "markdown",
     "description": "markdown",
     "displayMode": {
       "default" : {


### PR DESCRIPTION
Testing: in the questionnaire wizard, create a question with simple markdown formatting in the text, e.g "This is an _important_ question".