### PR TITLE
[misc] Remove maxAnswers=1 from *_department reference questions in prems surveys

### DIFF
--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/CPESIC.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/CPESIC.xml
@@ -111,11 +111,6 @@ Your response to this survey is voluntary but will provide us with important inf
 			<name>cpesic_department</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
-				<name>maxAnswers</name>
-				<value>1</value>
-				<type>Long</type>
-			</property>
-			<property>
 				<name>dataType</name>
 				<value>text</value>
 				<type>String</type>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/OAIP.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/OAIP.xml
@@ -98,11 +98,6 @@
 			<name>oaip_department</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
-				<name>maxAnswers</name>
-				<value>1</value>
-				<type>Long</type>
-			</property>
-			<property>
 				<name>dataType</name>
 				<value>text</value>
 				<type>String</type>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Rehab.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Rehab.xml
@@ -93,11 +93,6 @@
 			<name>rs_department</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
-				<name>maxAnswers</name>
-				<value>1</value>
-				<type>Long</type>
-			</property>
-			<property>
 				<name>dataType</name>
 				<value>text</value>
 				<type>String</type>


### PR DESCRIPTION
These reference questions copy the value of `Visit information/provider`, which is multi-valued. Placing more than one value in `Visit information/provider` now causes the CPESIC, OAIP, and Rehab forms to be flagged as `INVALID`.

While in production we will always have a single value there and shouldn't have any issues, it is best practice for the referencing question to match the settings of its source.