### PR TITLE
CARDS-2221: Create a script within the CARDS repository for building a self-contained Docker image using the cards-sling-feature-downloader utility

### DIFF
--- a/Utilities/Packaging/Docker/add_artifacts_to_docker_image.sh
+++ b/Utilities/Packaging/Docker/add_artifacts_to_docker_image.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+INPUT_DOCKER_IMAGE=$1
+OUTPUT_DOCKER_IMAGE=$2
+JARS_M2_DIRECTORY=$3
+
+touch docker_context.tar || exit -1
+DOCKER_CONTEXT_TAR_PATH=$(realpath docker_context.tar) || exit -1
+
+# Add all the JAR files into the Docker context
+(cd $JARS_M2_DIRECTORY && tar -c -v -f $DOCKER_CONTEXT_TAR_PATH .) || exit -1
+
+# Create a Docker context
+mkdir .tmpctx || exit -1
+cd .tmpctx
+
+# Add metadata files to the Docker context
+mkdir metadata
+
+# Add the yarn.lock file listing the contained JavaScript packages to the metadata
+cp $CARDS_DIRECTORY/aggregated-frontend/src/main/frontend/yarn.lock metadata/yarn.lock
+
+# Add a Dockerfile to the Docker context
+cat << EOF > Dockerfile || exit -1
+FROM $INPUT_DOCKER_IMAGE
+COPY repository /root/.m2/repository
+COPY metadata /metadata
+EOF
+
+# Build the Docker context into a usable Docker image
+tar -r -v -f $DOCKER_CONTEXT_TAR_PATH . || exit -1
+cd ..
+rm -rf .tmpctx || exit -1
+
+cat $DOCKER_CONTEXT_TAR_PATH | docker build -t $OUTPUT_DOCKER_IMAGE - || exit -1
+rm $DOCKER_CONTEXT_TAR_PATH || exit -1

--- a/Utilities/Packaging/Docker/build_self_contained.sh
+++ b/Utilities/Packaging/Docker/build_self_contained.sh
@@ -19,6 +19,12 @@
 
 OUTPUT_DOCKER_IMAGE=$1
 
+if [ -z $OUTPUT_DOCKER_IMAGE ]
+then
+	echo "You must specify an output Docker image name (eg. ./build_self_contained.sh cards/cards:latest-dev)"
+	exit 1
+fi
+
 # First check that the cards/sling-feature-downloader Docker image exists on the local machine
 (docker image inspect cards/sling-feature-downloader > /dev/null) || { echo "Fail: The cards/sling-feature-downloader Docker image does not exist. Exiting."; exit -1; }
 

--- a/Utilities/Packaging/Docker/build_self_contained.sh
+++ b/Utilities/Packaging/Docker/build_self_contained.sh
@@ -26,7 +26,12 @@ then
 fi
 
 # First check that the cards/sling-feature-downloader Docker image exists on the local machine
-(docker image inspect cards/sling-feature-downloader > /dev/null) || { echo "Fail: The cards/sling-feature-downloader Docker image does not exist. Exiting."; exit -1; }
+(docker image inspect cards/sling-feature-downloader > /dev/null) || {
+	echo "Fail: The cards/sling-feature-downloader Docker image does not exist.";
+	echo "It can be obtained from https://github.com/data-team-uhn/cards-sling-feature-downloader."
+	echo "Exiting."
+	exit 1;
+}
 
 UTILITIES_PACKAGING_DOCKER_DIRECTORY=$(pwd)
 export CARDS_DIRECTORY=$(realpath ../../../)

--- a/Utilities/Packaging/Docker/build_self_contained.sh
+++ b/Utilities/Packaging/Docker/build_self_contained.sh
@@ -19,7 +19,8 @@
 
 OUTPUT_DOCKER_IMAGE=$1
 
-# TODO: First check that the cards/sling-feature-downloader Docker image exists on the local machine
+# First check that the cards/sling-feature-downloader Docker image exists on the local machine
+(docker image inspect cards/sling-feature-downloader > /dev/null) || exit -1
 
 UTILITIES_PACKAGING_DOCKER_DIRECTORY=$(pwd)
 export CARDS_DIRECTORY=$(realpath ../../../)

--- a/Utilities/Packaging/Docker/build_self_contained.sh
+++ b/Utilities/Packaging/Docker/build_self_contained.sh
@@ -32,8 +32,10 @@ cd $CARDS_DIRECTORY
 mvn clean install -Pdocker || { echo "Failed to build CARDS Docker image. Exiting."; exit -1; }
 
 # Get the name of the newly built Docker image
-# TODO: IMPLEMENT ME!
-INPUT_DOCKER_IMAGE="cards/cards:latest"
+CARDS_VERSION=$(cat ${CARDS_DIRECTORY}/pom.xml | grep --max-count=1 '<version>' | cut '-d>' -f2 | cut '-d<' -f1)
+
+INPUT_DOCKER_IMAGE="cards/cards:${CARDS_VERSION}"
+(echo "$CARDS_VERSION" | grep -e '-SNAPSHOT$' -q) && INPUT_DOCKER_IMAGE="cards/cards:latest"
 
 # Switch back to the Utilities/Packaging/Docker directory
 cd $UTILITIES_PACKAGING_DOCKER_DIRECTORY
@@ -41,8 +43,6 @@ cd $UTILITIES_PACKAGING_DOCKER_DIRECTORY
 # --- Based on run.sh from cards-sling-feature-downloader utility
 
 export DEPLOYMENT_M2_DIRECTORY=$(realpath $(mktemp -d -p .))
-
-CARDS_VERSION=$(cat ${CARDS_DIRECTORY}/pom.xml | grep --max-count=1 '<version>' | cut '-d>' -f2 | cut '-d<' -f1)
 
 IFS=$'\n'
 for pkg in $(cat cards_feature_list.txt | grep -v -e '^#' | grep -e '^.' | PROJECT_VERSION=$CARDS_VERSION envsubst)

--- a/Utilities/Packaging/Docker/build_self_contained.sh
+++ b/Utilities/Packaging/Docker/build_self_contained.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+OUTPUT_DOCKER_IMAGE=$1
+
+# TODO: First check that the cards/sling-feature-downloader Docker image exists on the local machine
+
+UTILITIES_PACKAGING_DOCKER_DIRECTORY=$(pwd)
+export CARDS_DIRECTORY=$(realpath ../../../)
+
+# Switch to the root of the CARDS repository
+cd $CARDS_DIRECTORY
+
+# Build CARDS including a Docker image
+mvn clean install -Pdocker || { echo "Failed to build CARDS Docker image. Exiting."; exit -1; }
+
+# Get the name of the newly built Docker image
+# TODO: IMPLEMENT ME!
+INPUT_DOCKER_IMAGE="cards/cards:latest"
+
+# Switch back to the Utilities/Packaging/Docker directory
+cd $UTILITIES_PACKAGING_DOCKER_DIRECTORY
+
+# --- Based on run.sh from cards-sling-feature-downloader utility
+
+export DEPLOYMENT_M2_DIRECTORY=$(realpath $(mktemp -d -p .))
+
+CARDS_VERSION=$(cat ${CARDS_DIRECTORY}/pom.xml | grep --max-count=1 '<version>' | cut '-d>' -f2 | cut '-d<' -f1)
+
+IFS=$'\n'
+for pkg in $(cat cards_feature_list.txt | grep -v -e '^#' | grep -e '^.' | PROJECT_VERSION=$CARDS_VERSION envsubst)
+do
+	echo "Getting $pkg"
+	./download_feature_dependencies.sh "$pkg" "tar" || { echo "FAILED!"; exit 1; }
+	./download_feature_dependencies.sh "$pkg" "mongo" || { echo "FAILED!"; exit 1; }
+done
+
+./add_artifacts_to_docker_image.sh $INPUT_DOCKER_IMAGE $OUTPUT_DOCKER_IMAGE $DEPLOYMENT_M2_DIRECTORY || { echo "FAILED!"; exit 1; }
+rm -rf $DEPLOYMENT_M2_DIRECTORY || { echo "FAILED!"; exit 1; }

--- a/Utilities/Packaging/Docker/build_self_contained.sh
+++ b/Utilities/Packaging/Docker/build_self_contained.sh
@@ -20,7 +20,7 @@
 OUTPUT_DOCKER_IMAGE=$1
 
 # First check that the cards/sling-feature-downloader Docker image exists on the local machine
-(docker image inspect cards/sling-feature-downloader > /dev/null) || exit -1
+(docker image inspect cards/sling-feature-downloader > /dev/null) || { echo "Fail: The cards/sling-feature-downloader Docker image does not exist. Exiting."; exit -1; }
 
 UTILITIES_PACKAGING_DOCKER_DIRECTORY=$(pwd)
 export CARDS_DIRECTORY=$(realpath ../../../)

--- a/Utilities/Packaging/Docker/cards_feature_list.txt
+++ b/Utilities/Packaging/Docker/cards_feature_list.txt
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+mvn:io.uhndata.cards/cards4kids/${PROJECT_VERSION}/slingosgifeature
+mvn:io.uhndata.cards/cards4lfs/${PROJECT_VERSION}/slingosgifeature
+mvn:io.uhndata.cards/cards4proms/${PROJECT_VERSION}/slingosgifeature
+mvn:io.uhndata.cards/cards4prems/${PROJECT_VERSION}/slingosgifeature
+mvn:io.uhndata.cards/cards4heracles/${PROJECT_VERSION}/slingosgifeature
+mvn:io.uhndata.cards/cards/${PROJECT_VERSION}/slingosgifeature/composum
+mvn:io.uhndata.cards/cards-modules-demo-banner/${PROJECT_VERSION}/slingosgifeature
+mvn:io.uhndata.cards/cards-modules-upgrade-marker/${PROJECT_VERSION}/slingosgifeature
+mvn:io.uhndata.cards/cards-dataentry/${PROJECT_VERSION}/slingosgifeature/forms_demo
+mvn:io.uhndata.cards/cards-modules-demo-banner/${PROJECT_VERSION}/slingosgifeature
+mvn:io.uhndata.cards/cards-modules-test-forms/${PROJECT_VERSION}/slingosgifeature
+mvn:io.uhndata.cards/cards-cloud-iam-demo-saml-support-ssl/${PROJECT_VERSION}/slingosgifeature
+mvn:io.uhndata.cards/cards-cloud-iam-demo-saml-support/${PROJECT_VERSION}/slingosgifeature
+mvn:io.uhndata.cards/cards-email-notifications/${PROJECT_VERSION}/slingosgifeature
+mvn:io.uhndata.cards/cards-saml-support/${PROJECT_VERSION}/slingosgifeature/base -C io.dropwizard.metrics:metrics-core:ALL
+mvn:io.uhndata.cards/cards-fetch-requires-saml-login/${PROJECT_VERSION}/slingosgifeature
+mvn:io.uhndata.cards/cards-scheduled-csv-export/${PROJECT_VERSION}/slingosgifeature
+mvn:io.uhndata.cards/cards-clarity-integration/${PROJECT_VERSION}/slingosgifeature
+mvn:io.uhndata.cards/cards-dataentry/${PROJECT_VERSION}/slingosgifeature/permissions_open
+mvn:io.uhndata.cards/cards-dataentry/${PROJECT_VERSION}/slingosgifeature/permissions_trusted
+mvn:io.uhndata.cards/cards-dataentry/${PROJECT_VERSION}/slingosgifeature/permissions_ownership

--- a/Utilities/Packaging/Docker/download_feature_dependencies.sh
+++ b/Utilities/Packaging/Docker/download_feature_dependencies.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+MAVEN_FEATURE_NAME=$1
+STORAGE_TYPE=$2
+
+docker run \
+	--rm \
+	--user $UID:$(id -g) \
+	-v ~/.m2:/host_m2:ro \
+	-v $CARDS_DIRECTORY:/cards:ro \
+	-v $DEPLOYMENT_M2_DIRECTORY:/m2 \
+	-e MAVEN_FEATURE_NAME="$MAVEN_FEATURE_NAME" \
+	-e STORAGE_TYPE="$STORAGE_TYPE" \
+	--network none \
+	-it cards/sling-feature-downloader


### PR DESCRIPTION
This Pull Request adds the `Utilities/Packaging/Docker/build_self_contained.sh` script (and its dependencies) for easily building a self-contained CARDS Docker image. Many of the scripts included in this Pull Request are slightly modified versions of the ones in the https://github.com/data-team-uhn/cards-sling-feature-downloader (private) GitHub repository.

Testing Instructions
--------------------------

1. Ensure that you have built a `cards/sling-feature-downloader` Docker image from the https://github.com/data-team-uhn/cards-sling-feature-downloader (private) GitHub repository.
2. `cd Utilities/Packaging/Docker`
3. `./build_self_contained.sh cards/cards-self-contained`. Ensure that the `cards/cards-self-contained` Docker image is built without error.
4. `cd ../../../compose-cluster`
5. `python3 generate_compose_yaml.py --oak_filesystem --cards_project cards4proms --composum`
6. Edit `docker-compose.yml` and change `image: cards/cards:latest` to `image: cards/cards-self-contained:latest`
7. `docker-compose build && docker-compose up -d`
8. Ensure that CARDS starts and is available on http://localhost:8080
9. Clean up with `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`