### PR TITLE
Maven packages security updates

### DIFF
--- a/.github/actions/install-ci-dependencies/action.yml
+++ b/.github/actions/install-ci-dependencies/action.yml
@@ -30,7 +30,7 @@ runs:
     - name: Install Python Modules
       run: |
         echo "::group::Install Python Modules"
-        sudo apt-get -y install python3-psutil python3-openssl python3-yaml
+        sudo apt-get -y install python3-psutil python3-openssl python3-yaml python3-tzlocal
         echo "::endgroup::"
       shell: bash
     - name: Install curl

--- a/distribution/src/main/features/base.json
+++ b/distribution/src/main/features/base.json
@@ -210,11 +210,11 @@
             "start-order":"10"
         },
         {
-            "id":"org.apache.tika:tika-core:1.28.1",
+            "id":"org.apache.tika:tika-core:1.28.5",
             "start-order":"10"
         },
         {
-            "id":"org.apache.tika:tika-parsers:1.28.1",
+            "id":"org.apache.tika:tika-parsers:1.28.5",
             "start-order":"10"
         },
         {

--- a/distribution/src/main/features/base.json
+++ b/distribution/src/main/features/base.json
@@ -82,7 +82,7 @@
             "start-order":"20"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.i18n:2.5.18",
+            "id":"org.apache.sling:org.apache.sling.i18n:2.6.2",
             "start-order":"20"
         },
         {

--- a/distribution/src/main/features/base.json
+++ b/distribution/src/main/features/base.json
@@ -74,7 +74,7 @@
             "start-order":"15"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.engine:2.9.0",
+            "id":"org.apache.sling:org.apache.sling.engine:2.14.0",
             "start-order":"20"
         },
         {
@@ -102,7 +102,7 @@
             "start-order":"20"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.resourceresolver:1.8.4",
+            "id":"org.apache.sling:org.apache.sling.resourceresolver:1.10.0",
             "start-order":"20"
         },  
         {
@@ -118,7 +118,7 @@
             "start-order":"20"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.servlets.resolver:2.9.4",
+            "id":"org.apache.sling:org.apache.sling.servlets.resolver:2.9.10",
             "start-order":"20"
         },
         {
@@ -174,7 +174,7 @@
             "start-order":"5"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.api:2.25.4",
+            "id":"org.apache.sling:org.apache.sling.api:2.27.0",
             "start-order":"5"
         },
         {

--- a/distribution/src/main/features/core/base-configuration.json
+++ b/distribution/src/main/features/core/base-configuration.json
@@ -24,7 +24,8 @@
             "servlet.post.checkinNewVersionableNodes":true
         },
         "org.apache.sling.engine.parameters":{
-            "sling.default.parameter.encoding":"UTF-8"
+            "sling.default.parameter.encoding":"UTF-8",
+            "request.max.file.count": 1000000
         },
         // By default, deny self-registration
         "org.apache.sling.jackrabbit.usermanager.impl.post.CreateUserServlet":{

--- a/distribution/src/main/features/oak/oak_base.json
+++ b/distribution/src/main/features/oak/oak_base.json
@@ -134,7 +134,7 @@
             "start-order":"20"
         },
         {
-            "id":"org.apache.sling:org.apache.sling.jcr.jackrabbit.usermanager:2.2.20",
+            "id":"org.apache.sling:org.apache.sling.jcr.jackrabbit.usermanager:2.2.26",
             "start-order":"20"
         }
     ],

--- a/heracles-resources/feature/src/main/features/feature.json
+++ b/heracles-resources/feature/src/main/features/feature.json
@@ -54,6 +54,10 @@
       "start-order":"26"
     },
     {
+      "id":"io.netty:netty-transport-native-unix-common:4.1.89.Final",
+      "start-order":"26"
+    },
+    {
       "id":"io.netty:netty-resolver:4.1.89.Final",
       "start-order":"26"
     },

--- a/heracles-resources/feature/src/main/features/feature.json
+++ b/heracles-resources/feature/src/main/features/feature.json
@@ -26,35 +26,35 @@
       "start-order":"26"
     },
     {
-      "id":"io.netty:netty-tcnative-classes:2.0.46.Final",
+      "id":"io.netty:netty-tcnative-classes:2.0.59.Final",
       "start-order":"26"
     },
     {
-      "id":"io.netty:netty-codec-http:4.1.74.Final",
+      "id":"io.netty:netty-codec-http:4.1.89.Final",
       "start-order":"26"
     },
     {
-      "id":"io.netty:netty-codec:4.1.74.Final",
+      "id":"io.netty:netty-codec:4.1.89.Final",
       "start-order":"26"
     },
     {
-      "id":"io.netty:netty-handler:4.1.74.Final",
+      "id":"io.netty:netty-handler:4.1.89.Final",
       "start-order":"26"
     },
     {
-      "id":"io.netty:netty-buffer:4.1.74.Final",
+      "id":"io.netty:netty-buffer:4.1.89.Final",
       "start-order":"26"
     },
     {
-      "id":"io.netty:netty-common:4.1.74.Final",
+      "id":"io.netty:netty-common:4.1.89.Final",
       "start-order":"26"
     },
     {
-      "id":"io.netty:netty-transport:4.1.74.Final",
+      "id":"io.netty:netty-transport:4.1.89.Final",
       "start-order":"26"
     },
     {
-      "id":"io.netty:netty-resolver:4.1.74.Final",
+      "id":"io.netty:netty-resolver:4.1.89.Final",
       "start-order":"26"
     },
     {

--- a/modules/data-entry/src/main/features/feature.json
+++ b/modules/data-entry/src/main/features/feature.json
@@ -34,7 +34,7 @@
       "start-order":"26"
     },
     {
-      "id":"org.apache.sling:org.apache.sling.api:2.25.4",
+      "id":"org.apache.sling:org.apache.sling.api:2.27.0",
       "start-order":"25"
     },
     {

--- a/modules/email-notifications/src/main/features/feature.json
+++ b/modules/email-notifications/src/main/features/feature.json
@@ -53,7 +53,7 @@
       "start-order":"25"
     },
     {
-      "id":"org.apache.sling:org.apache.sling.api:2.25.4",
+      "id":"org.apache.sling:org.apache.sling.api:2.27.0",
       "start-order":"25"
     },
     {

--- a/modules/metrics/src/main/features/feature.json
+++ b/modules/metrics/src/main/features/feature.json
@@ -20,7 +20,7 @@
   "description": "Feature enabling support for performance metrics recording",
   "bundles":[
     {
-      "id":"org.apache.sling:org.apache.sling.api:2.25.4",
+      "id":"org.apache.sling:org.apache.sling.api:2.27.0",
       "start-order":"25"
     },
     {

--- a/modules/ui-extension/src/main/features/feature.json
+++ b/modules/ui-extension/src/main/features/feature.json
@@ -30,7 +30,7 @@
       "start-order":"26"
     },
     {
-      "id":"org.apache.sling:org.apache.sling.api:2.25.4",
+      "id":"org.apache.sling:org.apache.sling.api:2.27.0",
       "start-order":"26"
     },
     {

--- a/modules/vocabularies/src/main/features/feature.json
+++ b/modules/vocabularies/src/main/features/feature.json
@@ -42,7 +42,7 @@
       "start-order":"25"
     },
     {
-      "id":"org.apache.sling:org.apache.sling.api:2.25.4",
+      "id":"org.apache.sling:org.apache.sling.api:2.27.0",
       "start-order":"25"
     },
     {

--- a/modules/webhook-backup/src/main/features/feature.json
+++ b/modules/webhook-backup/src/main/features/feature.json
@@ -46,6 +46,10 @@
       "start-order":"25"
     },
     {
+      "id":"io.netty:netty-transport-native-unix-common:4.1.89.Final",
+      "start-order":"25"
+    },
+    {
       "id":"io.netty:netty-resolver:4.1.89.Final",
       "start-order":"25"
     },

--- a/modules/webhook-backup/src/main/features/feature.json
+++ b/modules/webhook-backup/src/main/features/feature.json
@@ -22,31 +22,31 @@
       "start-order":"25"
     },
     {
-      "id":"io.netty:netty-codec-http:4.1.74.Final",
+      "id":"io.netty:netty-codec-http:4.1.89.Final",
       "start-order":"25"
     },
     {
-      "id":"io.netty:netty-codec:4.1.74.Final",
+      "id":"io.netty:netty-codec:4.1.89.Final",
       "start-order":"25"
     },
     {
-      "id":"io.netty:netty-handler:4.1.74.Final",
+      "id":"io.netty:netty-handler:4.1.89.Final",
       "start-order":"25"
     },
     {
-      "id":"io.netty:netty-buffer:4.1.74.Final",
+      "id":"io.netty:netty-buffer:4.1.89.Final",
       "start-order":"25"
     },
     {
-      "id":"io.netty:netty-common:4.1.74.Final",
+      "id":"io.netty:netty-common:4.1.89.Final",
       "start-order":"25"
     },
     {
-      "id":"io.netty:netty-transport:4.1.74.Final",
+      "id":"io.netty:netty-transport:4.1.89.Final",
       "start-order":"25"
     },
     {
-      "id":"io.netty:netty-resolver:4.1.74.Final",
+      "id":"io.netty:netty-resolver:4.1.89.Final",
       "start-order":"25"
     },
     {
@@ -58,7 +58,7 @@
       "start-order":"25"
     },
     {
-      "id":"io.netty:netty-tcnative-classes:2.0.46.Final",
+      "id":"io.netty:netty-tcnative-classes:2.0.59.Final",
       "start-order":"25"
     },
     {

--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,7 @@
       <dependency>
         <groupId>org.apache.sling</groupId>
         <artifactId>org.apache.sling.api</artifactId>
-        <version>2.25.4</version>
+        <version>2.27.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.sling</groupId>


### PR DESCRIPTION
This PR upgrades the versions of several Maven packages to address security issues found by the Trivy scanner on the latest of the `dev` branch. Specifically, the following Maven packages are upgraded:

- `org.apache.sling:org.apache.sling.engine` from `2.9.0` to `2.14.0`
- `org.apache.sling:org.apache.sling.i18n` from `2.5.18` to `2.6.2`
- `org.apache.sling:org.apache.sling.resourceresolver` from `1.8.4` to `1.10.0`
- `org.apache.sling:org.apache.sling.servlets.resolver` from `2.9.4` to `2.9.10`
-  `org.apache.sling:org.apache.sling.api` from `2.25.4` to `2.27.0`
-  `org.apache.tika:tika-core` from `1.28.1` to `1.28.5`
-  `org.apache.tika:tika-parsers` from `1.28.1` to `1.28.5`
-  `org.apache.sling:org.apache.sling.jcr.jackrabbit.usermanager` from `2.2.20` to `2.2.26`
-  `io.netty:netty-tcnative-classes` from `2.0.46.Final` to `2.0.59.Final`
- Other `io.netty:netty-*` packages that were at `4.1.74.Final` are now at `4.1.89.Final`
- Any newly required dependencies for these upgraded packages have also been added

I have done the following tests with this PR:

- Was able to start in `cards4heracles`, `cards4proms`, `cards4prems` and `cards4lfs` modes :heavy_check_mark:.
- Was able to persist data both on the file system as well as in MongoDB :heavy_check_mark:.
- S3 export works :heavy_check_mark:.
- Vocabulary installation from BioPortal works :heavy_check_mark:.
- SAML login works :heavy_check_mark:.
- Clarity import works :heavy_check_mark:.
- [SMTPS CI test on GitHub Actions passes](https://github.com/data-team-uhn/cards/actions/runs/4822709928) :heavy_check_mark:.