### PR TITLE
CARDS-2186: Statistics: add a configuration to bundle null and false together for boolean variables

### DIFF
--- a/modules/statistics/src/main/frontend/src/Statistics/Statistics.json
+++ b/modules/statistics/src/main/frontend/src/Statistics/Statistics.json
@@ -17,6 +17,7 @@
     "type": "reference",
     "primaryType": "cards:Question"
   },
+  "groupNullAndFalse" : "boolean",
   "order": "long",
   "//REQUIRED": ["name", "xVar", "yVar"]
 }

--- a/modules/statistics/src/main/frontend/src/Statistics/Statistics.json
+++ b/modules/statistics/src/main/frontend/src/Statistics/Statistics.json
@@ -8,6 +8,7 @@
     "type": "reference",
     "primaryType": "cards:Question"
   },
+  "groupNullAndFalseAnswersForXVar": "boolean",
   "yVar": {
     "type": "reference",
     "primaryType": "cards:SubjectType",
@@ -17,8 +18,7 @@
     "type": "reference",
     "primaryType": "cards:Question"
   },
-  "groupNullAndFalseXVar" : "boolean",
-  "groupNullAndFalseSplitVar" : "boolean",
+  "groupNullAndFalseAnswersForSplitVar": "boolean",
   "order": "long",
   "//REQUIRED": ["name", "xVar", "yVar"]
 }

--- a/modules/statistics/src/main/frontend/src/Statistics/Statistics.json
+++ b/modules/statistics/src/main/frontend/src/Statistics/Statistics.json
@@ -17,7 +17,8 @@
     "type": "reference",
     "primaryType": "cards:Question"
   },
-  "groupNullAndFalse" : "boolean",
+  "groupNullAndFalseXVar" : "boolean",
+  "groupNullAndFalseSplitVar" : "boolean",
   "order": "long",
   "//REQUIRED": ["name", "xVar", "yVar"]
 }

--- a/modules/statistics/src/main/frontend/src/Statistics/UserStatistics.jsx
+++ b/modules/statistics/src/main/frontend/src/Statistics/UserStatistics.jsx
@@ -86,7 +86,8 @@ function UserStatistics(props) {
           'name': fullJson.name,
           'x-label': fullJson.xVar['@path'],
           'y-label': fullJson.yVar['@path'],
-          'groupNullAndFalse': (!!fullJson.groupNullAndFalse).toString(),
+          'groupNullAndFalseAnswersForXVar': (!!fullJson.groupNullAndFalseAnswersForXVar).toString(),
+          'groupNullAndFalseAnswersForSplitVar': (!!fullJson.groupNullAndFalseAnswersForSplitVar).toString(),
         }
         if (fullJson.splitVar) {
           requestData['splitVar'] = fullJson.splitVar['@path']

--- a/modules/statistics/src/main/frontend/src/Statistics/UserStatistics.jsx
+++ b/modules/statistics/src/main/frontend/src/Statistics/UserStatistics.jsx
@@ -85,7 +85,8 @@ function UserStatistics(props) {
         let requestData = {
           'name': fullJson.name,
           'x-label': fullJson.xVar['@path'],
-          'y-label': fullJson.yVar['@path']
+          'y-label': fullJson.yVar['@path'],
+          'groupNullAndFalse': (!!fullJson.groupNullAndFalse).toString(),
         }
         if (fullJson.splitVar) {
           requestData['splitVar'] = fullJson.splitVar['@path']

--- a/modules/statistics/src/main/java/io/uhndata/cards/statistics/StatisticQueryServlet.java
+++ b/modules/statistics/src/main/java/io/uhndata/cards/statistics/StatisticQueryServlet.java
@@ -138,7 +138,8 @@ public class StatisticQueryServlet extends SlingAllMethodsServlet
         Node question = session.getNode(arguments.get("x-label"));
 
         final String answerNodeType = getAnswerNodeType(question);
-        this.groupNullAndFalseXVar.set(isNullFalse(arguments, answerNodeType, "groupNullAndFalseXVar"));
+        this.groupNullAndFalseXVar.set(isNullFalse(arguments, answerNodeType,
+            "groupNullAndFalseAnswersForXVar"));
 
         Iterator<Resource> answers = null;
         Map<Resource, String> data = new LinkedHashMap<>();
@@ -157,7 +158,8 @@ public class StatisticQueryServlet extends SlingAllMethodsServlet
             this.splitValueDictionary.set(new HashMap<>());
             Node split = session.getNode(arguments.get("splitVar"));
             final String splitNodeType = getAnswerNodeType(split);
-            this.groupNullAndFalseSplitVar.set(isNullFalse(arguments, splitNodeType, "groupNullAndFalseSplitVar"));
+            this.groupNullAndFalseSplitVar.set(isNullFalse(arguments, splitNodeType,
+                "groupNullAndFalseAnswersForSplitVar"));
 
             data = getAnswersWithType(data, "x", question, resolver);
             data = getAnswersWithType(data, "split", split, resolver);


### PR DESCRIPTION
[CARDS-2186](https://phenotips.atlassian.net/browse/CARDS-2186)

- To test in the `/admin/Statistics` section click on edit button for any stats entity in table. 
- In the edit dialog observe a new boolean `groupNullAndFalse` flag -> set it to true
- In the `/Statistics/User` page network tab observe the corresponding  `/Statistics.query` request payload to contain the new flag set to `true`
/the rest of testing is TBD/

[CARDS-2186]: https://phenotips.atlassian.net/browse/CARDS-2186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ