### PR TITLE
[misc] Fix issue of Maven packages not being detected by build_maven_package_list.py

### DIFF
--- a/Utilities/SecurityScanning/build_maven_package_list.py
+++ b/Utilities/SecurityScanning/build_maven_package_list.py
@@ -34,6 +34,8 @@ packages = []
 for raw_line in sys.stdin.readlines():
 	line = raw_line.rstrip()
 	line = line[2:]
+	if len(line.split('/')) < 3:
+		continue
 	groupId = '.'.join(line.split('/')[0:-3])
 	artifactId = line.split('/')[-3]
 	version = line.split('/')[-2]

--- a/Utilities/SecurityScanning/build_maven_package_list.py
+++ b/Utilities/SecurityScanning/build_maven_package_list.py
@@ -34,12 +34,12 @@ packages = []
 for raw_line in sys.stdin.readlines():
 	line = raw_line.rstrip()
 	line = line[2:]
-	if not line.endswith('.pom'):
-		continue
 	groupId = '.'.join(line.split('/')[0:-3])
 	artifactId = line.split('/')[-3]
 	version = line.split('/')[-2]
-	packages.append({'groupId': groupId, 'artifactId': artifactId, 'version': version})
+	package = {'groupId': groupId, 'artifactId': artifactId, 'version': version}
+	if package not in packages:
+		packages.append(package)
 
 with open(OUTPUT_JSON_FILE_PATH, 'w') as f_json:
 	json.dump(packages, f_json, indent=2)


### PR DESCRIPTION
This PR fixes an issue where Maven packages which did not have a `.pom` file were being omitted from the Maven package JSON list generated by `build_maven_package_list.py`.

Testing Instructions
--------------------------

1. `docker pull ghcr.io/data-team-uhn/cards:0.9.7`

#### On the `dev` branch

1. `cd Utilities/SecurityScanning`
2. `./list_maven_packages_in_docker_image.sh ghcr.io/data-team-uhn/cards:0.9.7 ~/maven_test_dev.json`

#### On the `misc-maven_package_list_fix` branch

1. `cd Utilities/SecurityScanning`
2. `./list_maven_packages_in_docker_image.sh ghcr.io/data-team-uhn/cards:0.9.7 ~/maven_test_fix.json`

There should be more packages listed in `~/maven_test_fix.json` than in `~/maven_test_dev.json`,