### PR TITLE
[misc] The default survey page looks unbalanced on narrow screens due to logo size

### DIFF
--- a/modules/commons/src/main/frontend/src/components/ErrorPage.jsx
+++ b/modules/commons/src/main/frontend/src/components/ErrorPage.jsx
@@ -38,6 +38,7 @@ const useStyles = makeStyles(theme => ({
   },
   logo: {
     maxWidth: "360px",
+    width: "100%",
   },
   extendedIcon: {
     marginRight: theme.spacing(1),


### PR DESCRIPTION
The following screenshots are taken on Chrome's Samsung Galaxy S8+ emulator.

Before:

![image](https://user-images.githubusercontent.com/651980/220523199-e0aa5729-5a24-4f1b-b158-651bcb000e79.png)

After:

![image](https://user-images.githubusercontent.com/651980/220523424-0adcb377-9f7b-480b-9554-dd8ff3996a96.png)
