### PR TITLE
CARDS-1842: Configure the periodic task to export survey data as csv

### DIFF
--- a/modules/scheduled-csv-export/src/main/java/io/uhndata/cards/scheduledcsvexport/ExportConfigDefinition.java
+++ b/modules/scheduled-csv-export/src/main/java/io/uhndata/cards/scheduledcsvexport/ExportConfigDefinition.java
@@ -51,17 +51,21 @@ public @interface ExportConfigDefinition
 
     @AttributeDefinition(name = "Selectors",
         description = "Optional selectors to add to the questionnaire when exporting,"
-        + " e.g. \".labels\" to export labels instead of raw values")
+            + " e.g. \".labels\" to export labels instead of raw values")
     String selectors();
 
     @AttributeDefinition(name = "Save path",
         description = "The local disk path to the directory where exported survey CSV files are to be saved")
     String save_path() default SAVE_PATH;
 
-    @AttributeDefinition(name = "Save file format", description = "The format of the file name. "
+    @AttributeDefinition(name = "Filename format", description = "The format of the file name. "
         + "Special values are {questionnaire} for the questionnaire name, "
         + "{date} for the current date,"
         + "{time} for the current time,"
         + "{period} for the time period being queried")
     String file_name_format() default FILE_NAME_FORMAT;
+
+    @AttributeDefinition(name = "Export format",
+        description = "Whether this should be a CSV or a TSV. Must be one of 'csv' or 'tsv'.")
+    String export_format() default "csv";
 }

--- a/modules/scheduled-csv-export/src/main/java/io/uhndata/cards/scheduledcsvexport/ExportConfigDefinition.java
+++ b/modules/scheduled-csv-export/src/main/java/io/uhndata/cards/scheduledcsvexport/ExportConfigDefinition.java
@@ -19,11 +19,9 @@
 package io.uhndata.cards.scheduledcsvexport;
 
 import org.osgi.service.metatype.annotations.AttributeDefinition;
-import org.osgi.service.metatype.annotations.AttributeType;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
-@ObjectClassDefinition(name = "Survey csv export",
-    description = "Configuration for the Surveys csv exporter")
+@ObjectClassDefinition(name = "Survey csv export", description = "Configuration for the Surveys csv exporter")
 public @interface ExportConfigDefinition
 {
     /** Default value of how often the task should be invoked. */
@@ -34,6 +32,9 @@ public @interface ExportConfigDefinition
 
     /** Default value of the local path where exported survey CSV files should be saved to. */
     String SAVE_PATH = ".";
+
+    /** Default value for the file name format. */
+    String FILE_NAME_FORMAT = "ExportedForms_{questionnaire}_{date}_{time}.csv";
 
     @AttributeDefinition(name = "Name", description = "Configuration name")
     String name();
@@ -48,13 +49,19 @@ public @interface ExportConfigDefinition
         description = "List of questionnaires specified to be exported periodically, as full paths")
     String[] questionnaires_to_be_exported();
 
+    @AttributeDefinition(name = "Selectors",
+        description = "Optional selectors to add to the questionnaire when exporting,"
+        + " e.g. \".labels\" to export labels instead of raw values")
+    String selectors();
+
     @AttributeDefinition(name = "Save path",
         description = "The local disk path to the directory where exported survey CSV files are to be saved")
     String save_path() default SAVE_PATH;
 
-    @AttributeDefinition(
-        name = "Enable labels processor",
-        description = "This property indicates whether the answer labels will be exported instead of the values",
-        type = AttributeType.BOOLEAN)
-    boolean enable_label();
+    @AttributeDefinition(name = "Save file format", description = "The format of the file name. "
+        + "Special values are {questionnaire} for the questionnaire name, "
+        + "{date} for the current date,"
+        + "{time} for the current time,"
+        + "{period} for the time period being queried")
+    String file_name_format() default FILE_NAME_FORMAT;
 }

--- a/modules/scheduled-csv-export/src/main/java/io/uhndata/cards/scheduledcsvexport/ExportEndpoint.java
+++ b/modules/scheduled-csv-export/src/main/java/io/uhndata/cards/scheduledcsvexport/ExportEndpoint.java
@@ -86,8 +86,7 @@ public class ExportEndpoint extends SlingSafeMethodsServlet
             return;
         }
 
-        final Runnable exportJob = new ExportTask(this.resolverFactory, this.rrp, config.frequency_in_days(),
-            config.questionnaires_to_be_exported(), config.save_path(), config.enable_label());
+        final Runnable exportJob = new ExportTask(this.resolverFactory, this.rrp, config);
         final Thread thread = new Thread(exportJob);
         thread.start();
         response.setStatus(200);

--- a/modules/scheduled-csv-export/src/main/java/io/uhndata/cards/scheduledcsvexport/ExportTask.java
+++ b/modules/scheduled-csv-export/src/main/java/io/uhndata/cards/scheduledcsvexport/ExportTask.java
@@ -62,6 +62,8 @@ public class ExportTask implements Runnable
 
     private final String fileNameFormat;
 
+    private final String exportFormat;
+
     ExportTask(final ResourceResolverFactory resolverFactory, final ThreadResourceResolverProvider rrp,
         final ExportConfigDefinition config)
     {
@@ -72,6 +74,7 @@ public class ExportTask implements Runnable
         this.customSelectors = config.selectors();
         this.savePath = config.save_path();
         this.fileNameFormat = config.file_name_format();
+        this.exportFormat = config.export_format();
     }
 
     @Override
@@ -96,8 +99,9 @@ public class ExportTask implements Runnable
                     this.savePath + File.separatorChar + getTargetFileName(questionnaire, timePeriod));
                 try (FileWriter writer = new FileWriter(csvFile)) {
                     final String csvPath = String.format(
-                        questionnaire + "%s.data.dataFilter:modifiedAfter=%s.dataFilter:modifiedBefore=%s.csv",
-                        StringUtils.defaultString(this.customSelectors), modifiedAfterDate, modifiedBeforeDate);
+                        questionnaire + "%s.data.dataFilter:modifiedAfter=%s.dataFilter:modifiedBefore=%s.%s",
+                        StringUtils.defaultString(this.customSelectors), modifiedAfterDate, modifiedBeforeDate,
+                        this.exportFormat);
                     final CSVString csv = resolver.resolve(csvPath).adaptTo(CSVString.class);
                     writer.write(csv.toString());
                 } catch (IOException e) {

--- a/modules/scheduled-csv-export/src/main/java/io/uhndata/cards/scheduledcsvexport/ScheduledExport.java
+++ b/modules/scheduled-csv-export/src/main/java/io/uhndata/cards/scheduledcsvexport/ScheduledExport.java
@@ -75,8 +75,7 @@ public class ScheduledExport
 
         final Runnable csvExportJob;
         csvExportJob =
-            new ExportTask(this.resolverFactory, this.rrp, configDef.frequency_in_days(),
-                configDef.questionnaires_to_be_exported(), configDef.save_path(), configDef.enable_label());
+            new ExportTask(this.resolverFactory, this.rrp, configDef);
         try {
             this.scheduler.schedule(csvExportJob, options);
         } catch (final Exception e) {

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -190,7 +190,7 @@
         "/Questionnaires/OED",
         "/Questionnaires/Rehab"
       ],
-      "selectors": ".labels.dataFilter:status=SUBMITTED.csvHeader:raw",
+      "selectors": ".labels.dataFilter:status=SUBMITTED.csvHeader:raw.questionnaireFilter.questionnaireFilter:exclude=/Questionnaires/CPESIC/OverallRatingofHospital/cpesic_hospital_overall",
       "save.path": ".",
       "file.name.format": "{questionnaire}_{period}_labels.csv",
       "export.format": "csv"
@@ -205,7 +205,7 @@
         "/Questionnaires/OED",
         "/Questionnaires/Rehab"
       ],
-      "selectors": ".dataFilter:status=SUBMITTED.csvHeader:raw",
+      "selectors": ".dataFilter:status=SUBMITTED.csvHeader:raw.questionnaireFilter.questionnaireFilter:exclude=/Questionnaires/CPESIC/OverallRatingofHospital/cpesic_hospital_overall",
       "save.path": ".",
       "file.name.format": "{questionnaire}_{period}.csv",
       "export.format": "csv"
@@ -217,7 +217,7 @@
       "questionnaires.to.be.exported": [
         "/Questionnaires/Survey events"
       ],
-      "selectors": ".dataFilter:statusNot=INCOMPLETE.csvHeader:raw",
+      "selectors": ".dataFilter:statusNot=INCOMPLETE",
       "save.path": ".",
       "file.name.format": "SurveyStatuses_{period}.csv",
       "export.format": "csv"

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -219,7 +219,7 @@
       ],
       "selectors": ".dataFilter:statusNot=INCOMPLETE",
       "save.path": ".",
-      "file.name.format": "SurveyStatuses_{period}.csv",
+      "file.name.format": "{questionnaire}_{period}.csv",
       "export.format": "csv"
     }
   }

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -179,6 +179,48 @@
       "clinicId": "/Survey/ClinicMapping/78840662",
       "emailConfiguration": "/apps/cards/clinics/UHN-Rehab/mailTemplates/ReminderNotification",
       "daysToVisit": -11
+    },
+    "io.uhndata.cards.scheduledcsvexport.ExportConfig~UHN-Labeled-Forms":{
+      "name": "UHN-Labeled-Forms",
+      "frequency.in.days": 7,
+      "export.schedule": "0 0 2 ? * SAT *",
+      "questionnaires.to.be.exported": [
+        "/Questionnaires/CPESIC",
+        "/Questionnaires/OAIP",
+        "/Questionnaires/OED",
+        "/Questionnaires/Rehab"
+      ],
+      "selectors": ".labels.dataFilter:status=SUBMITTED.csvHeader:raw",
+      "save.path": ".",
+      "file.name.format": "{questionnaire}_{period}_labels.csv",
+      "export.format": "csv"
+    },
+    "io.uhndata.cards.scheduledcsvexport.ExportConfig~UHN-Raw-Forms":{
+      "name": "UHN-Raw-Forms",
+      "frequency.in.days": 7,
+      "export.schedule": "0 0 2 ? * SAT *",
+      "questionnaires.to.be.exported": [
+        "/Questionnaires/CPESIC",
+        "/Questionnaires/OAIP",
+        "/Questionnaires/OED",
+        "/Questionnaires/Rehab"
+      ],
+      "selectors": ".dataFilter:status=SUBMITTED.csvHeader:raw",
+      "save.path": ".",
+      "file.name.format": "{questionnaire}_{period}.csv",
+      "export.format": "csv"
+    },
+    "io.uhndata.cards.scheduledcsvexport.ExportConfig~UHN-Survey-Events":{
+      "name": "UHN-Survey-Events",
+      "frequency.in.days": 7,
+      "export.schedule": "0 0 2 ? * SAT *",
+      "questionnaires.to.be.exported": [
+        "/Questionnaires/Survey events"
+      ],
+      "selectors": ".dataFilter:statusNot=INCOMPLETE.csvHeader:raw",
+      "save.path": ".",
+      "file.name.format": "SurveyStatuses_{period}.csv",
+      "export.format": "csv"
     }
   }
 }


### PR DESCRIPTION
To test:

- Build the **CARDS-1842** branch
- Start in prems mode
- On `http://localhost:8080/system/console/configMgr` make sure there are 3 entries for `Survey csv export`
- On `http://localhost:8080/system/console/status-slingscheduler` check that the 3 CSV jobs are scheduled for next Saturday at 02:00
- Stop, checkout and build the **CARDS-1842-test** branch
- Start with `NIGHTLY_NOTIFICATIONS_SCHEDULE="0 * * * * ? *" ./start_cards.sh -P prems --dev`
- Create and fill in a Patient Information form, including name and a valid email address
- Create and fill in a Visit Information form, for UHN-ED, set 7 days ago
- Fill in and submit the the OED form
- Repeat for another patient and another UHN-ED form set 2 days ago
- Repeat for another patient and another UHN-ED form set 7 days ago, but **do not submit** this survey
- Wait 2 minutes
- Using composum at `http://localhost:8080/bin/browser.html/Forms`, **checkout** and change the `jcr:lastModified` date to yesterday for every form
- Wait 1 minute
- On disk, in the directory where cards was started from, check that:
    - `Questionnaires_OED_2023-02-08_2023-02-14_labels.csv` has the contents of the 2 submitted forms with labels for the answers and both headers, but not the unsubmitted form
    - `Questionnaires_OED_2023-02-08_2023-02-14.csv` has the contents of the 2 submitted forms with raw numbers for the answers and both headers, but not the unsubmitted form
    - `Questionnaires_Survey events_2023-02-08_2023-02-14.csv` has both survey from 7 days ago, but not the one from 2 days ago