### PR TITLE
Upgrade commons-fileupload from 1.4 to 1.5

### DIFF
--- a/distribution/src/main/features/base.json
+++ b/distribution/src/main/features/base.json
@@ -130,7 +130,7 @@
             "start-order":"4"
         },
         {
-            "id":"commons-fileupload:commons-fileupload:1.4",
+            "id":"commons-fileupload:commons-fileupload:1.5",
             "start-order":"5"
         },
         {


### PR DESCRIPTION
Upgrade `commons-fileupload:commons-fileupload:1.4` to `commons-fileupload:commons-fileupload:1.5` as `commons-fileupload:commons-fileupload:1.4` is vulnerable to:
- CVE-2023-24998

Should be compatible with our code (https://github.com/apache/commons-fileupload/blob/1d9a750e5091b6e36aa81c2277200a4b2b5ecd8a/RELEASE-NOTES.txt#L9)