### PR TITLE
CARDS-2132 - PREMs: line about about supported browsers in the email keeps getting missed by recepients

### DIFF
--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/mailTemplates/bodyTemplate.header.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/mailTemplates/bodyTemplate.header.html
@@ -30,10 +30,10 @@
         max-width: 45% !important;
       }
       .note {
-        color: #a00;
+        color: #c6934b;
         font-size: small;
-        border: 1px solid #ddd;
-        background: #f5f5f5;
+        border: 1px solid #c6934b;
+        background: #c6934b10;
         padding: 0 2em;
         border-radius: 6px;
       }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/mailTemplates/bodyTemplate.header.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/mailTemplates/bodyTemplate.header.html
@@ -33,7 +33,7 @@
         color: #c6934b;
         font-size: small;
         border: 1px solid #c6934b;
-        background: #c6934b10;
+        background: rgba(198, 147, 75, .065);
         padding: 0 2em;
         border-radius: 6px;
       }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/mailTemplates/bodyTemplate.header.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/mailTemplates/bodyTemplate.header.html
@@ -30,7 +30,7 @@
         max-width: 45% !important;
       }
       .note {
-        color: #f00;
+        color: #a00;
         font-size: small;
         border: 1px solid #ddd;
         background: #f5f5f5;

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/mailTemplates/bodyTemplate.header.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/mailTemplates/bodyTemplate.header.html
@@ -30,7 +30,7 @@
         max-width: 45% !important;
       }
       .note {
-        opacity: .6;
+        color: #f00;
         font-size: small;
         border: 1px solid #ddd;
         background: #f5f5f5;


### PR DESCRIPTION
All emails (invitation & reminders for all surveys) should reflect this change.

Example email body **BEFORE** this change:

![image](https://user-images.githubusercontent.com/651980/221681059-2e213fa9-89e9-4b51-8c00-7a3ce0d80b0c.png)


Example email body **AFTER** this change:

![image](https://user-images.githubusercontent.com/651980/221712482-519e84ea-acc7-4186-b30a-fc14387b4993.png)


