### PR TITLE
CARDS-2081: Regression: `Surveys completed` does not get set upon completion of the surveys by patient

### DIFF
--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
@@ -120,6 +120,8 @@ public class VisitChangeListener implements ResourceChangeListener
         boolean mustPopResolver = false;
         try (ResourceResolver localResolver = this.resolverFactory
             .getServiceResourceResolver(Map.of(ResourceResolverFactory.SUBSERVICE, "VisitFormsPreparation"))) {
+            this.rrp.push(localResolver);
+            mustPopResolver = true;
             // Get the information needed from the triggering form
             final Session session = localResolver.adaptTo(Session.class);
             if (!session.nodeExists(event.getPath())) {
@@ -130,8 +132,6 @@ public class VisitChangeListener implements ResourceChangeListener
             if (!this.formUtils.isForm(form)) {
                 return;
             }
-            this.rrp.push(localResolver);
-            mustPopResolver = true;
             final Node questionnaire = this.formUtils.getQuestionnaire(form);
             final Node subject = this.formUtils.getSubject(form);
 


### PR DESCRIPTION
The cause of the bug is that the restriction that doesn't let the visit backend service user see the Survey Events forms wasn't active. The cause of that bug is that the restriction pattern is instantiated the first time the session is used, which happens to be the `!session.nodeExists` call at line 125, at which point there was no session pushed into the resolver. Lesson learned: always push the resolver right after it is created, don't try to optimize by delaying the push until it is really needed.

To test:
- start in prems mode
- create a visit information form
- generate a token for the visit
- complete the survey as a patient
- check that the visit is marked as complete