### PR TITLE
[misc] In patient portal, find the clinic answer in the Visit information form json by node name, not by question text

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -257,7 +257,7 @@ function QuestionnaireSet(props) {
         if (!questionnaires) {
           setSubjectData(json);
           setVisitInformation(json[visitInformationFormTitle]?.[0] || {});
-          let clinicPath = Object.values(json[visitInformationFormTitle]?.[0]).find(o => o?.question?.text == "Clinic")?.value;
+          let clinicPath = Object.values(json[visitInformationFormTitle]?.[0]).find(o => o?.question?.["@name"] == "clinic")?.value;
           return fetchWithReLogin(globalLoginDisplay, `${clinicPath}.deep.json`)
             .then((response) => response.ok ? response.json() : Promise.reject(response))
             .then((json) => {


### PR DESCRIPTION
To test:
- in `dev`:
  - change the text of the "Clinic" question in Visit information
  - create a visit with surveys
  - try to complete the surveys as patient -> can't find the surveys
- in this branch:
  - see that a patient can fill in surveys correctly with and without the above steps  