### PR TITLE
CARDS-2065: Add a questionnaire setting to hide answer instructions, CARDS-2066: Reword "This question is mandatory"

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/AnswerInstructions.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/AnswerInstructions.jsx
@@ -63,7 +63,7 @@ function AnswerInstructions (props) {
     >
       {
         (isMandatory) ?
-        "This question is mandatory"
+        "This answer is required"
         :
         "Please provide " + range + " " + answerLabel + "s"
       }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -99,6 +99,7 @@ function Form (props) {
   let [ actionsMenu, setActionsMenu ] = useState(null);
   let [ formContentOffsetTop, setFormContentOffsetTop ] = useState(contentOffset);
   let [ formContentOffsetBottom, setFormContentOffsetBottom ] = useState(0);
+  let [ classNames, setClassNames ] = useState(className ? [className] : []);
 
   // Whether we reached the of the form (as opposed to a page that is not the last on a paginated form)
   let [ endReached, setEndReached ] = useState();
@@ -198,6 +199,9 @@ function Form (props) {
       // grab it from the questionnaire definition
       typeof(requireCompletion == "undefined") && setRequireCompletion(json?.['questionnaire']?.['requireCompletion']);
       setIncompleteQuestionEl(null);
+      // Take into account the option to hide answer instructions as specified in the questionnaire definition
+      let hideInstructions = json?.['questionnaire']?.['hideAnswerInstructions'];
+      !!hideInstructions && setClassNames(names => ([...names, classes.hideAnswerInstructions]));
       //Perform a JCR check-out of the Form
       let checkoutForm = new FormData();
       checkoutForm.set(":operation", "checkout");
@@ -475,7 +479,7 @@ function Form (props) {
                    }
           key={id}
           ref={formNode}
-          className={className || null}
+          className={classNames?.join(' ')}
       >
       <Grid container {...FORM_ENTRY_CONTAINER_PROPS} >
         { !disableHeader &&

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
@@ -72,7 +72,7 @@ function QuestionnairePreview (props) {
     );
   }
 
-  return (<>
+  return (<div className={data?.hideAnswerInstructions ? classes.hideAnswerInstructions : null}>
     <Grid container {...FORM_ENTRY_CONTAINER_PROPS} >
       { /* Added dummy save functionality for mocking file and pedigree questions functionality. */ }
       <FormProvider additionalFormData={{
@@ -124,7 +124,7 @@ function QuestionnairePreview (props) {
         label="Close"
       />
     }
-  </>);
+  </div>);
 };
 
 export default withStyles(QuestionnaireStyle)(QuestionnairePreview);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -137,6 +137,11 @@ const questionnaireStyle = theme => ({
         margin: theme.spacing(-3,0,1),
         padding: theme.spacing(1, 0),
     },
+    hideAnswerInstructions: {
+      "& p[class*='-answerInstructions']" : {
+        display: "none",
+      }
+    },
     thumbnail: {
         border: "1px solid " + theme.palette.divider,
     },
@@ -565,6 +570,9 @@ const questionnaireStyle = theme => ({
       "&.MuiCard-root, > .MuiCard-root" : {
         outline: `1px solid ${theme.palette.error.light}`,
       },
+      "& p[class*='-answerInstructions']" : {
+        display: "block",
+      }
     },
     fileResourceAnswerList: {
       listStyleType: 'none',

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Questionnaire.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Questionnaire.json
@@ -15,6 +15,7 @@
     "description" : "markdown",
     "maxPerSubject": "long",
     "requireCompletion" : "boolean",
+    "hideAnswerInstructions" : "boolean",
     "paginate": {
       "true" : {
         "paginationVariant" : {

--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/nodetypes/forms.cnd
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/nodetypes/forms.cnd
@@ -449,6 +449,12 @@
   // In paginated forms, do not permit advancing to the next page until the current page is complete.
   - requireCompletion (BOOLEAN)
 
+  // If true, notes such as "This answer is required" or "Please provide at least 3 files"
+  // will not be shown under the text of the questions with such restrictions, unless
+  // requireCompletion is true and the question is highlighted for having a missing or
+  // invalid answer
+  - hideAnswerInstructions (BOOLEAN)
+
   // Children
 
   // The sections and standalone questions that make up this questionnaire.


### PR DESCRIPTION
**Includes:**
* [CARDS-2065](https://phenotips.atlassian.net/browse/CARDS-2065): _Add a questionnaire setting to hide answer instruction_
* [CARDS-2066](https://phenotips.atlassian.net/browse/CARDS-2066): _Reword "This question is mandatory" to "This answer is required" to make it more user-friendly_

**Testing**
* Start `prems`
* From Administration > Questionnaires, preview the prems surveys - notice that "This question is mandatory" has become "This answer is required" (per CARDS-2065)
* In the questionnaire wizard. for one of the surveys, e.g. CPESIC, set the new questionnaire property labeled **Hide answer instructions** to true
* Start filling out the survey
  *  Notice none of the "This answer is required" lines appear
  * Try to advance to the next page without filling in a question -> notice "This answer is required" appears under the red-outlined question's text

[CARDS-2065]: https://phenotips.atlassian.net/browse/CARDS-2065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CARDS-2066]: https://phenotips.atlassian.net/browse/CARDS-2066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ