### PR TITLE
CARDS-2092: Make the schema and table name used by Clarity Import configurable

### DIFF
--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -896,6 +896,8 @@ if args.mssql:
   yaml_obj['services']['cardsinitial']['environment'].append('CLARITY_SQL_USERNAME=sa')
   yaml_obj['services']['cardsinitial']['environment'].append('CLARITY_SQL_PASSWORD=testPassword_')
   yaml_obj['services']['cardsinitial']['environment'].append('CLARITY_SQL_ENCRYPT=false')
+  yaml_obj['services']['cardsinitial']['environment'].append('CLARITY_SQL_SCHEMA=path')
+  yaml_obj['services']['cardsinitial']['environment'].append('CLARITY_SQL_TABLE=CL_EP_IP_EMAIL_CONSENT_IN_LAST_7_DAYS')
   if args.expose_mssql:
     yaml_obj['services']['mssql']['ports'] = ['127.0.0.1:{}:1433'.format(args.expose_mssql)]
 

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
@@ -410,7 +410,7 @@ public class ClarityImportTask implements Runnable
                 queryString += ", ";
             }
         }
-        queryString += " FROM path.CL_EP_IP_EMAIL_CONSENT_IN_LAST_7_DAYS";
+        queryString += " FROM " + System.getenv("CLARITY_SQL_SCHEMA") + "." + System.getenv("CLARITY_SQL_TABLE");
         queryString += " WHERE CAST(LoadTime AS DATE) = CAST(GETDATE()-" + this.pastDayToQuery + " AS DATE);";
 
         return queryString;


### PR DESCRIPTION
This PR implements CARDS-2092 by making the Clarity import schema and table name configurable through the `CLARITY_SQL_SCHEMA` and `CLARITY_SQL_TABLE` environment variables.

### Testing Instructions

1. Build this (`CARDS-2092`) branch, including a Docker image, with `mvn clean install -Pdocker`.
2. `cd compose-cluster`.
3. Ensure that no other Docker environments are running (`docker ps -a` and `docker volume ls` should both return empty lists)
4. Clean up any previous Docker Compose configuration with `./cleanup.sh`
5. `python3 generate_compose_yaml.py --dev_docker_image --oak_filesystem --composum --adminer --cards_project cards4prems --mssql`
6. `docker-compose build && docker-compose up -d`
7. Navigate to http://localhost:1435/ to access adminer. Login with the following credentials:
    - System: `MS SQL (beta)`
    - Server: `mssql`
    - Username: `sa`
    - Password: `testPassword_`
    - Database: `master`
8. On the left bar, click _Import_, upload the `compose-cluster/mssql/importTestSql.sql` file, and click _Execute_.
9. Visit http://localhost:8080 and login as `admin`:`admin`.
10. In a new tab, visit http://localhost:8080/Subjects.importClarity
11. Refresh the tab showing the main CARDS dashboard.
12. _9_ new _Patients_ should be created
13. Stop and clean up everything with `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`