### PR TITLE
CARDS-2129: Patient portal: the process of emailing survey links to patients is too slow

### DIFF
--- a/compose-cluster/mssql/generate_test_sql.py
+++ b/compose-cluster/mssql/generate_test_sql.py
@@ -71,7 +71,6 @@ CREATE TABLE [path].[CL_EP_IP_EMAIL_CONSENT_IN_LAST_7_DAYS] (
     DISCH_DEPT_NAME varchar(254) NULL,
     DISCH_LOC_NAME varchar(254) NULL,
     EMAIL_CONSENT_YN varchar(3),
-    LoadTime datetime2 NULL,
     DEATH_DATE datetime2 NULL,
     DISCH_DISPOSITION varchar(255) NULL,
     LEVEL_OF_CARE varchar(255) NULL,
@@ -90,6 +89,7 @@ CREATE TABLE [path].[CL_EP_IP_EMAIL_CONSENT_IN_LAST_7_DAYS] (
 
 HOSPITALS_TO_DEPARTMENTS = {}
 HOSPITALS_TO_DEPARTMENTS['Toronto General Hospital'] = []
+HOSPITALS_TO_DEPARTMENTS['Toronto General Hospital'].append("TG-EMERGENCY")
 HOSPITALS_TO_DEPARTMENTS['Toronto General Hospital'].append("TG-4MA Cardiovascular Surgery")
 HOSPITALS_TO_DEPARTMENTS['Toronto General Hospital'].append("TG-4MB Cardiovascular Surgery")
 HOSPITALS_TO_DEPARTMENTS['Toronto General Hospital'].append("TG-5MB Cardiology")
@@ -103,6 +103,7 @@ HOSPITALS_TO_DEPARTMENTS['Toronto General Hospital'].append("TG-ES13 General Med
 HOSPITALS_TO_DEPARTMENTS['Toronto General Hospital'].append("TG-ES14 General Medicine")
 
 HOSPITALS_TO_DEPARTMENTS['Toronto Western Hospital'] = []
+HOSPITALS_TO_DEPARTMENTS['Toronto Western Hospital'].append("TW-EMERGENCY")
 HOSPITALS_TO_DEPARTMENTS['Toronto Western Hospital'].append("TW-3B Fell Pavilion")
 HOSPITALS_TO_DEPARTMENTS['Toronto Western Hospital'].append("TW-4B Fell Pavilion")
 HOSPITALS_TO_DEPARTMENTS['Toronto Western Hospital'].append("TW-5A Fell Pavilion")
@@ -170,20 +171,23 @@ for i in range(args.n):
     insertion_values['DISCH_DEPT_NAME'] = disch_dept_name
 
     # EMAIL_CONSENT_YN
-    email_consent_yn = random.choice(['Yes', 'No'])
+    email_consent_yn = random.choices(['Yes', 'No'], [10, 1])[0]
     insertion_values['EMAIL_CONSENT_YN'] = email_consent_yn
 
+    # MYCHART STATUS
+    insertion_values['MYCHART STATUS'] = random.choices([None, 'Activating', 'Activated'], [2, 1, 3])[0]
+
     # DISCH_DISPOSITION
-    insertion_values['DISCH_DISPOSITION'] = random.choice(['Home', 'Deceased'])
+    insertion_values['DISCH_DISPOSITION'] = random.choices(['Home', 'Deceased'], [20, 1])[0]
 
     # DEATH_DATE
-    insertion_values['DEATH_DATE'] = random.choice([None, potential_death_time_str])
+    insertion_values['DEATH_DATE'] = random.choices([None, potential_death_time_str], [20, 1])[0]
 
     # LEVEL_OF_CARE
-    insertion_values['LEVEL_OF_CARE'] = random.choice(['regular', 'ALC-AB', 'ALC 123'])
+    insertion_values['LEVEL_OF_CARE'] = random.choices(['regular', 'ALC-AB', 'ALC 123'], [10, 1, 1])[0]
 
     # ED_IP_TRANSFER_YN
-    insertion_values['ED_IP_TRANSFER_YN'] = random.choice(['Yes', 'No'])
+    insertion_values['ED_IP_TRANSFER_YN'] = random.choices(['Yes', 'No'], [1, 5])[0]
 
     # LENGTH_OF_STAY_DAYS
     insertion_values['LENGTH_OF_STAY_DAYS'] = random.randint(1, 15)
@@ -193,8 +197,8 @@ for i in range(args.n):
     insertion_values['PAT_ENC_CSN_ID'] = i
 
     args.file.write("INSERT INTO [path].[CL_EP_IP_EMAIL_CONSENT_IN_LAST_7_DAYS]")
-    args.file.write("\t(ID, PAT_ENC_CSN_ID, PAT_MRN, PAT_FIRST_NAME, PAT_LAST_NAME, EMAIL_ADDRESS, HOSP_DISCHARGE_DTTM, DISCH_DEPT_NAME, DISCH_LOC_NAME, EMAIL_CONSENT_YN, LoadTime, DEATH_DATE, DISCH_DISPOSITION, LEVEL_OF_CARE, ED_IP_TRANSFER_YN, LENGTH_OF_STAY_DAYS)\n")
+    args.file.write("\t(ID, PAT_ENC_CSN_ID, PAT_MRN, PAT_FIRST_NAME, PAT_LAST_NAME, EMAIL_ADDRESS, HOSP_DISCHARGE_DTTM, DISCH_DEPT_NAME, DISCH_LOC_NAME, EMAIL_CONSENT_YN, [MYCHART STATUS], DEATH_DATE, DISCH_DISPOSITION, LEVEL_OF_CARE, ED_IP_TRANSFER_YN, LENGTH_OF_STAY_DAYS)\n")
     args.file.write("\tVALUES\n")
-    args.file.write("\t({ID:07d}, {PAT_ENC_CSN_ID:07d}, {PAT_MRN:07d}, {PAT_FIRST_NAME}, {PAT_LAST_NAME}, {EMAIL_ADDRESS}, {HOSP_DISCHARGE_DTTM}, {DISCH_DEPT_NAME}, {DISCH_LOC_NAME}, {EMAIL_CONSENT_YN}, CAST(GETDATE()-1 AS DATE), {DEATH_DATE}, {DISCH_DISPOSITION}, {LEVEL_OF_CARE}, {ED_IP_TRANSFER_YN}, {LENGTH_OF_STAY_DAYS})\n".format(**convertToSqlType(insertion_values)))
+    args.file.write("\t({ID:07d}, {PAT_ENC_CSN_ID:07d}, {PAT_MRN:07d}, {PAT_FIRST_NAME}, {PAT_LAST_NAME}, {EMAIL_ADDRESS}, {HOSP_DISCHARGE_DTTM}, {DISCH_DEPT_NAME}, {DISCH_LOC_NAME}, {EMAIL_CONSENT_YN}, {MYCHART STATUS}, {DEATH_DATE}, {DISCH_DISPOSITION}, {LEVEL_OF_CARE}, {ED_IP_TRANSFER_YN}, {LENGTH_OF_STAY_DAYS})\n".format(**convertToSqlType(insertion_values)))
 
 args.file.close()

--- a/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
@@ -595,7 +595,7 @@ public class PaginationServlet extends SlingSafeMethodsServlet
                 final String answerSource = filter.source;
                 joins.append(
                     String.format(
-                        " inner join [%s] as %s on isdescendantnode(%s, n)",
+                        " inner join [%s] as %s on %s.form = n.[jcr:uuid]",
                         filter.nodeType,
                         answerSource,
                         answerSource));
@@ -635,11 +635,11 @@ public class PaginationServlet extends SlingSafeMethodsServlet
                 final String answerSource = filter.source;
                 joins.append(
                     String.format(
-                        " inner join [%s] as %s on isdescendantnode(%s, %s)",
+                        " inner join [%s] as %s on %s.[jcr:uuid] = %s.form",
                         filter.nodeType,
                         answerSource,
-                        answerSource,
-                        formSource));
+                        formSource,
+                        answerSource));
             }
         }
 

--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
@@ -19,6 +19,10 @@
                     "analyzed": false,
                     "jcr:primaryType": "nt:unstructured"
                 },
+                "form": {
+                    "propertyIndex": true,
+                    "type": "String"
+                },
                 "value": {
                     "name": "value",
                     "propertyIndex": true,
@@ -40,6 +44,10 @@
                     "type": "String",
                     "analyzed": false,
                     "jcr:primaryType": "nt:unstructured"
+                },
+                "form": {
+                    "propertyIndex": true,
+                    "type": "String"
                 },
                 "value": {
                     "name": "value",
@@ -63,6 +71,10 @@
                     "analyzed": false,
                     "jcr:primaryType": "nt:unstructured"
                 },
+                "form": {
+                    "propertyIndex": true,
+                    "type": "String"
+                },
                 "value": {
                     "name": "value",
                     "propertyIndex": true,
@@ -84,6 +96,10 @@
                     "type": "String",
                     "analyzed": false,
                     "jcr:primaryType": "nt:unstructured"
+                },
+                "form": {
+                    "propertyIndex": true,
+                    "type": "String"
                 },
                 "value": {
                     "name": "value",
@@ -107,6 +123,10 @@
                     "analyzed": false,
                     "jcr:primaryType": "nt:unstructured"
                 },
+                "form": {
+                    "propertyIndex": true,
+                    "type": "String"
+                },
                 "value": {
                     "name": "value",
                     "propertyIndex": true,
@@ -128,6 +148,10 @@
                     "type": "String",
                     "analyzed": false,
                     "jcr:primaryType": "nt:unstructured"
+                },
+                "form": {
+                    "propertyIndex": true,
+                    "type": "String"
                 },
                 "value": {
                     "name": "value",
@@ -151,6 +175,10 @@
                     "analyzed": false,
                     "jcr:primaryType": "nt:unstructured"
                 },
+                "form": {
+                    "propertyIndex": true,
+                    "type": "String"
+                },
                 "value": {
                     "name": "value",
                     "propertyIndex": true,
@@ -172,6 +200,10 @@
                     "type": "String",
                     "analyzed": false,
                     "jcr:primaryType": "nt:unstructured"
+                },
+                "form": {
+                    "propertyIndex": true,
+                    "type": "String"
                 },
                 "value": {
                     "name": "value",
@@ -195,6 +227,10 @@
                     "analyzed": false,
                     "jcr:primaryType": "nt:unstructured"
                 },
+                "form": {
+                    "propertyIndex": true,
+                    "type": "String"
+                },
                 "value": {
                     "name": "value",
                     "propertyIndex": true,
@@ -216,6 +252,10 @@
                     "type": "String",
                     "analyzed": false,
                     "jcr:primaryType": "nt:unstructured"
+                },
+                "form": {
+                    "propertyIndex": true,
+                    "type": "String"
                 },
                 "value": {
                     "name": "value",
@@ -239,6 +279,10 @@
                     "analyzed": false,
                     "jcr:primaryType": "nt:unstructured"
                 },
+                "form": {
+                    "propertyIndex": true,
+                    "type": "String"
+                },
                 "value": {
                     "name": "value",
                     "propertyIndex": true,
@@ -260,6 +304,10 @@
                     "type": "String",
                     "analyzed": false,
                     "jcr:primaryType": "nt:unstructured"
+                },
+                "form": {
+                    "propertyIndex": true,
+                    "type": "String"
                 },
                 "value": {
                     "name": "value",

--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
@@ -52,6 +52,28 @@
                 }
             }
         },
+        "cards:ResourceAnswer": {
+            "jcr:primaryType": "nt:unstructured",
+            "properties": {
+                "jcr:primaryType": "nt:unstructured",
+                "question": {
+                    "name": "question",
+                    "propertyIndex": true,
+                    "type": "String",
+                    "analyzed": false,
+                    "jcr:primaryType": "nt:unstructured"
+                },
+                "value": {
+                    "name": "value",
+                    "propertyIndex": true,
+                    "type": "String",
+                    "analyzed": false,
+                    "notNullCheckEnabled": true,
+                    "nullCheckEnabled": true,
+                    "jcr:primaryType": "nt:unstructured"
+                }
+            }
+        },
         "cards:LongAnswer": {
             "jcr:primaryType": "nt:unstructured",
             "properties": {

--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/nodetypes/forms.cnd
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/nodetypes/forms.cnd
@@ -528,7 +528,7 @@
   // so we add this property to be able to do joins on answer.form = form.jcr:uuid.
   // This doesn't have to be a REFERENCE, since we don't want to overcrowd the references index,
   // and we don't want to list all the answers when trying to delete a form.
-  - form (STRING) autocreated nofulltext
+  - form (STRING) nofulltext
 
   // A reference to the question being answered.
   // Mandatory, every answer needs a question.

--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/nodetypes/forms.cnd
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/nodetypes/forms.cnd
@@ -522,6 +522,14 @@
   // Hardcode the resource supertype: each answer is a resource.
   - sling:resourceSuperType (STRING) = "cards/Resource" mandatory autocreated protected
 
+  // A pseudo-link to the form this answer belongs to.
+  // Normally this wouldn't be necessary, since the hierarchy of the two nodes makes it redundant,
+  // but in queries ISDESCENDANTNODE(answer, form) is not yet efficiently implemented,
+  // so we add this property to be able to do joins on answer.form = form.jcr:uuid.
+  // This doesn't have to be a REFERENCE, since we don't want to overcrowd the references index,
+  // and we don't want to list all the answers when trying to delete a form.
+  - form (STRING) autocreated nofulltext
+
   // A reference to the question being answered.
   // Mandatory, every answer needs a question.
   // No full text search, since it's just a non-textual reference.

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/AnswerFormEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/AnswerFormEditor.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.forms.internal;
+
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.spi.commit.DefaultEditor;
+import org.apache.jackrabbit.oak.spi.commit.Editor;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+
+import io.uhndata.cards.forms.api.FormUtils;
+
+/**
+ * An {@link Editor} that sets the {@code form} property for every Answer. Normally this wouldn't be needed, but queries
+ * joining answers to their forms using {@code isdescendantnode} don't scale well.
+ *
+ * @version $Id$
+ */
+public class AnswerFormEditor extends DefaultEditor
+{
+    private final NodeBuilder currentNodeBuilder;
+
+    private final FormUtils formUtils;
+
+    private final boolean isFormNode;
+
+    private final String formIdentifier;
+
+    /**
+     * Simple constructor.
+     *
+     * @param currentNodeBuilder the NodeBuilder to process
+     * @param formUtils for working with form data
+     */
+    public AnswerFormEditor(final NodeBuilder currentNodeBuilder, final FormUtils formUtils)
+    {
+        this.currentNodeBuilder = currentNodeBuilder;
+        this.formUtils = formUtils;
+        this.isFormNode = this.formUtils.isForm(currentNodeBuilder);
+        this.formIdentifier = this.isFormNode ? currentNodeBuilder.getProperty("jcr:uuid").getValue(Type.STRING) : null;
+    }
+
+    @Override
+    public Editor childNodeAdded(final String name, final NodeState after)
+        throws CommitFailedException
+    {
+        if (this.isFormNode) {
+            return null;
+        }
+        return new AnswerFormEditor(this.currentNodeBuilder.getChildNode(name), this.formUtils);
+    }
+
+    @Override
+    public Editor childNodeChanged(final String name, final NodeState before, final NodeState after)
+        throws CommitFailedException
+    {
+        return childNodeAdded(name, after);
+    }
+
+    @Override
+    public void enter(final NodeState before, final NodeState after)
+        throws CommitFailedException
+    {
+        if (this.isFormNode) {
+            processNode(this.currentNodeBuilder);
+        }
+    }
+
+    private void processNode(final NodeBuilder node)
+    {
+        node.getChildNodeNames().iterator().forEachRemaining(name -> processNode(node.getChildNode(name)));
+        if (!this.formUtils.isForm(node)) {
+            node.setProperty("form", this.formIdentifier);
+        }
+    }
+}

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/AnswerFormEditorProvider.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/AnswerFormEditorProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.forms.internal;
+
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
+import org.apache.jackrabbit.oak.spi.commit.Editor;
+import org.apache.jackrabbit.oak.spi.commit.EditorProvider;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import io.uhndata.cards.forms.api.FormUtils;
+
+/**
+ * A {@link EditorProvider} returning {@link AnswerFormEditor}.
+ *
+ * @version $Id$
+ */
+@Component(property = "service.ranking:Integer=100")
+public class AnswerFormEditorProvider implements EditorProvider
+{
+    @Reference
+    private FormUtils formUtils;
+
+    @Override
+    public Editor getRootEditor(final NodeState before, final NodeState after, final NodeBuilder builder,
+        final CommitInfo info)
+        throws CommitFailedException
+    {
+        return new AnswerFormEditor(builder, this.formUtils);
+    }
+}

--- a/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/subjects.json
+++ b/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/subjects.json
@@ -20,6 +20,10 @@
                     "ordered": true,
                     "propertyIndex": true
                 },
+                "type": {
+                    "type": "String",
+                    "propertyIndex": true
+                },
                 "created": {
                     "name": "jcr:created",
                     "ordered": true,

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/ClinicForms.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/ClinicForms.jsx
@@ -52,10 +52,10 @@ function ClinicForms(props) {
   "from " +
     "[cards:Subject] as visitSubject " +
     "inner join [cards:Form] as visitInformation on visitSubject.[jcr:uuid] = visitInformation.subject " +
-      "inner join [cards:DateAnswer] as visitDate on isdescendantnode(visitDate, visitInformation) " +
-      "inner join [cards:ResourceAnswer] as visitClinic on isdescendantnode(visitClinic, visitInformation) " +
-      "inner join [cards:TextAnswer] as visitStatus on isdescendantnode(visitStatus, visitInformation) " +
-      "inner join [cards:BooleanAnswer] as patientSubmitted on isdescendantnode(patientSubmitted, visitInformation) " +
+      "inner join [cards:DateAnswer] as visitDate on visitDate.form = visitInformation.[jcr:uuid] " +
+      "inner join [cards:ResourceAnswer] as visitClinic on visitClinic.form = visitInformation.[jcr:uuid] " +
+      "inner join [cards:TextAnswer] as visitStatus on visitStatus.form = visitInformation.[jcr:uuid] " +
+      "inner join [cards:BooleanAnswer] as patientSubmitted on patientSubmitted.form = visitInformation.[jcr:uuid] " +
     "inner join [cards:Form] as dataForm on visitSubject.[jcr:uuid] = dataForm.subject " +
   "where " +
     `visitInformation.questionnaire = '${visitInfo?.["jcr:uuid"]}' ` +

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/ClinicVisits.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/ClinicVisits.jsx
@@ -54,9 +54,9 @@ function ClinicVisits(props) {
 "select distinct visitInformation.* " +
   "from " +
     "[cards:Form] as visitInformation " +
-      "inner join [cards:ResourceAnswer] as visitClinic on isdescendantnode(visitClinic, visitInformation) " +
-      "inner join [cards:DateAnswer] as visitDate on isdescendantnode(visitDate, visitInformation) " +
-      "inner join [cards:TextAnswer] as visitStatus on isdescendantnode(visitStatus, visitInformation) " +
+      "inner join [cards:ResourceAnswer] as visitClinic on visitClinic.form = visitInformation.[jcr:uuid] " +
+      "inner join [cards:DateAnswer] as visitDate on visitDate.form = visitInformation.[jcr:uuid] " +
+      "inner join [cards:TextAnswer] as visitStatus on visitStatus.form = visitInformation.[jcr:uuid] " +
   "where " +
     `visitInformation.questionnaire = '${visitInfo?.["jcr:uuid"]}' ` +
       `and visitDate.question = '${visitInfo?.time?.["jcr:uuid"]}' and __DATE_FILTER_PLACEHOLDER__ ` +

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ValidateCredentialsServlet.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ValidateCredentialsServlet.java
@@ -244,7 +244,7 @@ public class ValidateCredentialsServlet extends SlingAllMethodsServlet
         // Find patients matching the provided ID
         final Iterator<Resource> results = rr.findResources(
             "SELECT f.* FROM [cards:TextAnswer] AS t "
-                + "  INNER JOIN [cards:Form] AS f ON isdescendantnode(t, f) "
+                + "  INNER JOIN [cards:Form] AS f ON t.form = f.[jcr:uuid] "
                 + "WHERE t.'question'='" + identifierQuestion + "' "
                 + "  AND t.'value'='" + presentedID.replaceAll("'", "''") + "'",
             "JCR-SQL2");

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentUtils.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentUtils.java
@@ -313,11 +313,10 @@ public final class AppointmentUtils
                 formatter.format(upperBoundDate.getTime()));
 
             final String query = "SELECT vdate.* FROM [cards:DateAnswer] AS vdate "
-                + "  INNER JOIN [cards:Form] AS form ON vdate.form = form.[jcr:uuid] "
-                + "  INNER JOIN [cards:TextAnswer] AS vstatus ON vstatus.form = form.[jcr:uuid] "
-                + "  INNER JOIN [cards:BooleanAnswer] AS has_surveys ON has_surveys.form = form.[jcr:uuid] "
+                + "  INNER JOIN [cards:TextAnswer] AS vstatus ON vstatus.form = vdate.form "
+                + "  INNER JOIN [cards:BooleanAnswer] AS has_surveys ON has_surveys.form = vdate.form "
                 + ((clinicId != null)
-                    ? "  INNER JOIN [cards:ResourceAnswer] AS clinic ON clinic.form = form.[jcr:uuid] " : "")
+                    ? "  INNER JOIN [cards:ResourceAnswer] AS clinic ON clinic.form = vdate.form " : "")
                 + "WHERE vdate.'question'='" + visitTimeUUID + "' "
                 + "  AND vdate.'value' >= cast('" + formatter.format(lowerBoundDate.getTime()) + "' AS date)"
                 + "  AND vdate.'value' < cast('" + formatter.format(upperBoundDate.getTime()) + "' AS date)"
@@ -327,7 +326,8 @@ public final class AppointmentUtils
                 + "  AND has_surveys.'question' = '" + hasSurveysUUID + "' "
                 + "  AND has_surveys.'value' = 1 "
                 + ((clinicId != null)
-                    ? ("  AND clinic.'question' = '" + clinicUUID + "' AND clinic.'value' = '" + clinicId + "'") : "");
+                    ? ("  AND clinic.'question' = '" + clinicUUID + "' AND clinic.'value' = '" + clinicId + "'") : "")
+                + " OPTION (INDEX TAG cards)";
 
             return session.getWorkspace().getQueryManager().createQuery(query, "JCR-SQL2").execute().getNodes();
         } catch (RepositoryException e) {

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentUtils.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentUtils.java
@@ -313,11 +313,11 @@ public final class AppointmentUtils
                 formatter.format(upperBoundDate.getTime()));
 
             final String query = "SELECT vdate.* FROM [cards:DateAnswer] AS vdate "
-                + "  INNER JOIN [cards:Form] AS form ON isdescendantnode(vdate, form) "
-                + "  INNER JOIN [cards:TextAnswer] AS vstatus ON isdescendantnode(vstatus, form) "
-                + "  INNER JOIN [cards:BooleanAnswer] AS has_surveys ON isdescendantnode(has_surveys, form) "
+                + "  INNER JOIN [cards:Form] AS form ON vdate.form = form.[jcr:uuid] "
+                + "  INNER JOIN [cards:TextAnswer] AS vstatus ON vstatus.form = form.[jcr:uuid] "
+                + "  INNER JOIN [cards:BooleanAnswer] AS has_surveys ON has_surveys.form = form.[jcr:uuid] "
                 + ((clinicId != null)
-                    ? "  INNER JOIN [cards:ResourceAnswer] AS clinic ON isdescendantnode(clinic, form) " : "")
+                    ? "  INNER JOIN [cards:ResourceAnswer] AS clinic ON clinic.form = form.[jcr:uuid] " : "")
                 + "WHERE vdate.'question'='" + visitTimeUUID + "' "
                 + "  AND vdate.'value' >= cast('" + formatter.format(lowerBoundDate.getTime()) + "' AS date)"
                 + "  AND vdate.'value' < cast('" + formatter.format(upperBoundDate.getTime()) + "' AS date)"

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/DraftsAnswersCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/DraftsAnswersCleanupTask.java
@@ -102,7 +102,7 @@ public class DraftsAnswersCleanupTask implements Runnable
                     + "  from [cards:Form] as dataForm"
                     // belonging to a visit
                     + "  inner join [cards:Form] as visitInformation on visitInformation.subject = dataForm.subject"
-                    + "    inner join [cards:Answer] as submitted on isdescendantnode(submitted, visitInformation)"
+                    + "    inner join [cards:Answer] as submitted on submitted.form = visitInformation.[jcr:uuid]"
                     + " where"
                     // link to the correct Visit Information questionnaire
                     + "  visitInformation.questionnaire = '%1$s'"

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
@@ -93,8 +93,8 @@ public class UnsubmittedFormsCleanupTask implements Runnable
                     + "  from [cards:Form] as dataForm"
                     // belonging to a visit
                     + "  inner join [cards:Form] as visitInformation on visitInformation.subject = dataForm.subject"
-                    + "    inner join [cards:Answer] as visitDate on isdescendantnode(visitDate, visitInformation)"
-                    + "    inner join [cards:Answer] as submitted on isdescendantnode(submitted, visitInformation)"
+                    + "    inner join [cards:Answer] as visitDate on visitDate.form = visitInformation.[jcr:uuid]"
+                    + "    inner join [cards:Answer] as submitted on submitted.form = visitInformation.[jcr:uuid]"
                     + " where"
                     // link to the correct Visit Information questionnaire
                     + "  visitInformation.questionnaire = '%1$s'"


### PR DESCRIPTION
To test:

- delete whatever is in `~/cardsmail`
- build with `mvn clean install -Pdocker`
- in `compose-cluster` run `python3 generate_compose_yaml.py --mssql --cards_project cards4prems --oak_filesystem --dev_docker_image --smtps --smtps_test_container --smtps_test_mail_path ~/cardsmail --composum --adminer`
- in `compose-cluster/docker-compose.yml` add `    - NIGHTLY_NOTIFICATIONS_SCHEDULE=0 0/10 * 1/1 * ? *` to the cardsinitial environment section
- in `compose-cluster/mssql`  run `python3 generate_test_sql.py -n 2500 --basedate 2023-02-22 --time_spread_seconds 0 big_sample.sql` (use the date from exactly 7 days ago)
- start docker with `docker-compose build && docker-compose up`
- in adminer import the big_sample.sql file
- in cards access `/Subjects.importClarity?pastDayToQuery=7`
- wait about 20 minutes for the import to finish and the emails to go out
- check that in `~/cardsmail` there are already more than 500 emails

 To test that things didn't break:
- check that the filters on the dashboard still work and are fast
- index HANCESTRO, look for a CPESIC form, generate a token and fill it in as a patient, check that the vocabulary question still works
- start a standalone instance in **proms** mode, create two patient with 3 upcoming visits each (1 year apart to have the surveys assigned), log in (without a token) at `/Survey.html` and make sure the patient is presented with the correct 3 visits
