### PR TITLE
CARDS-2173: Upgrade the version of Alpine Linux used by CARDS Docker container images

### DIFF
--- a/compose-cluster/cleanup.sh
+++ b/compose-cluster/cleanup.sh
@@ -43,7 +43,7 @@ rm -r secrets
 
 # Due permissions issues, we have to first remove all contents of SLING with Docker
 echo "Removing SLING"
-docker run --rm -v $(realpath ./SLING):/sling -it alpine:3.14 sh -c 'cd /sling; find . -delete'
+docker run --rm -v $(realpath ./SLING):/sling -it alpine:3.17 sh -c 'cd /sling; find . -delete'
 rm -rf SLING
 
 echo "Done"

--- a/compose-cluster/percona_encryption_at_rest.md
+++ b/compose-cluster/percona_encryption_at_rest.md
@@ -79,7 +79,7 @@ Tests
 by mounting it to an Alpine Linux container and exploring it as `UID=1001`.
 
 ```bash
-docker run --rm -u 1001 -v $(realpath PERCONA_DATA):/data:ro -it alpine:3.14
+docker run --rm -u 1001 -v $(realpath PERCONA_DATA):/data:ro -it alpine:3.17
 
 cd /data
 

--- a/distribution/Dockerfile
+++ b/distribution/Dockerfile
@@ -20,7 +20,7 @@
 # JARs
 
 # Build Image
-FROM alpine:3.14
+FROM alpine:3.17
 
 ARG build_jars
 
@@ -42,7 +42,7 @@ RUN mkdir /metadata
 RUN if [[ "$build_jars" == "true" ]] ; then cp /cards/aggregated-frontend/src/main/frontend/yarn.lock /metadata/yarn.lock ; fi
 
 # Production Image: Start from a small Alpine Linux base image
-FROM alpine:3.14
+FROM alpine:3.17
 
 # Install utilities for patching the JAR file, if such is necessary
 RUN apk update

--- a/distribution/make_filled_m2.sh
+++ b/distribution/make_filled_m2.sh
@@ -19,5 +19,4 @@
 
 apk update || exit -1
 apk add bash openjdk11 maven python3 gcompat || exit -1
-ln -s /usr/bin/python3 /usr/bin/python || exit -1
 mvn clean install -Prelease -Dgpg.skip -Dmaven.javadoc.skip || exit -1


### PR DESCRIPTION
This Pull Request upgrades the base image used by the CARDS Docker images from `alpine:3.14` to `alpine:3.17`. I have tested this branch and can confirm that:

- The startup check at https://github.com/data-team-uhn/cards/blob/04413caf6f26a56214894e22765b4d8c10cfb237/distribution/docker_entry.sh#L29 works as expected :heavy_check_mark:.

- The startup check at https://github.com/data-team-uhn/cards/blob/04413caf6f26a56214894e22765b4d8c10cfb237/distribution/docker_entry.sh#L32 works as expected :heavy_check_mark:.

- The `keytool` utility runs properly for loading the self-signed SSL certificate for the `smtps_test_container` (postfix) when `generate_compose_yaml.py` is invoked with `--smtps --smtps_test_container --smtps_test_mail_path /path/to/test/maildir` :heavy_check_mark:. https://github.com/data-team-uhn/cards/blob/04413caf6f26a56214894e22765b4d8c10cfb237/distribution/docker_entry.sh#L210-L215
- When `generate_compose_yaml.py` is invoked with `--debug`, CARDS waits for JDB to connect on TCP/5005 as expected :heavy_check_mark:.
- Self-contained Docker images can be built using `MAVEN_OPTS="-Ddocker.verbose -Ddocker.buildArg.build_jars=true" mvn clean install -Pdocker` :heavy_check_mark:.