### PR TITLE
CARDS-2088 - Patient portal: the "Submit my answers" button can be easily missed on the review screen

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -74,6 +74,12 @@ const useStyles = makeStyles(theme => ({
       textAlign: "center",
     }
   },
+  reviewScreen : {
+    "& > .MuiGrid-item:last-child" : {
+      position: "sticky",
+      bottom: theme.spacing(1),
+    },
+  },
   stepIndicator : {
     border: "1px solid " + theme.palette.action.disabled,
     background: "transparent",
@@ -153,6 +159,8 @@ function QuestionnaireSet(props) {
   const [ error, setError ] = useState("");
   // Screen layout props
   const [ screenType, setScreenType ] = useState();
+  // Subtype for non-survey screens
+  const [screenSubtype, setScreenSubtype ] = useState();
 
   const classes = useStyles();
 
@@ -173,6 +181,19 @@ function QuestionnaireSet(props) {
   useEffect(() => {
     setScreenType(crtStep >= 0 && crtStep < questionnaireIds?.length ? "survey" : "screen");
   }, [crtStep]);
+
+  useEffect(() => {
+    setScreenSubtype(
+      screenType == "screen" ?
+        isComplete ?
+          isSubmitted ?
+            "summaryScreen"
+            :
+            "reviewScreen"
+        : "incompleteScreen"
+      : ""
+    )
+  }, [screenType, isComplete, isSubmitted]);
 
   // Reset the crtFormId when returning to the welcome screen
   useEffect(() => {
@@ -621,8 +642,8 @@ function QuestionnaireSet(props) {
       <Grid item key="review-loading"><CircularProgress/></Grid>
     </Grid>
   ] : [
-    <Typography variant="h4" key="review-title">Please review your answers</Typography>,
-    <Typography paragraph key="review-desc">You can update the response for each question in the survey by using the "Update this Survey" button below.</Typography>,
+    <Typography variant="h4" key="review-title">Please review and submit your answers</Typography>,
+    <FormattedText paragraph key="review-desc">You can update the response for each question in the survey by using the **Update this Survey** button below. After reviewing, please click on **Submit my answers** to send your responses.</FormattedText>,
     <Grid container direction="column" spacing={8} key="review-list">
       {(questionnaireIds || []).map((q, i) => (
       <Grid item key={q+"Review"}>
@@ -721,7 +742,7 @@ function QuestionnaireSet(props) {
         subtitle={questionnaires[questionnaireIds[crtStep]]?.title}
         step={stepIndicator(crtStep, true)}
       />
-      <QuestionnaireSetScreen className={classes[screenType]} key="screen">
+      <QuestionnaireSetScreen className={classes[screenType] + (screenSubtype && classes[screenSubtype] ? (" " + classes[screenSubtype]) : "")} key="screen">
         {
           crtStep == -1 ? welcomeScreen :
           crtStep < questionnaireIds.length ? formScreen :


### PR DESCRIPTION
See [CARDS-2088](https://phenotips.atlassian.net/browse/CARDS-2088) on Jira.

**Changes made:**
* Mentioned in the title and instructions at the top of the review page that they must submit after reviewing
* Made the submit button always visible, sticky at the bottom of the screen

**Testing:**
* As admin, create a visit with surveys (ED recommended since it's the shortest)
* As patient, fill in the survey to advance to the review screen, check if it's clearer now that answers must be submitted

![image](https://user-images.githubusercontent.com/651980/219452936-ec3611c4-2c97-42cc-a7ac-f9aeee982382.png)


[CARDS-2088]: https://phenotips.atlassian.net/browse/CARDS-2088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ