### PR TITLE
CARDS-2137: Query servlet is too slow;  CARDS-2182: Query servlet sometimes outputs the same node multiple times

### DIFF
--- a/modules/data-entry/src/main/java/io/uhndata/cards/QueryBuilder.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/QueryBuilder.java
@@ -120,7 +120,7 @@ public class QueryBuilder implements Use
     private ResourceResolver resourceResolver;
 
     /** Whether or not the input should be escaped, if it is used in a contains() call. */
-    private boolean shouldEscape;
+    private boolean disableEscaping;
 
     /** A token sent in the request to be copied in the response, to help distinguish between multiple requests. */
     private String requestID;
@@ -168,7 +168,7 @@ public class QueryBuilder implements Use
             this.limit = getLongValueOrDefault(request.getParameter("limit"), 10);
             this.resourceTypes = request.getParameterValues("allowedResourceTypes");
             final String doNotEscape = request.getParameter("doNotEscapeQuery");
-            this.shouldEscape = !("true".equals(doNotEscape));
+            this.disableEscaping = "true".equals(doNotEscape);
             final String showTotalRowsParam = request.getParameter("showTotalRows");
             this.showTotalRows = StringUtils.isBlank(showTotalRowsParam) || "true".equals(showTotalRowsParam);
 
@@ -511,7 +511,7 @@ public class QueryBuilder implements Use
      */
     private String fullTextEscape(String input)
     {
-        if (!this.shouldEscape) {
+        if (this.disableEscaping) {
             return input;
         }
 

--- a/modules/data-entry/src/main/java/io/uhndata/cards/QueryBuilder.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/QueryBuilder.java
@@ -22,12 +22,21 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.query.QueryResult;
+import javax.jcr.query.Row;
+import javax.jcr.query.RowIterator;
 import javax.json.Json;
+import javax.json.JsonArray;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
@@ -48,15 +57,57 @@ import io.uhndata.cards.spi.SearchParameters;
 import io.uhndata.cards.spi.SearchParametersFactory;
 
 /**
- * A HTL Use-API that can run a JCR query and output the results as JSON. The query to execute is taken from the request
- * parameter {@code query}, and must be in the JCR-SQL2 syntax. To use this API, simply place the following code in a
- * HTL file:
- *
- * <p><code>
+ * A HTL Use-API that can run a JCR query and output the results as JSON. The query to execute is taken from request
+ * parameters, and the query result is retrieved from the {@code content} method. Multiple query types are supported:
+ * <ul>
+ * <li>{@code query}, a full query in the JCR-SQL2 syntax</li>
+ * <li>{@code lucene}, a lucene query</li>
+ * <li>{@code fulltext}, a textual query that will be matched against indexed nodes</li>
+ * <li>{@code quick}, search input that will be matched by pluggable {@link QuickSearchEngine quick search engines}</li>
+ * </ul>
+ * <p>
+ * If more than one of these parameters is sent, the first one, in the order above, that is not empty, will be used, and
+ * the others will be ignored. If none of these parameters is sent, then an empty query result is returned.
+ * </p>
+ * <p>
+ * The output is a JSON with some query metadata, and an array of results, in the format:
+ * </p>
+ * <p>
+ * <code>
+ * {
+ *   "req": "", or string copied from the request
+ *   "offset": 0, or integer value copied from the request
+ *   "limit": 10, or integer value copied from the request
+ *   "returnedrows": number of returned rows, 0 if no rows are returned
+ *   "totalrows": number of rows matching the query, 0 if nothing matches the query
+ *   "rows": [ array of search results ]
+ * }
+ * </code>
+ * <p>
+ * By default the rows are serialized nodes in the default JSON serialization format. Other request parameters can
+ * change the output format:
+ * </p>
+ * <ul>
+ * <li>{@code serializeChildren=1} causes the direct children of the results to be serialized as well</li>
+ * <li>{@code rawResults=true} causes the exact query results, as specified in the query selectors, to be returned as an
+ * array, instead of serializing the matching nodes</li>
+ * <li>{@code showTotalRows=false} causes the total number of results to not be computed, resulting in slightly better
+ * performance</li>
+ * </ul>
+ * <p>
+ * Quick search results are returned in a special format, including match highlighting.
+ * </p>
+ * <p>
+ * To use this API, simply place the following code in a HTL file:
+ * </p>
+ * <p>
+ * <code>
  * &lt;sly data-sly-use.query="io.uhndata.cards.QueryBuilder"&gt;${query.content @ context='unsafe'}&lt;/sly&gt;
- * </code></p>
- *
- * <p>Or, send a HTTP request to {@code /query?query=select%20*%20from%20[cards:Form]}.</p>
+ * </code>
+ * </p>
+ * <p>
+ * Or, send a HTTP request to {@code /query?query=select%20*%20from%20[cards:Form]}.
+ * </p>
  *
  * @version $Id$
  */
@@ -68,22 +119,39 @@ public class QueryBuilder implements Use
 
     private ResourceResolver resourceResolver;
 
-    /* Whether or not the input should be escaped, if it is used in a contains() call. */
+    /** Whether or not the input should be escaped, if it is used in a contains() call. */
     private boolean shouldEscape;
 
-    /* The requested, default or set by admin limit. */
+    /** A token sent in the request to be copied in the response, to help distinguish between multiple requests. */
+    private String requestID;
+
+    /** The requested or default offset, i.e. how many results to skip. */
+    private long offset;
+
+    /** The requested or default limit on the number of returned results. */
     private long limit;
 
-    /* Whether to show the total number of results. */
+    /** Whether to show the total number of results. */
     private boolean showTotalRows;
 
-    /* Resource types allowed for a search. */
+    private boolean serializeChildren;
+
+    /** Resource types allowed for a search. */
     private String[] resourceTypes;
 
     /** Quick search engines. */
     private List<QuickSearchEngine> searchEngines;
 
-    @SuppressWarnings({"checkstyle:ExecutableStatementCount"})
+    /**
+     * Get the results of the query as a JSON array.
+     *
+     * @return a serialized JsonArray with all the content matching the query
+     */
+    public String getContent()
+    {
+        return this.content;
+    }
+
     @Override
     public void init(Bindings bindings)
     {
@@ -93,41 +161,29 @@ public class QueryBuilder implements Use
         this.searchEngines = Arrays.asList(slingHelper.getServices(QuickSearchEngine.class, null));
 
         try {
-            final String jcrQuery = request.getParameter("query");
-            final String luceneQuery = request.getParameter("lucene");
-            final String fullTextQuery = request.getParameter("fulltext");
-            final String quickQuery = request.getParameter("quick");
-            final long offset = getLongValueOrDefault(request.getParameter("offset"), 0);
-            final boolean serializeChildren = getLongValueOrDefault(request.getParameter("serializeChildren"), 0) != 0;
-            String requestID = request.getParameter("req");
-            if (StringUtils.isBlank(requestID)) {
-                requestID = "";
-            }
-            final String doNotEscape = request.getParameter("doNotEscapeQuery");
-            final String showTotalRowsParam = request.getParameter("showTotalRows");
+            this.offset = getLongValueOrDefault(request.getParameter("offset"), 0);
+            this.serializeChildren = getLongValueOrDefault(request.getParameter("serializeChildren"), 0) != 0;
+            this.requestID = StringUtils.defaultString(request.getParameter("req"));
 
             this.limit = getLongValueOrDefault(request.getParameter("limit"), 10);
             this.resourceTypes = request.getParameterValues("allowedResourceTypes");
+            final String doNotEscape = request.getParameter("doNotEscapeQuery");
             this.shouldEscape = !("true".equals(doNotEscape));
+            final String showTotalRowsParam = request.getParameter("showTotalRows");
             this.showTotalRows = StringUtils.isBlank(showTotalRowsParam) || "true".equals(showTotalRowsParam);
 
-            // Try to use a JCR-SQL2 query first
-            Iterator<JsonObject> results;
-            if (StringUtils.isNotBlank(jcrQuery)) {
-                results = QueryBuilder.adaptNodes(queryJCR(this.urlDecode(jcrQuery)), serializeChildren);
-            } else if (StringUtils.isNotBlank(luceneQuery)) {
-                results = QueryBuilder.adaptNodes(queryLucene(this.urlDecode(luceneQuery)), serializeChildren);
-            } else if (StringUtils.isNotBlank(fullTextQuery)) {
-                results = QueryBuilder.adaptNodes(fullTextSearch(this.urlDecode(fullTextQuery)), serializeChildren);
-            } else if (StringUtils.isNotBlank(quickQuery)) {
-                results = quickSearch(this.urlDecode(quickQuery));
-            } else {
-                results = Collections.emptyIterator();
+            QueryResult results = query(request);
+            if (results == null) {
+                return;
             }
 
             // output the results into our content
             JsonObjectBuilder builder = Json.createObjectBuilder();
-            this.addObjects(builder, results, requestID, offset);
+            if ("true".equals(request.getParameter("rawResults"))) {
+                this.outputRawQueryResults(builder, results);
+            } else {
+                this.outputQueryResults(builder, results);
+            }
             this.content = builder.build().toString();
         } catch (Exception e) {
             this.logger.error("Failed to query resources: {}", e.getMessage(), e);
@@ -135,16 +191,45 @@ public class QueryBuilder implements Use
         }
     }
 
-    /**
-     * URL-decodes the given request parameter.
-     *
-     * @param param a URL-encoded request parameter
-     * @return a decoded version of the input
-     * @throws UnsupportedEncodingException should not be thrown unless UTF_8 is somehow not available
-     */
-    private String urlDecode(String param) throws UnsupportedEncodingException
+    private QueryResult query(final SlingHttpServletRequest request)
+        throws UnsupportedEncodingException, RepositoryException
     {
-        return URLDecoder.decode(param, StandardCharsets.UTF_8.name());
+        final String jcrQuery = request.getParameter("query");
+        final String luceneQuery = request.getParameter("lucene");
+        final String fullTextQuery = request.getParameter("fulltext");
+        final String quickQuery = request.getParameter("quick");
+
+        QueryResult results;
+        if (StringUtils.isNotBlank(jcrQuery)) {
+            results = queryJCR(this.urlDecode(jcrQuery));
+        } else if (StringUtils.isNotBlank(luceneQuery)) {
+            results = queryLucene(this.urlDecode(luceneQuery));
+        } else if (StringUtils.isNotBlank(fullTextQuery)) {
+            results = fullTextSearch(this.urlDecode(fullTextQuery));
+        } else if (StringUtils.isNotBlank(quickQuery)) {
+            // A quick search is special, since the results are not simply serialized nodes, but search results
+            // enriched with match information, and the quick search engines already take care of not returning more
+            // results than needed
+            JsonObjectBuilder builder = Json.createObjectBuilder();
+            this.outputQuickSearchResults(builder, quickSearch(this.urlDecode(quickQuery)));
+            this.content = builder.build().toString();
+            return null;
+        } else {
+            results = EmptyResults.INSTANCE;
+        }
+        return results;
+    }
+
+    /**
+     * Finds content matching the given JCR_SQL2 query.
+     *
+     * @param query a JCR-SQL2 query
+     * @return the content matching the query
+     */
+    private QueryResult queryJCR(String query) throws RepositoryException
+    {
+        return this.resourceResolver.adaptTo(Session.class).getWorkspace().getQueryManager()
+            .createQuery(query, "JCR-SQL2").execute();
     }
 
     /**
@@ -153,7 +238,7 @@ public class QueryBuilder implements Use
      * @param query a lucene query
      * @return the content matching the query
      */
-    private Iterator<Resource> queryLucene(String query) throws RepositoryException
+    private QueryResult queryLucene(String query) throws RepositoryException
     {
         // Wrap our lucene query in JCR-SQL2 syntax for the resource resolver to understand
         return queryJCR(
@@ -165,10 +250,9 @@ public class QueryBuilder implements Use
      * Finds content using the given full text search.
      *
      * @param query text to search
-     *
      * @return the content matching the query
      */
-    private Iterator<Resource> fullTextSearch(String query) throws RepositoryException
+    private QueryResult fullTextSearch(String query) throws RepositoryException
     {
         // Wrap our full-text query in JCR-SQL2 syntax for the resource resolver to understand
         return queryJCR(
@@ -176,29 +260,11 @@ public class QueryBuilder implements Use
     }
 
     /**
-     * Escapes the input query if this.shouldEscape is true.
-     *
-     * @param input text to escape
-     *
-     * @return an escaped version of the input
-     */
-    private String fullTextEscape(String input)
-    {
-        if (!this.shouldEscape) {
-            return input;
-        }
-
-        // Escape sequence taken from https://jackrabbit.apache.org/archive/wiki/JCR/EncodingAndEscaping_115513396.html
-        return input.replaceAll("([\\Q+-&|!(){}[]^\"~*?:\\_%/\\E])", "\\\\$1").replaceAll("'", "''");
-    }
-
-    /**
-     * Finds [cards:Form]s, [cards:Subject]s, and [cards:Questionnaire]s using the given full text search.
-     * This performs the search in such a way that values in child nodes (e.g. cards:Answers of an cards:Form)
-     * are aggregated to their parent.
+     * Finds [cards:Form]s, [cards:Subject]s, and [cards:Questionnaire]s using the given full text search. This performs
+     * the search in such a way that values in child nodes (e.g. cards:Answers of an cards:Form) are aggregated to their
+     * parent.
      *
      * @param query text to search
-     *
      * @return the content matching the query
      */
     private Iterator<JsonObject> quickSearch(String query) throws RepositoryException, UnsupportedEncodingException
@@ -225,105 +291,194 @@ public class QueryBuilder implements Use
     }
 
     /**
-     * Finds content matching the given JCR_SQL2 query.
+     * Serialize search results, subject to the an offset and a limit. Write metadata about the request and response.
+     * This includes the number of returned and total matching nodes, and copying some request parameters.
      *
-     * @param query a JCR-SQL2 query
-     * @return the content matching the query
-     */
-    private Iterator<Resource> queryJCR(String query) throws RepositoryException
-    {
-        return this.resourceResolver.findResources(query, "JCR-SQL2");
-    }
-
-    /**
-     * Convert an iterator of nodes into an iterator of JsonObjects.
-     * @param nodes the iterator to convert
-     * @param serializeChildren If true, this also includes the immediate children of each node
-     * @return An iterator of the input nodes
-     */
-    private static Iterator<JsonObject> adaptNodes(Iterator<Resource> resources, boolean serializeChildren)
-    {
-        ArrayList<JsonObject> list = new ArrayList<>();
-        while (resources.hasNext()) {
-            Resource resource = resources.next();
-
-            // If there are children we can add, we'll add them as child properties of the JsonObject
-            if (serializeChildren && resource.hasChildren()) {
-                Iterator<Resource> children = resource.listChildren();
-                JsonObjectBuilder builder = Json.createObjectBuilder();
-
-                // First convert the original JsonObject into a JsonObjectBuilder we can adjust
-                JsonObject original = resource.adaptTo(JsonObject.class);
-                for (Map.Entry<String, JsonValue> entry : original.entrySet()) {
-                    builder.add(entry.getKey(), entry.getValue());
-                }
-
-                // Next, add each child
-                while (children.hasNext()) {
-                    Resource child = children.next();
-                    builder.add(child.getName(), child.adaptTo(JsonObject.class));
-                }
-
-                list.add(builder.build());
-            } else {
-                list.add(resource.adaptTo(JsonObject.class));
-            }
-        }
-        return list.iterator();
-    }
-
-    /**
-     * Write the contents of the input nodes, subject to the an offset and a limit. Write metadata about the request
-     * and response. This includes the number of returned and total matching nodes, and copying some request parameters.
-     *
-     * @param jsonGen the JSON object generator where the results should be serialized
-     * @param objects an iterator over the nodes to serialize, which will be consumed
+     * @param output the JSON object generator where the results should be serialized
+     * @param rows an iterator over the nodes to serialize, which will be consumed
+     * @param serializeChildren whether child nodes of the search results must be serialized as well
      * @param req the current request number
      * @param offset the requested offset, may be the default value of {0}
-     *
+     * @throws RepositoryException if running the query fails
      */
-    private void addObjects(final JsonObjectBuilder jsonGen, final Iterator<JsonObject> objects, String req,
-        final long offset)
+    private void outputQueryResults(final JsonObjectBuilder output, final QueryResult queryResults)
+        throws RepositoryException
     {
-        long returnedrows = 0;
-        long totalrows = 0;
+        Set<String> seenPaths = new HashSet<>();
+        long returnedRows = 0;
+        long totalRows = 0;
 
-        long offsetCounter = offset < 0 ? 0 : offset;
-        long limitCounter = this.limit < 0 ? 0 : this.limit;
+        long offsetCounter = this.offset;
+        long limitCounter = this.limit;
 
         final JsonArrayBuilder builder = Json.createArrayBuilder();
 
-        while (objects.hasNext()) {
-            JsonObject n = objects.next();
+        final RowIterator rows = queryResults.getRows();
+
+        while (rows.hasNext()) {
+            try {
+                final Row row = rows.nextRow();
+
+                // It's faster to just work with paths instead of loading the full node
+                final String path = row.getPath();
+                if (seenPaths.contains(path)) {
+                    // The query may return the same node multiple times when joins are used, we only return it once
+                    continue;
+                }
+                seenPaths.add(path);
+
+                // Skip results up to the offset provided
+                if (offsetCounter > 0) {
+                    --offsetCounter;
+                    // Count up to our limit
+                } else if (limitCounter > 0) {
+                    builder.add(serializeNode(path));
+                    --limitCounter;
+                    ++returnedRows;
+                } else if (!this.showTotalRows) {
+                    break;
+                }
+                // Count the total number of results
+                ++totalRows;
+            } catch (RepositoryException e) {
+                this.logger.warn("Failed to serialize search results: {}", e.getMessage(), e);
+            }
+        }
+
+        buildResults(output, builder.build(), returnedRows, totalRows);
+    }
+
+    /**
+     * Serialize search results, subject to the an offset and a limit. Write metadata about the request and response.
+     * This includes the number of returned and total matching nodes, and copying some request parameters.
+     *
+     * @param output the JSON object generator where the results should be serialized
+     * @param queryResults the raw query results
+     * @throws RepositoryException if running the query fails
+     */
+    private void outputRawQueryResults(final JsonObjectBuilder output, final QueryResult queryResults)
+        throws RepositoryException
+    {
+        long returnedRows = 0;
+        long totalRows = 0;
+
+        long offsetCounter = this.offset;
+        long limitCounter = this.limit;
+
+        final JsonArrayBuilder builder = Json.createArrayBuilder();
+
+        final RowIterator rows = queryResults.getRows();
+
+        while (rows.hasNext()) {
+            try {
+                final Row row = rows.nextRow();
+
+                // Skip results up to the offset provided
+                if (offsetCounter > 0) {
+                    --offsetCounter;
+                    // Count up to our limit
+                } else if (limitCounter > 0) {
+                    JsonObjectBuilder serializedRow = Json.createObjectBuilder();
+                    for (String selector : queryResults.getSelectorNames()) {
+                        final String path = row.getPath(selector);
+                        serializedRow.add(selector, path == null ? JsonValue.NULL : Json.createValue(path));
+                    }
+                    for (String column : queryResults.getColumnNames()) {
+                        final Value value = row.getValue(column);
+                        serializedRow.add(column, value == null ? JsonValue.NULL : Json.createValue(value.getString()));
+                    }
+                    builder.add(serializedRow.build());
+                    --limitCounter;
+                    ++returnedRows;
+                } else if (!this.showTotalRows) {
+                    break;
+                }
+                // Count the total number of results
+                ++totalRows;
+            } catch (RepositoryException e) {
+                this.logger.warn("Failed to serialize search results: {}", e.getMessage(), e);
+            }
+        }
+        buildResults(output, builder.build(), returnedRows, totalRows);
+    }
+
+    /**
+     * Serialize quick search results. Write metadata about the request and response. This includes the number of
+     * returned and total matching nodes, and copying some request parameters.
+     *
+     * @param output the JSON object generator where the results should be serialized
+     * @param searchResults an iterator over quick search results, which will be consumed
+     */
+    private void outputQuickSearchResults(final JsonObjectBuilder output, final Iterator<JsonObject> searchResults)
+    {
+        long returnedRows = 0;
+        long totalRows = 0;
+
+        long offsetCounter = this.offset;
+        long limitCounter = this.limit;
+
+        final JsonArrayBuilder builder = Json.createArrayBuilder();
+
+        while (searchResults.hasNext()) {
             // Skip results up to the offset provided
             if (offsetCounter > 0) {
                 --offsetCounter;
                 // Count up to our limit
             } else if (limitCounter > 0) {
-                builder.add(n);
+                builder.add(searchResults.next());
                 --limitCounter;
-                ++returnedrows;
+                ++returnedRows;
             } else if (!this.showTotalRows) {
                 break;
             }
             // Count the total number of results
-            ++totalrows;
+            ++totalRows;
         }
 
-        jsonGen.add("rows", builder.build());
-        jsonGen.add("req", req);
-        jsonGen.add("offset", offset);
-        jsonGen.add("limit", this.limit);
-        jsonGen.add("returnedrows", returnedrows);
-        jsonGen.add("totalrows", totalrows);
+        buildResults(output, builder.build(), returnedRows, totalRows);
+    }
+
+    /**
+     * Serialize a node to be placed in the output.
+     *
+     * @param path JCR path of the node to serialize
+     * @return a JsonObject
+     */
+    private JsonObject serializeNode(final String path)
+    {
+        final Resource resource = this.resourceResolver.getResource(path);
+        // If there are children we can add, we'll add them as child properties of the JsonObject
+        if (this.serializeChildren && resource.hasChildren()) {
+            Iterator<Resource> children = resource.listChildren();
+            JsonObjectBuilder builder = Json.createObjectBuilder(resource.adaptTo(JsonObject.class));
+            while (children.hasNext()) {
+                Resource child = children.next();
+                builder.add(child.getName(), child.adaptTo(JsonObject.class));
+            }
+
+            return builder.build();
+        } else {
+            return resource.adaptTo(JsonObject.class);
+        }
+    }
+
+    private void buildResults(final JsonObjectBuilder output, final JsonArray data, final long returnedRows,
+        final long totalRows)
+    {
+        output.add("rows", data);
+        output.add("req", this.requestID);
+        output.add("offset", this.offset);
+        output.add("limit", this.limit);
+        output.add("returnedrows", returnedRows);
+        output.add("totalrows", this.showTotalRows ? totalRows : -1L);
     }
 
     /**
      * Use the value given (usually from a request.getParameter()) or use a default value.
      *
      * @param stringValue the value to use if provided
-     * @param defaultValue the value to use if stringValue is not given
-     * @return Either stringValue, if provided, or defaultValue
+     * @param defaultValue the value to use if stringValue is not given, not a number, or a negative number
+     * @return a positive number
      */
     private long getLongValueOrDefault(final String stringValue, final long defaultValue)
     {
@@ -333,16 +488,116 @@ public class QueryBuilder implements Use
         } catch (NumberFormatException exception) {
             value = defaultValue;
         }
-        return value;
+        return value < 0 ? defaultValue : value;
     }
 
     /**
-     * Get the results of the query as a JSON array.
+     * URL-decodes the given request parameter.
      *
-     * @return a JsonArray with all the content matching the query
+     * @param param a URL-encoded request parameter
+     * @return a decoded version of the input
+     * @throws UnsupportedEncodingException should not be thrown unless UTF_8 is somehow not available
      */
-    public String getContent()
+    private String urlDecode(String param) throws UnsupportedEncodingException
     {
-        return this.content;
+        return URLDecoder.decode(param, StandardCharsets.UTF_8.name());
+    }
+
+    /**
+     * Escapes the input query if this.shouldEscape is true.
+     *
+     * @param input text to escape
+     * @return an escaped version of the input
+     */
+    private String fullTextEscape(String input)
+    {
+        if (!this.shouldEscape) {
+            return input;
+        }
+
+        // Escape sequence taken from https://jackrabbit.apache.org/archive/wiki/JCR/EncodingAndEscaping_115513396.html
+        return input.replaceAll("([\\Q+-&|!(){}[]^\"~*?:\\_%/\\E])", "\\\\$1").replaceAll("'", "''");
+    }
+
+    /**
+     * Helper class, an empty query result to use when no query string is sent in the request.
+     */
+    private static final class EmptyResults implements QueryResult
+    {
+        public static final QueryResult INSTANCE = new EmptyResults();
+
+        @Override
+        public String[] getSelectorNames() throws RepositoryException
+        {
+            return new String[0];
+        }
+
+        @Override
+        public String[] getColumnNames() throws RepositoryException
+        {
+            return new String[0];
+        }
+
+        @Override
+        public RowIterator getRows() throws RepositoryException
+        {
+            return EmptyIterator.INSTANCE;
+        }
+
+        @Override
+        public NodeIterator getNodes() throws RepositoryException
+        {
+            return EmptyIterator.INSTANCE;
+        }
+    }
+
+    /**
+     * Helper class, an empty iterator to use when no query string is sent in the request.
+     */
+    private static final class EmptyIterator implements RowIterator, NodeIterator
+    {
+        public static final EmptyIterator INSTANCE = new EmptyIterator();
+
+        @Override
+        public long getSize()
+        {
+            return 0;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return false;
+        }
+
+        @Override
+        public Object next()
+        {
+            return null;
+        }
+
+        @Override
+        public Row nextRow()
+        {
+            return null;
+        }
+
+        @Override
+        public Node nextNode()
+        {
+            return null;
+        }
+
+        @Override
+        public void skip(long skipNum)
+        {
+            // Nothing to do
+        }
+
+        @Override
+        public long getPosition()
+        {
+            return 0;
+        }
     }
 }

--- a/modules/data-entry/src/main/java/io/uhndata/cards/spi/SearchUtils.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/spi/SearchUtils.java
@@ -82,6 +82,38 @@ public final class SearchUtils
      * Searches through a list of Strings and returns the first String in that list for which in itself contains a given
      * substring.
      *
+     * @param value the raw answer value, may be a single or multivalue of any JCR type
+     * @param str the String to check if the value contains this substring
+     * @return the (single) value, or the first value in a multivalue that contains the query substring
+     */
+    public static String getMatch(Object value, String str)
+    {
+        if (value == null) {
+            return null;
+        }
+
+        if (value instanceof String[]) {
+            return getMatchFromArray((String[]) value, str);
+        } else if (value instanceof Object[]) {
+            Object[] valueArray = (Object[]) value;
+            String[] valueStr = new String[valueArray.length];
+            for (int i = 0; i < valueArray.length; ++i) {
+                valueStr[i] = String.valueOf(valueArray[i]);
+            }
+            return getMatchFromArray(valueStr, str);
+        } else if (value != null) {
+            if (StringUtils.containsIgnoreCase(value.toString(), str)) {
+                return value.toString();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Searches through a list of Strings and returns the first String in that list for which in itself contains a given
+     * substring.
+     *
      * @param arr the list of Strings to search through
      * @param str the String to check if any array elements contain this substring
      * @return the first String in the list that contains the given substring
@@ -168,6 +200,7 @@ public final class SearchUtils
 
     /**
      * Check whether the given name is a valid node name.
+     *
      * @param name Node name to check
      * @return True if the given name is a valid node name
      */


### PR DESCRIPTION
Old behavior: for every matching result, load it as a resource, serialize it as a JSON, then ignore all of these JSONs except the few actually needed in the output.
New behavior: from the raw results, only load and serialize the ones needed in the output

To test:
- build with `-Pdocker` (build may fail in the postgres image, in which case run `docker builder prune -f` and build again)
- in `compose-cluster/mssql`: `python3 generate_test_sql.py -n 6000 --basedate 2023-04-11 --time_spread_seconds 0 big_sample.sql` (use the day for "yesterday")
- in `compose-cluster`: `python3 generate_compose_yaml.py --mssql --cards_project cards4prems --oak_filesystem --dev_docker_image --smtps --smtps_test_container --smtps_test_mail_path ~/cardsmail --composum --adminer`
- start with `docker-compose build && docker-compose up`
- import the generated sql file at `http://localhost:1435/`
- import visits at `http://localhost:8080/Subjects.importClarity`, wait for about an hour for the import to finish
- check that manually creating forms from the dashboard is speedy
- check that `http://localhost:8080/query?query=select%20a.form%20from%20[cards:TextAnswer]%20as%20a%20where%20a.value=%27discharged%27&limit=2&offset=1000` is speedy and doesn't contain duplicates
- check that `http://localhost:8080/query?query=select%20c.value,%20d.value%20from%20[cards:DateAnswer]%20as%20d%20inner%20join%20[cards:ResourceAnswer]%20as%20c%20on%20d.form%20=%20c.form%20where%20c.value=%27/Survey/ClinicMapping/-1792626663%27%20and%20d.value%20is%20not%20null%20option(index%20tag%20cards)&limit=2&offset=1000&rawResults=true` returns direct values instead of node JSONs