### PR TITLE
CARDS-1995: Sign out is not working for patients

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -528,16 +528,18 @@ function Form (props) {
           ['/AllowResave']: ()=>setLastSaveStatus(undefined)
           }}>
           <FormUpdateProvider>
-            <SelectorDialog
-              allowedTypes={parseToArray(data?.['questionnaire']?.['requiredSubjectTypes'])}
-              error={selectorDialogError}
-              open={selectorDialogOpen}
-              onChange={changeSubject}
-              onClose={() => {setSelectorDialogOpen(false)}}
-              onError={setSelectorDialogError}
-              title="Set subject"
-              selectedQuestionnaire={data?.questionnaire}
+            {!disableHeader &&
+              <SelectorDialog
+                allowedTypes={parseToArray(data?.['questionnaire']?.['requiredSubjectTypes'])}
+                error={selectorDialogError}
+                open={selectorDialogOpen}
+                onChange={changeSubject}
+                onClose={() => {setSelectorDialogOpen(false)}}
+                onError={setSelectorDialogError}
+                title="Set subject"
+                selectedQuestionnaire={data?.questionnaire}
               />
+            }
             {changedSubject &&
               <React.Fragment>
                 <input type="hidden" name={`${data["@path"]}/subject`} value={changedSubject["@path"]}></input>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -220,7 +220,7 @@ function QuestionnaireSet(props) {
 
   // Automatically log out the user at the end
   useEffect(() => {
-    isSubmitted && fetch('/system/sling/logout');
+    isSubmitted && fetch('/system/sling/logout', {"redirect": "manual"});
   }, [isSubmitted]);
 
   // Determine if the user has already submitted their forms

--- a/modules/token-authentication/src/main/java/io/uhndata/cards/auth/token/impl/sling/TokenAuthenticationHandler.java
+++ b/modules/token-authentication/src/main/java/io/uhndata/cards/auth/token/impl/sling/TokenAuthenticationHandler.java
@@ -101,6 +101,7 @@ public class TokenAuthenticationHandler extends DefaultAuthenticationFeedbackHan
             response.reset();
             final Cookie eraseCookie = new Cookie(TOKEN_COOKIE_NAME, "");
             eraseCookie.setMaxAge(0);
+            eraseCookie.setHttpOnly(true);
             final String ctxPath = request.getContextPath();
             final String cookiePath = (ctxPath == null || ctxPath.length() == 0) ? "/" : ctxPath;
             eraseCookie.setPath(cookiePath);


### PR DESCRIPTION
To test [CARDS-1995](https://phenotips.atlassian.net/browse/CARDS-1995):
- start in prems or proms mode
- create patient and visit information forms
- in proms: log in as the patient, fill in part of the survey and click the sign out link in the header
- check that the new request doesn't send the `cards_auth_token` cookie
- in prems: log in as the patient, fill in and submit the survey
- check that reloading the page does not send the `cards_auth_token` cookie
- as the admin, check that the "Change subject" menu entry is still working well

[CARDS-1995]: https://phenotips.atlassian.net/browse/CARDS-1995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ