### PR TITLE
CARDS-2072: Checking "Patients can answer surveys without a personalized link" in Administration > Patient access is not sufficient to enable the identification form

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
@@ -123,6 +123,9 @@ function PatientIdentification(props) {
   // Internal state
   // Flag specifying that the required authentication token is missing, so the user cannot be identified
   const [ canAuthenticate, setCanAuthenticate ] = useState();
+  // Flag specifying if the identification form needs to be displayed
+  const [ showIdentificationForm, setShowIdentificationForm ] = useState();
+  
   // Holds an error message for display
   const [ error, setError ] = useState();
   // Returned from the server after successful validation of the authentication,
@@ -206,6 +209,12 @@ function PatientIdentification(props) {
       validateCredentials(requestData, () => {});
     }
   }, [config?.tokenlessAuthEnabled]);
+
+  // The identification form should be made availavle whenever tokenless auth is enabled,
+  // as well as when specifically required according to the patient access config
+  useEffect(() => {
+    setShowIdentificationForm(config?.tokenlessAuthEnabled || config?.PIIAuthRequired);
+  }, [config?.tokenlessAuthEnabled, config?.PIIAuthRequired]);
 
   // Once a visit is selected, finalize the identification
   useEffect(() => {
@@ -302,7 +311,7 @@ function PatientIdentification(props) {
          { /* If we don't have the authentication token yet or we don't need the identification form,
              display the welcome message and a circular progress while we wait for the next step */ }
 
-         { (typeof(canAuthenticate) == "undefined" || !config?.PIIAuthRequired) ?
+         { (typeof(canAuthenticate) == "undefined" || !showIdentificationForm) ?
 
          <>
          { welcomeMessage &&


### PR DESCRIPTION
See steps to replicate [CARDS-2072](https://phenotips.atlassian.net/browse/CARDS-2072) on jira.

[CARDS-2072]: https://phenotips.atlassian.net/browse/CARDS-2072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ