### PR TITLE
CARDS-2177: In the Heracles S3 exporter, the "Failed to perform the nightly export" message should be logged for all types of failures that occur during the data export task

### DIFF
--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
@@ -21,7 +21,6 @@ package io.uhndata.cards.heracles.internal.export;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -41,7 +40,6 @@ import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.amazonaws.AmazonServiceException;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -86,16 +84,20 @@ public class ExportTask implements Runnable
     @Override
     public void run()
     {
-        if ("nightly".equals(this.exportRunMode) || "manualToday".equals(this.exportRunMode)) {
-            doNightlyExport();
-        } else if ("manualAfter".equals(this.exportRunMode)) {
-            doManualExport(this.exportLowerBound, null);
-        } else if ("manualBetween".equals(this.exportRunMode)) {
-            doManualExport(this.exportLowerBound, this.exportUpperBound);
+        try {
+            if ("nightly".equals(this.exportRunMode) || "manualToday".equals(this.exportRunMode)) {
+                doNightlyExport();
+            } else if ("manualAfter".equals(this.exportRunMode)) {
+                doManualExport(this.exportLowerBound, null);
+            } else if ("manualBetween".equals(this.exportRunMode)) {
+                doManualExport(this.exportLowerBound, this.exportUpperBound);
+            }
+        } catch (Exception e) {
+            LOGGER.error("Failed to perform the nightly export", e.getMessage(), e);
         }
     }
 
-    public void doManualExport(LocalDate lower, LocalDate upper)
+    public void doManualExport(LocalDate lower, LocalDate upper) throws LoginException
     {
         LOGGER.info("Executing ManualExport");
         String fileDateString = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
@@ -120,7 +122,7 @@ public class ExportTask implements Runnable
         }
     }
 
-    public void doNightlyExport()
+    public void doNightlyExport() throws LoginException
     {
         LOGGER.info("Executing NightlyExport");
         LocalDate today = LocalDate.now();
@@ -235,7 +237,7 @@ public class ExportTask implements Runnable
     }
 
     private Set<SubjectIdentifier> getChangedSubjects(String requestDateStringLower,
-        String requestDateStringUpper)
+        String requestDateStringUpper) throws LoginException
     {
         try (ResourceResolver resolver = this.resolverFactory.getServiceResourceResolver(null)) {
             Set<SubjectIdentifier> subjects = new HashSet<>();
@@ -255,14 +257,13 @@ public class ExportTask implements Runnable
                 subjects.add(new SubjectIdentifier(path, participantId));
             }
             return subjects;
-        } catch (LoginException e) {
-            LOGGER.warn("Failed to get service session: {}", e.getMessage(), e);
+        } catch (Exception e) {
+            throw e;
         }
-        return Collections.emptySet();
     }
 
     private SubjectContents getSubjectContents(String path, String requestDateStringLower,
-        String requestDateStringUpper)
+        String requestDateStringUpper) throws LoginException
     {
         String subjectDataUrl = String.format("%s.data.deep.bare.-labels.-identify.relativeDates"
             + ".dataFilter:modifiedAfter=%s" + (requestDateStringUpper != null ? ".dataFilter:modifiedBefore=%s" : "")
@@ -280,9 +281,8 @@ public class ExportTask implements Runnable
             Resource identifiedSubjectData = resolver.resolve(identifiedSubjectDataUrl);
             return new SubjectContents(subjectData.adaptTo(JsonObject.class).toString(),
                 identifiedSubjectData.adaptTo(JsonObject.class), subjectDataUrl);
-        } catch (LoginException e) {
-            LOGGER.warn("Failed to get service session: {}", e.getMessage(), e);
-            return null;
+        } catch (Exception e) {
+            throw e;
         } finally {
             if (mustPopResolver) {
                 this.rrp.pop();
@@ -309,8 +309,8 @@ public class ExportTask implements Runnable
             s3.putObject(s3BucketName, filename, input.getData());
             input.getSummary().forEach(form -> LOGGER.info("Exported {}", form));
             LOGGER.info("Exported {} to {}", input.getUrl(), filename);
-        } catch (AmazonServiceException e) {
-            LOGGER.error("Failed to perform the nightly export", e.getMessage(), e);
+        } catch (Exception e) {
+            throw e;
         }
     }
 }


### PR DESCRIPTION
The goal of this Pull Request is to ensure that the error `Failed to perform the nightly export` is logged if _any_ exception is thrown during S3 data export. Before this, the `Failed to perform the nightly export` error would only be logged if a `com.amazonaws.AmazonServiceException` was thrown inside the `output` method. This missed many failure cases - for example, if a network error prevented a connection from being made between CARDS and the S3 bucket, a `com.amazonaws.SdkClientException` and not a `com.amazonaws.AmazonServiceException` would be thrown and thus the `Failed to perform the nightly export` error would not be logged.

Testing Instructions
--------------------------

1. Build this (`CARDS-2177`) branch, including a Docker image, with `mvn clean install -Pdocker`
2. `cd compose-cluster`
3. `python3 generate_compose_yaml.py --dev_docker_image --composum --cards_project cards4heracles --s3_test_container --oak_filesystem`
4. `docker-compose build && docker-compose up -d`
5. Visit http://localhost:8080 and login as `admin`:`admin`
6. Create a new _Demographics_ Form and an associated Patient
7. Visit http://localhost:8080/Subjects.s3push
8. Run `docker-compose logs cardsinitial` - the `Failed to perform the nightly export` error should be logged because the specified `uhn` bucket does not exist in the MinIO container.
9. Stop the MinIO container with `docker-compose stop s3_test_container`
10. Visit http://localhost:8080/Subjects.s3push once again
11. Run `docker-compose logs cardsinitial` - the `Failed to perform the nightly export` error should be logged because the `cardsinitial` container could not send a HTTP request to the `minio` host.
12. Stop and clean up with `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`
13. To verify that `Failed to perform the nightly export` is logged if an exception is thrown in the `getChangedSubjects` method, run instructions 2-7 on a build of the `CARDS-2177_getChangedSubjects_fail` branch.
14. To verify that `Failed to perform the nightly export` is logged if an exception is thrown in the `getSubjectContents` method, run instructions 2-7 on a build of the `CARDS-2177_getSubjectContents_fail` method. 