### PR TITLE
CARDS-2127: Reusable Logo component; CARDS-2125: Affiliation logo on the login page; CARDS-2126: Affiliation logo on error pages

### DIFF
--- a/modules/commons/src/main/frontend/src/components/ErrorPage.jsx
+++ b/modules/commons/src/main/frontend/src/components/ErrorPage.jsx
@@ -23,6 +23,7 @@ import makeStyles from '@mui/styles/makeStyles';
 
 import NavigationIcon from '@mui/icons-material/Navigation';
 
+import Logo from "./Logo";
 import FormattedText from "./FormattedText";
 
 const useStyles = makeStyles(theme => ({
@@ -35,10 +36,6 @@ const useStyles = makeStyles(theme => ({
     "& .MuiGrid-item" : {
       textAlign: "center",
     },
-  },
-  logo: {
-    maxWidth: "360px",
-    width: "100%",
   },
   extendedIcon: {
     marginRight: theme.spacing(1),
@@ -58,9 +55,7 @@ export default function ErrorPage(props) {
           alignItems="center"
           alignContent="center"
         >
-          <Grid item>
-            <img src={document.querySelector('meta[name="logoLight"]').content} alt="" className={classes.logo}/>
-          </Grid>
+          <Logo maxWidth="360px" component={Grid} item/>
           <Grid item>
             {errorCode && <Typography variant="h1" color={errorCodeColor || "primary"}>
               {errorCode}

--- a/modules/commons/src/main/frontend/src/components/Logo.jsx
+++ b/modules/commons/src/main/frontend/src/components/Logo.jsx
@@ -1,0 +1,85 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Box } from '@mui/material';
+import makeStyles from '@mui/styles/makeStyles';
+
+const useStyles = makeStyles(theme => ({
+  logo : {
+    "& > img" : {
+      maxWidth: "240px",
+      width: "100%",
+    },
+    "@media (max-height: 725px)" : {
+      "& > img" : {
+        maxHeight: "70px",
+      },
+    },
+  },
+  doubleLogo : {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    flexWrap: "wrap-reverse",
+    maxWidth: "600px !important",
+    "& > img" : {
+      width: `calc(50% - ${theme.spacing(4)})`,
+      minWidth: "100px",
+      height: "fit-content",
+      margin: theme.spacing(1, 2),
+    },
+  },
+}));
+
+export default function Logo(props) {
+  const { component, mode, className, maxWidth, disableAffiliation, ...rest } = props;
+  const classes = useStyles();
+
+  const appName = document.querySelector('meta[name="title"]')?.content;
+  const logo = document.querySelector(`meta[name="logo${mode}"]`).content;
+  const affiliationLogo = document.querySelector(`meta[name="affiliationLogo${mode}"]`)?.content;
+  const withAffiliation = !disableAffiliation && !!affiliationLogo;
+
+  const Component = component;
+  const style = typeof(maxWidth) != "undefined" ? {maxWidth: maxWidth} : {};
+  let classNames = withAffiliation ? [classes.doubleLogo] : [classes.logo];
+  if (className) classNames.push(className);
+
+  return (
+    <Component className={classNames.join(' ')} {...rest} >
+      <img src={logo} alt={appName} style={style} />
+      {withAffiliation && <img src={affiliationLogo} alt="" style={style} />}
+    </Component>
+  );
+}
+
+Logo.propTypes = {
+  component: PropTypes.object,
+  mode: PropTypes.oneOf(["Light", "Dark"]),
+  className: PropTypes.string,
+  maxWidth: PropTypes.string,
+  disableAffiliation: PropTypes.bool,
+}
+
+Logo.defaultProps = {
+  component: Box,
+  mode: "Light",
+}

--- a/modules/login/src/main/frontend/src/login/loginMainComponent.js
+++ b/modules/login/src/main/frontend/src/login/loginMainComponent.js
@@ -17,11 +17,13 @@
 //  under the License.
 //
 import React from 'react';
-import SignUpForm from './signUpForm';
-import SignIn from './loginForm';
 
 import { Breadcrumbs, Button, Grid, Paper, Tooltip, Typography } from '@mui/material';
 import { withStyles } from '@mui/styles';
+
+import SignUpForm from './signUpForm';
+import SignIn from './loginForm';
+import Logo from "../components/Logo";
 
 import styles from "../styling/styles";
 
@@ -50,9 +52,7 @@ class MainLoginContainer extends React.Component {
     return (
         <Paper className={`${classes.paper}  ${selfContained ? classes.selfContained : ''}`} elevation={0}>
           <Grid container direction="column" spacing={3} alignItems="center" alignContent="center">
-            <Grid item>
-              <img src={document.querySelector('meta[name="logoLight"]').content} alt="" className={classes.logo}/>
-            </Grid>
+            <Logo maxWidth="200px" component={Grid} item />
             <Grid item>
             { this.state.signInShown ? <SignIn handleLogin={this.props.handleLogin} redirectOnLogin={this.props.redirectOnLogin}/> : <SignUpForm loginOnSuccess={true} handleLogin={this.props.handleLogin} /> }
             </Grid>

--- a/modules/login/src/main/frontend/src/styling/styles.js
+++ b/modules/login/src/main/frontend/src/styling/styles.js
@@ -36,9 +36,6 @@ const styles = theme => ({
     marginTop: theme.spacing(10),
     marginBottom: theme.spacing(2),
   },
-  logo: {
-    maxWidth: "200px",
-  },
   form: {
     width: '100%', // Fix IE 11 issue.
     marginTop: theme.spacing(1),

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Header.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Header.jsx
@@ -99,7 +99,7 @@ function Header (props) {
     : <></>;
 
   const logo = document.querySelector('meta[name="logoLight"]').content;
-  const affiliationLogo = document.querySelector('meta[name="affiliationLogo"]')?.content;
+  const affiliationLogo = document.querySelector('meta[name="affiliationLogoLight"]')?.content;
 
   return (
     <>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Header.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Header.jsx
@@ -31,6 +31,8 @@ import {
 
 import makeStyles from '@mui/styles/makeStyles';
 
+import Logo from "../components/Logo";
+
 const useStyles = makeStyles(theme => ({
   appbar : {
     margin: theme.spacing(-1, -1, 4),
@@ -48,22 +50,47 @@ const useStyles = makeStyles(theme => ({
     background: theme.palette.background.paper,
     paddingTop: theme.spacing(1),
     paddingBottom: theme.spacing(1),
+    "& > .cards-patientPortal-surveyTitle" : {
+      "@media (max-width: 500px)" : {
+        display: "none",
+      },
+    },
   },
-  titleLine : {
-    display: "flex",
-    alignItems: "center",
-    "& * + *" : {
-      marginLeft: theme.spacing(4),
+  withAffiliation : {
+    display: "block",
+    "& > .cards-patientPortal-surveyTitle" : {
+      textAlign: "center",
+      margin: "-4rem 140px 0",
+    },
+    "& > .MuiBreadcrumbs-root" : {
+       width: "fit-content",
+       margin: "auto",
     }
   },
   logo : {
-    maxHeight: theme.spacing(6),
-    "@media (max-width: 500px)" : {
-      maxHeight: theme.spacing(4),
+    maxWidth: "780px !important",
+    "& > img" : {
+      "@media (max-width: 500px)" : {
+        maxHeight: theme.spacing(4),
+      }
+    }
+  },
+  sideMenu : {
+    float: "right",
+    textAlign: "right",
+    width: "160px",
+    "& .MuiBreadcrumbs-ol": {
+      display: "block",
+    },
+    "& .MuiBreadcrumbs-separator": {
+      display: "none",
+    },
+    "& .MuiBreadcrumbs-li:not(:last-child)": {
+      marginBottom: theme.spacing(1),
     }
   },
   greeting: {
-    "@media (max-width: 600px)" : {
+    "@media (max-width: 500px)" : {
       display: "none",
     },
   },
@@ -98,25 +125,20 @@ function Header (props) {
     </Toolbar>
     : <></>;
 
-  const logo = document.querySelector('meta[name="logoLight"]').content;
-  const affiliationLogo = document.querySelector('meta[name="affiliationLogoLight"]')?.content;
+  const withAffiliation = !!(document.querySelector('meta[name="affiliationLogoLight"]')?.content);
+
+  let toolbarClassNames = [classes.toolbar];
+  if (withAffiliation) toolbarClassNames.push(classes.withAffiliation);
 
   return (
     <>
     <AppBar position="sticky" className={classes.appbar}>
       <Collapse in={!subtitle || !(scrollTrigger)}>
-        <Toolbar variant="dense" className={classes.toolbar}>
-          <div className={classes.titleLine}>
-            <img src={logo} alt="logo" className={classes.logo} />
-            { title &&
-              <Typography variant="overline" color="textPrimary">{ title }</Typography>
-            }
-          </div>
-          { affiliationLogo &&
-            <img src={affiliationLogo} alt="logo" className={classes.logo} />
-          }
+        <Toolbar variant="dense" className={toolbarClassNames.join(' ')}>
+          <Logo className={classes.logo} maxWidth="160px" />
+          { title && <Typography variant="overline" color="textPrimary" component="div" className="cards-patientPortal-surveyTitle">{ title }</Typography>}
           { (greeting || withSignout) &&
-            <Breadcrumbs separator = "·">
+            <Breadcrumbs separator="·" className={!withAffiliation ? classes.sideMenu : undefined}>
             { greeting && <span className={classes.greeting}>{ greeting }</span>}
             { withSignout &&
               <Link href="/system/sling/logout" underline="hover" onClick={(event) => {event.preventDefault(); window.location = "/system/sling/logout?resource=" + encodeURIComponent(window.location.pathname);}}>Sign out</Link>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/LandingPage.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/LandingPage.jsx
@@ -31,6 +31,8 @@ import {
 
 import makeStyles from '@mui/styles/makeStyles';
 
+import Logo from '../components/Logo';
+
 const useStyles = makeStyles(theme => ({
   paper: {
     display: 'flex',
@@ -39,7 +41,6 @@ const useStyles = makeStyles(theme => ({
     height: '100%',
   },
   logo : {
-    maxWidth: "200px",
     marginBottom: theme.spacing(5),
     marginTop: theme.spacing(9.5),
   },
@@ -85,9 +86,7 @@ function LandingPage(props) {
     >
           <DialogContent className={classes.paper}>
             <Grid container direction="column" spacing={2} alignItems="center" alignContent="center">
-              <Grid item>
-                <img src={document.querySelector('meta[name="logoLight"]').content} alt="" className={classes.logo} />
-              </Grid>
+              <Logo component={Grid} item className={classes.logo} maxWidth="200px" />
               <Grid item>
                 <Typography variant="h6">I am a...</Typography>
               </Grid>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
@@ -39,6 +39,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import CloseIcon from '@mui/icons-material/Close';
 import AppointmentIcon from '@mui/icons-material/Event';
 
+import Logo from "../components/Logo.jsx";
 import ErrorPage from "../components/ErrorPage.jsx";
 import ToUDialog from "./ToUDialog.jsx";
 
@@ -50,27 +51,6 @@ const useStyles = makeStyles(theme => ({
     maxWidth: "500px",
     margin: "auto",
     padding: theme.spacing(2),
-  },
-  logo : {
-    "& > img" : {
-      maxWidth: "240px",
-    },
-    "@media (max-height: 725px)" : {
-      "& > img" : {
-        maxHeight: "70px",
-      },
-    },
-  },
-  doubleLogo : {
-    display: "flex",
-    justifyContent: "center",
-    flexWrap: "wrap-reverse",
-    "& > img" : {
-      width: `calc(50% - ${theme.spacing(4)})`,
-      minWidth: "100px",
-      height: "fit-content",
-      margin: theme.spacing(1, 2),
-    },
   },
   description : {
     "& > *" : {
@@ -140,7 +120,7 @@ function PatientIdentification(props) {
   const [ canAuthenticate, setCanAuthenticate ] = useState();
   // Flag specifying if the identification form needs to be displayed
   const [ showIdentificationForm, setShowIdentificationForm ] = useState();
-  
+
   // Holds an error message for display
   const [ error, setError ] = useState();
   // Returned from the server after successful validation of the authentication,
@@ -276,9 +256,6 @@ function PatientIdentification(props) {
     )
   }
 
-  const logo = document.querySelector('meta[name="logoLight"]').content;
-  const affiliationLogo = document.querySelector('meta[name="affiliationLogo"]')?.content;
-
   return (<>
     <ToUDialog
       open={showTou}
@@ -322,10 +299,7 @@ function PatientIdentification(props) {
 
     <form className={classes.form} onSubmit={onSubmit} >
       <Grid container direction="column" spacing={4} alignItems="center" justifyContent="center">
-         <Grid item className={affiliationLogo ? classes.doubleLogo : classes.logo} xs={12}>
-           <img src={logo} alt="logo" />
-           {affiliationLogo && <img src={affiliationLogo} alt="logo" />}
-         </Grid>
+         <Logo component={Grid} item xs={12} />
 
          { /* If we don't have the authentication token yet or we don't need the identification form,
              display the welcome message and a circular progress while we wait for the next step */ }

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/unsubscribe.jsx
@@ -25,6 +25,7 @@ import AlertTitle from '@mui/material/AlertTitle';
 import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
 import { appTheme } from "../themePalette.jsx";
 import ErrorPage from "../components/ErrorPage.jsx";
+import Logo from "../components/Logo.jsx";
 
 const useStyles = makeStyles(theme => ({
   paper: {
@@ -35,28 +36,6 @@ const useStyles = makeStyles(theme => ({
     textAlign: "center",
     "& .MuiGrid-item" : {
       textAlign: "center",
-    },
-  },
-  logo : {
-    "& > img" : {
-      maxWidth: "240px",
-    },
-    "@media (max-height: 725px)" : {
-      "& > img" : {
-        maxHeight: "70px",
-      },
-    },
-  },
-  doubleLogo : {
-    display: "flex",
-    justifyContent: "center",
-    flexWrap: "wrap-reverse",
-    maxWidth: "600px !important",
-    "& > img" : {
-      width: `calc(50% - ${theme.spacing(4)})`,
-      minWidth: "100px",
-      height: "fit-content",
-      margin: theme.spacing(1, 2),
     },
   },
   submit : {
@@ -106,9 +85,6 @@ function Unsubscribe (props) {
 
   let appName = document.querySelector('meta[name="title"]')?.content;
 
-  const logo = document.querySelector('meta[name="logoLight"]').content;
-  const affiliationLogo = document.querySelector('meta[name="affiliationLogo"]')?.content;
-
   return (
     <Paper className={classes.paper} elevation={0}>
         <Grid
@@ -118,10 +94,7 @@ function Unsubscribe (props) {
           alignItems="center"
           alignContent="center"
         >
-          <Grid item className={affiliationLogo ? classes.doubleLogo : classes.logo} xs={12}>
-            <img src={logo} alt="logo" />
-            {affiliationLogo && <img src={affiliationLogo} alt="logo" />}
-          </Grid>
+          <Logo component={Grid} item xs={12} />
           <Grid item>
             { error && <Alert severity="error">
               <AlertTitle>An error occurred</AlertTitle>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/conf/Media.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/conf/Media.json
@@ -2,6 +2,7 @@
   "jcr:primaryType": "nt:unstructured",
   "logoDark": "/libs/cards/resources/media/prems/logo.png",
   "logoLight": "/libs/cards/resources/media/prems/logo_light_bg.png",
-  "affiliationLogo" : "/libs/cards/resources/media/prems/logo2.png",
+  "affiliationLogoDark" : "/libs/cards/resources/media/prems/logo2.png",
+  "affiliationLogoLight" : "/libs/cards/resources/media/prems/logo2.png",
   "sidebarBackground": "/libs/cards/resources/media/default/background.jpg"
 }


### PR DESCRIPTION
**Includes:**
* [CARDS-2127](https://phenotips.atlassian.net/browse/CARDS-2127) - _Reusable Logo component that displays the app logo and includes the affiliation logo if the latter is defined_
* [CARDS-2125](https://phenotips.atlassian.net/browse/CARDS-2125) - _The error pages should display the affiliation logo when it is defined_
* [CARDS-2126](https://phenotips.atlassian.net/browse/CARDS-2126) - _The login page should display the affiliation logo when it is defined_
* [CARDS-1927](https://phenotips.atlassian.net/browse/CARDS-1927) - _Center title of the patient's survey_

**Reviewing:**
* commit by commit is recommended

**Testing:**
* test `prems`, `proms`, `lfs`, `heracles` as admin 
  * login page - should have affiliation logo for `prems`; should appear unchanged for others
  * inline login dialog - after signing in as admin, sign out in a different tab, then try to click a link in the side bar in the current tab - the inline login dialog should pop up, check that it looks right for all projects
  * error pages - while signed in as admin, navigate to a non-existing page, e.g. `http://localhost:8080/c` - check that in `prems` it has app logo and affiliation logo, while in other projects it is unchanged
  * **Note**: the affiliation logo is currently not displayed in the main UI in the sidebar; that is intentional.
* test `prems`, `proms` as patient
  * in prems, the affiliation logo should now be displayed when navigating to `http://localhost:8080/Survey.html` unauthenticated
  * in prems, test the unsubscribe page
  * in proms, check that the header of the survey ui after sign still looks good
  * in proms, test the new look of header of the DATA-PRO survey ui after sign in with and without a token (CARDS-1927)
* test `proms` with an affiliation logo
  * build the **test branch `CARDS-2127_test`**, where [the `DATA` logo is configured as affiliation logo](https://github.com/data-team-uhn/cards/compare/CARDS-2127...CARDS-2127_test)
  * start in proms
  * test landing page, admin login, error pages, patient login, unsubscribe page
  * test the new look of header of the DATA-PRO survey ui after sign in with and without a token (CARDS-1927)


[CARDS-2127]: https://phenotips.atlassian.net/browse/CARDS-2127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CARDS-2125]: https://phenotips.atlassian.net/browse/CARDS-2125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CARDS-2126]: https://phenotips.atlassian.net/browse/CARDS-2126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CARDS-1927]: https://phenotips.atlassian.net/browse/CARDS-1927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ