### PR TITLE
CARDS-2155: Prevent the import of visits for unsubscribed patients

### DIFF
--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/UnsubscribedFilter.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/UnsubscribedFilter.java
@@ -123,7 +123,7 @@ public class UnsubscribedFilter implements ClarityDataProcessor
     {
         final Node subject = subjectResource.adaptTo(Node.class);
         try {
-            // Iterate through forms for the patient for the patient
+            // Iterate through forms for the patient looking for the patient information form
             for (final PropertyIterator forms = subject.getReferences("subject"); forms.hasNext();) {
                 final Node form = forms.nextProperty().getParent();
                 if (formIsUnsubscribed(form)) {

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -246,6 +246,10 @@
       "subject.id.column": "PAT_MRN",
       "minimum.visit.frequency": 183
     },
+    // Don't import visits for patients who have opted out of emails
+    "io.uhndata.cards.prems.internal.importer.UnsubscribedFilter": {
+      "subject.id.column": "PAT_MRN"
+    },
     // Only look at events from the participating hospitals, discard everything else
     "io.uhndata.cards.prems.internal.importer.ConfiguredDiscardFilter~Discard-NonParticipatingHospitals":{
       "priority": 10,


### PR DESCRIPTION
Add new filter that discards visits for patients who have unsubscribed from emails.

To test, launch for PREMs with adminer. Use adminer and clarity import to import `visitFilterImportTestSql1` into cards.

Edit patient 1's patient information form to unsubscribe them. Then use composum to add a visit_sent date more than 6 months ago to the two survey event forms

Use adminer and clarity import to import `visitFilterImportTestSql2`. Make sure that patient 1 does not receive an extra form.

Edit patient 1's visit information form to no longer be unsubscribed.

Reimport visitFilterImportTestSql2. Verify that patient 1 now has a second visit