### PR TITLE
[misc] generate_compose_yaml.py should ask for the hostname when emails are enabled

### DIFF
--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -109,7 +109,7 @@ def getArgValueOrPrompt(arg_name):
     getArgValueOrPrompt.kv_map = {}
 
   # If this argument has been in the command-line, simply return it
-  if arg_name in vars(args):
+  if (arg_name in vars(args)) and (vars(args)[arg_name] is not None):
     return vars(args)[arg_name]
   else:
     # ...otherwise prompt and store the key -> value pair for future use

--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -108,7 +108,7 @@ def getArgValueOrPrompt(arg_name):
   if not hasattr(getArgValueOrPrompt, "kv_map"):
     getArgValueOrPrompt.kv_map = {}
 
-  # If this argument has been in the command-line, simply return it
+  # If this argument has been specified in the command-line, simply return it
   if (arg_name in vars(args)) and (vars(args)[arg_name] is not None):
     return vars(args)[arg_name]
   else:

--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -667,6 +667,12 @@ if args.smtps:
   yaml_obj['services']['cardsinitial']['environment'].append("SMTPS_ENABLED=true")
   yaml_obj['services']['cardsinitial']['environment'].append("SLING_COMMONS_CRYPTO_PASSWORD=password")
 
+  if args.server_address:
+    cards_server_address = args.server_address
+  else:
+    cards_server_address = input("Enter the public-facing server address for this deployment (eg. localhost:8080): ")
+  yaml_obj['services']['cardsinitial']['environment'].append("CARDS_HOST_AND_PORT={}".format(cards_server_address))
+
 if args.smtps_localhost_proxy:
   yaml_obj['services']['cardsinitial']['environment'].append("SMTPS_HOST=smtps_localhost_proxy")
   yaml_obj['services']['cardsinitial']['environment'].append("SMTPS_LOCALHOST_PROXY=true")


### PR DESCRIPTION
The code is copied from how `args.saml` is handled. Is there a way to not have to duplicate this code?