### PR TITLE
CARDS-2178: Survey Events CSV export has paths instead of labels for the assigned survey

### DIFF
--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -56,7 +56,9 @@
         // Prevent the cleanup task from deleting the survey status form
         "create service user patient-visit-backend \n set ACL for patient-visit-backend \n     deny jcr:all on /Forms restriction(cards:questionnaire,/Questionnaires/Survey*events) \n end",
         // This isn't actually used, but Patient.json references it; needs to be removed along with the torch import
-        "create service user proms-import-backend"
+        "create service user proms-import-backend",
+        // Allow the CSV export of Survey Events to include the proper label for the assigned survey
+        "create service user csv-export \n set ACL on /Survey \n   allow jcr:read for csv-export \n end"
       ]
     },
     "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~prems":{


### PR DESCRIPTION
- start in prems mode
- create a visit information form
- using /bin/browser.html, locate the Survey Events form that was generated, and in it:
- find the INCOMPLETE answer for "initial invitation sent on", add a new property of type `Date` named `value`, set any date for it
- change the `jcr:lastModified` date of the form to yesterday
- go to /system/console/configMgr
- edit the last configuration entry, for `UHN-Survey-Events`
- change the export path from `/csv-export` to `.`, save 
- go to `/Subjects.csvExport?config=UHN-Survey-Events`
- on disk, check the CSV that was dumped in the directory where you started cards from, make sure it has labels instead of `/Survey/ClinicMapping/2075099` paths.