### PR TITLE
CARDS-2075: The PrintHeader UIX and JSX code are fetched every time the form menu is opened or closed

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
@@ -57,13 +57,13 @@ async function getHeaderExtensions() {
 
 let headerExtensions = [];
 getHeaderExtensions()
-      .then(extensions => {
-        headerExtensions = extensions || [];
-      })
-      .catch(err => {
-        console.log("Something went wrong loading the print header extensions", err);
-        headerExtensions = [];
-      })
+  .then(extensions => {
+    headerExtensions = extensions || [];
+  })
+  .catch(err => {
+    console.log("Something went wrong loading the print header extensions", err);
+    headerExtensions = [];
+  })
 
 // Component that renders a form in a format/style ready for printing.
 // Internally, it queries and renders the markdown (.md) export of the form.

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
@@ -58,11 +58,11 @@ async function getHeaderExtensions() {
 let headerExtensions = [];
 getHeaderExtensions()
       .then(extensions => {
-	      headerExtensions = extensions || [];
+        headerExtensions = extensions || [];
       })
       .catch(err => {
         console.log("Something went wrong loading the print header extensions", err);
-        setHeaderExtensions([]);
+        headerExtensions = [];
       })
 
 // Component that renders a form in a format/style ready for printing.

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
@@ -62,7 +62,6 @@ getHeaderExtensions()
   })
   .catch(err => {
     console.log("Something went wrong loading the print header extensions", err);
-    headerExtensions = [];
   })
 
 // Component that renders a form in a format/style ready for printing.

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
@@ -55,6 +55,16 @@ async function getHeaderExtensions() {
     )
 }
 
+let headerExtensions = [];
+getHeaderExtensions()
+      .then(extensions => {
+	      headerExtensions = extensions || [];
+      })
+      .catch(err => {
+        console.log("Something went wrong loading the print header extensions", err);
+        setHeaderExtensions([]);
+      })
+
 // Component that renders a form in a format/style ready for printing.
 // Internally, it queries and renders the markdown (.md) export of the form.
 //
@@ -119,8 +129,6 @@ const useStyles = makeStyles(theme => ({
 function PrintPreview(props) {
   const { open, resourcePath, resourceData, title, breadcrumb, date, subtitle, disablePreview, fullScreen, onClose, ...rest } = props;
 
-  const [ headerExtensions, setHeaderExtensions ] = useState();
-
   const [ content, setContent ] = useState();
   const [ error, setError ] = useState();
 
@@ -151,15 +159,6 @@ function PrintPreview(props) {
       // onClose && onClose();
     }
   }, [content]);
-
-  useEffect(() => {
-    getHeaderExtensions()
-      .then(extensions => setHeaderExtensions(extensions || []))
-      .catch(err => {
-        console.log("Something went wrong loading the print header extensions", err);
-        setHeaderExtensions([]);
-      })
-  }, [])
 
   let header = (
     headerExtensions?.length ? <>{ headerExtensions.map((extension, index) => {


### PR DESCRIPTION
To test [CARDS-2075](https://phenotips.atlassian.net/browse/CARDS-2075):

- start in `prems` mode
- create a form
- on the form page in view mode, open and close the action menu (the one next to the pencil, with `Print Preview | Export as text | Delete form`), monitoring the network request
- observe if each opening and closing triggers a request for `/apps/cards/ExtensionPoints/PrintHeader` and `/libs/cards/resources/patient-portal.PrintHeader.XYZ.js`

[CARDS-2075]: https://phenotips.atlassian.net/browse/CARDS-2075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ