### PR TITLE
CARDS-2123: Bad data in one form can prevent all further changes from being imported

### DIFF
--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
@@ -269,10 +269,8 @@ public class ClarityImportTask implements Runnable
                 try {
                     createFormsAndSubjects(resolver, results);
                     session.save();
-                } catch (PersistenceException e) {
-                    LOGGER.error("PersistenceException while importing data to JCR", e);
-                } catch (ParseException e) {
-                    LOGGER.error("ParseException while importing data to JCR");
+                } catch (ParseException | PersistenceException e) {
+                    LOGGER.error("Exception while importing data to JCR", e);
                 } catch (Exception e) {
                     LOGGER.error("Unhandled exception while importing data: {}", e.getMessage(), e);
                 } finally {

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
@@ -268,16 +268,20 @@ public class ClarityImportTask implements Runnable
                 // Create the Subjects and Forms as is needed
                 try {
                     createFormsAndSubjects(resolver, results);
+                    session.save();
                 } catch (PersistenceException e) {
                     LOGGER.error("PersistenceException while importing data to JCR", e);
                 } catch (ParseException e) {
                     LOGGER.error("ParseException while importing data to JCR");
                 } catch (Exception e) {
                     LOGGER.error("Unhandled exception while importing data: {}", e.getMessage(), e);
+                } finally {
+                    // If everything was saved successfully, this shouldn't discard anything; but if there was an error,
+                    // without discarding the bad data all the subsequent saves would fail too
+                    session.refresh(false);
                 }
             }
 
-            session.save();
             checkinNodes();
             updatePerformanceCounters();
 


### PR DESCRIPTION
I didn't test this yet. To test:

- start in docker mode with adminer and mssql
- import the sample patients from processorImportTestSql.sql
- check that everything was correctly imported
- import the sample patients again
- check that no duplicates were created