### PR TITLE
CARDS-2106: Question matrix sub-questions should support text formatting

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionMatrix.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionMatrix.jsx
@@ -28,7 +28,6 @@ import {
   TableCell,
   TableHead,
   TableRow,
-  Typography
 } from "@mui/material";
 import withStyles from '@mui/styles/withStyles';
 import useMediaQuery from '@mui/material/useMediaQuery';
@@ -252,7 +251,7 @@ let QuestionMatrix = (props) => {
   let renderQuestion = (question, hasWarningFlags) => {
     return (
       <TableCell component="th" >
-        <Typography color={ hasWarningFlags ? 'error' : 'inherit'}>{question.text}</Typography>
+        <FormattedText color={ hasWarningFlags ? 'error' : 'inherit'}>{question.text}</FormattedText>
         { question.description &&
           <FormattedText variant="caption" display="block" color="textSecondary">
             { question.description }

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/QuestionMatrixEntry.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/QuestionMatrixEntry.json
@@ -1,6 +1,6 @@
 [
   {
-    "text": "string",
+    "text": "markdown",
     "description": "markdown"
   }
 ]


### PR DESCRIPTION
Testing:
* start with `--test`
* edit the `Question Matrix Test` questionnaire to add formatting to sub-questions
* create a `Question Matrix Test` form and test it in edit and view modes, with both incomplete and complete answers