### PR TITLE
CARDS-1275: Clicking on the description of checkbox and radio should select the option

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -604,6 +604,7 @@ const questionnaireStyle = theme => ({
       color: theme.palette.warning.main
     },
     selectionChild: {
+      cursor: "pointer",
       flexWrap: "wrap",
     },
     selectionDescription: {


### PR DESCRIPTION
Clicking on the description to select the option already works since #1318 (for [CARDS-2067](https://phenotips.atlassian.net/browse/CARDS-2067)) where clicking anywhere on the highlighted area selects the entry.

This PR simply **sets the cursor to pointer** so the user knows it's clickable.

[CARDS-2067]: https://phenotips.atlassian.net/browse/CARDS-2067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ