### PR TITLE
CARDS-2176: Switch from material-table to material-react-table

### DIFF
--- a/lfs-resources/variants/src/main/frontend/package.json
+++ b/lfs-resources/variants/src/main/frontend/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-auto-import": "0.1.1",
     "eslint": "8.32.0",
     "webpack": "5.77.0",
-    "material-react-table": "1.9.3",
+    "material-react-table": "1.10.0",
     "webpack-cli": "4.4.0",
     "webpack-assets-manifest": "5.1.0"
   },

--- a/lfs-resources/variants/src/main/frontend/package.json
+++ b/lfs-resources/variants/src/main/frontend/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-auto-import": "0.1.1",
     "eslint": "8.32.0",
     "webpack": "5.77.0",
+    "material-react-table": "1.9.3",
     "webpack-cli": "4.4.0",
     "webpack-assets-manifest": "5.1.0"
   },

--- a/lfs-resources/variants/src/main/frontend/src/variantFilesContainer.jsx
+++ b/lfs-resources/variants/src/main/frontend/src/variantFilesContainer.jsx
@@ -926,7 +926,7 @@ export default function VariantFilesContainer() {
             { header: 'Created', size: 10,
               muiTableBodyCellProps: {
                 sx: (theme) => ({
-                  paddingLeft: theme.spacing(1),
+                  paddingLeft: theme.spacing(2),
                   fontWeight: "bold",
                   whiteSpace: 'nowrap',
                 })

--- a/lfs-resources/variants/src/main/frontend/src/variantFilesContainer.jsx
+++ b/lfs-resources/variants/src/main/frontend/src/variantFilesContainer.jsx
@@ -925,11 +925,11 @@ export default function VariantFilesContainer() {
           columns={[
             { header: 'Created', size: 10,
               muiTableBodyCellProps: {
-                sx: {
-                  paddingLeft: 0,
+                sx: (theme) => ({
+                  paddingLeft: theme.spacing(1),
                   fontWeight: "bold",
                   whiteSpace: 'nowrap',
-                }
+                })
               },
               Cell: ({ row }) => <Link href={row.original["@path"]} underline="hover">
                                   {DateTime.fromISO(row.original['jcr:created']).toFormat("yyyy-MM-dd")}

--- a/lfs-resources/variants/src/main/frontend/src/variantFilesContainer.jsx
+++ b/lfs-resources/variants/src/main/frontend/src/variantFilesContainer.jsx
@@ -917,16 +917,15 @@ export default function VariantFilesContainer() {
           enableColumnFilters={false}
           enableSorting={false}
           enableTopToolbar={false}
-          enableToolbarInternalActions={false}
           muiTableBodyRowProps={({ row }) => ({
             sx: {
               verticalAlign: 'top',
             },
           })}
           columns={[
-            { header: 'Created',
+            { header: 'Created', size: 10,
               muiTableBodyCellProps: ({ cell }) => ({
-	            sx: {
+                sx: {
                   paddingLeft: 0,
                   fontWeight: "bold",
                   width: '1%',
@@ -939,31 +938,38 @@ export default function VariantFilesContainer() {
                                 </Link> },
             { header: 'Uploaded By',
               muiTableBodyCellProps: ({ cell }) => ({
-	            sx: {
+                sx: {
                   width: '50%',
                   whiteSpace: 'pre-wrap',
                   paddingBottom: "8px",
                 }
               }),
-              Cell: ({ renderedCellValue, row }) => row.original["jcr:createdBy"] },
-            { header: 'Actions',
-              muiTableBodyCellProps: ({ cell }) => ({
-	            sx: {
-                  padding: '0',
-                  width: '20px',
-                  textAlign: 'end'
-                }
-              }),
-              enableSorting: false,
-              Cell: ({ renderedCellValue, row }) =>
-                                <Tooltip title={"Download"}>
-                                  <IconButton size="large">
-                                    <Link underline="none" color="inherit" href={row.original["@path"]} download>
-                                      <GetApp />
-                                    </Link>
-                                  </IconButton>
-                                </Tooltip> },
+              Cell: ({ renderedCellValue, row }) => row.original["jcr:createdBy"] }
           ]}
+           displayColumnDefOptions={{
+            'mrt-row-actions': {
+              header: 'Actions',
+              size: 10,
+              muiTableHeadCellProps: {align: 'right'},
+              muiTableBodyCellProps: ({ cell }) => ({
+                sx: {
+                  padding: '0',
+                  textAlign: 'right'
+                },
+              }),
+            },
+          }}
+          enableRowActions
+          positionActionsColumn="last"
+          renderRowActions={({ row }) => (
+            <Tooltip title={"Download"}>
+              <IconButton size="large">
+                <Link underline="none" color="inherit" href={row.original["@path"]} download>
+                  <GetApp />
+                </Link>
+              </IconButton>
+            </Tooltip>
+          )}
         />
       </DialogContent>
     </Dialog>

--- a/lfs-resources/variants/src/main/frontend/src/variantFilesContainer.jsx
+++ b/lfs-resources/variants/src/main/frontend/src/variantFilesContainer.jsx
@@ -917,52 +917,50 @@ export default function VariantFilesContainer() {
           enableColumnFilters={false}
           enableSorting={false}
           enableTopToolbar={false}
-          muiTableBodyRowProps={({ row }) => ({
+          muiTableBodyRowProps={{
             sx: {
               verticalAlign: 'top',
             },
-          })}
+          }}
           columns={[
             { header: 'Created', size: 10,
-              muiTableBodyCellProps: ({ cell }) => ({
+              muiTableBodyCellProps: {
                 sx: {
                   paddingLeft: 0,
                   fontWeight: "bold",
-                  width: '1%',
                   whiteSpace: 'nowrap',
                 }
-              }),
-              Cell: ({ renderedCellValue, row }) =>
-                                <Link href={row.original["@path"]} underline="hover">
+              },
+              Cell: ({ row }) => <Link href={row.original["@path"]} underline="hover">
                                   {DateTime.fromISO(row.original['jcr:created']).toFormat("yyyy-MM-dd")}
-                                </Link> },
+                                </Link>
+            },
             { header: 'Uploaded By',
-              muiTableBodyCellProps: ({ cell }) => ({
+              muiTableBodyCellProps: {
                 sx: {
-                  width: '50%',
                   whiteSpace: 'pre-wrap',
                   paddingBottom: "8px",
                 }
-              }),
-              Cell: ({ renderedCellValue, row }) => row.original["jcr:createdBy"] }
+              },
+              Cell: ({ row }) => row.original["jcr:createdBy"] }
           ]}
            displayColumnDefOptions={{
             'mrt-row-actions': {
               header: 'Actions',
               size: 10,
               muiTableHeadCellProps: {align: 'right'},
-              muiTableBodyCellProps: ({ cell }) => ({
+              muiTableBodyCellProps: {
                 sx: {
                   padding: '0',
                   textAlign: 'right'
                 },
-              }),
+              },
             },
           }}
           enableRowActions
           positionActionsColumn="last"
           renderRowActions={({ row }) => (
-            <Tooltip title={"Download"}>
+            <Tooltip title="Download">
               <IconButton size="large">
                 <Link underline="none" color="inherit" href={row.original["@path"]} download>
                   <GetApp />

--- a/lfs-resources/variants/src/main/frontend/src/variantFilesContainer.jsx
+++ b/lfs-resources/variants/src/main/frontend/src/variantFilesContainer.jsx
@@ -39,7 +39,7 @@ import AlertTitle from '@mui/material/AlertTitle';
 import BackupIcon from '@mui/icons-material/Backup';
 import CloseIcon from '@mui/icons-material/Close';
 import GetApp from '@mui/icons-material/GetApp';
-import MaterialTable from "material-table";
+import MaterialReactTable from "material-react-table";
 import { v4 as uuidv4 } from 'uuid';
 import { DateTime } from "luxon";
 import DragAndDrop from "./components/dragAndDrop.jsx";
@@ -911,48 +911,60 @@ export default function VariantFilesContainer() {
         </IconButton>
       </DialogTitle>
       <DialogContent className={classes.dialogContent}>
-        <MaterialTable
+        <MaterialReactTable
           data={fileSelected?.sameFiles}
-          style={{ boxShadow : 'none' }}
-          options={{
-            toolbar: false,
-            rowStyle: {
+          enableColumnActions={false}
+          enableColumnFilters={false}
+          enableSorting={false}
+          enableTopToolbar={false}
+          enableToolbarInternalActions={false}
+          muiTableBodyRowProps={({ row }) => ({
+            sx: {
               verticalAlign: 'top',
-            }
-          }}
-          title={""}
+            },
+          })}
           columns={[
-            { title: 'Created',
-              cellStyle: {
-                paddingLeft: 0,
-                fontWeight: "bold",
-                width: '1%',
-                whiteSpace: 'nowrap',
-              },
-              render: rowData => <Link href={rowData["@path"]} underline="hover">
-                                  {DateTime.fromISO(rowData['jcr:created']).toFormat("yyyy-MM-dd")}
+            { header: 'Created',
+              muiTableBodyCellProps: ({ cell }) => ({
+	            sx: {
+                  paddingLeft: 0,
+                  fontWeight: "bold",
+                  width: '1%',
+                  whiteSpace: 'nowrap',
+                }
+              }),
+              Cell: ({ renderedCellValue, row }) =>
+                                <Link href={row.original["@path"]} underline="hover">
+                                  {DateTime.fromISO(row.original['jcr:created']).toFormat("yyyy-MM-dd")}
                                 </Link> },
-            { title: 'Uploaded By',
-              cellStyle: {
-                width: '50%',
-                whiteSpace: 'pre-wrap',
-                paddingBottom: "8px",
-              },
-              render: rowData => rowData["jcr:createdBy"] },
-            { title: 'Actions',
-              cellStyle: {
-                padding: '0',
-                width: '20px',
-                textAlign: 'end'
-              },
-              sorting: false,
-              render: rowData => <Tooltip title={"Download"}>
+            { header: 'Uploaded By',
+              muiTableBodyCellProps: ({ cell }) => ({
+	            sx: {
+                  width: '50%',
+                  whiteSpace: 'pre-wrap',
+                  paddingBottom: "8px",
+                }
+              }),
+              Cell: ({ renderedCellValue, row }) => row.original["jcr:createdBy"] },
+            { header: 'Actions',
+              muiTableBodyCellProps: ({ cell }) => ({
+	            sx: {
+                  padding: '0',
+                  width: '20px',
+                  textAlign: 'end'
+                }
+              }),
+              enableSorting: false,
+              Cell: ({ renderedCellValue, row }) =>
+                                <Tooltip title={"Download"}>
                                   <IconButton size="large">
-                                    <Link underline="none" color="inherit" href={rowData["@path"]} download><GetApp /></Link>
+                                    <Link underline="none" color="inherit" href={row.original["@path"]} download>
+                                      <GetApp />
+                                    </Link>
                                   </IconButton>
                                 </Tooltip> },
           ]}
-          />
+        />
       </DialogContent>
     </Dialog>
   </React.Fragment>

--- a/lfs-resources/variants/src/main/frontend/src/variantFilesContainer.jsx
+++ b/lfs-resources/variants/src/main/frontend/src/variantFilesContainer.jsx
@@ -90,6 +90,7 @@ const useStyles = makeStyles(theme => ({
     marginRight: theme.spacing(5)
   },
   dialogContent: {
+    padding: theme.spacing(0, 1),
     minWidth: "500px"
   },
   closeButton: {
@@ -917,6 +918,7 @@ export default function VariantFilesContainer() {
           enableColumnFilters={false}
           enableSorting={false}
           enableTopToolbar={false}
+          muiTablePaperProps={{ elevation: 0 }}
           muiTableBodyRowProps={{
             sx: {
               verticalAlign: 'top',

--- a/modules/data-entry/src/main/frontend/package.json
+++ b/modules/data-entry/src/main/frontend/package.json
@@ -50,7 +50,7 @@
     "react-number-format": "5.1.2",
     "react-router-dom": "5.2.0",
     "react-to-print": "2.14.4",
-    "material-table": "^2.0.3",
+    "material-react-table": "1.9.3",
     "material-ui-dropzone": "3.5.0",
     "luxon": "3.2.1",
     "prop-types": "15.8.1",

--- a/modules/data-entry/src/main/frontend/package.json
+++ b/modules/data-entry/src/main/frontend/package.json
@@ -50,7 +50,7 @@
     "react-number-format": "5.1.2",
     "react-router-dom": "5.2.0",
     "react-to-print": "2.14.4",
-    "material-react-table": "1.9.3",
+    "material-react-table": "1.10.0",
     "material-ui-dropzone": "3.5.0",
     "luxon": "3.2.1",
     "prop-types": "15.8.1",

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -370,6 +370,7 @@ function NewFormDialog(props) {
                 onPaginationChange={setPagination}
                 rowCount={rowCount}
                 state={{
+                  rowSelection: { [selectedQuestionnaire?.["jcr:uuid"]]: true },
                   globalFilter,
                   isLoading,
                   pagination,
@@ -387,14 +388,15 @@ function NewFormDialog(props) {
                   },
                   { accessorKey: 'description' }
                 ]}
+                getRowId={ (row) => row["jcr:uuid"] }
                 data={data}
+                positionToolbarAlertBanner="none"
                 muiSearchTextFieldProps={{ autoFocus: true }}
                 muiTableBodyRowProps={({ row }) => ({
                   sx: {
                     cursor: isRowDisabled(row) ? 'default' : 'pointer',
                   },
                   onClick: () => { onClickRow(row); },
-                  selected: isRowSelected(row),
                 })}
                 muiTableBodyCellProps={({ cell }) => ({
                   sx: {

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -48,7 +48,7 @@ export const MODE_DIALOG = 1;
  * @param {presetPath} string The questionnaire to use automatically, if any.
  */
 function NewFormDialog(props) {
-  const { children, classes, presetPath, currentSubject, theme, mode, open, onClose } = { mode:MODE_ACTION, open: false, ...props };
+  const { children, classes, presetPath, currentSubject, theme, mode, open, onClose } = { mode: MODE_ACTION, open: false, ...props };
   const [ dialogOpen, setDialogOpen ] = useState(false);
   const [ newSubjectPopperOpen, setNewSubjectPopperOpen ] = useState(false);
   const [ initialized, setInitialized ] = useState(false);
@@ -356,12 +356,10 @@ function NewFormDialog(props) {
             {relatedForms &&
               <MaterialReactTable
                 tableInstanceRef={tableRef}
-                enableColumnActions={false}
-                enableColumnFilters={false}
-                enableSorting={false}
                 enableToolbarInternalActions={false}
-                manualPagination
+                enableTableHead={false}
                 onGlobalFilterChange={setGlobalFilter}
+                manualPagination
                 onPaginationChange={setPagination}
                 rowCount={rowCount}
                 state={{
@@ -371,29 +369,31 @@ function NewFormDialog(props) {
                   showProgressBars: isRefetching
                 }}
                 initialState={{ showGlobalFilter: true, columnVisibility: { description: false } }}
-                columns={[{
-                  accessorKey: 'title',
-                  Cell: ({ renderedCellValue, row }) => (<>
+                columns={[
+                  { accessorKey: 'title',
+                    Cell: ({ row }) => (<>
                                   <Typography component="div">{row.original.title}</Typography>
                                   <FormattedText variant="caption" color="textSecondary">
                                     {row.original.description}
                                   </FormattedText>
                                 </>)
-                }, {
-                  accessorKey: 'description',
-                }]}
+                  },
+                  { accessorKey: 'description' }
+                ]}
                 data={data}
                 muiTableBodyRowProps={({ row }) => ({
-                  onClick: () => { !isFetching && setSelectedQuestionnaire(row.original); setError(false); },
                   sx: {
                     cursor: 'pointer',
                   },
+                  onClick: () => { !isFetching && setSelectedQuestionnaire(row.original);
+                                   setError(false);
+                                   row.toggleSelected();
+                                 },
+                  selected: row.original["jcr:uuid"] === selectedQuestionnaire?.["jcr:uuid"],
                 })}
                 muiTableBodyCellProps={({ cell }) => ({
                   sx: {
-                    // /* It doesn't seem possible to alter the className from here */
-                    backgroundColor: (selectedQuestionnaire?.["jcr:uuid"] === cell.row.original["jcr:uuid"]) ? theme.palette.grey["200"] : theme.palette.background.default,
-                    // // grey out subjects that have already reached maxPerSubject
+                    // grey out subjects that have already reached maxPerSubject
                     color: ((relatedForms?.length && (selectedSubject || currentSubject) && (relatedForms.filter((i) => (i["q.jcr:uuid"] == cell.row.original["jcr:uuid"])).length >= (+(cell.row.original?.["maxPerSubject"]) || undefined)))
                     ? theme.palette.grey["500"]
                     : theme.palette.grey["900"]
@@ -458,9 +458,7 @@ function NewFormDialog(props) {
         onClose={() => {
           resetDialogState();
           closeAllDialogs();
-          if (onClose) {
-            onClose();
-          }
+          onClose && onClose();
         }}
         onChangeSubject={(event) => {setNewSubjectName(event.target.value);}}
         currentSubject={currentSubject}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -385,15 +385,19 @@ function NewFormDialog(props) {
                 data={data}
                 muiTableBodyRowProps={({ row }) => ({
                   onClick: () => { !isFetching && setSelectedQuestionnaire(row.original); setError(false); },
-                  sx: (theme) => ({
+                  sx: {
+                    cursor: 'pointer',
+                  },
+                })}
+                muiTableBodyCellProps={({ cell }) => ({
+                  sx: {
                     // /* It doesn't seem possible to alter the className from here */
-                    backgroundColor: (selectedQuestionnaire?.["jcr:uuid"] === row.original["jcr:uuid"]) ? theme.palette.grey["200"] : theme.palette.background.default,
+                    backgroundColor: (selectedQuestionnaire?.["jcr:uuid"] === cell.row.original["jcr:uuid"]) ? theme.palette.grey["200"] : theme.palette.background.default,
                     // // grey out subjects that have already reached maxPerSubject
-                    color: ((relatedForms?.length && (selectedSubject || currentSubject) && (relatedForms.filter((i) => (i["q.jcr:uuid"] == row.original["jcr:uuid"])).length >= (+(row.original?.["maxPerSubject"]) || undefined)))
+                    color: ((relatedForms?.length && (selectedSubject || currentSubject) && (relatedForms.filter((i) => (i["q.jcr:uuid"] == cell.row.original["jcr:uuid"])).length >= (+(cell.row.original?.["maxPerSubject"]) || undefined)))
                     ? theme.palette.grey["500"]
                     : theme.palette.grey["900"]
-                    )
-                  }),
+                    )},
                 })}
               />
             }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -333,7 +333,6 @@ function NewFormDialog(props) {
     if (isRowDisabled(row) && currentSubject) {
       // only considers currentSubject, since setting this error would only be necessary on the 'Subject' page, which would set a currentSubject
       setError(`${currentSubject?.["type"]["@name"]} ${currentSubject?.["identifier"]} already has ${row.original?.["maxPerSubject"]} ${row.original?.["title"]} form(s) filled out.`);
-      setDisableProgress(true);
     } else {
       setSelectedQuestionnaire(row.original);
       setError("");

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -315,6 +315,7 @@ function NewFormDialog(props) {
     };
     fetchData();
   }, [
+    currentSubject?.["jcr:uuid"],
     globalFilter,
     pagination.pageIndex,
     pagination.pageSize

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -388,6 +388,7 @@ function NewFormDialog(props) {
                   { accessorKey: 'description' }
                 ]}
                 data={data}
+                muiSearchTextFieldProps={{ autoFocus: true }}
                 muiTableBodyRowProps={({ row }) => ({
                   sx: {
                     cursor: isRowDisabled(row) ? 'default' : 'pointer',

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect, useContext } from "react";
+import React, { useState, useEffect, useContext, useRef } from "react";
 import { withRouter } from "react-router-dom";
 import { v4 as uuidv4 } from 'uuid';
 
@@ -71,6 +71,7 @@ function NewFormDialog(props) {
     pageIndex: 0,
     pageSize: 5,
   });
+  const tableRef = useRef();
 
   const globalLoginDisplay = useContext(GlobalLoginContext);
 
@@ -185,6 +186,7 @@ function NewFormDialog(props) {
 
   let goBack = () => {
     setError(false);
+    tableRef.current.resetGlobalFilter();
     // Exit the dialog if we're at the first page or if there is a preset path
     if (progress === PROGRESS_SELECT_QUESTIONNAIRE || presetPath) {
       setDialogOpen(false);
@@ -353,6 +355,7 @@ function NewFormDialog(props) {
           <React.Fragment>
             {relatedForms &&
               <MaterialReactTable
+                tableInstanceRef={tableRef}
                 enableColumnActions={false}
                 enableColumnFilters={false}
                 enableSorting={false}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -185,7 +185,7 @@ function NewFormDialog(props) {
   }
 
   let goBack = () => {
-    setError(false);
+    resetDialogState();
     tableRef.current.resetGlobalFilter();
     // Exit the dialog if we're at the first page or if there is a preset path
     if (progress === PROGRESS_SELECT_QUESTIONNAIRE || presetPath) {
@@ -384,7 +384,7 @@ function NewFormDialog(props) {
                 }]}
                 data={data}
                 muiTableBodyRowProps={({ row }) => ({
-                  onClick: () => { !isFetching && setSelectedQuestionnaire(row.original) },
+                  onClick: () => { !isFetching && setSelectedQuestionnaire(row.original); setError(false); },
                   sx: (theme) => ({
                     // /* It doesn't seem possible to alter the className from here */
                     backgroundColor: (selectedQuestionnaire?.["jcr:uuid"] === row.original["jcr:uuid"]) ? theme.palette.grey["200"] : theme.palette.background.default,

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -18,7 +18,7 @@
 //
 import React, { useState, useEffect } from "react";
 
-import MaterialTable from "material-table";
+import MaterialReactTable from "material-react-table";
 
 import { loadExtensions } from "../uiextension/extensionManager";
 import NewItemButton from "../components/NewItemButton.jsx";
@@ -61,7 +61,6 @@ function UserDashboard(props) {
   let [ selectedCreation, setSelectedCreation ] = useState(-1);
   let [ selectedRow, setSelectedRow ] = useState(undefined);
   let [ open, setOpen ] = useState(false);
-  let [ pageSize, setPageSize ] = useState(10);
 
   let onClose = () => {
     setSelectedCreation(-1);
@@ -102,26 +101,29 @@ function UserDashboard(props) {
       </Grid>
       <ResponsiveDialog title="New" width="xs" open={open} onClose={onClose}>
         <DialogContent dividers className={classes.dialogContentWithTable}>
-          <MaterialTable
+          <MaterialReactTable
+            enableColumnActions={false}
+            enableColumnFilters={false}
+            enableSorting={false}
+            enableToolbarInternalActions={false}
+            initialState={{ showGlobalFilter: true }}
             columns={[
-              { field: 'cards:extensionName' },
+              { accessorKey: 'cards:extensionName' },
             ]}
             data={creationExtensions}
-            options={{
-              toolbar: false,
-              header: false,
-              pageSize: pageSize,
-              paging: creationExtensions.length > 5,
-              rowStyle: rowData => ({
-                // /* It doesn't seem possible to alter the className from here */
-                backgroundColor: (selectedRow && selectedRow["jcr:uuid"] === rowData["jcr:uuid"]) ? theme.palette.grey["200"] : theme.palette.background.default
-              })
-            }}
-            onRowClick={(event, rowData) => {
-              setSelectedRow(rowData);
-            }}
-            onChangeRowsPerPage={setPageSize}
-            />
+            muiTableBodyRowProps={({ row }) => ({
+              sx: {
+                cursor: 'pointer',
+                backgroundColor:
+                  selectedRow && selectedRow["jcr:uuid"] === row.original["jcr:uuid"] ? theme.palette.grey["200"] : theme.palette.background.default
+              },
+              onClick: (event) => {
+                  setSelectedRow(row.original);
+                },
+            })}
+            enablePagination={creationExtensions.length > 5}
+            initialState={{ pagination: { pageSize: 10, pageIndex: 0 } }}
+          />
         </DialogContent>
         <DialogActions>
           <Button

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -108,6 +108,8 @@ function UserDashboard(props) {
             enableTopToolbar={creationExtensions.length > 5}
             enableBottomToolbar={creationExtensions.length > 5}
             enablePagination={creationExtensions.length > 5}
+            getRowId={ (row) => row["jcr:uuid"] }
+            state={{ rowSelection: { [selectedRow?.["jcr:uuid"]]: true } }}
             initialState={{ showGlobalFilter: (creationExtensions.length > 5),
                             pagination: { pageSize: 10, pageIndex: 0 }
                          }}
@@ -124,8 +126,7 @@ function UserDashboard(props) {
               sx: {
                 cursor: 'pointer',
               },
-              onClick: () => { setSelectedRow(row.original); row.toggleSelected(); },
-              selected: row.original["jcr:uuid"] === selectedRow?.["jcr:uuid"],
+              onClick: () => { setSelectedRow(row?.original); },
             })}
             muiTableBodyCellProps={{
               sx: {

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -109,7 +109,6 @@ function UserDashboard(props) {
             enableToolbarInternalActions={false}
             enableTopToolbar={creationExtensions.length > 5}
             enableBottomToolbar={creationExtensions.length > 5}
-            muiTableHeadProps={{ sx: { display: creationExtensions.length < 5 ? 'none' : 'contents' } }}
             enablePagination={creationExtensions.length > 5}
             initialState={{ showGlobalFilter: (creationExtensions.length > 5),
                             pagination: { pageSize: 10, pageIndex: 0 }
@@ -118,6 +117,11 @@ function UserDashboard(props) {
               { accessorKey: 'cards:extensionName' },
             ]}
             data={creationExtensions}
+            muiTableHeadProps={{
+              sx: {
+                display: creationExtensions.length < 5 ? 'none' : 'contents',
+              },
+            }}
             muiTableBodyRowProps={({ row }) => ({
               sx: {
                 cursor: 'pointer',

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -53,7 +53,7 @@ async function getMenuItems() {
 // visible by the user. Each LiveTable contains all forms that use the given
 // questionnaire.
 function UserDashboard(props) {
-  const { classes, theme } = props;
+  const { classes } = props;
   let [ dashboardExtensions, setDashboardExtensions ] = useState([]);
   let [ creationExtensions, setCreationExtensions ] = useState([]);
   let [ loading, setLoading ] = useState(true);
@@ -102,12 +102,8 @@ function UserDashboard(props) {
       <ResponsiveDialog title="New" width="xs" open={open} onClose={onClose}>
         <DialogContent dividers className={classes.dialogContentWithTable}>
           <MaterialReactTable
-            enableColumnActions={false}
-            enableColumnFilters={false}
-            enableSorting={false}
-            enableGrouping={false}
             enableToolbarInternalActions={false}
-            enableTableHead={creationExtensions.length > 5}
+            enableTableHead={false}
             enableTableFooter={creationExtensions.length > 5}
             enableTopToolbar={creationExtensions.length > 5}
             enableBottomToolbar={creationExtensions.length > 5}
@@ -127,25 +123,22 @@ function UserDashboard(props) {
             muiTableBodyRowProps={({ row }) => ({
               sx: {
                 cursor: 'pointer',
-                backgroundColor:
-                  selectedRow && selectedRow["jcr:uuid"] === row.original["jcr:uuid"] ? theme.palette.grey["200"] : theme.palette.background.default
               },
-              onClick: (event) => {
-                  setSelectedRow(row.original);
-                },
+              onClick: () => { setSelectedRow(row.original); row.toggleSelected(); },
+              selected: row.original["jcr:uuid"] === selectedRow?.["jcr:uuid"],
             })}
-            muiTableBodyCellProps={({ cell }) => ({
+            muiTableBodyCellProps={{
               sx: {
                 fontSize: '1rem'
               },
-            })}
+            }}
           />
         </DialogContent>
         <DialogActions>
           <Button
             variant="outlined"
             onClick={onClose}
-            >
+          >
             Cancel
           </Button>
           <Button
@@ -185,4 +178,4 @@ function UserDashboard(props) {
   );
 }
 
-export default withStyles(QuestionnaireStyle, {withTheme: true})(UserDashboard);
+export default withStyles(QuestionnaireStyle)(UserDashboard);

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -105,8 +105,15 @@ function UserDashboard(props) {
             enableColumnActions={false}
             enableColumnFilters={false}
             enableSorting={false}
+            enableGrouping={false}
             enableToolbarInternalActions={false}
-            initialState={{ showGlobalFilter: true }}
+            enableTopToolbar={creationExtensions.length > 5}
+            enableBottomToolbar={creationExtensions.length > 5}
+            muiTableHeadProps={{ sx: { display: creationExtensions.length < 5 ? 'none' : 'contents' } }}
+            enablePagination={creationExtensions.length > 5}
+            initialState={{ showGlobalFilter: (creationExtensions.length > 5),
+                            pagination: { pageSize: 10, pageIndex: 0 }
+                         }}
             columns={[
               { accessorKey: 'cards:extensionName' },
             ]}
@@ -121,8 +128,11 @@ function UserDashboard(props) {
                   setSelectedRow(row.original);
                 },
             })}
-            enablePagination={creationExtensions.length > 5}
-            initialState={{ pagination: { pageSize: 10, pageIndex: 0 } }}
+            muiTableBodyCellProps={({ cell }) => ({
+              sx: {
+                fontSize: '1rem'
+              },
+            })}
           />
         </DialogContent>
         <DialogActions>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -107,6 +107,8 @@ function UserDashboard(props) {
             enableSorting={false}
             enableGrouping={false}
             enableToolbarInternalActions={false}
+            enableTableHead={creationExtensions.length > 5}
+            enableTableFooter={creationExtensions.length > 5}
             enableTopToolbar={creationExtensions.length > 5}
             enableBottomToolbar={creationExtensions.length > 5}
             enablePagination={creationExtensions.length > 5}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -238,6 +238,7 @@ const questionnaireStyle = theme => ({
     subjectFormAvatar : {
         backgroundColor: theme.palette.primary.main,
         marginTop: theme.spacing(-.5),
+        marginRight: theme.spacing(1.5),
         zoom: .75,
     },
     childSubjectHeader: {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -547,7 +547,8 @@ const questionnaireStyle = theme => ({
     DefaultChip: {
     },
     formPreview: {
-        padding: theme.spacing(1, 1, 1, 5.25),
+        padding: theme.spacing(1),
+        marginLeft: theme.spacing(9),
         background: theme.palette.action.hover,
     },
     formPreviewQuestion: {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -548,7 +548,6 @@ const questionnaireStyle = theme => ({
     },
     formPreview: {
         padding: theme.spacing(1),
-        marginLeft: theme.spacing(9),
         background: theme.palette.action.hover,
     },
     formPreviewQuestion: {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -483,11 +483,6 @@ function SubjectMemberInternal (props) {
                 muiTableBodyCellProps={{
                   sx: {
                     flex: '0 0 auto',
-                  },
-                }}
-                muiTableDetailPanelProps={{
-                  sx: {
-                    paddingTop: '0',
                   }
                 }}
                 renderDetailPanel={({ row }) => <FormData formID={row.original["@name"]} maxDisplayed={maxDisplayed} classes={classes}/> }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -469,7 +469,6 @@ function SubjectMemberInternal (props) {
                 enableColumnFilters={false}
                 enableSorting={false}
                 enableTopToolbar={false}
-                enableToolbarInternalActions={false}
                 enableBottomToolbar={!!(subjectGroups[questionnaireTitle]?.length > pageSize)}
                 enablePagination={!!(subjectGroups[questionnaireTitle]?.length > pageSize)}
                 initialState={{ pagination: { pageSize: pageSize, pageIndex: 0 } }}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -490,62 +490,81 @@ function SubjectMemberInternal (props) {
                     display: 'none',
                   },
                 }}
+                layoutMode="grid"
+                muiTableHeadCellProps={{
+                    sx: {
+                      flex: '0 0 auto',
+                    },
+                  }}
+                muiTableBodyCellProps={{
+                    sx: {
+                      flex: '0 0 auto',
+                    },
+                }}
                 renderDetailPanel={({ row }) => <FormData formID={row.original["@name"]} maxDisplayed={maxDisplayed} classes={classes}/> }
+                defaultColumn={{
+                  minSize: 20,
+                  maxSize: 9001
+                }}
                 displayColumnDefOptions={{
                   'mrt-row-actions': {
                     id: 'Actions',
+                    size: 80,
                     muiTableBodyCellProps: ({ cell }) => ({
                       sx: {
                         padding: '0',
                         whiteSpace: 'nowrap',
-                        textAlign: 'right'
+                        textAlign: 'right',
+                        flex: '0 0 auto',
                       },
                     }),
                   },
                   'mrt-row-expand': {
-                    size: 4,
+                    size: 40,
+                    minSize: 40,
+                    maxSize: 40,
                     muiTableBodyCellProps: ({ cell }) => ({
                       sx: {
-                        paddingRight: '0',
+                        paddingRight: '2px',
+                        paddingLeft: '0',
+                        flex: '0 0 auto',
+                        alignItems: 'start'
                       },
                     }),
                   },
                 }}
                 columns={[
-                  { id: 'Avatar', size: 4,
-                    muiTableBodyCellProps: ({ cell }) => ({
-                      sx: {
-                        paddingLeft: 0,
-                        paddingRight: 0,
-                        paddingTop: "10px",
-                      },
-                    }),
-                    Cell: ({ renderedCellValue, row }) => (<Avatar className={classes.subjectFormAvatar}><FormIcon/></Avatar>),
-                  },
                   { id: 'Questionnaire',
+                    size: 400,
                     muiTableBodyCellProps: ({ cell }) => ({
-                      sx: {
+                      sx: (theme) => ({
                         paddingLeft: 0,
                         fontWeight: "bold",
                         paddingTop: "10px",
                         whiteSpace: 'nowrap',
-                      },
+                      }),
                     }),
                     Cell: ({ renderedCellValue, row }) => (<>
-                                         <Link to={"/content.html" + row.original["@path"]} underline="hover">
-                                           {questionnaireTitle} {subjectGroups[questionnaireTitle].length > 1 ? `#${row.original.tableData.id + 1}` : ''}
-                                         </Link>
-                                         <Typography variant="caption" component="div" color="textSecondary">
-                                           Created {DateTime.fromISO(row.original['jcr:created']).toFormat("yyyy-MM-dd HH:mm")}
-                                         </Typography>
-                                         <Typography variant="caption" component="div" color="textSecondary">
-                                           Last modified {DateTime.fromISO(row.original['jcr:lastModified']).toFormat("yyyy-MM-dd HH:mm")}
-                                         </Typography>
-                                       </>) },
+                                   <Grid container direction="row" spacing={1} justifyContent="flex-start">
+                                     <Grid item xs={false}>
+                                       <Avatar className={classes.subjectFormAvatar}><FormIcon/></Avatar>
+                                     </Grid>
+                                     <Grid item xs={false}>
+                                       <Link to={"/content.html" + row.original["@path"]} underline="hover">
+                                         {questionnaireTitle} {subjectGroups[questionnaireTitle].length > 1 ? `#${row.original.tableData.id + 1}` : ''}
+                                       </Link>
+                                       <Typography variant="caption" component="div" color="textSecondary">
+                                         Created {DateTime.fromISO(row.original['jcr:created']).toFormat("yyyy-MM-dd HH:mm")}
+                                       </Typography>
+                                       <Typography variant="caption" component="div" color="textSecondary">
+                                         Last modified {DateTime.fromISO(row.original['jcr:lastModified']).toFormat("yyyy-MM-dd HH:mm")}
+                                       </Typography>
+                                     </Grid>
+                                   </Grid>
+                                 </>) },
                   { id: 'Status',
                     muiTableBodyCellProps: ({ cell }) => ({
                       sx: {
-                        width: '99%',
                         whiteSpace: 'nowrap',
                         paddingTop: "10px",
                         paddingBottom: "8px",

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -480,16 +480,8 @@ function SubjectMemberInternal (props) {
                     verticalAlign: 'top',
                   },
                 }}
-                muiTableHeadProps={{
-                  sx: {
-                    display: 'none',
-                  },
-                }}
-                muiTableFooterProps={{
-                  sx: {
-                    display: 'none',
-                  },
-                }}
+                enableTableHead={false}
+                enableTableFooter={false}
                 layoutMode="grid"
                 muiTableHeadCellProps={{
                     sx: {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -28,8 +28,9 @@ import NewFormDialog from "../dataHomepage/NewFormDialog";
 import { QUESTION_TYPES, SECTION_TYPES, ENTRY_TYPES } from "./FormEntry.jsx";
 import { usePageNameWriterContext } from "../themePage/Page.jsx";
 import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
-import MaterialTable from 'material-table';
 import { getSubjectIdFromPath, getHierarchyAsList, getTextHierarchy } from "./SubjectIdentifier";
+import MaterialReactTable from 'material-react-table';
+import { Box } from '@mui/material';
 
 import {
   Avatar,
@@ -462,57 +463,77 @@ function SubjectMemberInternal (props) {
         {
           Object.keys(subjectGroups).map( (questionnaireTitle, j) => (
             <Grid item key={questionnaireTitle}>
-              <MaterialTable
+              <MaterialReactTable
                 data={subjectGroups[questionnaireTitle]}
-                style={{ boxShadow : 'none' }}
-                options={{
-                  actionsColumnIndex: -1,
-                  emptyRowsWhenPaging: false,
-                  toolbar: false,
-                  paging: !!(subjectGroups[questionnaireTitle]?.length > pageSize),
-                  pageSize: pageSize,
-                  header: false,
-                  rowStyle: {
+                enableColumnActions={false}
+                enableColumnFilters={false}
+                enableSorting={false}
+                enableTopToolbar={false}
+                enableToolbarInternalActions={false}
+                enablePagination={!!(subjectGroups[questionnaireTitle]?.length > pageSize)}
+                initialState={{ pagination: { pageSize: pageSize, pageIndex: 0 } }}
+                muiTableBodyRowProps={({ row }) => ({
+                  sx: {
                     verticalAlign: 'top',
-                  }
+                  },
+                })}
+                renderDetailPanel={({ row }) => <FormData formID={row.original["@name"]} maxDisplayed={maxDisplayed} classes={classes}/> }
+                displayColumnDefOptions={{
+                  'mrt-row-actions': {
+                    header: 'Actions',
+                    muiTableBodyCellProps: ({ cell }) => ({
+                      sx: {
+                        padding: '0',
+                        whiteSpace: 'nowrap',
+                        textAlign: 'end'
+                      },
+                    }),
+                  },
+                  'mrt-row-expand': {
+                    size: 8,
+                  },
                 }}
-                detailPanel={[
-                  { tooltip: 'Excerpt',
-                    render: rowData => <FormData formID={rowData["@name"]} maxDisplayed={maxDisplayed} classes={classes}/> },
-                ]}
                 columns={[
-                  { title: 'Avatar',
-                    cellStyle: {
-                      paddingLeft: 0,
-                      paddingTop: "10px",
-                    },
-                    render: rowData => <Avatar className={classes.subjectFormAvatar}><FormIcon/></Avatar> },
-                  { title: 'Questionnaire',
-                    cellStyle: {
-                      paddingLeft: 0,
-                      fontWeight: "bold",
-                      paddingTop: "10px",
-                      whiteSpace: 'nowrap',
-                    },
-                    render: rowData => <><Link to={"/content.html" + rowData["@path"]} underline="hover">
-                                           {questionnaireTitle} {subjectGroups[questionnaireTitle].length > 1 ? `#${rowData.tableData.id + 1}` : ''}
+                  { header: 'Avatar', size: 10,
+                    muiTableBodyCellProps: ({ cell }) => ({
+                      sx: {
+                        paddingLeft: 0,
+                        paddingTop: "10px",
+                      },
+                    }),
+                    Cell: ({ renderedCellValue, row }) => (<Avatar className={classes.subjectFormAvatar}><FormIcon/></Avatar>),
+                  },
+                  { header: 'Questionnaire',
+                    muiTableBodyCellProps: ({ cell }) => ({
+                      sx: {
+                        paddingLeft: 0,
+                        fontWeight: "bold",
+                        paddingTop: "10px",
+                        whiteSpace: 'nowrap',
+                      },
+                    }),
+                    Cell: ({ renderedCellValue, row }) => (<>
+                                         <Link to={"/content.html" + row.original["@path"]} underline="hover">
+                                           {questionnaireTitle} {subjectGroups[questionnaireTitle].length > 1 ? `#${row.original.tableData.id + 1}` : ''}
                                          </Link>
                                          <Typography variant="caption" component="div" color="textSecondary">
-                                           Created {DateTime.fromISO(rowData['jcr:created']).toFormat("yyyy-MM-dd HH:mm")}
+                                           Created {DateTime.fromISO(row.original['jcr:created']).toFormat("yyyy-MM-dd HH:mm")}
                                          </Typography>
                                          <Typography variant="caption" component="div" color="textSecondary">
-                                           Last modified {DateTime.fromISO(rowData['jcr:lastModified']).toFormat("yyyy-MM-dd HH:mm")}
+                                           Last modified {DateTime.fromISO(row.original['jcr:lastModified']).toFormat("yyyy-MM-dd HH:mm")}
                                          </Typography>
-                                       </> },
-                  { title: 'Status',
-                    cellStyle: {
-                      width: '99%',
-                      whiteSpace: 'nowrap',
-                      paddingTop: "10px",
-                      paddingBottom: "8px",
-                    },
-                    render: rowData => <React.Fragment>
-                                         {rowData["statusFlags"].map((status) => {
+                                       </>) },
+                  { header: 'Status',
+                    muiTableBodyCellProps: ({ cell }) => ({
+                      sx: {
+                        width: '99%',
+                        whiteSpace: 'nowrap',
+                        paddingTop: "10px",
+                        paddingBottom: "8px",
+                      },
+                    }),
+                    Cell: ({ renderedCellValue, row }) => (<>
+                                         { row.original["statusFlags"].map((status) => {
                                            return <Chip
                                              key={status}
                                              label={wordToTitleCase(status)}
@@ -521,28 +542,28 @@ function SubjectMemberInternal (props) {
                                              size="small"
                                            />
                                          })}
-                                       </React.Fragment> },
-                  { title: 'Actions',
-                    cellStyle: {
-                      padding: '0',
-                      whiteSpace: 'nowrap',
-                      textAlign: 'end'
-                    },
-                    render: rowData => <React.Fragment>
-                                         <EditButton
-                                           entryPath={rowData["@path"]}
-                                           entryType="Form"
-                                         />
-                                         <DeleteButton
-                                           entryPath={rowData["@path"]}
-                                           entryName={getEntityIdentifier(rowData)}
-                                           entryType="Form"
-                                           warning={rowData ? rowData["@referenced"] : false}
-                                           onComplete={fetchTableData}
-                                         />
-                                       </React.Fragment> },
+                                       </>) },
                 ]}
-               />
+                enableRowActions
+                positionActionsColumn="last"
+                renderRowActions={({ row }) => (
+                    <Box sx={{ display: 'flex', flexWrap: 'nowrap', gap: '8' }}>
+                    <>
+                      <EditButton
+                        entryPath={row.original["@path"]}
+                        entryType="Form"
+                      />
+                      <DeleteButton
+                        entryPath={row.original["@path"]}
+                        entryName={getEntityIdentifier(row.original)}
+                        entryType="Form"
+                        warning={row.original ? row.original["@referenced"] : false}
+                        onComplete={fetchTableData}
+                      />
+                    </>
+                    </Box>
+                )}
+              />
             </Grid>
           ))
         }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -470,40 +470,60 @@ function SubjectMemberInternal (props) {
                 enableSorting={false}
                 enableTopToolbar={false}
                 enableToolbarInternalActions={false}
+                enableBottomToolbar={!!(subjectGroups[questionnaireTitle]?.length > pageSize)}
                 enablePagination={!!(subjectGroups[questionnaireTitle]?.length > pageSize)}
                 initialState={{ pagination: { pageSize: pageSize, pageIndex: 0 } }}
-                muiTableBodyRowProps={({ row }) => ({
+                muiTablePaperProps={{
+                  elevation: 0,
+                }}
+                muiTableBodyRowProps={{
                   sx: {
                     verticalAlign: 'top',
                   },
-                })}
+                }}
+                muiTableHeadProps={{
+                  sx: {
+                    display: 'none',
+                  },
+                }}
+                muiTableFooterProps={{
+                  sx: {
+                    display: 'none',
+                  },
+                }}
                 renderDetailPanel={({ row }) => <FormData formID={row.original["@name"]} maxDisplayed={maxDisplayed} classes={classes}/> }
                 displayColumnDefOptions={{
                   'mrt-row-actions': {
-                    header: 'Actions',
+                    id: 'Actions',
                     muiTableBodyCellProps: ({ cell }) => ({
                       sx: {
                         padding: '0',
                         whiteSpace: 'nowrap',
-                        textAlign: 'end'
+                        textAlign: 'right'
                       },
                     }),
                   },
                   'mrt-row-expand': {
-                    size: 8,
+                    size: 4,
+                    muiTableBodyCellProps: ({ cell }) => ({
+                      sx: {
+                        paddingRight: '0',
+                      },
+                    }),
                   },
                 }}
                 columns={[
-                  { header: 'Avatar', size: 10,
+                  { id: 'Avatar', size: 4,
                     muiTableBodyCellProps: ({ cell }) => ({
                       sx: {
                         paddingLeft: 0,
+                        paddingRight: 0,
                         paddingTop: "10px",
                       },
                     }),
                     Cell: ({ renderedCellValue, row }) => (<Avatar className={classes.subjectFormAvatar}><FormIcon/></Avatar>),
                   },
-                  { header: 'Questionnaire',
+                  { id: 'Questionnaire',
                     muiTableBodyCellProps: ({ cell }) => ({
                       sx: {
                         paddingLeft: 0,
@@ -523,7 +543,7 @@ function SubjectMemberInternal (props) {
                                            Last modified {DateTime.fromISO(row.original['jcr:lastModified']).toFormat("yyyy-MM-dd HH:mm")}
                                          </Typography>
                                        </>) },
-                  { header: 'Status',
+                  { id: 'Status',
                     muiTableBodyCellProps: ({ cell }) => ({
                       sx: {
                         width: '99%',
@@ -547,7 +567,7 @@ function SubjectMemberInternal (props) {
                 enableRowActions
                 positionActionsColumn="last"
                 renderRowActions={({ row }) => (
-                    <Box sx={{ display: 'flex', flexWrap: 'nowrap', gap: '8' }}>
+                    <Box sx={{ display: 'flex', flexWrap: 'nowrap', gap: '8', float: 'right' }}>
                     <>
                       <EditButton
                         entryPath={row.original["@path"]}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -485,6 +485,12 @@ function SubjectMemberInternal (props) {
                     flex: '0 0 auto',
                   }
                 }}
+                muiTableDetailPanelProps={{
+                  sx: (theme) => ({
+                    marginLeft: theme.spacing(9),
+                    width: '100%'
+                  })
+                }}
                 renderDetailPanel={({ row }) => <FormData formID={row.original["@name"]} maxDisplayed={maxDisplayed} classes={classes}/> }
                 defaultColumn={{
                   minSize: 20,

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -551,7 +551,7 @@ function SubjectMemberInternal (props) {
                                      </Grid>
                                      <Grid item xs={false}>
                                        <Link to={"/content.html" + row.original["@path"]} underline="hover">
-                                         {questionnaireTitle} {subjectGroups[questionnaireTitle].length > 1 ? `#${row.original.tableData.id + 1}` : ''}
+                                         {questionnaireTitle}
                                        </Link>
                                        <Typography variant="caption" component="div" color="textSecondary">
                                          Created {DateTime.fromISO(row.original['jcr:created']).toFormat("yyyy-MM-dd HH:mm")}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -503,13 +503,13 @@ function SubjectMemberInternal (props) {
                     id: 'Actions',
                     size: 80,
                     muiTableBodyCellProps: ({ cell }) => ({
-                      sx: {
+                      sx: (theme) => ({
                         padding: '0',
-                        paddingRight: '16px',
+                        paddingRight: theme.spacing(2),
                         whiteSpace: 'nowrap',
                         textAlign: 'right',
                         flex: '0 0 auto',
-                      },
+                      }),
                     }),
                   },
                   'mrt-row-expand': {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -465,10 +465,9 @@ function SubjectMemberInternal (props) {
             <Grid item key={questionnaireTitle}>
               <MaterialReactTable
                 data={subjectGroups[questionnaireTitle]}
-                enableColumnActions={false}
-                enableColumnFilters={false}
-                enableSorting={false}
                 enableTopToolbar={false}
+                enableTableHead={false}
+                enableTableFooter={false}
                 enableBottomToolbar={!!(subjectGroups[questionnaireTitle]?.length > pageSize)}
                 enablePagination={!!(subjectGroups[questionnaireTitle]?.length > pageSize)}
                 initialState={{ pagination: { pageSize: pageSize, pageIndex: 0 } }}
@@ -480,8 +479,6 @@ function SubjectMemberInternal (props) {
                     verticalAlign: 'top',
                   },
                 }}
-                enableTableHead={false}
-                enableTableFooter={false}
                 layoutMode="grid"
                 muiTableBodyCellProps={{
                   sx: {
@@ -502,42 +499,39 @@ function SubjectMemberInternal (props) {
                   'mrt-row-actions': {
                     id: 'Actions',
                     size: 80,
-                    muiTableBodyCellProps: ({ cell }) => ({
+                    muiTableBodyCellProps: {
                       sx: (theme) => ({
-                        padding: '0',
                         paddingRight: theme.spacing(2),
-                        whiteSpace: 'nowrap',
-                        textAlign: 'right',
                         flex: '0 0 auto',
                       }),
-                    }),
+                    },
                   },
                   'mrt-row-expand': {
                     size: 40,
                     minSize: 40,
                     maxSize: 40,
-                    muiTableBodyCellProps: ({ cell }) => ({
+                    muiTableBodyCellProps: {
                       sx: {
                         paddingRight: '2px',
                         paddingLeft: '0',
                         flex: '0 0 auto',
                         alignItems: 'start'
                       },
-                    }),
+                    },
                   },
                 }}
                 columns={[
                   { id: 'Questionnaire',
                     size: 400,
-                    muiTableBodyCellProps: ({ cell }) => ({
+                    muiTableBodyCellProps: {
                       sx: {
                         paddingLeft: 0,
                         fontWeight: "bold",
                         paddingTop: "10px",
                         whiteSpace: 'nowrap',
                       },
-                    }),
-                    Cell: ({ renderedCellValue, row }) => (
+                    },
+                    Cell: ({ row }) => (
                                    <Grid container direction="row" spacing={1} justifyContent="flex-start" wrap="nowrap">
                                      <Grid item xs={false}>
                                        <Avatar className={classes.subjectFormAvatar}><FormIcon/></Avatar>
@@ -556,14 +550,14 @@ function SubjectMemberInternal (props) {
                                    </Grid>
                                  ) },
                   { id: 'Status',
-                    muiTableBodyCellProps: ({ cell }) => ({
-                      sx: {
+                    muiTableBodyCellProps: {
+                      sx: (theme) => ({
                         whiteSpace: 'nowrap',
                         paddingTop: "10px",
-                        paddingBottom: "8px",
-                      },
-                    }),
-                    Cell: ({ renderedCellValue, row }) => (<>
+                        paddingBottom: theme.spacing(1),
+                      }),
+                    },
+                    Cell: ({ row }) => (<>
                                          { row.original["statusFlags"].map((status) => {
                                            return <Chip
                                              key={status}
@@ -578,7 +572,7 @@ function SubjectMemberInternal (props) {
                 enableRowActions
                 positionActionsColumn="last"
                 renderRowActions={({ row }) => (
-                    <Box sx={{ display: 'flex', flexWrap: 'nowrap', float: 'right' }}>
+                    <Box sx={{ display: 'flex', flexWrap: 'nowrap'}}>
                       <EditButton
                         entryPath={row.original["@path"]}
                         entryType="Form"

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -483,15 +483,15 @@ function SubjectMemberInternal (props) {
                 enableTableHead={false}
                 enableTableFooter={false}
                 layoutMode="grid"
-                muiTableHeadCellProps={{
-                    sx: {
-                      flex: '0 0 auto',
-                    },
-                  }}
                 muiTableBodyCellProps={{
-                    sx: {
-                      flex: '0 0 auto',
-                    },
+                  sx: {
+                    flex: '0 0 auto',
+                  },
+                }}
+                muiTableDetailPanelProps={{
+                  sx: {
+                    paddingTop: '0',
+                  }
                 }}
                 renderDetailPanel={({ row }) => <FormData formID={row.original["@name"]} maxDisplayed={maxDisplayed} classes={classes}/> }
                 defaultColumn={{
@@ -505,6 +505,7 @@ function SubjectMemberInternal (props) {
                     muiTableBodyCellProps: ({ cell }) => ({
                       sx: {
                         padding: '0',
+                        paddingRight: '16px',
                         whiteSpace: 'nowrap',
                         textAlign: 'right',
                         flex: '0 0 auto',
@@ -537,7 +538,7 @@ function SubjectMemberInternal (props) {
                       },
                     }),
                     Cell: ({ renderedCellValue, row }) => (
-                                   <Grid container direction="row" spacing={1} justifyContent="flex-start">
+                                   <Grid container direction="row" spacing={1} justifyContent="flex-start" wrap="nowrap">
                                      <Grid item xs={false}>
                                        <Avatar className={classes.subjectFormAvatar}><FormIcon/></Avatar>
                                      </Grid>
@@ -577,7 +578,7 @@ function SubjectMemberInternal (props) {
                 enableRowActions
                 positionActionsColumn="last"
                 renderRowActions={({ row }) => (
-                    <Box sx={{ display: 'flex', flexWrap: 'nowrap', gap: '8', float: 'right' }}>
+                    <Box sx={{ display: 'flex', flexWrap: 'nowrap', float: 'right' }}>
                       <EditButton
                         entryPath={row.original["@path"]}
                         entryType="Form"

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -537,14 +537,14 @@ function SubjectMemberInternal (props) {
                   { id: 'Questionnaire',
                     size: 400,
                     muiTableBodyCellProps: ({ cell }) => ({
-                      sx: (theme) => ({
+                      sx: {
                         paddingLeft: 0,
                         fontWeight: "bold",
                         paddingTop: "10px",
                         whiteSpace: 'nowrap',
-                      }),
+                      },
                     }),
-                    Cell: ({ renderedCellValue, row }) => (<>
+                    Cell: ({ renderedCellValue, row }) => (
                                    <Grid container direction="row" spacing={1} justifyContent="flex-start">
                                      <Grid item xs={false}>
                                        <Avatar className={classes.subjectFormAvatar}><FormIcon/></Avatar>
@@ -561,7 +561,7 @@ function SubjectMemberInternal (props) {
                                        </Typography>
                                      </Grid>
                                    </Grid>
-                                 </>) },
+                                 ) },
                   { id: 'Status',
                     muiTableBodyCellProps: ({ cell }) => ({
                       sx: {
@@ -586,7 +586,6 @@ function SubjectMemberInternal (props) {
                 positionActionsColumn="last"
                 renderRowActions={({ row }) => (
                     <Box sx={{ display: 'flex', flexWrap: 'nowrap', gap: '8', float: 'right' }}>
-                    <>
                       <EditButton
                         entryPath={row.original["@path"]}
                         entryType="Form"
@@ -598,7 +597,6 @@ function SubjectMemberInternal (props) {
                         warning={row.original ? row.original["@referenced"] : false}
                         onComplete={fetchTableData}
                       />
-                    </>
                     </Box>
                 )}
               />

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -174,7 +174,7 @@ function UnstyledNewSubjectDialog (props) {
             }}
             muiTableBodyRowProps={({ row }) => ({
               onClick: () => { changeType(row.original); row.toggleSelected(); },
-              selected: row.original['label'] === newSubjectType?.['label'],
+              selected: !isLoading && row.original['label'] === newSubjectType?.['label'],
               sx: {
                 cursor: 'pointer',
               },
@@ -320,7 +320,7 @@ function UnstyledSelectParentDialog (props) {
               muiSearchTextFieldProps={{ autoFocus: true }}
               muiTableBodyRowProps={({ row }) => ({
                 onClick: () => { !hasChildWithId(row.original, childName) && onChangeParent && onChangeParent(row.original); row.toggleSelected(); },
-                selected: row.original["jcr:uuid"] === value?.["jcr:uuid"],
+                selected: !isLoading && row.original["jcr:uuid"] === value?.["jcr:uuid"],
                 sx: {
                   cursor: 'pointer',
                 },
@@ -1041,7 +1041,7 @@ function SubjectSelectorList(props) {
         muiSearchTextFieldProps={{ autoFocus: true }}
         muiTableBodyRowProps={({ row }) => ({
           onClick: () => { onSelect(row.original); handleSelection(row.original); row.toggleSelected(); },
-          selected: row.original["jcr:uuid"] === selectedSubject?.["jcr:uuid"],
+          selected: !isLoading && row.original["jcr:uuid"] === selectedSubject?.["jcr:uuid"],
           sx: {
             cursor: 'pointer',
           },

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -89,6 +89,7 @@ function UnstyledNewSubjectDialog (props) {
     if (allowedTypes?.length === 1) {
       changeType(allowedTypes[0]);
     }
+    allowedTypes?.length && setRowCount(allowedTypes?.length);
   }, [allowedTypes]);
 
   useEffect(() => {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -285,6 +285,7 @@ function UnstyledSelectParentDialog (props) {
     };
     fetchData();
   }, [
+    currentSubject?.["jcr:uuid"],
     globalFilter,
     pagination.pageIndex,
     pagination.pageSize,

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -942,10 +942,12 @@ function SubjectSelectorList(props) {
     if (atMax) {
       onError(`${rowData?.["type"]["@name"]} ${rowData?.["identifier"]} already has ${selectedQuestionnaire?.["maxPerSubject"]} ${selectedQuestionnaire?.["title"]} form(s) filled out.`);
       disableProgress(true);
+      return false;
     }
     else {
       onError("");
       disableProgress(false);
+      return true;
     }
   }
 
@@ -1001,8 +1003,7 @@ function SubjectSelectorList(props) {
       // Auto-select if there is only one subject available which has not execeeded maximum Forms per Subject
       let atMax = (latestRelatedSubjects?.length && selectedQuestionnaire && (latestRelatedSubjects.filter((i) => (i["s.jcr:uuid"] == filteredData[0]["jcr:uuid"])).length >= (+(selectedQuestionnaire?.["maxPerSubject"]) || undefined)))
       if (filteredData.length === 1 && !atMax) {
-        onSelect(filteredData[0]);
-        handleSelection(filteredData[0]);
+        handleSelection(filteredData[0]) && onSelect(filteredData[0]);
       }
       setData(filteredData.map((row) => ({
         hierarchy: getHierarchy(row, React.Fragment, () => ({})),
@@ -1047,7 +1048,7 @@ function SubjectSelectorList(props) {
         positionToolbarAlertBanner="none"
         muiSearchTextFieldProps={{ autoFocus: true }}
         muiTableBodyRowProps={({ row }) => ({
-          onClick: () => { onSelect(row.original); handleSelection(row.original); },
+          onClick: () => { handleSelection(row.original) && onSelect(row.original); },
           sx: {
             cursor: 'pointer',
           },

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -146,8 +146,10 @@ function UnstyledNewSubjectDialog (props) {
             manualPagination
             onGlobalFilterChange={setGlobalFilter}
             onPaginationChange={setPagination}
+            getRowId={ (row) => row["label"] }
             rowCount={rowCount}
             state={{
+              rowSelection: { [newSubjectType?.["label"]]: true },
               globalFilter,
               isLoading,
               pagination,
@@ -161,6 +163,7 @@ function UnstyledNewSubjectDialog (props) {
             renderTopToolbarCustomActions={() => {
               return <Typography variant="h6" sx={{ paddingLeft: theme.spacing(2) }}>Select a type</Typography>;
             }}
+            positionToolbarAlertBanner="none"
             muiTableHeadCellProps={{
               sx: {
                 fontSize: 'large',
@@ -173,8 +176,7 @@ function UnstyledNewSubjectDialog (props) {
               },
             }}
             muiTableBodyRowProps={({ row }) => ({
-              onClick: () => { changeType(row.original); row.toggleSelected(); },
-              selected: !isLoading && row.original['label'] === newSubjectType?.['label'],
+              onClick: () => { changeType(row.original); },
               sx: {
                 cursor: 'pointer',
               },
@@ -307,6 +309,7 @@ function UnstyledSelectParentDialog (props) {
               onPaginationChange={setPagination}
               rowCount={rowCount}
               state={{
+                rowSelection: { [value?.["jcr:uuid"]]: true },
                 globalFilter,
                 isLoading,
                 pagination,
@@ -317,10 +320,11 @@ function UnstyledSelectParentDialog (props) {
                   { accessorKey: 'hierarchy' }
               ]}
               data={data}
+              getRowId={ (row) => row["jcr:uuid"] }
+              positionToolbarAlertBanner="none"
               muiSearchTextFieldProps={{ autoFocus: true }}
               muiTableBodyRowProps={({ row }) => ({
-                onClick: () => { !hasChildWithId(row.original, childName) && onChangeParent && onChangeParent(row.original); row.toggleSelected(); },
-                selected: !isLoading && row.original["jcr:uuid"] === value?.["jcr:uuid"],
+                onClick: () => { !hasChildWithId(row.original, childName) && onChangeParent && onChangeParent(row.original); },
                 sx: {
                   cursor: 'pointer',
                 },
@@ -1026,8 +1030,10 @@ function SubjectSelectorList(props) {
         manualPagination
         onGlobalFilterChange={setGlobalFilter}
         onPaginationChange={setPagination}
+        getRowId={ (row) => row["jcr:uuid"] }
         rowCount={rowCount}
         state={{
+          rowSelection: { [selectedSubject?.["jcr:uuid"]]: true },
           globalFilter,
           isLoading,
           pagination,
@@ -1038,10 +1044,10 @@ function SubjectSelectorList(props) {
           { accessorKey: 'hierarchy' }
         ]}
         data={data}
+        positionToolbarAlertBanner="none"
         muiSearchTextFieldProps={{ autoFocus: true }}
         muiTableBodyRowProps={({ row }) => ({
-          onClick: () => { onSelect(row.original); handleSelection(row.original); row.toggleSelected(); },
-          selected: !isLoading && row.original["jcr:uuid"] === selectedSubject?.["jcr:uuid"],
+          onClick: () => { onSelect(row.original); handleSelection(row.original); },
           sx: {
             cursor: 'pointer',
           },

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -493,7 +493,6 @@ export function NewSubjectDialog (props) {
         // Display the parent type to select
         setError();
         setNewSubjectPopperOpen(false);
-        tableRef.current && tableRef.current.onQueryChange(); // Force the table to re-query our server with the new subjectType
         setSelectParentPopperOpen(true);
       }
     } else {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -21,7 +21,7 @@ import React, { useRef, useEffect, useState, useContext } from "react";
 import { useHistory } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 
-import { Avatar, Button, CircularProgress, DialogActions, DialogContent, ListItem, ListItemAvatar, TextField } from "@mui/material";
+import { Avatar, Button, CircularProgress, DialogActions, DialogContent, ListItem, ListItemAvatar, TextField, Typography } from "@mui/material";
 import withStyles from '@mui/styles/withStyles';
 import AssignmentIndIcon from "@mui/icons-material/AssignmentInd";
 import MaterialReactTable from "material-react-table";
@@ -156,9 +156,12 @@ function UnstyledNewSubjectDialog (props) {
             }}
             initialState={{ showGlobalFilter: true }}
             columns={[
-                { header: 'Select a type', accessorKey: 'label' }
+                { accessorKey: 'label' }
               ]}
             data={ allowedTypes?.length ? allowedTypes : data }
+            renderTopToolbarCustomActions={() => {
+              return <Typography variant="h6" sx={{ paddingLeft: theme.spacing(2) }}>Select a type</Typography>;
+            }}
             muiTableHeadCellProps={{
               sx: {
                 fontSize: 'large',
@@ -277,9 +280,7 @@ function UnstyledSelectParentDialog (props) {
         changeType(json["rows"][0]);
       }
 
-      setData(json["rows"].map((row) => ({
-        hierarchy: getHierarchy(row, React.Fragment, ()=>({})),
-        ...row })));
+      setData(json["rows"].map((row) => ({ hierarchy: getHierarchy(row, React.Fragment, ()=>({})),...row })));
       setRowCount(json.totalrows);
 
       setIsLoading(false);
@@ -289,7 +290,8 @@ function UnstyledSelectParentDialog (props) {
   }, [
     globalFilter,
     pagination.pageIndex,
-    pagination.pageSize
+    pagination.pageSize,
+    getHierarchy
   ]);
 
   return(

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -156,14 +156,20 @@ function UnstyledNewSubjectDialog (props) {
             }}
             initialState={{ showGlobalFilter: true }}
             columns={[
-                { header: 'Select a subject type', accessorKey: 'label' }
+                { header: 'Select a type', accessorKey: 'label' }
               ]}
             data={ allowedTypes?.length ? allowedTypes : data }
             muiTableHeadCellProps={{
-              sx: (theme) => ({
-                background: theme.palette.grey['200'],
-              }),
+              sx: {
+                fontSize: 'large',
+                paddingTop: '0',
+              },
             }}
+            muiTableBodyCellProps={({ cell }) => ({
+              sx: {
+                fontSize: '1rem'
+              },
+            })}
             muiTableBodyRowProps={({ row }) => ({
               onClick: () => { changeType(row.original) },
               sx: (theme) => ({
@@ -320,6 +326,11 @@ function UnstyledSelectParentDialog (props) {
                   // grey out subjects that already have something by this name
                   color: (hasChildWithId(row.original, childName) ? theme.palette.grey["500"] : theme.palette.grey["900"])
                 })
+              })}
+              muiTableBodyCellProps={({ cell }) => ({
+                sx: {
+                  fontSize: '1rem'
+                },
               })}
             />
         }
@@ -1022,7 +1033,7 @@ function SubjectSelectorList(props) {
           showProgressBars: isRefetching
         }}
         initialState={{ showGlobalFilter: true }}
-        columns={[{ header: 'Identifier', accessorKey: 'hierarchy' }]}
+        columns={[{ accessorKey: 'hierarchy' }]}
         data={data}
         muiTableBodyRowProps={({ row }) => ({
             onClick: () => { onSelect(row.original); handleSelection(row.original) },
@@ -1035,6 +1046,11 @@ function SubjectSelectorList(props) {
             : theme.palette.grey["900"]
             )
           }),
+        })}
+        muiTableBodyCellProps={({ cell }) => ({
+          sx: {
+            fontSize: '1rem'
+          },
         })}
       />
     </React.Fragment>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -317,6 +317,7 @@ function UnstyledSelectParentDialog (props) {
                   { accessorKey: 'hierarchy' }
               ]}
               data={data}
+              muiSearchTextFieldProps={{ autoFocus: true }}
               muiTableBodyRowProps={({ row }) => ({
                 onClick: () => { !hasChildWithId(row.original, childName) && onChangeParent && onChangeParent(row.original); row.toggleSelected(); },
                 selected: row.original["jcr:uuid"] === value?.["jcr:uuid"],
@@ -1037,6 +1038,7 @@ function SubjectSelectorList(props) {
           { accessorKey: 'hierarchy' }
         ]}
         data={data}
+        muiSearchTextFieldProps={{ autoFocus: true }}
         muiTableBodyRowProps={({ row }) => ({
           onClick: () => { onSelect(row.original); handleSelection(row.original); row.toggleSelected(); },
           selected: row.original["jcr:uuid"] === selectedSubject?.["jcr:uuid"],

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -275,12 +275,9 @@ function UnstyledSelectParentDialog (props) {
       const response = await fetchWithReLogin(globalLoginDisplay, url);
       const json = await response.json();
 
-      // Auto-select if there's only one available SubjectType
-      if (json["rows"].length === 1) {
-        changeType(json["rows"][0]);
-      }
-
-      setData(json["rows"].map((row) => ({ hierarchy: getHierarchy(row, React.Fragment, ()=>({})),...row })));
+      setData(json["rows"].map((row) => ({
+	    hierarchy: getHierarchy(row, React.Fragment, ()=>({})),
+	    ...row })));
       setRowCount(json.totalrows);
 
       setIsLoading(false);
@@ -318,7 +315,7 @@ function UnstyledSelectParentDialog (props) {
               }}
               initialState={{ showGlobalFilter: true }}
               columns={[
-                  { header: 'Subject', accessorKey: 'label' }
+                  { accessorKey: 'hierarchy' }
               ]}
               data={data}
               muiTableBodyRowProps={({ row }) => ({

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -167,15 +167,16 @@ function UnstyledNewSubjectDialog (props) {
             }}
             muiTableBodyCellProps={({ cell }) => ({
               sx: {
-                fontSize: '1rem'
+                fontSize: '1rem',
+                /* It doesn't seem possible to alter the className from here */
+                backgroundColor: (newSubjectType?.["label"] === cell.row.original["label"]) ? theme.palette.grey["200"] : theme.palette.background.default
               },
             })}
             muiTableBodyRowProps={({ row }) => ({
               onClick: () => { changeType(row.original) },
-              sx: (theme) => ({
-                /* It doesn't seem possible to alter the className from here */
-                backgroundColor: (newSubjectType?.["label"] === row.original["label"]) ? theme.palette.grey["200"] : theme.palette.background.default
-              })
+              sx: {
+                cursor: 'pointer',
+              },
             })}
           />
         </DialogContent>
@@ -320,16 +321,17 @@ function UnstyledSelectParentDialog (props) {
               data={data}
               muiTableBodyRowProps={({ row }) => ({
                 onClick: () => { !hasChildWithId(row.original, childName) && onChangeParent(row.original) },
-                sx: (theme) => ({
-                  /* It doesn't seem possible to alter the className from here */
-                  backgroundColor: (value?.["jcr:uuid"] === row.original["jcr:uuid"]) ? theme.palette.grey["200"] : theme.palette.background.default,
-                  // grey out subjects that already have something by this name
-                  color: (hasChildWithId(row.original, childName) ? theme.palette.grey["500"] : theme.palette.grey["900"])
-                })
+                sx: {
+                  cursor: 'pointer',
+                },
               })}
               muiTableBodyCellProps={({ cell }) => ({
                 sx: {
-                  fontSize: '1rem'
+                  fontSize: '1rem',
+                  /* It doesn't seem possible to alter the className from here */
+                  backgroundColor: (value?.["jcr:uuid"] === cell.row.original["jcr:uuid"]) ? theme.palette.grey["200"] : theme.palette.background.default,
+                  // grey out subjects that already have something by this name
+                  color: (hasChildWithId(cell.row.original, childName) ? theme.palette.grey["500"] : theme.palette.grey["900"])
                 },
               })}
             />
@@ -1036,20 +1038,21 @@ function SubjectSelectorList(props) {
         columns={[{ accessorKey: 'hierarchy' }]}
         data={data}
         muiTableBodyRowProps={({ row }) => ({
-            onClick: () => { onSelect(row.original); handleSelection(row.original) },
-            sx: (theme) => ({
-              /* It doesn't seem possible to alter the className from here */
-              backgroundColor: (selectedSubject?.["jcr:uuid"] === row.original["jcr:uuid"]) ? theme.palette.grey["200"] : theme.palette.background.default,
-            // grey out subjects that have already reached maxPerSubject
-            color: ((relatedSubjects?.length && selectedQuestionnaire && (relatedSubjects.filter((i) => (i["s.jcr:uuid"] == row.original["jcr:uuid"])).length >= (+(selectedQuestionnaire?.["maxPerSubject"]) || undefined)))
-            ? theme.palette.grey["500"]
-            : theme.palette.grey["900"]
-            )
-          }),
+          onClick: () => { onSelect(row.original); handleSelection(row.original) },
+          sx: {
+            cursor: 'pointer',
+          },
         })}
         muiTableBodyCellProps={({ cell }) => ({
           sx: {
-            fontSize: '1rem'
+            fontSize: '1rem',
+            /* It doesn't seem possible to alter the className from here */
+            backgroundColor: (selectedSubject?.["jcr:uuid"] === cell.row.original["jcr:uuid"]) ? theme.palette.grey["200"] : theme.palette.background.default,
+            // grey out subjects that have already reached maxPerSubject
+            color: ((relatedSubjects?.length && selectedQuestionnaire && (relatedSubjects.filter((i) => (i["s.jcr:uuid"] == cell.row.original["jcr:uuid"])).length >= (+(selectedQuestionnaire?.["maxPerSubject"]) || undefined)))
+            ? theme.palette.grey["500"]
+            : theme.palette.grey["900"]
+            )
           },
         })}
       />

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -333,7 +333,7 @@ function UnstyledSelectParentDialog (props) {
                 sx: {
                   fontSize: '1rem',
                   // grey out subjects that already have something by this name
-                  color: (hasChildWithId(cell.row.original, childName) ? theme.palette.grey["500"] : theme.palette.grey["900"])
+                  color: (hasChildWithId(cell.row.original, childName) ? theme.palette.text.disabled : theme.palette.text.primary)
                 },
               })}
             />
@@ -1058,8 +1058,8 @@ function SubjectSelectorList(props) {
             fontSize: '1rem',
             // grey out subjects that have already reached maxPerSubject
             color: ((relatedSubjects?.length && selectedQuestionnaire && (relatedSubjects.filter((i) => (i["s.jcr:uuid"] == cell.row.original["jcr:uuid"])).length >= (+(selectedQuestionnaire?.["maxPerSubject"]) || undefined)))
-            ? theme.palette.grey["500"]
-            : theme.palette.grey["900"]
+            ? theme.palette.text.disabled
+            : theme.palette.text.primary
             )
           },
         })}

--- a/modules/homepage/src/main/frontend/src/themePage/index.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/index.jsx
@@ -33,7 +33,6 @@ import PageStart from "../PageStart";
 import IndexStyle from "./indexStyle.jsx";
 import DialogueLoginContainer, { GlobalLoginContext } from "../login/loginDialogue.js";
 
-// Temporary fix for the duplicate displayedRows occurring in material-react-table 2.0.3
 const materialTableStyles = <GlobalStyles styles={{
   "div[class^=MTablePaginationInner-root] .MuiTypography-caption" : {
     display: "none"

--- a/modules/homepage/src/main/frontend/src/themePage/index.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/index.jsx
@@ -33,7 +33,7 @@ import PageStart from "../PageStart";
 import IndexStyle from "./indexStyle.jsx";
 import DialogueLoginContainer, { GlobalLoginContext } from "../login/loginDialogue.js";
 
-// Temporary fix for the duplicate displayedRows occurring in material-table 2.0.3
+// Temporary fix for the duplicate displayedRows occurring in material-react-table 2.0.3
 const materialTableStyles = <GlobalStyles styles={{
   "div[class^=MTablePaginationInner-root] .MuiTypography-caption" : {
     display: "none"

--- a/modules/homepage/src/main/frontend/src/themePage/index.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/index.jsx
@@ -33,12 +33,6 @@ import PageStart from "../PageStart";
 import IndexStyle from "./indexStyle.jsx";
 import DialogueLoginContainer, { GlobalLoginContext } from "../login/loginDialogue.js";
 
-const materialTableStyles = <GlobalStyles styles={{
-  "div[class^=MTablePaginationInner-root] .MuiTypography-caption" : {
-    display: "none"
-  }
-}} />;
-
 class Main extends React.Component {
   constructor(props) {
     super(props);
@@ -111,7 +105,6 @@ class Main extends React.Component {
 
     return (
       <React.Fragment>
-      {materialTableStyles}
       <GlobalLoginContext.Provider
         value={{
           dialogOpen: (loginHandlerFcn, discardOnFailure) => {

--- a/modules/principals/src/main/frontend/package.json
+++ b/modules/principals/src/main/frontend/package.json
@@ -42,7 +42,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "5.2.0",
-    "material-react-table": "1.9.3",
+    "material-react-table": "1.10.0",
     "formik": "2.2.9",
     "history": "4.10.1",
     "semantic-ui-css": "2.5.0",

--- a/modules/principals/src/main/frontend/package.json
+++ b/modules/principals/src/main/frontend/package.json
@@ -42,7 +42,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "5.2.0",
-    "material-table": "2.0.3",
+    "material-react-table": "1.9.3",
     "formik": "2.2.9",
     "history": "4.10.1",
     "semantic-ui-css": "2.5.0",

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/addusertogroupdialogue.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/addusertogroupdialogue.jsx
@@ -114,13 +114,13 @@ class AddUserToGroupDialogue extends React.Component {
                               })}
                               columns={[
                                 { header: 'Avatar', accessorKey: 'imageUrl', size: 8,
-                                  Cell: ({ renderedCellValue, row }) => <Avatar src={row.original.imageUrl} className={classes.info}>{row.original.initials}</Avatar>},
+                                  Cell: ({ row }) => <Avatar src={row.original.imageUrl} className={classes.info}>{row.original.initials}</Avatar>},
                                 { header: 'User Name', accessorKey: 'name' },
                                 { header: 'Admin', accessorKey: 'isAdmin', size: 10,
-                                  Cell: ({ renderedCellValue, row }) => (row.original.isAdmin ? <CheckIcon /> : "")
+                                  Cell: ({ row }) => (row.original.isAdmin ? <CheckIcon /> : "")
                                 },
                                 { header: 'Disabled', accessorKey: 'isDisabled', size: 10,
-                                  Cell: ({ renderedCellValue, row }) => (row.original.isDisabled ? <CheckIcon /> : "")
+                                  Cell: ({ row }) => (row.original.isDisabled ? <CheckIcon /> : "")
                                 },
                               ]}
                               data={this.state.freeUsers}

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/addusertogroupdialogue.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/addusertogroupdialogue.jsx
@@ -22,6 +22,8 @@ import userboardStyle from '../userboardStyle.jsx';
 
 import { Avatar, Button, Dialog, DialogTitle, DialogActions, DialogContent, Grid } from "@mui/material";
 
+import CheckIcon from '@mui/icons-material/Check';
+
 import MaterialReactTable from 'material-react-table';
 
 const GROUP_URL="/system/userManager/group/";

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/addusertogroupdialogue.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/addusertogroupdialogue.jsx
@@ -38,7 +38,7 @@ class AddUserToGroupDialogue extends React.Component {
     handleAddUsers() {
         let formData = new FormData();
 
-        let selectedUsers = Object.keys(this.tableRef.current.getState().rowSelection);
+        let selectedUsers = Object.keys(this.tableRef.current?.getState().rowSelection);
         for (var i = 0; i < selectedUsers.length; ++i) {
             formData.append(':member', this.state.freeUsers[selectedUsers[i]].name);
         }
@@ -98,7 +98,6 @@ class AddUserToGroupDialogue extends React.Component {
                               enableColumnFilters={false}
                               enableSorting={false}
                               enableTopToolbar={false}
-                              enableToolbarInternalActions={false}
                               muiTableHeadCellProps={{
                                 sx: (theme) => ({
                                   background: theme.palette.grey['200'],

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/groupsmanager.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/groupsmanager.jsx
@@ -69,7 +69,7 @@ class GroupsManager extends React.Component {
   handleRemoveUsers(currentGroupName, groupUsers) {
     let formData = new FormData();
 
-    let selectedUsers = Object.keys(this.tableRef.current.getState().rowSelection);
+    let selectedUsers = Object.keys(this.tableRef.current?.getState().rowSelection);
     for (var i = 0; i < selectedUsers.length; ++i) {
       formData.append(':member@Delete', groupUsers[selectedUsers[i]].name);
     }
@@ -90,7 +90,7 @@ class GroupsManager extends React.Component {
 
   handleReload (doClear) {
     doClear && this.clearSelectedGroup();
-    this.tableRef.current.resetRowSelection();
+    this.tableRef.current?.resetRowSelection();
     this.props.reload();
   }
 
@@ -122,6 +122,8 @@ class GroupsManager extends React.Component {
             enableColumnActions={false}
             enableColumnFilters={false}
             enableSorting={false}
+            enableToolbarInternalActions={false}
+            initialState={{ showGlobalFilter: true }}
             muiTableHeadCellProps={{
               sx: (theme) => ({
                 background: theme.palette.grey['200'],
@@ -129,6 +131,7 @@ class GroupsManager extends React.Component {
             }}
             displayColumnDefOptions={{
               'mrt-row-actions': {
+                size: 10,
                 muiTableHeadCellProps: {align: 'right'},
                 muiTableBodyCellProps: ({ cell }) => ({
                   sx: {
@@ -144,9 +147,9 @@ class GroupsManager extends React.Component {
               { header: 'Avatar', accessorKey: 'imageUrl', size: 10,
                 Cell: ({ renderedCellValue, row }) => (<Avatar src={row.original.imageUrl} className={classes.info}>{row.original.name.charAt(0)}</Avatar>)
               },
-              { header: 'Name', accessorKey: 'name' },
-              { header: 'Members', accessorKey: 'members' },
-              { header: 'Declared Members', accessorKey: 'declaredMembers' },
+              { header: 'Name', accessorKey: 'name', size: 300, },
+              { header: 'Members', accessorKey: 'members', size: 10, },
+              { header: 'Declared Members', accessorKey: 'declaredMembers', size: 10, },
             ]}
             data={this.props.groups}
             enableRowActions
@@ -168,7 +171,6 @@ class GroupsManager extends React.Component {
                     <Card className={classes.cardRoot}>
                       <CardContent>
                         { groupUsers.length > 0 &&
-                          <div>
                             <MaterialReactTable
                               tableInstanceRef={this.tableRef}
                               enableColumnActions={false}
@@ -185,6 +187,11 @@ class GroupsManager extends React.Component {
                               enableRowSelection
                               enableSelectAll={false}
                               muiSelectCheckboxProps={{ color: 'primary' }}
+                              displayColumnDefOptions={{
+                                'mrt-row-select': {
+                                  size: 7,
+                                },
+                              }}
                               muiTableBodyRowProps={({ row }) => ({
                                 onClick: row.getToggleSelectedHandler(),
                                 sx: {
@@ -198,7 +205,7 @@ class GroupsManager extends React.Component {
                                   { header: 'Avatar', accessorKey: 'imageUrl', size: 10,
                                     Cell: ({ renderedCellValue, row }) => (<Avatar src={row.original.imageUrl} className={classes.info}>{row.original.initials}</Avatar>)
                                   },
-                                  { header: 'User Name', accessorKey: 'name' },
+                                  { header: 'User Name', accessorKey: 'name', size: 300, },
                                   { header: 'Admin', accessorKey: 'isAdmin', size: 10,
                                     Cell: ({ renderedCellValue, row }) => (row.original.isAdmin ? <CheckIcon /> : "")
                                   },
@@ -209,7 +216,6 @@ class GroupsManager extends React.Component {
                               }]}
                               data={groupUsers}
                               />
-                          </div>
                         }
                         <Grid container className={classes.cardActions}>
                           <Button

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/groupsmanager.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/groupsmanager.jsx
@@ -19,7 +19,7 @@ import React from "react";
 
 import withStyles from '@mui/styles/withStyles';
 
-import { Avatar, Button, Card, CardContent, Grid } from "@mui/material";
+import { Avatar, Button, Card, CardContent, Grid, IconButton, Tooltip } from "@mui/material";
 
 import userboardStyle from '../userboardStyle.jsx';
 import CreateGroupDialogue from "./creategroupdialogue.jsx";
@@ -27,8 +27,9 @@ import DeletePrincipalDialogue from "../deleteprincipaldialogue.jsx";
 import AddUserToGroupDialogue from "./addusertogroupdialogue.jsx";
 import NewItemButton from "../../components/NewItemButton.jsx"
 import AdminScreen from "../../adminDashboard/AdminScreen.jsx";
-
-import MaterialTable from 'material-table';
+import DeleteIcon from '@mui/icons-material/Delete';
+import CheckIcon from '@mui/icons-material/Check';
+import MaterialReactTable from 'material-react-table';
 
 const GROUP_URL = "/system/userManager/group/";
 
@@ -36,11 +37,8 @@ class GroupsManager extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      selectedUsers: [],
       currentGroupUsers: [],
-
       currentGroupName: "",
-      currentGroupIndex: -1,
 
       deployCreateGroup: false,
       deployDeleteGroup: false,
@@ -49,7 +47,6 @@ class GroupsManager extends React.Component {
     };
 
     this.tableRef = React.createRef();
-    this.openDetailsPanel = this.openDetailsPanel.bind(this);
   }
 
   getGroupUsers (groupName){
@@ -65,45 +62,25 @@ class GroupsManager extends React.Component {
     this.setState(
       {
         currentGroupName: "",
-        currentGroupIndex: -1,
-        selectedUsers: [],
       }
     );
   }
 
-  clearSelectedUsers () {
-    this.setState(
-      {
-        selectedUsers: [],
-      }
-    );
-  }
-
-  addName(name) {
-    return { name }
-  }
-
-  handleSelectRowClick(rows) {
-    let chosens = rows.map((row) => row.name);
-    this.setState({ selectedUsers: chosens });
-  }
-
-  handleRemoveUsers() {
+  handleRemoveUsers(currentGroupName, groupUsers) {
     let formData = new FormData();
 
-    var i;
-    for (i = 0; i < this.state.selectedUsers.length; ++i) {
-      formData.append(':member@Delete', this.state.selectedUsers[i]);
+    let selectedUsers = Object.keys(this.tableRef.current.getState().rowSelection);
+    for (var i = 0; i < selectedUsers.length; ++i) {
+      formData.append(':member@Delete', groupUsers[selectedUsers[i]].name);
     }
 
-    fetch(GROUP_URL + this.state.currentGroupName + ".update.html",
+    fetch(GROUP_URL + currentGroupName + ".update.html",
       {
         method: 'POST',
         credentials: 'include',
         body: formData
       })
       .then(() => {
-        this.clearSelectedUsers();
         this.handleReload();
       })
       .catch((error) => {
@@ -111,33 +88,10 @@ class GroupsManager extends React.Component {
       });
   }
 
-  handleGroupRowClick(index, name) {
-    this.setState(
-      {
-        currentGroupName: name,
-        currentGroupIndex: index
-      }
-    );
-  }
-
-  handleGroupDeleteClick(index, name) {
-    this.handleGroupRowClick(index, name);
-    this.setState({deployDeleteGroup: true});
-  }
-
   handleReload (doClear) {
     doClear && this.clearSelectedGroup();
+    this.tableRef.current.resetRowSelection();
     this.props.reload();
-  }
-
-  openDetailsPanel (event) {
-    event.preventDefault();
-    if (this.state.currentGroupIndex > -1 && this.props.groups[this.state.currentGroupIndex]) {
-      this.tableRef.current.onToggleDetailPanel(
-          [this.state.currentGroupIndex],
-          this.tableRef.current.props.detailPanel
-       );
-    }
   }
 
   componentDidMount () {
@@ -150,7 +104,7 @@ class GroupsManager extends React.Component {
 
   render() {
     const { classes } = this.props;
-    const headerBackground = this.props.theme.palette.grey['200'];
+
     return (
       <AdminScreen
         title="Groups"
@@ -164,32 +118,48 @@ class GroupsManager extends React.Component {
         <DeletePrincipalDialogue isOpen={this.state.deployDeleteGroup} handleClose={() => {this.setState({deployDeleteGroup: false});}} name={this.state.currentGroupName} reload={() => this.handleReload(true)} url={GROUP_URL} type={"group"} />
         <AddUserToGroupDialogue isOpen={this.state.deployAddGroupUsers} handleClose={() => {this.setState({deployAddGroupUsers: false});}} name={this.state.currentGroupName} groupUsers={this.state.currentGroupUsers} allUsers={this.props.users}  reload={() => this.handleReload()} />
         <div className={classes.root}>
-          <MaterialTable
-            tableRef={this.tableRef}
-            title=""
-            style={{ boxShadow : 'none' }}
-            options={{
-              actionsColumnIndex: -1,
-              headerStyle: {backgroundColor: headerBackground},
-              emptyRowsWhenPaging: false
+          <MaterialReactTable
+            enableColumnActions={false}
+            enableColumnFilters={false}
+            enableSorting={false}
+            muiTableHeadCellProps={{
+              sx: (theme) => ({
+                background: theme.palette.grey['200'],
+              }),
+            }}
+            displayColumnDefOptions={{
+              'mrt-row-actions': {
+                muiTableHeadCellProps: {align: 'right'},
+                muiTableBodyCellProps: ({ cell }) => ({
+                  sx: {
+                    textAlign: 'right'
+                  },
+                }),
+              },
+              'mrt-row-expand': {
+                size: 8,
+              },
             }}
             columns={[
-              { title: 'Avatar', field: 'imageUrl', render: rowData => <Avatar src={rowData.imageUrl} className={classes.info}>{rowData.name.charAt(0)}</Avatar> },
-              { title: 'Name', field: 'name', cellStyle: {textAlign: 'left'} },
-              { title: 'Members', field: 'members', type: 'numeric', cellStyle: {textAlign: 'left'}, headerStyle: {textAlign: 'left', flexDirection: 'initial'} },
-              { title: 'Declared Members', field: 'declaredMembers', type: 'numeric', cellStyle: {textAlign: 'left'}, headerStyle: {textAlign: 'left', flexDirection: 'initial'} },
+              { header: 'Avatar', accessorKey: 'imageUrl', size: 10,
+                Cell: ({ renderedCellValue, row }) => (<Avatar src={row.original.imageUrl} className={classes.info}>{row.original.name.charAt(0)}</Avatar>)
+              },
+              { header: 'Name', accessorKey: 'name' },
+              { header: 'Members', accessorKey: 'members' },
+              { header: 'Declared Members', accessorKey: 'declaredMembers' },
             ]}
             data={this.props.groups}
-            actions={[
-              {
-                icon: 'delete',
-                tooltip: 'Delete Group',
-                onClick: (event, rowData) => this.handleGroupDeleteClick(rowData.tableData.id, rowData.name)
-              }
-             ]}
-            onRowClick={(event, rowData, togglePanel) => {this.handleGroupRowClick(rowData.tableData.id, rowData.name); togglePanel()}}
-            detailPanel={rowData => {
-                const group = rowData || this.props.groups[this.state.currentGroupIndex];
+            enableRowActions
+            positionActionsColumn="last"
+            renderRowActions={({ row }) => (
+              <Tooltip title="Delete Group">
+                <IconButton onClick={ () => this.setState({currentGroupName: row.original.name, deployDeleteGroup: true}) } >
+                  <DeleteIcon />
+                </IconButton>
+              </Tooltip>
+            )}
+            renderDetailPanel={({ row }) => {
+                const group = row.original;
                 const groupUsers = group.members > 0 ? this.getGroupUsers(group.name) : [];
                 const tableTitle = "Group " + group.name + " users";
 
@@ -197,29 +167,47 @@ class GroupsManager extends React.Component {
                   <div>
                     <Card className={classes.cardRoot}>
                       <CardContent>
-                        { groupUsers.length > 0 && 
+                        { groupUsers.length > 0 &&
                           <div>
-                            <MaterialTable
-                                title={tableTitle}
-                                style={{ boxShadow : 'none' }}
-                                options={{
-                                  emptyRowsWhenPaging: false,
-                                  selection: true,
-                                  showSelectAllCheckbox : false,
-                                  showTextRowsSelected: false,
-                                  headerStyle: {backgroundColor: headerBackground},
-                                  selectionProps: rowData => ({
-                                    color: 'primary'
-                                  })
-                                }}
-                              columns={[
-                                { title: 'Avatar', field: 'imageUrl', render: rowData => <Avatar src={rowData.imageUrl} className={classes.info}>{rowData.initials}</Avatar>},
-                                { title: 'User Name', field: 'name' },
-                                { title: 'Admin', field: 'isAdmin', type: 'boolean' },
-                                { title: 'Disabled', field: 'isDisabled', type: 'boolean' },
-                              ]}
+                            <MaterialReactTable
+                              tableInstanceRef={this.tableRef}
+                              enableColumnActions={false}
+                              enableColumnFilters={false}
+                              enableSorting={false}
+                              enableTopToolbar={false}
+                              enableToolbarInternal
+                              Actions={false}
+                              muiTableHeadCellProps={{
+                                sx: (theme) => ({
+                                  color: theme.palette.text.primary,
+                                }),
+                              }}
+                              enableRowSelection
+                              enableSelectAll={false}
+                              muiSelectCheckboxProps={{ color: 'primary' }}
+                              muiTableBodyRowProps={({ row }) => ({
+                                onClick: row.getToggleSelectedHandler(),
+                                sx: {
+                                  cursor: 'pointer',
+                                },
+                              })}
+                              columns={[{
+                                id: tableTitle,
+                                header: tableTitle,
+                                columns: [
+                                  { header: 'Avatar', accessorKey: 'imageUrl', size: 10,
+                                    Cell: ({ renderedCellValue, row }) => (<Avatar src={row.original.imageUrl} className={classes.info}>{row.original.initials}</Avatar>)
+                                  },
+                                  { header: 'User Name', accessorKey: 'name' },
+                                  { header: 'Admin', accessorKey: 'isAdmin', size: 10,
+                                    Cell: ({ renderedCellValue, row }) => (row.original.isAdmin ? <CheckIcon /> : "")
+                                  },
+                                  { header: 'Disabled', accessorKey: 'isDisabled', size: 10,
+                                    Cell: ({ renderedCellValue, row }) => (row.original.isDisabled ? <CheckIcon /> : "")
+                                  },
+                                ]
+                              }]}
                               data={groupUsers}
-                                onSelectionChange={(rows) => {this.handleSelectRowClick(rows)}}
                               />
                           </div>
                         }
@@ -229,7 +217,11 @@ class GroupsManager extends React.Component {
                             color="primary"
                             size="small"
                             className={classes.containerButton}
-                            onClick={() => {this.setState({currentGroupName: group.principalName, currentGroupIndex: rowData.tableData.id, deployAddGroupUsers: true, currentGroupUsers: groupUsers});}}
+                            onClick={() => { this.setState({currentGroupName: group.principalName,
+                                                            deployAddGroupUsers: true,
+                                                            currentGroupUsers: groupUsers});
+                                           }
+                            }
                           >
                             Add User to Group
                           </Button>
@@ -237,8 +229,7 @@ class GroupsManager extends React.Component {
                             variant="contained"
                             color="secondary"
                             size="small"
-                            disabled={this.state.selectedUsers.length == 0}
-                            onClick={() => {this.setState({currentGroupName: group.principalName, currentGroupIndex: rowData.tableData.id}); this.handleRemoveUsers();}}
+                            onClick={() => { this.handleRemoveUsers(group.principalName, groupUsers) }}
                           >
                             Remove User from Group
                           </Button>

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/groupsmanager.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/groupsmanager.jsx
@@ -133,11 +133,11 @@ class GroupsManager extends React.Component {
               'mrt-row-actions': {
                 size: 10,
                 muiTableHeadCellProps: {align: 'right'},
-                muiTableBodyCellProps: ({ cell }) => ({
+                muiTableBodyCellProps: {
                   sx: {
                     textAlign: 'right'
                   },
-                }),
+                },
               },
               'mrt-row-expand': {
                 size: 8,
@@ -145,7 +145,7 @@ class GroupsManager extends React.Component {
             }}
             columns={[
               { header: 'Avatar', accessorKey: 'imageUrl', size: 10,
-                Cell: ({ renderedCellValue, row }) => (<Avatar src={row.original.imageUrl} className={classes.info}>{row.original.name.charAt(0)}</Avatar>)
+                Cell: ({ row }) => (<Avatar src={row.original.imageUrl} className={classes.info}>{row.original.name.charAt(0)}</Avatar>)
               },
               { header: 'Name', accessorKey: 'name', size: 300, },
               { header: 'Members', accessorKey: 'members', size: 10, },
@@ -177,8 +177,6 @@ class GroupsManager extends React.Component {
                               enableColumnFilters={false}
                               enableSorting={false}
                               enableTopToolbar={false}
-                              enableToolbarInternal
-                              Actions={false}
                               muiTableHeadCellProps={{
                                 sx: (theme) => ({
                                   color: theme.palette.text.primary,
@@ -203,19 +201,19 @@ class GroupsManager extends React.Component {
                                 header: tableTitle,
                                 columns: [
                                   { header: 'Avatar', accessorKey: 'imageUrl', size: 10,
-                                    Cell: ({ renderedCellValue, row }) => (<Avatar src={row.original.imageUrl} className={classes.info}>{row.original.initials}</Avatar>)
+                                    Cell: ({ row }) => (<Avatar src={row.original.imageUrl} className={classes.info}>{row.original.initials}</Avatar>)
                                   },
                                   { header: 'User Name', accessorKey: 'name', size: 300, },
                                   { header: 'Admin', accessorKey: 'isAdmin', size: 10,
-                                    Cell: ({ renderedCellValue, row }) => (row.original.isAdmin ? <CheckIcon /> : "")
+                                    Cell: ({ row }) => (row.original.isAdmin ? <CheckIcon /> : "")
                                   },
                                   { header: 'Disabled', accessorKey: 'isDisabled', size: 10,
-                                    Cell: ({ renderedCellValue, row }) => (row.original.isDisabled ? <CheckIcon /> : "")
+                                    Cell: ({ row }) => (row.original.isDisabled ? <CheckIcon /> : "")
                                   },
                                 ]
                               }]}
                               data={groupUsers}
-                              />
+                            />
                         }
                         <Grid container className={classes.cardActions}>
                           <Button

--- a/modules/principals/src/main/frontend/src/Userboard/Users/usersmanager.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Users/usersmanager.jsx
@@ -99,6 +99,8 @@ class UsersManager extends React.Component {
               enableColumnActions={false}
               enableColumnFilters={false}
               enableSorting={false}
+              enableToolbarInternalActions={false}
+              initialState={{ showGlobalFilter: true }}
               muiTableHeadCellProps={{
                 sx: (theme) => ({
                   background: theme.palette.grey['200'],

--- a/modules/principals/src/main/frontend/src/Userboard/Users/usersmanager.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Users/usersmanager.jsx
@@ -108,25 +108,24 @@ class UsersManager extends React.Component {
               }}
               columns={[
                 { header: 'Avatar', accessorKey: 'imageUrl', size: 10,
-                  Cell: ({ renderedCellValue, row }) => (<Avatar src={row.original.imageUrl} className={classes.info}>{row.original.initials}</Avatar>)
+                  Cell: ({ row }) => (<Avatar src={row.original.imageUrl} className={classes.info}>{row.original.initials}</Avatar>)
                 },
                 { header: 'User Name', accessorKey: 'name' },
                 { header: 'Admin', accessorKey: 'isAdmin', size: 10,
-                  Cell: ({ renderedCellValue, row }) => (row.original.isAdmin ? <CheckIcon /> : "")
+                  Cell: ({ row }) => (row.original.isAdmin ? <CheckIcon /> : "")
                 },
                 { header: 'Disabled', accessorKey: 'isDisabled', size: 10,
-                  Cell: ({ renderedCellValue, row }) => (row.original.isDisabled ? <CheckIcon /> : "")
+                  Cell: ({ row }) => (row.original.isDisabled ? <CheckIcon /> : "")
                 },
               ]}
               displayColumnDefOptions={{
                 'mrt-row-actions': {
                   muiTableHeadCellProps: {align: 'right'},
-                  muiTableBodyCellProps: ({ cell }) => ({
+                  muiTableBodyCellProps: {
                     sx: {
                       padding: '0',
-                      textAlign: 'right'
                     },
-                  }),
+                  },
                 },
                 'mrt-row-expand': {
                   size: 8,
@@ -136,7 +135,7 @@ class UsersManager extends React.Component {
               enableRowActions
               positionActionsColumn="last"
               renderRowActions={({ row }) => (
-                <Box sx={{ display: 'flex', flexWrap: 'nowrap', gap: '0', float: 'right' }}>
+                <Box sx={{ display: 'flex', flexWrap: 'nowrap', float: 'right' }}>
                   <Tooltip title="Change Password">
                     <IconButton onClick={ () => this.setState({currentUserName: row.original.name, deployChangeUserPassword: true}) } >
                       <LockIcon />
@@ -170,7 +169,7 @@ class UsersManager extends React.Component {
                                 header: tableTitle,
                                 columns: [
                                   { header: 'Avatar', accessorKey: 'imageUrl', size: 10,
-                                    Cell: ({ renderedCellValue, row }) => ( <Avatar src={row.original.imageUrl} className={classes.info}>{row.original.name.charAt(0)}</Avatar> )
+                                    Cell: ({ row }) => ( <Avatar src={row.original.imageUrl} className={classes.info}>{row.original.name.charAt(0)}</Avatar> )
                                   },
                                   { header: 'Name', accessorKey: 'name', muiTableBodyCellProps: {align: 'left'} },
                                   { header: 'Members', accessorKey: 'members', size: 10,

--- a/modules/principals/src/main/frontend/src/Userboard/Users/usersmanager.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Users/usersmanager.jsx
@@ -19,7 +19,7 @@ import React from "react";
 import { withRouter } from "react-router-dom";
 import withStyles from '@mui/styles/withStyles';
 
-import { Avatar, Card, CardContent } from "@mui/material";
+import { Avatar, Box, Card, CardContent, IconButton, Tooltip } from "@mui/material";
 
 import userboardStyle from '../userboardStyle.jsx';
 import CreateUserDialogue from "./createuserdialogue.jsx";
@@ -28,7 +28,12 @@ import ChangeUserPasswordDialogue from "./changeuserpassworddialogue.jsx";
 import NewItemButton from "../../components/NewItemButton.jsx";
 import AdminScreen from "../../adminDashboard/AdminScreen.jsx";
 
-import MaterialTable from 'material-table';
+import MaterialReactTable from 'material-react-table';
+import LockIcon from '@mui/icons-material/Lock';
+import DeleteIcon from '@mui/icons-material/Delete';
+import CheckIcon from '@mui/icons-material/Check';
+
+
 
 const USER_URL = "/system/userManager/user/";
 
@@ -36,11 +41,8 @@ class UsersManager extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      userFilter: null,
-
       currentUserName: "",
       currentGroupName: "",
-      currentUserIndex: -1,
 
       deployCreateUser: false,
       deployDeleteUser: false,
@@ -57,45 +59,13 @@ class UsersManager extends React.Component {
     return groups;
   }
 
-  clearSelectedUser () {
-    this.setState(
-      {
-        currentUserName: "",
-        currentUserIndex: -1,
-      }
-    );
-  }
-
-  handleUserRowClick(index, name) {
-    this.setState(
-      {
-        currentUserName: name,
-        currentUserIndex: index
-      }
-    );
-  }
-
-  handleGroupNameClick(name) {
-    this.setState(
-      {
-        currentGroupName: name
-      }
-    );
-  }
-
-  handleUserDeleteClick(index, name) {
-    this.handleUserRowClick(index, name);
-    this.setState({deployDeleteUser: true});
-  }
-
   handleReload () {
-    this.clearSelectedUser();
+    this.setState({currentUserName: ""});
     this.props.reload();
   }
 
   render() {
     const { classes, history } = this.props;
-    const headerBackground = this.props.theme.palette.grey['200'];
 
     return (
       <AdminScreen
@@ -103,44 +73,84 @@ class UsersManager extends React.Component {
         action={
           <NewItemButton
             title="Create new user"
-            onClick={(event) => this.setState({deployCreateUser: true})}
+            onClick={() => this.setState({deployCreateUser: true})}
           />
         }>
-        <CreateUserDialogue isOpen={this.state.deployCreateUser} handleClose={() => {this.setState({deployCreateUser: false});}} reload={() => this.handleReload()}/>
-        <DeletePrincipalDialogue isOpen={this.state.deployDeleteUser} handleClose={() => {this.setState({deployDeleteUser: false});}} name={this.state.currentUserName} reload={() => this.handleReload()} url={USER_URL} type={"user"} />
-        <ChangeUserPasswordDialogue isOpen={this.state.deployChangeUserPassword} handleClose={() => {this.setState({deployChangeUserPassword: false});}} name={this.state.currentUserName}/>
+        <CreateUserDialogue
+          isOpen={this.state.deployCreateUser}
+          handleClose={() => {this.setState({deployCreateUser: false});}}
+          reload={() => this.handleReload()}
+        />
+        <DeletePrincipalDialogue
+          isOpen={this.state.deployDeleteUser}
+          handleClose={() => {this.setState({deployDeleteUser: false});}}
+          name={this.state.currentUserName}
+          reload={() => this.handleReload()}
+          url={USER_URL} type={"user"}
+        />
+        <ChangeUserPasswordDialogue 
+          isOpen={this.state.deployChangeUserPassword}
+          handleClose={() => {this.setState({deployChangeUserPassword: false});}}
+          name={this.state.currentUserName}
+        />
 
         <div className={classes.root}>
-            <MaterialTable
-              title=""
-              style={{ boxShadow : 'none' }}
-              options={{
-                actionsColumnIndex: -1,
-                headerStyle: {backgroundColor: headerBackground},
-                emptyRowsWhenPaging: false
+          <MaterialReactTable
+              enableColumnActions={false}
+              enableColumnFilters={false}
+              enableSorting={false}
+              muiTableHeadCellProps={{
+                sx: (theme) => ({
+                  background: theme.palette.grey['200'],
+                }),
               }}
               columns={[
-                { title: 'Avatar', field: 'imageUrl', render: rowData => <Avatar src={rowData.imageUrl} className={classes.info}>{rowData.initials}</Avatar>},
-                { title: 'User Name', field: 'name' },
-                { title: 'Admin', field: 'isAdmin', type: 'boolean' },
-                { title: 'Disabled', field: 'isDisabled', type: 'boolean' },
-              ]}
-              data={this.props.users}
-              actions={[
-                {
-                  icon: 'lock',
-                  tooltip: 'Change Password',
-                  onClick: (event, rowData) => this.setState({currentUserName: rowData.name, deployChangeUserPassword: true})
+                { header: 'Avatar', accessorKey: 'imageUrl', size: 10,
+                  Cell: ({ renderedCellValue, row }) => (<Avatar src={row.original.imageUrl} className={classes.info}>{row.original.initials}</Avatar>)
                 },
-                {
-                  icon: 'delete',
-                  tooltip: 'Delete User',
-                  onClick: (event, rowData) => this.handleUserDeleteClick(rowData.tableData.id, rowData.name)
-                }
+                { header: 'User Name', accessorKey: 'name' },
+                { header: 'Admin', accessorKey: 'isAdmin', size: 10,
+                  Cell: ({ renderedCellValue, row }) => (row.original.isAdmin ? <CheckIcon /> : "")
+                },
+                { header: 'Disabled', accessorKey: 'isDisabled', size: 10,
+                  Cell: ({ renderedCellValue, row }) => (row.original.isDisabled ? <CheckIcon /> : "")
+                },
               ]}
-              onRowClick={(event, rowData, togglePanel) => {this.handleUserRowClick(rowData.tableData.id, rowData.name); togglePanel()}}
-              detailPanel={rowData => {
-                const user = rowData || this.props.users[this.state.currentUserIndex];
+              displayColumnDefOptions={{
+                'mrt-row-actions': {
+                  muiTableHeadCellProps: {align: 'right'},
+                  muiTableBodyCellProps: ({ cell }) => ({
+                    sx: {
+                      padding: '0',
+                      textAlign: 'right'
+                    },
+                  }),
+                },
+                'mrt-row-expand': {
+                  size: 8,
+                },
+              }}
+              data={this.props.users}
+              enableRowActions
+              positionActionsColumn="last"
+              renderRowActions={({ row }) => (
+                <Box sx={{ display: 'flex', flexWrap: 'nowrap', gap: '0', float: 'right' }}>
+                <>
+                  <Tooltip title="Change Password">
+                    <IconButton onClick={ () => this.setState({currentUserName: row.original.name, deployChangeUserPassword: true}) } >
+                      <LockIcon />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Delete User">
+                    <IconButton onClick={ () => this.setState({currentUserName: row.original.name, deployDeleteUser: true}) } >
+                      <DeleteIcon />
+                    </IconButton>
+                  </Tooltip>
+                </>
+                </Box>
+              )}
+              renderDetailPanel={({ row }) => {
+                const user = row.original;
                 const currentUserGroups = user.memberOf.length > 0 ? this.getUserGroups(user.memberOf) : [];
                 const tableTitle = "User " + user.name + " Groups";
 
@@ -150,19 +160,27 @@ class UsersManager extends React.Component {
                       <CardContent>
                       {
                         <div>
-                          <MaterialTable
-                              title={tableTitle}
-                              style={{ boxShadow : 'none' }}
-                              options={{
-                                headerStyle: { backgroundColor: headerBackground },
-                                emptyRowsWhenPaging: false
-                              }}
-                              columns={[
-                                  { title: 'Avatar', field: 'imageUrl', render: rowData => <Avatar src={rowData.imageUrl} className={classes.info}>{rowData.name.charAt(0)}</Avatar> },
-                                  { title: 'Name', field: 'name', cellStyle: {textAlign: 'left'} },
-                                  { title: 'Members', field: 'members', type: 'numeric', cellStyle: {textAlign: 'left'}, headerStyle: {textAlign: 'left', flexDirection: 'initial'} },
-                                  { title: 'Declared Members', field: 'declaredMembers', type: 'numeric', cellStyle: {textAlign: 'left'}, headerStyle: {textAlign: 'left', flexDirection: 'initial'} },
-                              ]}
+                          <MaterialReactTable
+                              enableColumnActions={false}
+                              enableColumnFilters={false}
+                              enableSorting={false}
+                              enableTopToolbar={false}
+                              columns={[{
+                                id: tableTitle,
+                                header: tableTitle,
+                                columns: [
+                                  { header: 'Avatar', accessorKey: 'imageUrl', size: 10,
+                                    Cell: ({ renderedCellValue, row }) => ( <Avatar src={row.original.imageUrl} className={classes.info}>{row.original.name.charAt(0)}</Avatar> )
+                                  },
+                                  { header: 'Name', accessorKey: 'name', muiTableBodyCellProps: {align: 'left'} },
+                                  { header: 'Members', accessorKey: 'members', size: 10,
+                                    muiTableBodyCellProps: {align: 'left'}, muiTableHeadCellProps: {align: 'left'}
+                                  },
+                                  { header: 'Declared Members', accessorKey: 'declaredMembers', size: 10,                                   
+                                    muiTableBodyCellProps: {align: 'left'}, muiTableHeadCellProps: {align: 'left'}
+                                  },
+                                ]
+                              }]}
                               data={currentUserGroups}
                           />
                         </div>
@@ -172,7 +190,7 @@ class UsersManager extends React.Component {
                 </div> 
                 ) || (<div>User is not in any group</div>)
               }}
-            />
+          />
         </div>
       </AdminScreen>
     );

--- a/modules/principals/src/main/frontend/src/Userboard/Users/usersmanager.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Users/usersmanager.jsx
@@ -137,7 +137,6 @@ class UsersManager extends React.Component {
               positionActionsColumn="last"
               renderRowActions={({ row }) => (
                 <Box sx={{ display: 'flex', flexWrap: 'nowrap', gap: '0', float: 'right' }}>
-                <>
                   <Tooltip title="Change Password">
                     <IconButton onClick={ () => this.setState({currentUserName: row.original.name, deployChangeUserPassword: true}) } >
                       <LockIcon />
@@ -148,7 +147,6 @@ class UsersManager extends React.Component {
                       <DeleteIcon />
                     </IconButton>
                   </Tooltip>
-                </>
                 </Box>
               )}
               renderDetailPanel={({ row }) => {

--- a/modules/principals/src/main/frontend/src/Userboard/userboardStyle.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/userboardStyle.jsx
@@ -19,7 +19,6 @@
 
 const userboardStyle = theme => ({
     root: {
-      marginTop: theme.spacing(-6),
       "& .MuiPaper-root" : {
         backgroundColor: "transparent",
       },

--- a/modules/statistics/src/main/frontend/package.json
+++ b/modules/statistics/src/main/frontend/package.json
@@ -39,7 +39,7 @@
     "@mui/material": "5.11.3",
     "@mui/styles": "5.11.2",
     "google-palette": "1.1.0",
-    "material-react-table": "1.9.3",
+    "material-react-table": "1.10.0",
     "luxon": "3.2.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/modules/statistics/src/main/frontend/package.json
+++ b/modules/statistics/src/main/frontend/package.json
@@ -39,7 +39,7 @@
     "@mui/material": "5.11.3",
     "@mui/styles": "5.11.2",
     "google-palette": "1.1.0",
-    "material-table": "2.0.3",
+    "material-react-table": "1.9.3",
     "luxon": "3.2.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/modules/vocabularies/src/main/frontend/package.json
+++ b/modules/vocabularies/src/main/frontend/package.json
@@ -39,7 +39,7 @@
     "eslint": "8.32.0",
     "webpack": "5.77.0",
     "webpack-assets-manifest": "5.1.0",
-    "material-react-table": "1.9.3",
+    "material-react-table": "1.10.0",
     "webpack-cli": "4.4.0"
   },
   "resolutions": {

--- a/modules/vocabularies/src/main/frontend/package.json
+++ b/modules/vocabularies/src/main/frontend/package.json
@@ -39,6 +39,7 @@
     "eslint": "8.32.0",
     "webpack": "5.77.0",
     "webpack-assets-manifest": "5.1.0",
+    "material-react-table": "1.9.3",
     "webpack-cli": "4.4.0"
   },
   "resolutions": {

--- a/modules/vocabularies/src/main/frontend/src/vocabularyTable.jsx
+++ b/modules/vocabularies/src/main/frontend/src/vocabularyTable.jsx
@@ -71,7 +71,7 @@ export default function VocabularyTable(props) {
               { header: 'Identifier', accessorKey: 'acronym', size: 30, filterFn: 'contains' },
               { header: 'Name', accessorKey: 'name', filterFn: 'contains' },
               { header: 'Version', accessorKey: 'version', size: 10, enableColumnFilter: false,
-                Cell: ({ renderedCellValue, row }) => row.original.version &&
+                Cell: ({ row }) => row.original.version &&
                   <Tooltip title={row.original.version}>
                     <Typography style={{fontWeight: "inherit"}} noWrap>
                       {row.original.version}
@@ -82,7 +82,7 @@ export default function VocabularyTable(props) {
                 accessorKey: 'released',
                 size: 20,
                 enableColumnFilter: false,
-                Cell: ({ renderedCellValue, row }) => (new Date(type === "local" ? row.original.installed : row.original.released)).toString().substring(4,15)
+                Cell: ({ row }) => (new Date(type === "local" ? row.original.installed : row.original.released)).toString().substring(4,15)
               }
             ]}
             muiTableHeadCellProps={{
@@ -94,13 +94,13 @@ export default function VocabularyTable(props) {
               'mrt-row-actions': {
                 size: 50,
                 muiTableHeadCellProps: {align: "right"},
-                muiTableBodyCellProps: ({ cell }) => ({
+                muiTableBodyCellProps: {
                   sx: {
                     whiteSpace: "pre",
                     textAlign: "right",
                     paddingRight: "0.3rem"
                   },
-                }),
+                },
                 enableColumnFilter: false,
               },
             }}

--- a/modules/vocabularies/src/main/frontend/src/vocabularyTable.jsx
+++ b/modules/vocabularies/src/main/frontend/src/vocabularyTable.jsx
@@ -65,7 +65,6 @@ export default function VocabularyTable(props) {
             enableColumnActions={false}
             enableSorting={false}
             enableTopToolbar={false}
-            enableToolbarInternalActions={false}
             state={{ isLoading: loading }}
             initialState={{ showColumnFilters: true }}
             columns={[


### PR DESCRIPTION
Affected components:
- New form/subect dialogs
- Subject selector dialogs
- Patient chart
- Users and groups from Admin
- Vocabularies page from Admin
- Variant Files Container

Resources, that helped with examples:
https://www.material-react-table.com/
https://www.material-react-table.dev/?path=/story/prop-playground--default
https://github.com/KevinVandy/material-react-table/tree/main/apps/material-react-table-storybook/stories