### PR TITLE
CARDS-2067: Clicking on the grey highlighting of a multiple choice option should have the same effect as clicking on the option text or radio/checkbox

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -589,7 +589,7 @@ function ResponseChild(props) {
 
   return (
     <React.Fragment>
-      <ListItem key={name} className={classes.selectionChild} onClick={() => onClick(id, name, checked)}>
+      <ListItem key={name} className={classes.selectionChild} onClick={evt => {evt.preventDefault(); onClick(id, name, checked);}}>
           { /* This is either a Checkbox/Radiobox if this is a default suggestion, or a delete button otherwise */
           isDefaultOption ?
             (<>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -589,7 +589,7 @@ function ResponseChild(props) {
 
   return (
     <React.Fragment>
-      <ListItem key={name} className={classes.selectionChild}>
+      <ListItem key={name} className={classes.selectionChild} onClick={() => onClick(id, name, checked)}>
           { /* This is either a Checkbox/Radiobox if this is a default suggestion, or a delete button otherwise */
           isDefaultOption ?
             (<>


### PR DESCRIPTION
Testing:
* Create a new form with multiple choice options (for example a `prems` survey`)
* Hover one of the options - notice a gray highlighting that takes up the whole width of the question box
* Click on the highlighted area (but outside of the radiobutton or label) -> the option should be selected
* Turn the question into multiselect by setting maxAnswers = 0, then check that clicking on the highlighting works
* Add NA/None of the above options, check that clicking on their highlighted area instead of the checkbox or label preserved the NA/None of the above functionality

