### PR TITLE
[misc] Remove useless filter from the query looking for existing questionnaires

### DIFF
--- a/modules/data-entry/src/main/java/io/uhndata/cards/FilterServlet.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/FilterServlet.java
@@ -116,7 +116,7 @@ public class FilterServlet extends SlingSafeMethodsServlet
         final StringBuilder query =
             // We select all child nodes of the homepage, filtering out nodes that aren't ours, such as rep:policy
             new StringBuilder("select n from [cards:Questionnaire] as n where isdescendantnode(n, '"
-                + parentPath + "') and n.'sling:resourceSuperType' = 'cards/Resource'");
+                + parentPath + "')");
         final Iterator<Resource> results =
             resolver.findResources(query.toString(), Query.JCR_SQL2);
 


### PR DESCRIPTION
Since we're selecting explicitly `[cards:Questionnaire]` nodes, it doesn't make sense to also check that they are a resource.