### PR TITLE
Upgrade libthrift from 0.13.0 to 0.14.1

### DIFF
--- a/modules/data-entry/src/main/features/feature.json
+++ b/modules/data-entry/src/main/features/feature.json
@@ -38,11 +38,11 @@
       "start-order":"25"
     },
     {
-      "id":"org.apache.jena:jena-osgi:3.17.0",
+      "id":"org.apache.jena:jena-osgi:4.1.0",
       "start-order":"25"
     },
     {
-      "id":"org.apache.thrift:libthrift:0.13.0",
+      "id":"org.apache.thrift:libthrift:0.14.1",
       "start-order":"25"
     },
     {

--- a/modules/vocabularies/src/main/features/feature.json
+++ b/modules/vocabularies/src/main/features/feature.json
@@ -46,11 +46,11 @@
       "start-order":"25"
     },
     {
-      "id":"org.apache.jena:jena-osgi:3.17.0",
+      "id":"org.apache.jena:jena-osgi:4.1.0",
       "start-order":"25"
     },
     {
-      "id":"org.apache.thrift:libthrift:0.13.0",
+      "id":"org.apache.thrift:libthrift:0.14.1",
       "start-order":"25"
     },
     {


### PR DESCRIPTION
Upgrade `org.apache.jena:jena-osgi:3.17.0` to `org.apache.jena:jena-osgi:4.1.0` and `org.apache.thrift:libthrift:0.13.0` to `org.apache.thrift:libthrift:0.14.1` to address CVE-2020-13949.

Tested by starting CARDS in `cards4lfs` mode. Installed the  _HANCESTRO_ vocabulary from BioPortal. Created a _Patient information_ Form with an _Race/Ethnicity reported_ value from HANCESTRO. All worked as expected.