### PR TITLE
CARDS-2141: The "Token Expired" page should display the affiliation logo when enabled

### DIFF
--- a/modules/token-authentication/src/main/frontend/src/tokenAuthentication/TokenExpired.jsx
+++ b/modules/token-authentication/src/main/frontend/src/tokenAuthentication/TokenExpired.jsx
@@ -19,52 +19,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import { Grid, Paper, Typography } from '@mui/material';
-import makeStyles from '@mui/styles/makeStyles';
 import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
 import { appTheme } from "../themePalette.jsx";
 
-const useStyles = makeStyles(theme => ({
-  paper: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    padding: theme.spacing(12, 3, 3),
-    "& .MuiGrid-item" : {
-      textAlign: "center",
-    },
-  },
-  logo: {
-    maxWidth: "240px",
-  },
-  extendedIcon: {
-    marginRight: theme.spacing(1),
-  },
-}));
+import ErrorPage from "../components/ErrorPage.jsx";
 
 export default function TokenExpired() {
-  const classes = useStyles();
-
   return (
-    <Paper className={`${classes.paper}`} elevation={0}>
-      <Grid
-        container
-        direction="column"
-        spacing={7}
-        alignItems="center"
-        alignContent="center"
-        className={classes.notFoundContainer}
-      >
-        <Grid item>
-          <img src={document.querySelector('meta[name="logoLight"]').content} alt="" className={classes.logo}/>
-        </Grid>
-        <Grid item>
-          <Typography variant="h1" color="primary" gutterBottom>
-            This link is no longer valid, please close the page.
-          </Typography>
-        </Grid>
-      </Grid>
-    </Paper>
+    <ErrorPage
+      title="This link is no longer valid"
+      message="Please close the page"
+    />
   );
 }
 


### PR DESCRIPTION
To test, start in `prems` and navigate to http://localhost:8080/Expired.html.

For more thorough testing:
* start in `prems`
* create a Visit dated in January 2023
* get the token of that visit
* navigate to http://localhost:8080/Survey.html?auth_token=<the token\>
-> You should be redirected to the Expired.html page with both logos