### PR TITLE
CARDS-1768: Refactoring/UX improvement: replace long Selects with Autocomplete - FIXES

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/VariableAutocomplete.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/VariableAutocomplete.jsx
@@ -113,8 +113,9 @@ let VariableAutocomplete = (props) => {
         >
           <ListItemText
             sx={groupBy ? {marginLeft: !!groupBy(option) ? 1 : -1} : undefined}
-            primary={<FormattedText variant="inherit">{ getOptionLabel(option) }</FormattedText>}
-            secondary={getOptionSecondaryLabel(option)}
+            disableTypography
+            primary={<FormattedText variant="body1">{ getOptionLabel(option) }</FormattedText>}
+            secondary={<FormattedText variant="body2" color="textSecondary">{ getOptionSecondaryLabel(option) }</FormattedText>}
           />
         </ListItemButton>
       }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/VariableAutocomplete.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/VariableAutocomplete.jsx
@@ -106,10 +106,10 @@ let VariableAutocomplete = (props) => {
       onChange={(event, value) => onValueChanged(getOptionValue(value))}
       renderOption={(props, option) =>
         <ListItemButton
+          {...props}
           value={getOptionValue(option)}
           key={getOptionValue(option)}
           dense
-          {...props}
         >
           <ListItemText
             sx={groupBy ? {marginLeft: !!groupBy(option) ? 1 : -1} : undefined}


### PR DESCRIPTION
### Overview of changes
#### 1. Fixed **console warning about duplicate keys** in the Filters variable autocomplete

Warnings appeared in `proms`, because the SF-12 questionnaire has 2 questions with the same label in different sections, and the label is used by default by Autocomplete as key for the entry. Due to the order of props, our setting of `key` to be the option value instead was getting overwritten.

#### 2. Added support for **formatting in the secondary label**

Easier to test together with #1444 where Section labels, which can have formatting, are used in the secondary option label in the variable autocomplete for the Dashboard Filters. 

#### 3. Better **visual differentiation between primary and secondary label** via different font sizes

In `proms` or `prems` (or wherever else stats are enabled) -> Administration -> Statistics -> Edit a statistic -> check the font sizes of the primary and secondary labels of the options in the variable autocomplete, before and after these changes.