### PR TITLE
CARDS-2213: Docker Compose environments generated by generate_compose_yaml.py should assign the unless-stopped restart policy to services

### DIFF
--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -951,12 +951,16 @@ if args.subnet:
   yaml_obj['networks']['internalnetwork']['ipam']['driver'] = 'default'
   yaml_obj['networks']['internalnetwork']['ipam']['config'] = [{'subnet': args.subnet}]
 
-#Add timezone configuration to services
+# Configuration items that should be added to *all* services
 for service_name in yaml_obj['services']:
+  # Timezone
   if 'environment' in yaml_obj['services'][service_name]:
     yaml_obj['services'][service_name]['environment'].append("TZ={}".format(getTimezoneName()))
   else:
     yaml_obj['services'][service_name]['environment'] = ["TZ={}".format(getTimezoneName())]
+
+  # Automatic restart policy
+  yaml_obj['services'][service_name]['restart'] = "unless-stopped"
 
 #Save it
 with open(OUTPUT_FILENAME, 'w') as f_out:


### PR DESCRIPTION
This PR implements CARDS-2213 and adds the `restart: unless-stopped` configuration option to _all_ services listed in the `generate_compose_yaml.py` generated `docker-compose.yml` file so that they will automatically be restarted whenever the Docker daemon is restarted (for example, when the server is restarted or when the `docker.io` OS package is upgraded).

Testing Instructions
--------------------------

1. Build this (`CARDS-2113`) branch, including a _development_ Docker image with `mvn clean install -Pdocker`.
2. `cd compose-cluster`
3. `python3 generate_compose_yaml.py --dev_docker_image --oak_filesystem --composum --cards_project cards4prems`
4. `docker-compose build && docker-compose up -d`
5. Visit http://localhost:8080 and ensure that CARDS works as expected
6. Restart the Docker daemon. In Debian (or any Linux distribution that uses _systemd_ for service management), this can be done with `systemctl restart docker`.
7. Verify that the CARDS Docker Compose environment comes back up. Repeating these same steps using the `dev` branch will result in CARDS _not_ restarting after the Docker daemon is restarted.