### PR TITLE
CARDS-2205: Improve the maximum number of forms per subject handling in the form creation dialog

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -199,7 +199,7 @@ function NewFormDialog(props) {
   useEffect(() => {
     // only considers currentSubject, since setting this error would only be necessary on the 'Subject' page, which would set a currentSubject
     if (currentSubject && relatedForms && selectedQuestionnaire) {
-      let atMax = (relatedForms.length && (relatedForms.filter((i) => (i["@name"] == selectedQuestionnaire["@name"])).length >= (+(selectedQuestionnaire?.["maxPerSubject"]) || undefined)));
+      let atMax = (relatedForms.length && (relatedForms.filter((i) => (i["q.jcr:uuid"] == selectedQuestionnaire["jcr:uuid"])).length >= (+(selectedQuestionnaire?.["maxPerSubject"]) || undefined)));
       if (atMax) {
         setError(`${currentSubject?.["type"]["@name"]} ${currentSubject?.["identifier"]} already has ${selectedQuestionnaire?.["maxPerSubject"]} ${selectedQuestionnaire?.["title"]} form(s) filled out.`);
         setDisableProgress(true);
@@ -213,7 +213,7 @@ function NewFormDialog(props) {
 
   // get all the forms related to the selectedSubject, saved in the `relatedForms` state
   let filterQuestionnaire = () => {
-    fetchWithReLogin(globalLoginDisplay, `/query?query=SELECT distinct q.* FROM [cards:Questionnaire] AS q inner join [cards:Form] as f on f.'questionnaire'=q.'jcr:uuid' where f.'subject'='${(currentSubject || selectedSubject)?.['jcr:uuid']}'&limit=1000`)
+    fetchWithReLogin(globalLoginDisplay, `/query?rawResults=true&query=SELECT q.[jcr:uuid] FROM [cards:Questionnaire] AS q inner join [cards:Form] as f on f.'questionnaire'=q.'jcr:uuid' where f.'subject'='${(currentSubject || selectedSubject)?.['jcr:uuid']}'&limit=1000`)
     .then((response) => response.ok ? response.json() : Promise.reject(response))
     .then((response) => {
       setRelatedForms(response.rows);
@@ -357,7 +357,7 @@ function NewFormDialog(props) {
                     // /* It doesn't seem possible to alter the className from here */
                     backgroundColor: (selectedQuestionnaire?.["jcr:uuid"] === rowData["jcr:uuid"]) ? theme.palette.grey["200"] : theme.palette.background.default,
                     // // grey out subjects that have already reached maxPerSubject
-                    color: ((relatedForms?.length && (selectedSubject || currentSubject) && (relatedForms.filter((i) => (i["@name"] == rowData["@name"])).length >= (+(rowData?.["maxPerSubject"]) || undefined)))
+                    color: ((relatedForms?.length && (selectedSubject || currentSubject) && (relatedForms.filter((i) => (i["q.jcr:uuid"] == rowData["jcr:uuid"])).length >= (+(rowData?.["maxPerSubject"]) || undefined)))
                     ? theme.palette.grey["500"]
                     : theme.palette.grey["900"]
                     )

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -213,7 +213,7 @@ function NewFormDialog(props) {
 
   // get all the forms related to the selectedSubject, saved in the `relatedForms` state
   let filterQuestionnaire = () => {
-    fetchWithReLogin(globalLoginDisplay, `/query?query=SELECT distinct q.* FROM [cards:Questionnaire] AS q inner join [cards:Form] as f on f.'questionnaire'=q.'jcr:uuid' where f.'subject'='${(currentSubject || selectedSubject)?.['jcr:uuid']}'`)
+    fetchWithReLogin(globalLoginDisplay, `/query?query=SELECT distinct q.* FROM [cards:Questionnaire] AS q inner join [cards:Form] as f on f.'questionnaire'=q.'jcr:uuid' where f.'subject'='${(currentSubject || selectedSubject)?.['jcr:uuid']}'&limit=1000`)
     .then((response) => response.ok ? response.json() : Promise.reject(response))
     .then((response) => {
       setRelatedForms(response.rows);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -895,7 +895,7 @@ function SubjectSelectorList(props) {
                 }
                 let querySubjectSubsetClause = (querySubjectSubset.length > 0) ? (" and (" + querySubjectSubset + ") ") : " ";
                 // fetch the Subjects of each form of this questionnaire type for all listed subjects
-                return fetchWithReLogin(globalLoginDisplay, `/query?query=SELECT distinct s.* FROM [cards:Subject] AS s inner join [cards:Form] as f on f.'subject'=s.'jcr:uuid' where f.'questionnaire'='${selectedQuestionnaire?.['jcr:uuid']}'${querySubjectSubsetClause}order by s.'fullIdentifier'&limit=${query.pageSize}`)
+                return fetchWithReLogin(globalLoginDisplay, `/query?query=SELECT distinct s.* FROM [cards:Subject] AS s inner join [cards:Form] as f on f.'subject'=s.'jcr:uuid' where f.'questionnaire'='${selectedQuestionnaire?.['jcr:uuid']}'${querySubjectSubsetClause}order by s.'fullIdentifier'&limit=${selectedQuestionnaire?.["maxPerSubject"] * query.pageSize}`)
                 .then((relatedSubjectsResp) => relatedSubjectsResp.json())
                 .then((relatedSubjectsResp) => {
                   setRelatedSubjects(relatedSubjectsResp.rows);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -848,7 +848,7 @@ function SubjectSelectorList(props) {
 
   // if the number of related forms of a certain questionnaire/subject is at the maxPerSubject, an error is set
   let handleSelection = (rowData) => {
-    let atMax = (relatedSubjects?.length && selectedQuestionnaire && (relatedSubjects.filter((i) => (i["jcr:uuid"] == rowData["jcr:uuid"])).length >= (+(selectedQuestionnaire?.["maxPerSubject"]) || undefined)))
+    let atMax = (relatedSubjects?.length && selectedQuestionnaire && (relatedSubjects.filter((i) => (i["s.jcr:uuid"] == rowData["jcr:uuid"])).length >= (+(selectedQuestionnaire?.["maxPerSubject"]) || undefined)))
     if (atMax) {
       onError(`${rowData?.["type"]["@name"]} ${rowData?.["identifier"]} already has ${selectedQuestionnaire?.["maxPerSubject"]} ${selectedQuestionnaire?.["title"]} form(s) filled out.`);
       disableProgress(true);
@@ -895,7 +895,7 @@ function SubjectSelectorList(props) {
                 }
                 let querySubjectSubsetClause = (querySubjectSubset.length > 0) ? (" and (" + querySubjectSubset + ") ") : " ";
                 // fetch the Subjects of each form of this questionnaire type for all listed subjects
-                return fetchWithReLogin(globalLoginDisplay, `/query?query=SELECT distinct s.* FROM [cards:Subject] AS s inner join [cards:Form] as f on f.'subject'=s.'jcr:uuid' where f.'questionnaire'='${selectedQuestionnaire?.['jcr:uuid']}'${querySubjectSubsetClause}order by s.'fullIdentifier'&limit=${selectedQuestionnaire?.["maxPerSubject"] * query.pageSize}`)
+                return fetchWithReLogin(globalLoginDisplay, `/query?rawResults=true&query=SELECT s.[jcr:uuid] FROM [cards:Subject] AS s inner join [cards:Form] as f on f.'subject'=s.'jcr:uuid' where f.'questionnaire'='${selectedQuestionnaire?.['jcr:uuid']}'${querySubjectSubsetClause}order by s.'fullIdentifier'&limit=${selectedQuestionnaire?.["maxPerSubject"] * query.pageSize}`)
                 .then((relatedSubjectsResp) => relatedSubjectsResp.json())
                 .then((relatedSubjectsResp) => {
                   setRelatedSubjects(relatedSubjectsResp.rows);
@@ -903,7 +903,7 @@ function SubjectSelectorList(props) {
                 })
                 .then((latestRelatedSubjects) => {
                   // Auto-select if there is only one subject available which has not execeeded maximum Forms per Subject
-                  let atMax = (latestRelatedSubjects?.length && selectedQuestionnaire && (latestRelatedSubjects.filter((i) => (i["jcr:uuid"] == filteredData[0]["jcr:uuid"])).length >= (+(selectedQuestionnaire?.["maxPerSubject"]) || undefined)))
+                  let atMax = (latestRelatedSubjects?.length && selectedQuestionnaire && (latestRelatedSubjects.filter((i) => (i["s.jcr:uuid"] == filteredData[0]["jcr:uuid"])).length >= (+(selectedQuestionnaire?.["maxPerSubject"]) || undefined)))
                   if (filteredData.length === 1 && !atMax) {
                     onSelect(filteredData[0]);
                     handleSelection(filteredData[0]);
@@ -990,7 +990,7 @@ function SubjectSelectorList(props) {
             /* It doesn't seem possible to alter the className from here */
             backgroundColor: (selectedSubject?.["jcr:uuid"] === rowData["jcr:uuid"]) ? theme.palette.grey["200"] : theme.palette.background.default,
             // grey out subjects that have already reached maxPerSubject
-            color: ((relatedSubjects?.length && selectedQuestionnaire && (relatedSubjects.filter((i) => (i["jcr:uuid"] == rowData["jcr:uuid"])).length >= (+(selectedQuestionnaire?.["maxPerSubject"]) || undefined)))
+            color: ((relatedSubjects?.length && selectedQuestionnaire && (relatedSubjects.filter((i) => (i["s.jcr:uuid"] == rowData["jcr:uuid"])).length >= (+(selectedQuestionnaire?.["maxPerSubject"]) || undefined)))
             ? theme.palette.grey["500"]
             : theme.palette.grey["900"]
             )

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/MaxPerSubjectTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/MaxPerSubjectTest.xml
@@ -1,0 +1,57 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>MaxPerSubjectTest</name>
+	<primaryNodeType>cards:Questionnaire</primaryNodeType>
+	<property>
+		<name>maxPerSubject</name>
+		<value>12</value>
+		<type>Long</type>
+	</property>
+	<property>
+		<name>description</name>
+		<value>Tests how well the maximum number of forms per subject is handled. At most 12 forms of this type are allowed per subject.</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>title</name>
+		<value>Max Forms Per Subject Test</value>
+		<type>String</type>
+	</property>
+	<node>
+		<name>number</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Number</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>long</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+	</node>
+</node>


### PR DESCRIPTION
And:

CARDS-2215: The form creation UI seems to allow more than the permitted max forms per subject when the limit is greater than 5 or 10

To test:

- start with `--test`
- create 12 forms of type `MaxPerSubjectTest` for the `Sample` patient
- wait 5 seconds
- try to create another `MaxPerSubjectTest` form from the patient chart, check that this questionnaire is grayed out and selecting it displays the "*Patient Sample already has 12 Max Forms Per Subject Test form(s) filled out*" warning
- try to create another `MaxPerSubjectTest` form from the dashboard, check that the `Sample` patient is grayed out and selecting it displays the "*Patient Sample already has 12 Max Forms Per Subject Test form(s) filled out*" warning
- create a new subject, repeat the steps above for this new subject