### PR TITLE
CARDS-2057 - PREMs: UX polishing

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -609,7 +609,7 @@ function QuestionnaireSet(props) {
           disableHeader
           questionnaireAddons={nextQuestionnaire?.questionnaireAddons}
           doneIcon={nextQuestionnaire ? <NextStepIcon /> : <DoneIcon />}
-          doneLabel={nextQuestionnaire ? `${nextQuestionnaire?.alias}` : enableReviewScreen ? "Review" : "Submit my answers"}
+          doneLabel={nextQuestionnaire ? "Next survey" : enableReviewScreen ? "Review" : "Submit my answers"}
           onDone={nextQuestionnaire ? launchNextForm : nextStep}
           doneButtonStyle={{position: "relative", right: 0, bottom: "unset", textAlign: "center"}}
           contentOffset={contentOffset || 0}


### PR DESCRIPTION
This PR tackles this part of CARDS-2057:
> The label of the button that takes the patient to the next survey is confusing

Changed the label to simply say "Next survey" instead of the next survey's alias.