### PR TITLE
Maven packages security updates (stable-0.8.x)

### DIFF
--- a/cardiac-rehab-resources/backend/pom.xml
+++ b/cardiac-rehab-resources/backend/pom.xml
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-osgi</artifactId>
-      <version>1.11.924</version>
+      <version>1.12.451</version>
     </dependency>
   </dependencies>
 </project>

--- a/cardiac-rehab-resources/backend/src/main/provisioning/model.txt
+++ b/cardiac-rehab-resources/backend/src/main/provisioning/model.txt
@@ -24,13 +24,14 @@
     ca.sickkids.ccm.lfs/cardiac-rehab-backend
     com.amazonaws/aws-java-sdk-osgi
     com.fasterxml.jackson.dataformat/jackson-dataformat-cbor/2.6.7
-    io.netty/netty-codec-http/4.1.17.Final
-    io.netty/netty-codec/4.1.17.Final
-    io.netty/netty-handler/4.1.17.Final
-    io.netty/netty-buffer/4.1.17.Final
-    io.netty/netty-common/4.1.17.Final
-    io.netty/netty-transport/4.1.17.Final
-    io.netty/netty-resolver/4.1.17.Final
+    io.netty/netty-codec-http/4.1.91.Final
+    io.netty/netty-codec/4.1.91.Final
+    io.netty/netty-handler/4.1.91.Final
+    io.netty/netty-buffer/4.1.91.Final
+    io.netty/netty-common/4.1.91.Final
+    io.netty/netty-transport/4.1.91.Final
+    io.netty/netty-resolver/4.1.91.Final
+    io.netty/netty-transport-native-unix-common/4.1.91.Final
     software.amazon.ion/ion-java/1.0.2
     joda-time/joda-time/2.8.1
 

--- a/cardiac-rehab-resources/backend/src/main/provisioning/model.txt
+++ b/cardiac-rehab-resources/backend/src/main/provisioning/model.txt
@@ -23,7 +23,7 @@
 [artifacts runModes=cardiac_rehab startLevel=10]
     ca.sickkids.ccm.lfs/cardiac-rehab-backend
     com.amazonaws/aws-java-sdk-osgi
-    com.fasterxml.jackson.dataformat/jackson-dataformat-cbor/2.6.7
+    com.fasterxml.jackson.dataformat/jackson-dataformat-cbor/2.13.5
     io.netty/netty-codec-http/4.1.91.Final
     io.netty/netty-codec/4.1.91.Final
     io.netty/netty-handler/4.1.91.Final

--- a/compose-cluster/load_apple_cert.sh
+++ b/compose-cluster/load_apple_cert.sh
@@ -17,6 +17,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+JAVA_HOME=/usr/lib/jvm/default-jvm
+
 keytool -import -trustcacerts -file /AppleIncRootCertificate.pem \
  -keystore $JAVA_HOME/lib/security/cacerts \
  -keypass changeit -storepass changeit -noprompt

--- a/distribution/Dockerfile
+++ b/distribution/Dockerfile
@@ -15,11 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Start from a small JRE8 base image
-FROM openjdk:8-jre-alpine
+# Start from a small Alpine Linux base image
+FROM alpine:3.17
 
-# Install utilities for patching the JAR file, if such is necessary
+# Install Java JRE and the utilities for patching the JAR file, if such is necessary
 RUN apk add \
+  openjdk11-jre \
   unzip \
   zip \
   tzdata

--- a/distribution/src/main/provisioning/10-sling-base.txt
+++ b/distribution/src/main/provisioning/10-sling-base.txt
@@ -60,7 +60,7 @@
     org.apache.commons/commons-collections4/4.2
     commons-codec/commons-codec/1.11
     commons-lang/commons-lang/2.6
-    commons-io/commons-io/2.6
+    commons-io/commons-io/2.11.0
     org.apache.commons/commons-lang3/3.8.1
     org.apache.commons/commons-math/2.2
     org.apache.geronimo.bundles/commons-httpclient/3.1_2

--- a/distribution/src/main/provisioning/10-sling-base.txt
+++ b/distribution/src/main/provisioning/10-sling-base.txt
@@ -76,8 +76,8 @@
     org.apache.pdfbox/pdfbox/2.0.12
     org.apache.pdfbox/fontbox/2.0.12
     org.apache.pdfbox/jempbox/1.8.16
-    org.apache.tika/tika-core/1.19.1
-    org.apache.tika/tika-parsers/1.19.1
+    org.apache.tika/tika-core/1.28.5
+    org.apache.tika/tika-parsers/1.28.5
 
 # Extra JCR features
 [artifacts startLevel=15]

--- a/distribution/src/main/provisioning/10-sling-base.txt
+++ b/distribution/src/main/provisioning/10-sling-base.txt
@@ -73,7 +73,7 @@
     org.apache.felix/org.apache.felix.http.sslfilter/1.2.6
     org.apache.felix/org.apache.felix.scr/2.1.14
     org.apache.felix/org.apache.felix.metatype/1.2.2
-    org.apache.pdfbox/pdfbox/2.0.12
+    org.apache.pdfbox/pdfbox/2.0.28
     org.apache.pdfbox/fontbox/2.0.12
     org.apache.pdfbox/jempbox/1.8.16
     org.apache.tika/tika-core/1.28.5

--- a/distribution/src/main/provisioning/10-sling-base.txt
+++ b/distribution/src/main/provisioning/10-sling-base.txt
@@ -65,7 +65,7 @@
     org.apache.commons/commons-math/2.2
     org.apache.geronimo.bundles/commons-httpclient/3.1_2
     org.apache.httpcomponents/httpcore-osgi/4.4.10
-    org.apache.httpcomponents/httpclient-osgi/4.5.6
+    org.apache.httpcomponents/httpclient-osgi/4.5.14
     javax.mail/mail/1.5.0-b01
 
 # Other Apache Felix modules

--- a/distribution/src/main/provisioning/10-sling-base.txt
+++ b/distribution/src/main/provisioning/10-sling-base.txt
@@ -39,7 +39,7 @@
     org.apache.sling/org.apache.sling.hc.api/1.0.2
     org.apache.sling/org.apache.sling.hc.core/1.2.10
     org.apache.sling/org.apache.sling.hc.webconsole/1.1.2
-    org.apache.sling/org.apache.sling.i18n/2.5.14
+    org.apache.sling/org.apache.sling.i18n/2.6.2
     org.apache.sling/org.apache.sling.installer.console/1.0.2
     org.apache.sling/org.apache.sling.installer.provider.jcr/3.1.26
     org.apache.sling/org.apache.sling.installer.hc/2.0.0

--- a/distribution/src/main/provisioning/10-sling-base.txt
+++ b/distribution/src/main/provisioning/10-sling-base.txt
@@ -83,7 +83,7 @@
 [artifacts startLevel=15]
     org.apache.sling/org.apache.sling.jcr.jcr-wrapper/2.0.0
     org.apache.sling/org.apache.sling.jcr.api/2.4.0
-    org.apache.sling/org.apache.sling.jcr.base/3.0.6
+    org.apache.sling/org.apache.sling.jcr.base/3.1.14
     org.apache.sling/org.apache.sling.jcr.registration/1.0.6
     org.apache.jackrabbit/jackrabbit-api/${jackrabbit.version}
     org.apache.jackrabbit/jackrabbit-jcr-commons/${jackrabbit.version}

--- a/distribution/src/main/provisioning/20-sling-models-jacksonexporter.txt
+++ b/distribution/src/main/provisioning/20-sling-models-jacksonexporter.txt
@@ -20,7 +20,7 @@
 # This adds support for serializing (exporting) nodes using Jackson
 [feature name=models-jacksonexporter]
 [variables]
-    jackson.version=2.9.7
+    jackson.version=2.13.5
 
 [artifacts]
   org.apache.sling/org.apache.sling.models.jacksonexporter/1.0.8

--- a/distribution/src/main/provisioning/50-sling-webconsole.txt
+++ b/distribution/src/main/provisioning/50-sling-webconsole.txt
@@ -38,5 +38,5 @@
     org.apache.aries.jmx/org.apache.aries.jmx.core/1.1.8
     org.apache.aries.jmx/org.apache.aries.jmx.whiteboard/1.2.0
     org.apache.sling/org.apache.sling.jcr.webconsole/1.0.2
-    commons-fileupload/commons-fileupload/1.3.3
+    commons-fileupload/commons-fileupload/1.5
     org.apache.sling/org.apache.sling.commons.log.webconsole/1.0.0

--- a/modules/utils/pom.xml
+++ b/modules/utils/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.6</version>
+      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/vocabularies/pom.xml
+++ b/modules/vocabularies/pom.xml
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-osgi</artifactId>
-      <version>4.5.6</version>
+      <version>4.5.14</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/modules/vocabularies/src/main/provisioning/model.txt
+++ b/modules/vocabularies/src/main/provisioning/model.txt
@@ -32,7 +32,7 @@
     org.apache.jena/jena-osgi/3.11.0
     com.github.andrewoma.dexx/collection/0.7
     com.github.jsonld-java/jsonld-java/0.12.3
-    org.apache.commons/commons-compress/1.18
+    org.apache.commons/commons-compress/1.23.0
     org.apache.thrift/libthrift/0.12.0
 
     javax.json/javax.json-api/1.1.4

--- a/modules/vocabularies/src/main/provisioning/model.txt
+++ b/modules/vocabularies/src/main/provisioning/model.txt
@@ -21,7 +21,7 @@
 [feature name=lfs-vocabularies]
 
 [artifacts]
-    commons-io/commons-io/2.4
+    commons-io/commons-io/2.11.0
     org.apache.commons/commons-csv/1.6
     org.apache.commons/commons-lang3/3.9
     org.apache.commons/commons-collections4/4.3


### PR DESCRIPTION
This PR upgrades the versions of several Maven packages to address security issues found by the Trivy scanner on the latest version of the `stable-0.8.x` branch. Unfortunately, not all security issues could be addressed as doing so would require an upgrade of Apache Sling and thus the `stable-0.8.x` branch would change so that it resembles more the latest `dev` and less the current state of `stable-0.8.x`.

I have tested and can confirm that the following works:

- Able to start with the `cardiac_rehab` (Cards4CaRe) _runmode_ :heavy_check_mark:.
- Data can be pushed to a MinIO S3 bucket both manually (via `/Subjects.s3push`) and via automated cron schedule :heavy_check_mark:.
- We can load a self-signed SSL certificate at container startup and this certificate is used for verifying the connection to the S3 bucket :heavy_check_mark:.
- Data can be persisted in an external Mongo database :heavy_check_mark:.
- Composum works and is available at `/bin/browser.html` :heavy_check_mark:.
- Vocabularies can be installed from BioPortal :heavy_check_mark:.
- Vocabularies can be installed from local files :heavy_check_mark:.