### PR TITLE
CARDS-2124: Create Metrics errors logged when trying to create the same metric

### DIFF
--- a/modules/metrics/src/main/java/io/uhndata/cards/metrics/Metrics.java
+++ b/modules/metrics/src/main/java/io/uhndata/cards/metrics/Metrics.java
@@ -97,6 +97,7 @@ public final class Metrics
 
     /**
      * Creates the performance metric node and its child nodes - total, prevTotal and name in the JCR.
+     * If the performance metric node already exists, no changes are made to the JCR.
      *
      * @param resolverFactory a ResourceResolverFactory that can be used for inserting nodes into the JCR under /Metrics
      * @param statName the name of this performace metric to be placed in the JCR as /Metrics/{statName}
@@ -112,6 +113,11 @@ public final class Metrics
             // Get the /Metrics sling:Folder JCR Resource
             Resource metricsFolderResource = resolver.getResource(METRICS_PATH);
             if (metricsFolderResource == null) {
+                return;
+            }
+
+            // If /Metrics/{statName} already exists, we don't need to try (and fail) to create it
+            if (metricsFolderResource.getChild(statName) != null) {
                 return;
             }
 


### PR DESCRIPTION
This PR fixes the bug described by the CARDS-2124 JIRA issue by adding a check to the `Metrics.createStatistic` method which prevents the (failing) attempt to create a node under `/Metrics` if a child node of `/Metrics` with that name already exists.

Testing Instructions
--------------------------

1. Build this (`CARDS-2124`) branch with `mvn clean install`.
2. Start CARDS in `cards4prems` mode with `./start_cards.sh --dev --project cards4prems`
3. Visit http://localhost:8080 and login as `admin`:`admin`.
4. In a new terminal (still in the `cards` repository directory) stream the error logs by running `tail -f .cards-data/logs/error.log`.
5. Visit http://localhost:8080/system/console/bundles and click on _CARDS - Patient Portal (io.uhndata.cards.patient-portal)_.
6. Click on the _Update_ (two arrows) button in the **Actions** column.
7. Click _Browse_, select the file `.mvnrepo/io/uhndata/cards/cards-patient-portal/0.9-SNAPSHOT/cards-patient-portal-0.9-*.jar`. Click _Upload..._.
8. Look at the error log stream (from step 4) and ensure that the _createStatistic failed_ message is not present. This message would be present if these steps were repeated on a build of the `dev` branch.