### PR TITLE
CARDS-1963: Improve LENGTH_OF_STAY handling

### DIFF
--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/LengthOfStayMapper.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/LengthOfStayMapper.java
@@ -59,7 +59,7 @@ public class LengthOfStayMapper implements ClarityDataProcessor
                 admission.setTime(dateFormat.parse(input.get("HOSP_ADMISSION_DTTM")));
                 discharge.setTime(dateFormat.parse(input.get("HOSP_DISCHARGE_DTTM")));
 
-                length = ChronoUnit.DAYS.between(discharge.toInstant(), admission.toInstant());
+                length = ChronoUnit.DAYS.between(admission.toInstant(), discharge.toInstant());
                 input.put("LENGTH_OF_STAY_DAYS", String.valueOf(length));
             } catch (ParseException e) {
                 // Do nothing, could not calculate a new length so leave empty

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/LengthOfStayMapper.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/LengthOfStayMapper.java
@@ -72,6 +72,6 @@ public class LengthOfStayMapper implements ClarityDataProcessor
     @Override
     public int getPriority()
     {
-        return 70;
+        return 10;
     }
 }

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/LengthOfStayMapper.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/LengthOfStayMapper.java
@@ -30,12 +30,12 @@ import org.osgi.service.component.annotations.Component;
 import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
 
 /**
- * Clarity import processor that only allows visits for patients with a valid email address who have given consent to
- * receiving emails.
+ * Clarity import processor that computes the {@code LENGTH_OF_STAY_DAYS} based on the admission and discharge dates, if
+ * no value is already present in the query result.
  *
  * @version $Id$
  */
-@Component()
+@Component
 public class LengthOfStayMapper implements ClarityDataProcessor
 {
     @Override

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/LengthOfStayMapper.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/LengthOfStayMapper.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.prems.internal.importer;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.temporal.ChronoUnit;
+import java.util.Calendar;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+
+import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
+
+/**
+ * Clarity import processor that only allows visits for patients with a valid email address who have given consent to
+ * receiving emails.
+ *
+ * @version $Id$
+ */
+@Component()
+public class LengthOfStayMapper implements ClarityDataProcessor
+{
+    @Override
+    public Map<String, String> processEntry(Map<String, String> input)
+    {
+        final String lengthStr = input.get("LENGTH_OF_STAY_DAYS");
+        Long length = null;
+        if (lengthStr != null && lengthStr.length() > 0) {
+            try {
+                length = Long.parseLong(lengthStr);
+            } catch (Exception e) {
+                // Do nothing
+            }
+        }
+
+        if (length == null) {
+            try {
+                SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+                Calendar admission = Calendar.getInstance();
+                Calendar discharge = Calendar.getInstance();
+                admission.setTime(dateFormat.parse(input.get("HOSP_ADMISSION_DTTM")));
+                discharge.setTime(dateFormat.parse(input.get("HOSP_DISCHARGE_DTTM")));
+
+                length = ChronoUnit.DAYS.between(discharge.toInstant(), admission.toInstant());
+                input.put("LENGTH_OF_STAY_DAYS", String.valueOf(length));
+            } catch (ParseException e) {
+                // Do nothing, could not calculate a new length so leave empty
+            }
+
+        }
+        return input;
+    }
+
+    @Override
+    public int getPriority()
+    {
+        return 70;
+    }
+}

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clarityMapping.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clarityMapping.xml
@@ -214,11 +214,39 @@
               </property>
             </node>
             <node>
+              <name>00000010</name>
+              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+              <property>
+                <name>column</name>
+                <value>LENGTH_OF_STAY_DAYS</value>
+                <type>String</type>
+              </property>
+              <property>
+                <name>question</name>
+                <value></value>
+                <type>String</type>
+              </property>
+            </node>
+            <node>
               <name>00000011</name>
               <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
               <property>
                 <name>column</name>
                 <value>MYCHART STATUS</value>
+                <type>String</type>
+              </property>
+              <property>
+                <name>question</name>
+                <value>/Questionnaires/Visit information/status</value>
+                <type>String</type>
+              </property>
+            </node>
+            <node>
+              <name>00000012</name>
+              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+              <property>
+                <name>column</name>
+                <value>HOSP_ADMISSION_DTTM</value>
                 <type>String</type>
               </property>
               <property>


### PR DESCRIPTION
Test via [1962-1963-test]( https://github.com/data-team-uhn/cards/tree/CARDS-1962-1963-test) branch using instructions in [1962-1963 configurable](https://github.com/data-team-uhn/cards/pull/1330) pull request.

Relevant test cases: Visit 20 should be an emergency department survey as stay should be calculated to be 1 day. Visit 21 should be an EDIP visit as stay should be calculated as 11 days.