### PR TITLE
CARDS-2105 - Patient identification page: "Where can I find my MRN?" dialog layout is slightly broken on narrow screens

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
@@ -21,13 +21,10 @@ import React, { useState, useEffect }  from 'react';
 import {
   Button,
   CircularProgress,
-  Dialog,
   DialogContent,
-  DialogTitle,
   FormControl,
   FormHelperText,
   Grid,
-  IconButton,
   Input,
   InputLabel,
   List,
@@ -36,11 +33,11 @@ import {
   Typography,
 } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
-import CloseIcon from '@mui/icons-material/Close';
 import AppointmentIcon from '@mui/icons-material/Event';
 
 import Logo from "../components/Logo.jsx";
 import ErrorPage from "../components/ErrorPage.jsx";
+import ResponsiveDialog from "../components/ResponsiveDialog.jsx";
 import ToUDialog from "./ToUDialog.jsx";
 
 import DropdownsDatePicker from "../components/DropdownsDatePicker.jsx";
@@ -86,9 +83,6 @@ const useStyles = makeStyles(theme => ({
   },
   identifierContainer : {
     alignItems: "start",
-  },
-  closeButton: {
-    float: 'right',
   },
   mrnHelperImage: {
     maxWidth: '100%',
@@ -276,13 +270,12 @@ function PatientIdentification(props) {
 
     {/* MRN hint dialog*/}
 
-    <Dialog onClose={() => {setMrnHelperOpen(false)}} open={mrnHelperOpen}>
-      <DialogTitle>
-        Where can I find my MRN?
-        <IconButton onClick={() => setMrnHelperOpen(false)} className={classes.closeButton} size="large">
-          <CloseIcon />
-        </IconButton>
-      </DialogTitle>
+    <ResponsiveDialog
+      title="Where can I find my MRN?"
+      withCloseButton
+      open={mrnHelperOpen}
+      onClose={() => {setMrnHelperOpen(false)}}
+    >
       <DialogContent>
         <Typography paragraph>
           1. Check the top right-hand corner of your Patient Itinerary.
@@ -293,7 +286,7 @@ function PatientIdentification(props) {
         </Typography>
         <img src="/libs/cards/resources/media/patient-portal/mrn_helper_2.png" alt="MRN location within the Patient Portal side bar" className={classes.mrnHelperImage} />
       </DialogContent>
-    </Dialog>
+    </ResponsiveDialog>
 
     {/* Patient identification form */}
 


### PR DESCRIPTION
The close button slides under the title, and there's unnecessary spacing around the dialog.

| Before | After | After on even narrower|
| ---- | ---- | ---- |
| ![image](https://user-images.githubusercontent.com/651980/233423488-d7379ce6-cf41-48d5-959a-5dfbcdade21f.png) | ![image](https://user-images.githubusercontent.com/651980/233425042-a43113b5-790d-4203-998b-35350dfc3079.png) | ![image](https://user-images.githubusercontent.com/651980/233425533-0198b95a-467d-4ccb-a514-413cfb54964d.png) |


