### PR TITLE
CARDS-2217: Display the clinic label in the Visit Information form

### DIFF
--- a/modules/patient-portal/src/main/resources/SLING-INF/content/Questionnaires/Visit information.xml
+++ b/modules/patient-portal/src/main/resources/SLING-INF/content/Questionnaires/Visit information.xml
@@ -62,7 +62,7 @@
 		</property>
 		<property>
 			<name>labelProperty</name>
-			<value>clinicName</value>
+			<value>displayName</value>
 			<type>String</type>
 		</property>
 		<property>


### PR DESCRIPTION
To test:
- start in prems mode
- create a new Visit Information form
- check that the Clinic dropdown lists full names like `Canadian Patient Experience` and `UHN Inpatient`, not short names like `CPES` or `UHN IP`
- save and view, check that the full name is displayed in view mode