### PR TITLE
Upgrade woodstox-core from 5.3.0 to 5.4.0

### DIFF
--- a/modules/saml-support/src/main/features/base.json
+++ b/modules/saml-support/src/main/features/base.json
@@ -40,7 +40,7 @@
       "start-order":"15"
     },
     {
-      "id":"com.fasterxml.woodstox:woodstox-core:5.3.0",
+      "id":"com.fasterxml.woodstox:woodstox-core:5.4.0",
       "start-order":"15"
     },
     {


### PR DESCRIPTION
Upgrade `com.fasterxml.woodstox:woodstox-core:5.3.0` to `com.fasterxml.woodstox:woodstox-core:5.4.0` as `com.fasterxml.woodstox:woodstox-core:5.3.0` is vulnerable to:

- CVE-2022-40151
- CVE-2022-40152

Tested by running a CARDS Docker image using the `generate_compose_yaml.py` script as `python3 generate_compose_yaml.py --dev_docker_image --oak_filesystem --saml --saml_cloud_iam_demo` and I was able to successfully authenticate (via SAML) as `alice@cloud-iam.demo` and as `bob@cloud-iam.demo`. 