### PR TITLE
CARDS-2080: Add the option to export a raw CSV header with variable names instead of questions' text

### DIFF
--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/QuestionnaireToCsvProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/QuestionnaireToCsvProcessor.java
@@ -106,22 +106,32 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
             final List<String> columns = new ArrayList<>();
             columns.add(IDENTIFIER_HEADER);
 
+            final List<String> rawColumns = new ArrayList<>();
+            rawColumns.add("@name");
+
             // Fetch the subject types expected to be for the questionnaire
             if (questionnaire.containsKey("requiredSubjectTypes")) {
-                getSubjectTypes(questionnaire.getJsonArray("requiredSubjectTypes"), csvData, columns);
+                getSubjectTypes(questionnaire.getJsonArray("requiredSubjectTypes"), csvData, columns, rawColumns);
             } else {
                 // No specific subject types for this questionnaire, output all known subject types
-                getSubjectTypes(resolver, csvData, columns);
+                getSubjectTypes(resolver, csvData, columns, rawColumns);
             }
             csvData.put(CREATED_HEADER, new HashMap<>());
             csvData.put(LAST_MODIFIED_HEADER, new HashMap<>());
             columns.add(CREATED_HEADER);
+            rawColumns.add("jcr:created");
             columns.add(LAST_MODIFIED_HEADER);
+            rawColumns.add("jcr:lastModified");
 
             // Get header titles from the questionnaire question objects
-            processSectionToHeaderRow(questionnaire, csvData, columns);
+            processSectionToHeaderRow(questionnaire, csvData, columns, rawColumns);
             // Print header
-            csvPrinter.printRecord(columns);
+            if (!resolutionPathInfo.contains("-csvHeader:labels")) {
+                csvPrinter.printRecord(columns);
+            }
+            if (resolutionPathInfo.contains("csvHeader:raw")) {
+                csvPrinter.printRecord(rawColumns);
+            }
 
             // Aggregate form answers to the csvData collector for the CSV output
             if (questionnaire.containsKey("@data")) {
@@ -138,19 +148,21 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
     }
 
     private void getSubjectTypes(final ResourceResolver resolver, final Map<String, Map<Integer, String>> csvData,
-        final List<String> columns)
+        final List<String> columns, final List<String> rawColumns)
     {
         final Iterator<Resource> subjectTypes = resolver.findResources(
             "SELECT st.* FROM [cards:SubjectType] AS st ORDER BY st.[cards:defaultOrder] ASC", Query.JCR_SQL2);
         while (subjectTypes.hasNext()) {
-            final ValueMap subjectTypeProperties = subjectTypes.next().getValueMap();
+            final Resource subjectType = subjectTypes.next();
+            final ValueMap subjectTypeProperties = subjectType.getValueMap();
             columns.add(subjectTypeProperties.get("label", String.class).concat(" ID"));
+            rawColumns.add(subjectType.getPath());
             csvData.put(subjectTypeProperties.get(UUID_PROP, String.class), new HashMap<>());
         }
     }
 
     private void getSubjectTypes(final JsonArray subjectTypesArray, final Map<String, Map<Integer, String>> csvData,
-        final List<String> columns)
+        final List<String> columns, final List<String> rawColumns)
     {
         final List<JsonObject> subjectTypes = new ArrayList<>();
         subjectTypesArray.stream().map(JsonValue::asJsonObject)
@@ -158,6 +170,7 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
         subjectTypes.sort((t1, t2) -> t1.getInt("cards:defaultOrder") - t2.getInt("cards:defaultOrder"));
         subjectTypes.forEach(subjectType -> {
             columns.add(subjectType.getString("label").concat(" ID"));
+            rawColumns.add(subjectType.getString("@path"));
             csvData.put(subjectType.getString(UUID_PROP), new HashMap<>());
         });
     }
@@ -174,13 +187,13 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
 
     private void processSectionToHeaderRow(final JsonObject questionnaire,
         final Map<String, Map<Integer, String>> csvData,
-        final List<String> columns)
+        final List<String> columns, final List<String> rawColumns)
     {
         questionnaire.values().stream()
             .filter(value -> ValueType.OBJECT.equals(value.getValueType()))
             .map(JsonValue::asJsonObject)
             .filter(value -> value.containsKey(PRIMARY_TYPE_PROP))
-            .forEach(value -> processHeaderElement(value, csvData, columns));
+            .forEach(value -> processHeaderElement(value, csvData, columns, rawColumns));
     }
 
     /**
@@ -192,13 +205,14 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
      * @param columns a list of column headers
      */
     private void processHeaderElement(final JsonObject nodeJson, final Map<String, Map<Integer, String>> csvData,
-        final List<String> columns)
+        final List<String> columns, final List<String> rawColumns)
     {
         final String nodeType = nodeJson.getString(PRIMARY_TYPE_PROP);
         if ("cards:Section".equals(nodeType)) {
-            processSectionToHeaderRow(nodeJson, csvData, columns);
+            processSectionToHeaderRow(nodeJson, csvData, columns, rawColumns);
         } else if ("cards:Question".equals(nodeType)) {
             String label = nodeJson.getString("@name");
+            rawColumns.add(label);
             if (nodeJson.containsKey("text")) {
                 label = nodeJson.getString("text");
             }


### PR DESCRIPTION
To test [CARDS-2080](https://phenotips.atlassian.net/browse/CARDS-2080):

- start in prems mode
- create and fill in a OAIP form
- `http://localhost:8080/Questionnaires/OAIP.csv` has only the labels header
- `http://localhost:8080/Questionnaires/OAIP.csvHeader:raw.csv` has two headers, one with labels, one with raw question names
- `http://localhost:8080/Questionnaires/OAIP.-csvHeader:labels.csvHeader:raw.csv` has only one header with raw question names
- `http://localhost:8080/Questionnaires/OAIP.-csvHeader:labels.csv` has no headers, just the form values

[CARDS-2080]: https://phenotips.atlassian.net/browse/CARDS-2080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ