### PR TITLE
CARDS-1962: Handle activated Mychart Status in email discard filter

### DIFF
--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
@@ -379,7 +379,11 @@ public class ClarityImportTask implements Runnable
             if ("date".equals(col.getValue())) {
                 queryString += "FORMAT(" + col.getKey() + ", 'yyyy-MM-dd HH:mm:ss') AS " + col.getKey();
             } else {
-                queryString += col.getKey();
+                String column = col.getKey();
+                if (column.contains(" ")) {
+                    column = "[" + column + "]";
+                }
+                queryString += column;
             }
             if (columnsIterator.hasNext()) {
                 queryString += ", ";

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
@@ -377,13 +377,9 @@ public class ClarityImportTask implements Runnable
         while (columnsIterator.hasNext()) {
             Map.Entry<String, String> col = columnsIterator.next();
             if ("date".equals(col.getValue())) {
-                queryString += "FORMAT(" + col.getKey() + ", 'yyyy-MM-dd HH:mm:ss') AS " + col.getKey();
+                queryString += "FORMAT([" + col.getKey() + "], 'yyyy-MM-dd HH:mm:ss') AS [" + col.getKey() + "]";
             } else {
-                String column = col.getKey();
-                if (column.contains(" ")) {
-                    column = "[" + column + "]";
-                }
-                queryString += column;
+                queryString += "[" + col.getKey() + "]";
             }
             if (columnsIterator.hasNext()) {
                 queryString += ", ";

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/FilterEmailConsent.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/FilterEmailConsent.java
@@ -40,8 +40,8 @@ public class FilterEmailConsent implements ClarityDataProcessor
     {
         final String email = input.get("EMAIL_ADDRESS");
         final Boolean consent = "Yes".equalsIgnoreCase(input.get("EMAIL_CONSENT_YN"));
-        final Boolean activated = "Activated".equalsIgnoreCase(input.get("MYCHART STATUS"));
-        if ((consent || activated) && EmailValidator.getInstance().isValid(email)) {
+        final Boolean myChartActivated = "Activated".equalsIgnoreCase(input.get("MYCHART STATUS"));
+        if ((consent || myChartActivated) && EmailValidator.getInstance().isValid(email)) {
             return input;
         }
         return null;

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/FilterEmailConsent.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/FilterEmailConsent.java
@@ -40,7 +40,8 @@ public class FilterEmailConsent implements ClarityDataProcessor
     {
         final String email = input.get("EMAIL_ADDRESS");
         final Boolean consent = "Yes".equalsIgnoreCase(input.get("EMAIL_CONSENT_YN"));
-        if (consent && EmailValidator.getInstance().isValid(email)) {
+        final Boolean activated = "Activated".equalsIgnoreCase(input.get("MYCHART STATUS"));
+        if ((consent || activated) && EmailValidator.getInstance().isValid(email)) {
             return input;
         }
         return null;

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clarityMapping.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clarityMapping.xml
@@ -213,6 +213,20 @@
                 <type>Boolean</type>
               </property>
             </node>
+            <node>
+              <name>00000011</name>
+              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+              <property>
+                <name>column</name>
+                <value>MYCHART STATUS</value>
+                <type>String</type>
+              </property>
+              <property>
+                <name>question</name>
+                <value></value>
+                <type>String</type>
+              </property>
+            </node>
           </node>
         </node>
       </node>


### PR DESCRIPTION
Test via [1962-1963-test]( https://github.com/data-team-uhn/cards/tree/CARDS-1962-1963-test) branch using instructions in [1962-1963 configurable](https://github.com/data-team-uhn/cards/pull/1330) pull request.

Relevant test cases: Visits 16, 17 and 19 should be discarded (no email consent, email consent but no email, my chart activated but no email). Visit 18 should be kept (no email consent but mycharts activated)