### PR TITLE
CARDS-2194: Add support for more advanced formatting for information cards in questionnaires

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -18,10 +18,11 @@
 //
 
 import React from "react";
-import { Card, CardContent, Grid } from "@mui/material";
+import { Grid } from "@mui/material";
 
 import AnswerComponentManager from "./AnswerComponentManager";
 import Section from "./Section";
+import Information from "./Information";
 
 // FIXME In order for the questions to be registered, they need to be loaded, and the only way to do that at the moment is to explicitly invoke them here. Find a way to automatically load all question types, possibly using self-declaration in a node, like the assets, or even by filtering through assets.
 
@@ -41,8 +42,6 @@ import QuestionMatrix from "./QuestionMatrix";
 import ResourceQuestion from "./ResourceQuestion";
 import DicomQuestion from "./DicomQuestion";
 import ReferenceQuestion from "./ReferenceQuestion";
-
-import FormattedText from "../components/FormattedText";
 
 import { hasWarningFlags } from "./FormUtilities";
 
@@ -142,14 +141,7 @@ let displayInformation = (infoDefinition, key, classes, pageActive, isEdit) => {
   return (
     isEdit && pageActive && infoDefinition.text &&
     <Grid item key={key}>
-      <Card
-        className={classes.informationCard}
-        variant="outlined"
-        >
-        <CardContent>
-          <FormattedText>{infoDefinition.text}</FormattedText>
-        </CardContent>
-      </Card>
+      <Information infoDefinition={infoDefinition} />
     </Grid>
     || null
   );

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Information.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Information.jsx
@@ -29,8 +29,8 @@ import FormattedText from "../components/FormattedText.jsx";
 
 // GUI for displaying Information cards
 function Information (props) {
-  let { classes, infoDefinition } = props;
-  let { text, type } = { ...infoDefinition }
+  let { classes, infoDefinition, ...otherProps } = props;
+  let { text, type } = { ...otherProps, ...infoDefinition }
 
   return (type == "plain" ?
     <Card

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Information.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Information.jsx
@@ -1,0 +1,54 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React from "react";
+import PropTypes from "prop-types";
+
+import { Card, CardContent } from "@mui/material";
+
+import withStyles from '@mui/styles/withStyles';
+
+import QuestionnaireStyle from "./QuestionnaireStyle";
+import FormattedText from "../components/FormattedText.jsx";
+
+// GUI for displaying Information cards
+function Information (props) {
+  let { classes, infoDefinition } = props;
+  let { text } = { ...infoDefinition }
+
+  return (
+    <Card
+      className={classes.informationCard}
+      variant="outlined"
+    >
+      <CardContent>
+        <FormattedText>{text}</FormattedText>
+      </CardContent>
+    </Card>
+  )
+}
+
+Information.propTypes = {
+  classes: PropTypes.object.isRequired,
+  infoDefinition: PropTypes.objectOf(PropTypes.shape({
+    text: PropTypes.string,
+  })),
+};
+
+export default withStyles(QuestionnaireStyle)(Information);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Information.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Information.jsx
@@ -50,10 +50,10 @@ function Information (props) {
 
 Information.propTypes = {
   classes: PropTypes.object.isRequired,
-  infoDefinition: PropTypes.objectOf(PropTypes.shape({
+  infoDefinition: PropTypes.shape({
     text: PropTypes.string,
     type: PropTypes.oneOf(["plain", "info", "warning", "error", "success"]),
-  })),
+  }),
 };
 
 Information.defaultProps = {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Information.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Information.jsx
@@ -20,7 +20,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { Card, CardContent } from "@mui/material";
+import { Alert, Card, CardContent } from "@mui/material";
 
 import withStyles from '@mui/styles/withStyles';
 
@@ -30,9 +30,9 @@ import FormattedText from "../components/FormattedText.jsx";
 // GUI for displaying Information cards
 function Information (props) {
   let { classes, infoDefinition } = props;
-  let { text } = { ...infoDefinition }
+  let { text, type } = { ...infoDefinition }
 
-  return (
+  return (type == "plain" ?
     <Card
       className={classes.informationCard}
       variant="outlined"
@@ -41,6 +41,10 @@ function Information (props) {
         <FormattedText>{text}</FormattedText>
       </CardContent>
     </Card>
+    :
+    <Alert severity={type} icon={false}>
+      <FormattedText>{text}</FormattedText>
+    </Alert>
   )
 }
 
@@ -48,7 +52,12 @@ Information.propTypes = {
   classes: PropTypes.object.isRequired,
   infoDefinition: PropTypes.objectOf(PropTypes.shape({
     text: PropTypes.string,
+    type: PropTypes.oneOf(["plain", "info", "warning", "error", "success"]),
   })),
+};
+
+Information.defaultProps = {
+  type: "plain",
 };
 
 export default withStyles(QuestionnaireStyle)(Information);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -65,6 +65,9 @@ const questionnaireStyle = theme => ({
       }
     },
     informationCard: {
+      "& .MuiCardContent-root" : {
+        padding: theme.spacing(1.5, 2),
+      },
     },
     viewModeAnswers :{
       "& .MuiList-root": {

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Information-hints.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Information-hints.json
@@ -1,0 +1,4 @@
+{
+  "type": "Enables rendering the information card with a different styling depending on the nature and purpose of the info displayed:\n* **plain** is a card with no distinct background,\n* **info** sets a blue background,\n* **warning** sets an orange background,\n* **error** sets a red background,\n* **success** sets a green background."
+}
+

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Information.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Information.json
@@ -1,5 +1,12 @@
 [
   {
+    "type" : {
+       "plain" : {},
+       "info" : {},
+       "warning": {},
+       "error": {},
+       "success" : {}
+    },
     "text": "markdown"
   }
 ]

--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/nodetypes/forms.cnd
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/nodetypes/forms.cnd
@@ -263,6 +263,11 @@
   // The text provided as information. Optional, it is possible not to have any text.
   - text (string)
 
+  // The type dictates the text and background colors used when displaying the information.
+  // One of: plain (normal text and background), info (blue), warning (orange), error (red),
+  // success (green). Optional, defaults to plain styling when absent.
+  - type (string)
+
 //-----------------------------------------------------------------------------
 // A section is a collection of questions.
 [cards:Section] > sling:Folder, mix:referenceable


### PR DESCRIPTION
**Summary of changes**
* Small refactoring to move Information rendering in a separate component
* Introduced a `type` property to `Information` cards, which has the effect of setting a specific background:
  * **plain** is a card with no distinct background,
  * **info** sets a blue background,
  * **warning** sets an orange background,
  * **error** sets a red background,
  * **success** sets a green background.
 * When `type` is other than **plain**, `Information` is rendered as an `Alert` with `severity` set to `type`. 

**Testing**
* In the questionnaire designer, create or modify Information cards with different types

**Reviewing**
* looking at the 2 commits separately might make it even easier to follow the changes