### PR TITLE
CARDS-2068 - Patient portal: on the start screen, the numbers in front of the surveys look like they should be clicked, but don't react to clicks

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -80,12 +80,14 @@ const useStyles = makeStyles(theme => ({
     color: theme.palette.action.disabled,
   },
   incompleteIndicator : {
-    border: "1px solid " + theme.palette.secondary.main,
+    border: "1px solid " + theme.palette.error.main,
     background: "transparent",
-    color: theme.palette.secondary.main,
+    color: theme.palette.error.main,
   },
   doneIndicator : {
-    background: theme.palette.success.main,
+    border: "1px solid " + theme.palette.success.main,
+    background: "transparent",
+    color: theme.palette.success.main,
   },
   survey : {
     alignItems: "stretch",

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -75,9 +75,9 @@ const useStyles = makeStyles(theme => ({
     }
   },
   stepIndicator : {
-    border: "1px solid " + theme.palette.text.secondary,
+    border: "1px solid " + theme.palette.action.disabled,
     background: "transparent",
-    color: theme.palette.text.secondary,
+    color: theme.palette.action.disabled,
   },
   incompleteIndicator : {
     border: "1px solid " + theme.palette.secondary.main,


### PR DESCRIPTION
Also includes the following related changes:
* Use `error` instead of `secondary` for incomplete surveys (since secondary color is no longer always red)
* outlined checkmark avatar instead of filled for completed surveys (to avoid looking like it should be clicked)

Testing:
* For 2068
  * start in `prems` or `proms`
  * create a visit with surveys
  * log in as a patient
  * compare the look of the patient portal page that lists the surveys needing to be filled (the first screen after patient authentication) in this branch and in dev
* For additional changes listed above
  * start in `proms`  (where completion is not required)
  * create a visit with surveys
  * authenticate as patient
  * fill in surveys - for some complete all the questions, for some leave out some answers
  * compare the screen that announces that you have missing answers in this branch and in `dev`