### PR TITLE
[misc] Terms of Use dialog: long links cause horizontal scrollbar on narrow screens

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/ToUDialog.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/ToUDialog.jsx
@@ -45,6 +45,9 @@ const useStyles = makeStyles(theme => ({
       borderLeft: "0 none",
       color: "inherit",
       fontStyle: "italic",
+      "& a" : {
+        wordBreak: "break-all",
+      },
     }
   },
   actionErrorMessage: {


### PR DESCRIPTION
The following screenshots are taken on Chrome's Samsung Galaxy S8+ emulator.

Before:

![image](https://user-images.githubusercontent.com/651980/220527712-f1515a21-5d99-465e-9867-0240ddf984f1.png)

After:

![image](https://user-images.githubusercontent.com/651980/220527823-6891f893-029b-4969-9e65-09b532514f1b.png)
