### PR TITLE
CARDS-2070 - Patient portal: the "Close" button on the last page is confusing

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -450,7 +450,7 @@ function QuestionnaireSet(props) {
       )
         .then(response => response.ok ? response.text() : Promise.reject(response))
         .then(() => setSubmitted(true))
-        .catch(response => setError(`Submitting the responses failed with error code ${response.status}: ${response.statusText}`));
+        .catch(() => setError("Recording the submission of the responses has failed. Please try again later or contact the sender of the survey for further assistance."));
     }
   }
 
@@ -477,7 +477,8 @@ function QuestionnaireSet(props) {
         }
       })
       .catch((response) => {
-        setError(`Failed to check in form with error code ${response.status}: ${response.statusText}`);
+        // The error is not important enough to display to the user
+        console.log(`Failed to check in form with error code ${response.status}: ${response.statusText}`);
       });
   }
 


### PR DESCRIPTION
**Specs:**
* [CARDS-2070](https://phenotips.atlassian.net/browse/CARDS-2070) - _Patient portal: the "Close" button on the last page is confusing_

**Testing**
* In both `prems` and `proms`:
  * before clicking on "submit my answers", open the network tab and check that a request is being made to `/system/sling/logout`
  * check that the last screen "Thank you..." is displayed correctly and does not have a "Close" button
    * for `proms` check that the interpretations are displayed
  * after submission, in the address bar enter a new address to the app (e.g. /content.html/admin/Questionnaires) and check that the login screen is being displayed as opposed to the "go to surveys" error page
  * return to the same survey address as before (as patient) - check the screen being displayed when there are no surveys to be filled out

[CARDS-2070]: https://phenotips.atlassian.net/browse/CARDS-2070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ