### PR TITLE
CARDS-2216: HERACLES: Remove maxPerSubject=6 restrictions

### DIFF
--- a/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/6MWT.xml
+++ b/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/6MWT.xml
@@ -22,7 +22,7 @@
 	<primaryNodeType>cards:Questionnaire</primaryNodeType>
 	<property>
 		<name>maxPerSubject</name>
-		<value>6</value>
+		<value>0</value>
 		<type>Long</type>
 	</property>
 	<property>

--- a/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/CPET Interpretation.xml
+++ b/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/CPET Interpretation.xml
@@ -22,7 +22,7 @@
 	<primaryNodeType>cards:Questionnaire</primaryNodeType>
 	<property>
 		<name>maxPerSubject</name>
-		<value>6</value>
+		<value>0</value>
 		<type>Long</type>
 	</property>
 	<property>

--- a/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Laboratory Results.xml
+++ b/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Laboratory Results.xml
@@ -22,7 +22,7 @@
 	<primaryNodeType>cards:Questionnaire</primaryNodeType>
 	<property>
 		<name>maxPerSubject</name>
-		<value>6</value>
+		<value>0</value>
 		<type>Long</type>
 	</property>
 	<property>


### PR DESCRIPTION
This affects the 6MWT, CPET Interpretation, and Laboratory Results questionnaires.