### PR TITLE
CARDS-2118: Add an Unsubscribe link in the footer + CARDS-2119: The unsubscribe page looks sloppy

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Footer.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Footer.jsx
@@ -18,6 +18,7 @@
 //
 import React, { useState, useEffect } from "react";
 import {
+  Breadcrumbs,
   Toolbar,
   Typography
 } from "@mui/material";
@@ -57,12 +58,14 @@ function Footer (props) {
 
   return (
     <Toolbar className={classes.footer}>
+    <Breadcrumbs separator="·">
     {
       footerExtensions.map((extension, index) => {
         let Extension = extension["cards:extensionRender"];
         return <Typography variant="caption" key={index}><Extension /></Typography>
       })
     }
+    </Breadcrumbs>
     </Toolbar>
   );
 }

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Footer.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Footer.jsx
@@ -18,9 +18,8 @@
 //
 import React, { useState, useEffect } from "react";
 import {
-  Breadcrumbs,
+  Link,
   Toolbar,
-  Typography
 } from "@mui/material";
 
 import makeStyles from '@mui/styles/makeStyles';
@@ -39,13 +38,16 @@ const useStyles = makeStyles(theme => ({
     color: theme.palette.text.secondary,
     justifyContent: "center",
     minHeight: theme.spacing(2),
-    "& > *" : {
-      margin: theme.spacing(0, 2),
+    "& > * + *:before" : {
+      content: '"·"',
+      display: "inline-block",
+      margin: theme.spacing(0, 1),
+      opacity: 0.5,
     },
   },
 }));
 
-function Footer (props) {
+export default function Footer (props) {
   let [ footerExtensions, setFooterExtensions ] = useState([]);
 
   const classes = useStyles();
@@ -58,16 +60,25 @@ function Footer (props) {
 
   return (
     <Toolbar className={classes.footer}>
-    <Breadcrumbs separator="·">
     {
       footerExtensions.map((extension, index) => {
         let Extension = extension["cards:extensionRender"];
-        return <Typography variant="caption" key={index}><Extension /></Typography>
+        return <Extension key={index} />
       })
     }
-    </Breadcrumbs>
     </Toolbar>
   );
 }
 
-export default Footer;
+export function FooterLink (props) {
+  return (
+    <span>
+      <Link
+        color="inherit"
+        variant="body2"
+        underline="hover"
+        {...props}
+      />
+    </span>
+  );
+}

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/ToULink.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/ToULink.jsx
@@ -17,24 +17,19 @@
 //  under the License.
 //
 import React, { useState } from "react";
-import {
-  Link,
-} from "@mui/material";
+import { FooterLink } from "./Footer";
 import ToUDialog from "./ToUDialog.jsx";
 
 function ToULink (props) {
   const [ showTou, setShowTou ] = useState(false);
 
   return (<>
-    <Link
+    <FooterLink
       component="button"
-      color="inherit"
-      variant="body2"
       onClick={() => {setShowTou(true);}}
-      underline="hover"
     >
       Terms of Use and Privacy Policy
-    </Link>
+    </FooterLink>
     <ToUDialog
       open={showTou}
       onClose={() => {setShowTou(false);}}

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/ToULink.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/ToULink.jsx
@@ -25,8 +25,8 @@ function ToULink (props) {
 
   return (<>
     <FooterLink
-      component="button"
-      onClick={() => {setShowTou(true);}}
+      href="#TermsOfUse"
+      onClick={event => {event.preventDefault(); setShowTou(true);}}
     >
       Terms of Use and Privacy Policy
     </FooterLink>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/UnsubscribeLink.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/UnsubscribeLink.jsx
@@ -17,23 +17,19 @@
 //  under the License.
 //
 import React, { useState } from "react";
-import {
-  Link,
-} from "@mui/material";
+
+import { FooterLink } from "./Footer";
 
 function UnsubscribeLink (props) {
 
   let auth_token = new URLSearchParams(window.location.search).get("auth_token");
 
   return (auth_token ?
-    <Link
-      color="inherit"
-      variant="body2"
-      underline="hover"
+    <FooterLink
       href={`/Survey.unsubscribe.html?auth_token=${auth_token}`}
     >
       Unsubscribe
-    </Link>
+    </FooterLink>
     : null);
 }
 

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/UnsubscribeLink.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/UnsubscribeLink.jsx
@@ -1,0 +1,40 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+import React, { useState } from "react";
+import {
+  Link,
+} from "@mui/material";
+
+function UnsubscribeLink (props) {
+
+  let auth_token = new URLSearchParams(window.location.search).get("auth_token");
+
+  return (auth_token ?
+    <Link
+      color="inherit"
+      variant="body2"
+      underline="hover"
+      href={`/Survey.unsubscribe.html?auth_token=${auth_token}`}
+    >
+      Unsubscribe
+    </Link>
+    : null);
+}
+
+export default UnsubscribeLink;

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/unsubscribe.jsx
@@ -37,9 +37,31 @@ const useStyles = makeStyles(theme => ({
       textAlign: "center",
     },
   },
-  logo: {
-    maxWidth: "240px",
+  logo : {
+    "& > img" : {
+      maxWidth: "240px",
+    },
+    "@media (max-height: 725px)" : {
+      "& > img" : {
+        maxHeight: "70px",
+      },
+    },
   },
+  doubleLogo : {
+    display: "flex",
+    justifyContent: "center",
+    flexWrap: "wrap-reverse",
+    maxWidth: "600px !important",
+    "& > img" : {
+      width: `calc(50% - ${theme.spacing(4)})`,
+      minWidth: "100px",
+      height: "fit-content",
+      margin: theme.spacing(1, 2),
+    },
+  },
+  submit : {
+    marginTop: theme.spacing(5),
+  }
 }));
 
 function Unsubscribe (props) {
@@ -48,6 +70,16 @@ function Unsubscribe (props) {
   const [ error, setError ] = useState();
   const [ alreadyUnsubscribed, setAlreadyUnsubscribed ] = useState(false);
   const classes = useStyles();
+
+  useEffect(() => {
+    fetch("/Survey.unsubscribe", {method: 'GET'})
+      .then( (response) => response.ok ? response.json() : Promise.reject(response) )
+      .then( json => json.status == "success" ? setAlreadyUnsubscribed(json.unsubscribed) : Promise.reject(json.error))
+      .catch((response) => {
+        let errMsg = "Cannot unsubscribe: ";
+        setError(errMsg + (response.status ? response.statusText : response));
+      });
+  }, []);
 
   let unsubscribe = (value) => {
     let request_data = new FormData();
@@ -72,15 +104,10 @@ function Unsubscribe (props) {
     );
   }
 
-  useEffect(() => {
-    fetch("/Survey.unsubscribe", {method: 'GET'})
-      .then( (response) => response.ok ? response.json() : Promise.reject(response) )
-      .then( json => json.status == "success" ? setAlreadyUnsubscribed(json.unsubscribed) : Promise.reject(json.error))
-      .catch((response) => {
-        let errMsg = "Cannot unsubscribe: ";
-        setError(errMsg + (response.status ? response.statusText : response));
-      });
-  }, []);
+  let appName = document.querySelector('meta[name="title"]')?.content;
+
+  const logo = document.querySelector('meta[name="logoLight"]').content;
+  const affiliationLogo = document.querySelector('meta[name="affiliationLogo"]')?.content;
 
   return (
     <Paper className={classes.paper} elevation={0}>
@@ -91,8 +118,9 @@ function Unsubscribe (props) {
           alignItems="center"
           alignContent="center"
         >
-          <Grid item>
-            <img src={document.querySelector('meta[name="logoLight"]').content} alt="" className={classes.logo}/>
+          <Grid item className={affiliationLogo ? classes.doubleLogo : classes.logo} xs={12}>
+            <img src={logo} alt="logo" />
+            {affiliationLogo && <img src={affiliationLogo} alt="logo" />}
           </Grid>
           <Grid item>
             { error && <Alert severity="error">
@@ -102,7 +130,7 @@ function Unsubscribe (props) {
             }
             { alreadyUnsubscribed ?
               <>
-                <Alert icon={false} severity="info">You are already unsubscribed.</Alert>
+                <Alert icon={false} severity="info">{ `You are already unsubscribed from ${appName}.` }</Alert>
                 <Button
                   type="submit"
                   variant="contained"
@@ -114,20 +142,32 @@ function Unsubscribe (props) {
                 </Button>
               </>
               : confirmed !== null ?
-              <Alert icon={false} severity="info">
-                You have been {confirmed ? "unsubscribed" : "resubscribed"}.
-              </Alert>
+              <>
+                <Alert icon={false} severity="info">
+                  You have been {confirmed ? "unsubscribed from" : "resubscribed to"} {appName}.
+                </Alert>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  color="primary"
+                  className={classes.submit}
+                  onClick={() => unsubscribe(1-confirmed)}
+                  >
+                  {confirmed ? "Resubscribe" : "Unsubscribe"}
+                </Button>
+              </>
               :
-              <><Typography>This will unsubscribe you from receiving all emails via DATA-PRO. If you wish to unsubscribe from all UHN communication, please contact your care team.</Typography>
-              <Button
-                type="submit"
-                variant="contained"
-                color="primary"
-                className={classes.submit}
-                onClick={() => unsubscribe(1)}
-                >
-                Unsubscribe
-              </Button>
+              <>
+                <Typography>{`This will unsubscribe you from all ${appName} emails.`}</Typography>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  color="primary"
+                  className={classes.submit}
+                  onClick={() => unsubscribe(1)}
+                  >
+                  Unsubscribe
+                </Button>
               </>
             }
           </Grid>

--- a/modules/patient-portal/src/main/frontend/webpack.config.js
+++ b/modules/patient-portal/src/main/frontend/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = {
     [module_name + 'index']: './src/patient-portal/index.jsx',
     [module_name + 'unsubscribe']: './src/patient-portal/unsubscribe.jsx',
     [module_name + 'ToULink']: './src/patient-portal/ToULink.jsx',
+    [module_name + 'UnsubscribeLink']: './src/patient-portal/UnsubscribeLink.jsx',
     [module_name + 'ClinicDashboard']: './src/patient-portal/ClinicDashboard.jsx',
     [module_name + 'ClinicForms']: './src/patient-portal/ClinicForms.jsx',
     [module_name + 'ClinicVisits']: './src/patient-portal/ClinicVisits.jsx',

--- a/modules/patient-portal/src/main/resources/SLING-INF/content/Extensions/Footer/Unsubscribe.json
+++ b/modules/patient-portal/src/main/resources/SLING-INF/content/Extensions/Footer/Unsubscribe.json
@@ -1,0 +1,7 @@
+{
+  "jcr:primaryType": "cards:Extension",
+  "cards:extensionPointId": "patient-portal/footer",
+  "cards:extensionName": "Unsubscribe",
+  "cards:extensionRenderURL": "asset:patient-portal.UnsubscribeLink.js",
+  "cards:defaultOrder": 20
+}


### PR DESCRIPTION
**Includes:**
* [CARDS-2118](https://phenotips.atlassian.net/browse/CARDS-2118) - Patient portal: add an Unsubscribe link in the footer
* [CARDS-2119](https://phenotips.atlassian.net/browse/CARDS-2119) - Patient portal: the unsubscribe page looks sloppy

**Testing:**
* start `prems`
* go to `/Survey.html` without a token - there should be no Unsubscribe link (it only appears when the patient is authenticated)
* as admin, create a Patient information form (can be left empty) and a Visit information form with any survey
* as patient, go to the link for filling out that survey -> notice the unsubscribe link in the footer
* click on Unsubscribe and follow instructions
* once unsubscribed, open the Patient information form and check that the "unsubscribed" answer is set accordingly
* bonus: start in `proms` and do similar testing

**Reviewing:**
* commit by commit, ignoring whitespace recommended

**Preview:**
![image](https://user-images.githubusercontent.com/651980/221086166-5c9394f9-3a3e-4933-a988-5e3b9e9433c1.png)

![image](https://user-images.githubusercontent.com/651980/221086101-8e5006c2-4cce-469b-bfa4-0f40590c6e11.png)


[CARDS-2118]: https://phenotips.atlassian.net/browse/CARDS-2118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CARDS-2119]: https://phenotips.atlassian.net/browse/CARDS-2119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ