### PR TITLE
[misc] Enable stats in prems

### DIFF
--- a/prems-resources/clinical-data/pom.xml
+++ b/prems-resources/clinical-data/pom.xml
@@ -65,6 +65,7 @@
               SLING-INF/content/apps/cards/clinics/UHN-EDIP/mailTemplates;path:=/apps/cards/clinics/UHN-EDIP/mailTemplates;overwrite:=true,
               SLING-INF/content/apps/cards/clinics/UHN-Rehab/mailTemplates;path:=/apps/cards/clinics/UHN-Rehab/mailTemplates;overwrite:=true,
               SLING-INF/content/apps/cards/clarityMapping.xml;path:=/apps/cards/clarityImport;overwrite:=true,
+              SLING-INF/content/Statistics/;path:=/Statistics/;overwriteProperties:=true;uninstall:=true,
             </Sling-Initial-Content>
           </instructions>
         </configuration>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Statistics/CPES-Overall.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Statistics/CPES-Overall.xml
@@ -1,0 +1,53 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>CPES-Overall</name>
+	<primaryNodeType>cards:Statistic</primaryNodeType>
+	<property>
+		<name>name</name>
+		<value>Long Form Overall Rating, split by hospital</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>order</name>
+		<value>5</value>
+		<type>Long</type>
+	</property>
+	<property>
+		<name>type</name>
+		<value>bar</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>xVar</name>
+		<value>/Questionnaires/CPESIC/YourOverallRatings/cpesic_41</value>
+		<type>Reference</type>
+	</property>
+	<property>
+		<name>yVar</name>
+		<value>/SubjectTypes/Patient/Visit</value>
+		<type>Reference</type>
+	</property>
+	<property>
+		<name>splitVar</name>
+		<value>/Questionnaires/CPESIC/Section1/cpesic_hospital</value>
+		<type>Reference</type>
+	</property>
+</node>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Statistics/ED-Overall.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Statistics/ED-Overall.xml
@@ -1,0 +1,53 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>ED-Overall</name>
+	<primaryNodeType>cards:Statistic</primaryNodeType>
+	<property>
+		<name>name</name>
+		<value>Emergency Department Overall Rating, split by hospital</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>order</name>
+		<value>10</value>
+		<type>Long</type>
+	</property>
+	<property>
+		<name>type</name>
+		<value>bar</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>xVar</name>
+		<value>/Questionnaires/OED/oed_module1/oed_8</value>
+		<type>Reference</type>
+	</property>
+	<property>
+		<name>yVar</name>
+		<value>/SubjectTypes/Patient/Visit</value>
+		<type>Reference</type>
+	</property>
+	<property>
+		<name>splitVar</name>
+		<value>/Questionnaires/OED/oed_module1/oed_hospital</value>
+		<type>Reference</type>
+	</property>
+</node>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Statistics/IP-Overall.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Statistics/IP-Overall.xml
@@ -1,0 +1,53 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>IP-Overall</name>
+	<primaryNodeType>cards:Statistic</primaryNodeType>
+	<property>
+		<name>name</name>
+		<value>Inpatient Overall Rating, split by hospital</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>order</name>
+		<value>20</value>
+		<type>Long</type>
+	</property>
+	<property>
+		<name>type</name>
+		<value>bar</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>xVar</name>
+		<value>/Questionnaires/OAIP/oaip_module1/oaip_8</value>
+		<type>Reference</type>
+	</property>
+	<property>
+		<name>yVar</name>
+		<value>/SubjectTypes/Patient/Visit</value>
+		<type>Reference</type>
+	</property>
+	<property>
+		<name>splitVar</name>
+		<value>/Questionnaires/OAIP/oaip_module1/oaip_hospital</value>
+		<type>Reference</type>
+	</property>
+</node>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Statistics/Rehab-Overall.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Statistics/Rehab-Overall.xml
@@ -1,0 +1,53 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>Rehab-Overall</name>
+	<primaryNodeType>cards:Statistic</primaryNodeType>
+	<property>
+		<name>name</name>
+		<value>Rehab Overall Rating, split by location</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>order</name>
+		<value>30</value>
+		<type>Long</type>
+	</property>
+	<property>
+		<name>type</name>
+		<value>bar</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>xVar</name>
+		<value>/Questionnaires/Rehab/Section7/rs_8</value>
+		<type>Reference</type>
+	</property>
+	<property>
+		<name>yVar</name>
+		<value>/SubjectTypes/Patient/Visit</value>
+		<type>Reference</type>
+	</property>
+	<property>
+		<name>splitVar</name>
+		<value>/Questionnaires/Rehab/rs_module1/rs_hospital</value>
+		<type>Reference</type>
+	</property>
+</node>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Statistics/Surveys.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Statistics/Surveys.xml
@@ -1,0 +1,53 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>Survey distribution</name>
+	<primaryNodeType>cards:Statistic</primaryNodeType>
+	<property>
+		<name>name</name>
+		<value>Survey Distribution, split by submission status</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>order</name>
+		<value>3</value>
+		<type>Long</type>
+	</property>
+	<property>
+		<name>type</name>
+		<value>bar</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>xVar</name>
+		<value>/Questionnaires/Visit information/clinic</value>
+		<type>Reference</type>
+	</property>
+	<property>
+		<name>yVar</name>
+		<value>/SubjectTypes/Patient/Visit</value>
+		<type>Reference</type>
+	</property>
+	<property>
+		<name>splitVar</name>
+		<value>/Questionnaires/Visit information/surveys_submitted</value>
+		<type>Reference</type>
+	</property>
+</node>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Statistics/Unsubscribed.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Statistics/Unsubscribed.xml
@@ -1,0 +1,48 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>Unsubscribed</name>
+	<primaryNodeType>cards:Statistic</primaryNodeType>
+	<property>
+		<name>name</name>
+		<value>Unsubscribed Patients</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>order</name>
+		<value>1</value>
+		<type>Long</type>
+	</property>
+	<property>
+		<name>type</name>
+		<value>bar</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>xVar</name>
+		<value>/Questionnaires/Patient information/email_unsubscribed</value>
+		<type>Reference</type>
+	</property>
+	<property>
+		<name>yVar</name>
+		<value>/SubjectTypes/Patient</value>
+		<type>Reference</type>
+	</property>
+</node>

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -29,6 +29,10 @@
       "start-order": "21"
     },
     {
+      "id":"${project.groupId}:cards-statistics:${project.version}",
+      "start-order":"25"
+    },
+    {
       "id":"${project.groupId}:prems-backend:${project.version}",
       "start-order": "26"
     },


### PR DESCRIPTION
Can be tested on branch `CARDS-2146_CARDS-2148_prems_stats` where labels display is improved (includes changes from #1411 and #1409 ).