### PR TITLE
CARDS-2160: When opening Select a subject dialog, move focus to the search bar

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -237,6 +237,7 @@ function UnstyledSelectParentDialog (props) {
               }
               options={{
                 search: true,
+                searchAutoFocus: true,
                 header: false,
                 addRowPosition: 'first',
                 pageSize: pageSize,


### PR DESCRIPTION
Added autofocus to a dialog to select parents for a new subject