### PR TITLE
CARDS-2161: Accessing the patient portal with a valid token for a deleted subject gets the UI stuck loading

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
@@ -201,7 +201,7 @@ function PatientIdentification(props) {
     if (auth_token) {
       let requestData = new FormData();
       requestData.append("auth_token", auth_token);
-      validateCredentials(requestData, () => {});
+      validateCredentials(requestData, (error) => { window.location = "/Expired.html"; });
     }
   }, [config?.tokenlessAuthEnabled]);
 

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ValidateCredentialsServlet.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ValidateCredentialsServlet.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
+import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.Property;
@@ -207,7 +208,12 @@ public class ValidateCredentialsServlet extends SlingAllMethodsServlet
         final SlingHttpServletResponse response, final Session session, String sessionSubjectIdentifier)
         throws IOException, RepositoryException
     {
-        final Node visitSubject = session.getNodeByIdentifier(sessionSubjectIdentifier);
+        Node visitSubject = null;
+        try {
+            visitSubject = session.getNodeByIdentifier(sessionSubjectIdentifier);
+        } catch (ItemNotFoundException e) {
+            writeError(response, SlingHttpServletResponse.SC_UNAUTHORIZED, "Visit not found");
+        }
 
         if (this.patientAccessConfiguration.isPatientIdentificationRequired()) {
             // Look for the patient's information in the repository


### PR DESCRIPTION
To reproduce:
- prems mode
- create a proper visit with subject and forms
- manually generate a token for the visit
- access the patient UI -> everything loads fine
- delete the visit subject
- access the patient UI -> old behavior: stuck loading; new behavior: redirected to "Link Expired" error page