### PR TITLE
CARDS-2101: Clarity import: discard patients with no MRN

### DIFF
--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
@@ -454,6 +454,9 @@ public class ClarityImportTask implements Runnable
         for (ClaritySubjectMapping childSubjectMapping : subjectMapping.childSubjects) {
             // Get or create the subject
             Resource newSubjectParent = getOrCreateSubject(resolver, row, childSubjectMapping, subjectParent);
+            if (newSubjectParent == null) {
+                return;
+            }
 
             for (ClarityQuestionnaireMapping questionnaireMapping : childSubjectMapping.questionnaires) {
                 boolean updatesExisting = questionnaireMapping.updatesExisting;
@@ -501,6 +504,10 @@ public class ClarityImportTask implements Runnable
         final String identifier = (!"".equals(subjectMapping.subjectIdColumn))
             ? row.get(subjectMapping.subjectIdColumn) : UUID.randomUUID().toString();
         final String incrementMetricOnCreation = subjectMapping.incrementMetricOnCreation;
+
+        if (StringUtils.isEmpty(identifier)) {
+            return null;
+        }
 
         String subjectMatchQuery = String.format(
             "SELECT * FROM [cards:Subject] as subject WHERE subject.'identifier'='%s' option (index tag property)",


### PR DESCRIPTION
I haven't seem such entries in the test database, but in theory the schema does allow `NULL` for that column.