### PR TITLE
Upgrade jackson.version from 2.13.2 to 2.13.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <!-- Versions to be replaced in the feature files -->
     <asm.version>9.3</asm.version>
     <composum.nodes.version>4.1.1</composum.nodes.version>
-    <jackson.version>2.13.2</jackson.version>
+    <jackson.version>2.13.5</jackson.version>
     <groovy.version>3.0.10</groovy.version>
 
     <enforcer.skip>false</enforcer.skip>


### PR DESCRIPTION
Upgrade `com.fasterxml.jackson.core:jackson-databind:2.13.2` to `com.fasterxml.jackson.core:jackson-databind:2.13.5` as `com.fasterxml.jackson.core:jackson-databind:2.13.2` is vulnerable to:

- CVE-2022-42004
- CVE-2022-42003
- CVE-2020-36518