### PR TITLE
CARDS-2145: On large instances, statistics are too slow or fail to load

### DIFF
--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/answerValue.json
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/answerValue.json
@@ -1,7 +1,12 @@
 {
   "jcr:primaryType": "oak:QueryIndexDefinition",
+  "type": "property",
+  "tags": ["cards", "property"],
   "jcr:name:propertyNames": [
-    "value"
+    "value",
+    "question"
   ],
-  "type": "property"
+  "jcr:name:declaringNodeTypes": [
+    "cards:Answer"
+  ]
 }


### PR DESCRIPTION
Add an index on answer questions.

Not yet ready to review, I'm still running tests on lots of data to make sure nothing else is broken.