### PR TITLE
[misc] Trivy security scanning hostname lookup failure fix

### DIFF
--- a/Utilities/SecurityScanning/trivy-utils/update_trivy_cache.sh
+++ b/Utilities/SecurityScanning/trivy-utils/update_trivy_cache.sh
@@ -17,8 +17,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
+resolve_ip () {
+	HOSTNAME=$1 python3 -c 'import os; import socket; print(os.environ["HOSTNAME"] + ":" + socket.gethostbyname(os.environ["HOSTNAME"]))'
+}
+
 docker run \
 	--rm \
+	--add-host $(resolve_ip ghcr.io) \
+	--add-host $(resolve_ip index.docker.io) \
+	--add-host $(resolve_ip production.cloudflare.docker.com) \
 	-v $(realpath ~/trivy-cache):/root/.cache \
 	aquasec/trivy fs \
 	--download-db-only


### PR DESCRIPTION
This Pull Request fixes an issue that I was having when running the Trivy security scanner in a Qubes OS Qube. For an unknown reason, when running the `./update_trivy_cache.sh` script, it would fail due to it not being able to resolve the `ghcr.io` hostname. This Pull request provides a work-around to that problem by resolving the `ghcr.io`, `index.docker.io`, and `production.cloudflare.docker.com` hosts before starting the `aquasec/trivy` Docker container.

Testing Instructions
--------------------------

- `docker pull aquasec/trivy`
- `cd Utilities/SecurityScanning/trivy-utils`
- `./update_trivy_cache.sh` and ensure that it runs without error.