### PR TITLE
CARDS-2167: responses_received updated incorrectly

### DIFF
--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/surveytracker/SurveyTracker.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/surveytracker/SurveyTracker.java
@@ -172,7 +172,7 @@ public class SurveyTracker implements ResourceChangeListener, EventHandler
             this.formUtils.getSubject(this.formUtils.getForm(submittedAnswer)), session);
         final Node submittedDateAnswer = this.formUtils.getAnswer(surveyStatusForm,
             session.getNode("/Questionnaires/Survey events/responses_received"));
-        if (submittedDateAnswer != null) {
+        if (submittedDateAnswer != null && this.formUtils.getValue(submittedDateAnswer) == null) {
             submittedDateAnswer.setProperty("value", Calendar.getInstance());
             session.save();
         }


### PR DESCRIPTION
To test:
Verify that the `Survey event` form's `responses received` question is set when a patient submits their PREMs surveys and that no other event after will cause the `responses recieved` to be changed to a different value.

Create a new patient/visit in PREMs. Fill out the visit information form so that surveys are generated, preferably with an easy to complete form. Use the patient UI to complete and submit the surveys. Verify that `responses_recieved` is set correctly. Modify the submitted survey, verify that `responses_received` is never changed.