### PR TITLE
CARDS-2087 - Patient portal: the "Next survey" and "Review" buttons look uncomfortable on narrow screens in paginated surveys with paginationVariant = progress

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -455,6 +455,7 @@ const questionnaireStyle = theme => ({
     paginationButton: {
         float: "right",
         margin: theme.spacing(1),
+        minWidth: "fit-content",
     },
     formStepperBufferBar: {
         backgroundColor: theme.palette.secondary.main,


### PR DESCRIPTION
See screenshots of the issue on jira: [CARDS-2087](https://phenotips.atlassian.net/browse/CARDS-2087).

**Testing:**
* As admin:
  * From the questionnaire wizard, change OAIP and OED to have **Pagination variant**: `progress` (you can also switch **Require completion** to `No` to allow moving through pages faster) 
  * Create a visit to the EDIP "clinic"
* As patient:
  * From the browser's dev tools > device emulator, choose a phone emulator (or simply make the browser window ~400px narrow)
  * Start start filling in the surveys for that visit
  * Observe the look of the "Next" button as you sift through the pages

[CARDS-2087]: https://phenotips.atlassian.net/browse/CARDS-2087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ