### PR TITLE
CARDS-2199: As a clinician, I can see on the DATA-PRO clinician dashboard whether surveys have been emailed to a patient prior to their appointment

### DIFF
--- a/modules/patient-portal/src/main/features/feature.json
+++ b/modules/patient-portal/src/main/features/feature.json
@@ -69,6 +69,10 @@
         "create service user patient-tou \n set ACL for patient-tou \n   allow jcr:read,rep:write,jcr:versionManagement on /Forms \n   allow jcr:read on /Questionnaires,/Subjects \n end",
         // Unsubscribe from email notifications
         "create service user patient-unsubscribe \n set ACL for patient-unsubscribe \n   allow jcr:read,rep:write,jcr:versionManagement on /Forms \n   allow jcr:read on /Questionnaires,/Subjects \n end",
+        // Tracking the status of the surveys
+        "create service user survey-tracker \n set ACL for survey-tracker \n   allow jcr:read on / \n     allow jcr:read,rep:write,jcr:versionManagement on /Forms \n end",
+        // Prevent the survey status form from being handled by the visit handling code, e.g. data cleanup or including it in the "survey is all completed" computation
+        "create service user patient-visit-backend \n set ACL for patient-visit-backend \n     deny jcr:all on /Forms restriction(cards:questionnaire,/Questionnaires/Survey*events) \n end",
         // Special handling of the 404 page button: patients go to the Patient UI, all other users go to the dashboard
         "create path (sling:Folder) /RedirectURL \n set ACL on /RedirectURL \n   deny jcr:read for everyone \n   allow jcr:read for patient \n   allow jcr:read for guest-patient \n end \n set properties on /RedirectURL \n   set RedirectURL to /Survey.html \n   set RedirectLabel to \"Go to my surveys\" \n end ",
         // A /Metrics sling:Folder for storing performance info to be sent periodically via Slack
@@ -96,6 +100,7 @@
         "io.uhndata.cards.patient-portal:tou=[patient-tou]",
         "io.uhndata.cards.patient-portal:unsubscribe=[patient-unsubscribe]",
         "io.uhndata.cards.patient-portal:EmailNotifications=[sling-readall]",
+        "io.uhndata.cards.patient-portal:SurveyTracker=[survey-tracker]",
         "io.uhndata.cards.patient-portal:MetricLogger=[cards-metrics]",
         "io.uhndata.cards.patient-portal:SlackNotifications=[cards-metrics]"
       ]

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/ClinicVisits.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/ClinicVisits.jsx
@@ -87,6 +87,15 @@ function ClinicVisits(props) {
       "format": "date:yyyy-MM-dd HH:mm"
     },
     {
+      "key": "email_sent",
+      "label": "Email sent",
+      "format" : (row) => {
+         let email_date = row.reminder2_sent || row.reminder1_sent || row.invitation_sent;
+         let label = row.reminder2_sent || row.reminder1_sent ? "(reminder)" : row.invitation_sent ? "(initial)" : "";
+         return email_date ? `${email_date.substring(0, 10)} ${label}` : "N/A";
+      }
+    },
+    {
       "key" : "status",
       "label" : "Survey completion",
       "format" : (row) => (

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/surveytracker/SurveyTracker.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/surveytracker/SurveyTracker.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.uhndata.cards.prems.internal.surveytracker;
+package io.uhndata.cards.patients.surveytracker;
 
 import java.util.Calendar;
 import java.util.List;

--- a/prems-resources/backend/pom.xml
+++ b/prems-resources/backend/pom.xml
@@ -54,11 +54,6 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>cards-patient-portal</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>cards-resolver-provider</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -87,10 +82,6 @@
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.metatype.annotations</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.service.event</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/surveytracker/SurveyTracker.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/surveytracker/SurveyTracker.java
@@ -32,11 +32,16 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.api.resource.observation.ResourceChange;
 import org.apache.sling.api.resource.observation.ResourceChangeListener;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventConstants;
 import org.osgi.service.event.EventHandler;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,12 +57,14 @@ import io.uhndata.cards.subjects.api.SubjectUtils;
  *
  * @version $Id$
  */
-@Component(immediate = true, service = { ResourceChangeListener.class, EventHandler.class }, property = {
-    ResourceChangeListener.PATHS + "=/Forms",
-    ResourceChangeListener.CHANGES + "=ADDED",
-    ResourceChangeListener.CHANGES + "=CHANGED",
-    EventConstants.EVENT_TOPIC + "=Notification/Patient/Appointment/*",
-})
+@Component(configurationPolicy = ConfigurationPolicy.REQUIRE,
+    service = { ResourceChangeListener.class, EventHandler.class }, property = {
+        ResourceChangeListener.PATHS + "=/Forms",
+        ResourceChangeListener.CHANGES + "=ADDED",
+        ResourceChangeListener.CHANGES + "=CHANGED",
+        EventConstants.EVENT_TOPIC + "=Notification/Patient/Appointment/*",
+    })
+@Designate(ocd = SurveyTracker.Config.class)
 public class SurveyTracker implements ResourceChangeListener, EventHandler
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(SurveyTracker.class);
@@ -83,15 +90,42 @@ public class SurveyTracker implements ResourceChangeListener, EventHandler
     @Reference
     private PatientAccessConfiguration accessConfiguration;
 
+    private final boolean trackSubmissions;
+
+    private final boolean trackEmails;
+
+    @ObjectClassDefinition(name = "Patient portal - Survey tracker")
+    public @interface Config
+    {
+        @AttributeDefinition(name = "Track survey submission")
+        boolean trackSubmissions() default true;
+
+        @AttributeDefinition(name = "Track invitation emails")
+        boolean trackEmails() default true;
+    }
+
+    @Activate
+    public SurveyTracker(Config config)
+    {
+        this.trackSubmissions = config.trackSubmissions();
+        this.trackEmails = config.trackEmails();
+    }
+
     @Override
     public void onChange(final List<ResourceChange> changes)
     {
+        if (!this.trackSubmissions) {
+            return;
+        }
         changes.forEach(this::handleResourceEvent);
     }
 
     @Override
     public void handleEvent(Event event)
     {
+        if (!this.trackEmails) {
+            return;
+        }
         boolean mustPopResolver = false;
         try (ResourceResolver localResolver = this.resolverFactory
             .getServiceResourceResolver(Map.of(ResourceResolverFactory.SUBSERVICE, "SurveyTracker"))) {
@@ -103,8 +137,12 @@ public class SurveyTracker implements ResourceChangeListener, EventHandler
             final Node surveyStatusQuestionnaire = session.getNode("/Questionnaires/Survey events");
             final Node surveyStatusForm =
                 ensureSurveyStatusFormExists(surveyStatusQuestionnaire, visitSubject, session);
-            final Node question = surveyStatusQuestionnaire
-                .getNode(StringUtils.toRootLowerCase(StringUtils.substringAfterLast(event.getTopic(), "/")) + "_sent");
+            final String questionName =
+                StringUtils.toRootLowerCase(StringUtils.substringAfterLast(event.getTopic(), "/")) + "_sent";
+            if (!surveyStatusQuestionnaire.hasNode(questionName)) {
+                return;
+            }
+            final Node question = surveyStatusQuestionnaire.getNode(questionName);
             final Node answer = this.formUtils.getAnswer(surveyStatusForm, question);
             if (answer != null) {
                 answer.setProperty("value", Calendar.getInstance());
@@ -167,6 +205,9 @@ public class SurveyTracker implements ResourceChangeListener, EventHandler
 
     private void updateSurveySubmittedDate(final Node submittedAnswer, final Session session) throws RepositoryException
     {
+        if (!session.nodeExists("/Questionnaires/Survey events/responses_received")) {
+            return;
+        }
         final Node surveyStatusQuestionnaire = session.getNode("/Questionnaires/Survey events");
         final Node surveyStatusForm = ensureSurveyStatusFormExists(surveyStatusQuestionnaire,
             this.formUtils.getSubject(this.formUtils.getForm(submittedAnswer)), session);
@@ -181,6 +222,9 @@ public class SurveyTracker implements ResourceChangeListener, EventHandler
     private void updateSurveyExpirationDate(final Node dischargedAnswer, final Session session)
         throws RepositoryException
     {
+        if (!session.nodeExists("/Questionnaires/Survey events/survey_expiry")) {
+            return;
+        }
         Calendar eventDate = (Calendar) this.formUtils.getValue(dischargedAnswer);
         if (eventDate != null) {
             final Node surveyStatusQuestionnaire = session.getNode("/Questionnaires/Survey events");

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/surveytracker/SurveyTracker.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/surveytracker/SurveyTracker.java
@@ -189,7 +189,7 @@ public class SurveyTracker implements ResourceChangeListener, EventHandler
                     session.getNode("/Questionnaires/Visit information/time")), session);
             } else if (isAnswerForSurveysSubmitted(node) && isSubmitted(node)) {
                 updateSurveySubmittedDate(node, session);
-            } else if (isAnswerForDischargeTime(node)) {
+            } else if (isAnswerForVisitTime(node)) {
                 updateSurveyExpirationDate(node, session);
             }
         } catch (final LoginException e) {
@@ -248,14 +248,18 @@ public class SurveyTracker implements ResourceChangeListener, EventHandler
 
     private boolean hasSurveys(final Node hasSurveysAnswer) throws RepositoryException
     {
-        final Long hasSurveys = (Long) this.formUtils.getValue(hasSurveysAnswer);
-        return hasSurveys != null && hasSurveys == 1;
+        return isTrue(hasSurveysAnswer);
     }
 
     private boolean isSubmitted(final Node submittedAnswer) throws RepositoryException
     {
-        final Long submitted = (Long) this.formUtils.getValue(submittedAnswer);
-        return submitted != null && submitted == 1;
+        return isTrue(submittedAnswer);
+    }
+
+    private boolean isTrue(final Node answer) throws RepositoryException
+    {
+        final Long value = (Long) this.formUtils.getValue(answer);
+        return value != null && value == 1;
     }
 
     private Node ensureSurveyStatusFormExists(final Node surveyStatusQuestionnaire, final Node visitSubject,
@@ -323,12 +327,12 @@ public class SurveyTracker implements ResourceChangeListener, EventHandler
     }
 
     /**
-     * Check if an answer is for the "patient discharge date" question.
+     * Check if an answer is for the "visit time" question.
      *
      * @param answer the answer node to check
      * @return {@code true} if the answer is indeed for the target question
      */
-    private boolean isAnswerForDischargeTime(final Node answer)
+    private boolean isAnswerForVisitTime(final Node answer)
     {
         return isAnswerForQuestion(answer, "time");
     }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/config/CopyAnswers/Questionnaires/Visit information.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/config/CopyAnswers/Questionnaires/Visit information.json
@@ -5,7 +5,7 @@
   "jcr:reference:surveys_submitted": "/Questionnaires/Visit information/surveys_submitted",
   "jcr:reference:invitation_sent": "/Questionnaires/Survey events/invitation_sent",
   "jcr:reference:reminder1_sent": "/Questionnaires/Survey events/reminder1_sent",
-  "jcr:reference:remindoe2_sent": "/Questionnaires/Survey events/reminder2_sent",
+  "jcr:reference:reminder2_sent": "/Questionnaires/Survey events/reminder2_sent",
   "jcr:reference:has_surveys": "/Questionnaires/Visit information/has_surveys",
   "jcr:reference:email_unsubscribed": "/Questionnaires/Patient information/email_unsubscribed",
   "jcr:reference:mrn": "/Questionnaires/Patient information/mrn"

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/config/CopyAnswers/Questionnaires/Visit information.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/config/CopyAnswers/Questionnaires/Visit information.json
@@ -3,6 +3,9 @@
   "jcr:reference:time": "/Questionnaires/Visit information/time",
   "jcr:reference:surveys_complete": "/Questionnaires/Visit information/surveys_complete",
   "jcr:reference:surveys_submitted": "/Questionnaires/Visit information/surveys_submitted",
+  "jcr:reference:invitation_sent": "/Questionnaires/Survey events/invitation_sent",
+  "jcr:reference:reminder1_sent": "/Questionnaires/Survey events/reminder1_sent",
+  "jcr:reference:remindoe2_sent": "/Questionnaires/Survey events/reminder2_sent",
   "jcr:reference:has_surveys": "/Questionnaires/Visit information/has_surveys",
   "jcr:reference:email_unsubscribed": "/Questionnaires/Patient information/email_unsubscribed",
   "jcr:reference:mrn": "/Questionnaires/Patient information/mrn"

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -51,19 +51,10 @@
         "create user patient \n set ACL for patient \n     deny jcr:all on /Questionnaires restriction(rep:itemNames,provider) \n     deny jcr:read on /Forms restriction(cards:question,/Questionnaires/Visit*information/provider) \n     deny jcr:all on /Forms restriction(cards:questionnaire,/Questionnaires/Patient*information) \n     deny jcr:all on /Forms restriction(cards:questionnaire,/Questionnaires/Survey*events) \n end",
         // Deny access to the patient's name to the validation servlet, which would otherwise return it to the patient portal
         "create service user patient-validation \n set ACL for patient-validation \n   deny jcr:all on /Questionnaires restriction(rep:itemNames,last_name,first_name) \n     deny jcr:all on /Forms restriction(cards:question,/Questionnaires/Patient*information/last_name,/Questionnaires/Patient*information/first_name) \n end",
-        // Service user for tracking the status of the surveys
-        "create service user survey-tracker \n set ACL for survey-tracker \n   allow jcr:read on / \n     allow jcr:read,rep:write,jcr:versionManagement on /Forms \n end",
-        // Prevent the cleanup task from deleting the survey status form
-        "create service user patient-visit-backend \n set ACL for patient-visit-backend \n     deny jcr:all on /Forms restriction(cards:questionnaire,/Questionnaires/Survey*events) \n end",
         // This isn't actually used, but Patient.json references it; needs to be removed along with the torch import
         "create service user proms-import-backend",
         // Allow the CSV export of Survey Events to include the proper label for the assigned survey
         "create service user csv-export \n set ACL on /Survey \n   allow jcr:read for csv-export \n end"
-      ]
-    },
-    "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~prems":{
-      "user.mapping":[
-        "io.uhndata.cards.prems-backend:SurveyTracker=[survey-tracker]"
       ]
     },
 

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -58,6 +58,12 @@
       ]
     },
 
+    // Enable the Survey Tracker
+    "io.uhndata.cards.patients.surveytracker.SurveyTracker":{
+      "trackSubmissions": true,
+      "trackEmails": true
+    },
+
     // Email notifications for patients
 
     "io.uhndata.cards.patients.emailnotifications.AppointmentEmailNotificationsFactory~CPES-InitialInvitationTask":{

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Survey events.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Survey events.xml
@@ -1,0 +1,181 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>Survey events</name>
+	<primaryNodeType>cards:Questionnaire</primaryNodeType>
+	<property>
+		<name>title</name>
+		<value>Survey events</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>requiredSubjectTypes</name>
+		<values>
+			<value>/SubjectTypes/Patient/Visit</value>
+		</values>
+		<type>Reference</type>
+	</property>
+	<property>
+		<name>maxPerSubject</name>
+		<value>1</value>
+		<type>Long</type>
+	</property>
+	<node>
+		<name>invitation_sent</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>minAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>date</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>text</name>
+			<value>Invitation email sent on</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>yyyy-MM-dd'T'HH:mm:ss.sssZ</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>plain</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>entryMode</name>
+			<value>autocreated</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>reminder1_sent</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>date</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>text</name>
+			<value>First reminder email sent on</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>yyyy-MM-dd'T'HH:mm:ss.sssZ</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>plain</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>entryMode</name>
+			<value>autocreated</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>reminder2_sent</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>date</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>text</name>
+			<value>Second reminder email sent on</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>yyyy-MM-dd'T'HH:mm:ss.sssZ</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>plain</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>entryMode</name>
+			<value>autocreated</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>responses_received</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>date</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>text</name>
+			<value>Patient responses received on</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>yyyy-MM-dd'T'HH:mm:ss.sssZ</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>plain</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>entryMode</name>
+			<value>autocreated</value>
+			<type>String</type>
+		</property>
+	</node>
+</node>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/config/CopyAnswers/Questionnaires/Visit information.json
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/config/CopyAnswers/Questionnaires/Visit information.json
@@ -4,6 +4,8 @@
   "jcr:reference:surveys_complete": "/Questionnaires/Visit information/surveys_complete",
   "jcr:reference:surveys_submitted": "/Questionnaires/Visit information/surveys_submitted",
   "jcr:reference:has_surveys": "/Questionnaires/Visit information/has_surveys",
+  "jcr:reference:invitation_sent": "/Questionnaires/Survey events/invitation_sent",
+  "jcr:reference:reminder1_sent": "/Questionnaires/Survey events/reminder1_sent",
   "jcr:reference:email_unsubscribed": "/Questionnaires/Patient information/email_unsubscribed",
   "jcr:reference:date_of_birth": "/Questionnaires/Patient information/date_of_birth",
   "jcr:reference:mrn": "/Questionnaires/Patient information/mrn",

--- a/proms-resources/feature/src/main/features/feature.json
+++ b/proms-resources/feature/src/main/features/feature.json
@@ -85,6 +85,12 @@
     //   "clinicId": "/Proms/ClinicMapping/853703519",
     //   "emailConfiguration": "/apps/cards/clinics/Cardio/mailTemplates/ReminderNotification",
     //   "daysToVisit": 1
+    },
+
+    // Enable the Survey Tracker
+    "io.uhndata.cards.patients.surveytracker.SurveyTracker":{
+      "trackSubmissions": true,
+      "trackEmails": true
     }
   }
 }


### PR DESCRIPTION
- [x] CARDS-2227: PROMs-specific Survey events questionnaire
- [x] CARDS-2201: Augment the Visit information json with the timestamps when notification emails were sent from Survey events
- [x] CARDS-2202: Update the Appointments dashboard widget to display whether survey links had been sent to the patient
- [x] CARDS-2200: Enable the Survey Tracker in proms

To test proms:
1. **on branch `CARDS-2200-test`** build with `mvn clean install -Pdocker`
2. in `compose-cluster/mssql` run `python3 generate_test_proms_sql.py --time_spread_minutes 4320 -n 30 proms_sample.sql`, check that there are events for tomorrow and 3 days from now, and if not, rerun the script
3. in `compose-cluster` run `python3 generate_compose_yaml.py --mssql --cards_project cards4proms --oak_filesystem --dev_docker_image --smtps --smtps_test_container --smtps_test_mail_path ~/cardsmail --composum --adminer --clarity`
4. edit `docker-compose.yml` and add `NIGHTLY_NOTIFICATIONS_SCHEDULE=0 * * * * ? *` to the cardsinitial environment to have emails sent every minute
5. in `compose-cluster` start cards with `docker-compose up`
6. at `http://localhost:1435/?mssql=mssql&username=sa&db=master&ns=path&import=` import the generated `proms_sample.sql` file
7. open `http://localhost:8080/Subjects.importClarity`
8. check that the patients have been imported correctly
9. check that Survey Events have been created
10. wait for one minute, check that patients with a visit 3 days from today have their Initial Notification question answered, patients with a visit tomorrow have their Reminder Notification question answered
11. log in, fill in and submit one of the visits, make sure that the Survey Events has an answer for the Responses Received question
12. go to the clinic dashboard, make sure that the upcoming visits shows the correct email type and date for the patients that were supposed to receive emails

To test regressions in prems:
  
1. **on branch `CARDS-2199`** build with `mvn clean install -Pdocker`
2. in `compose-cluster/mssql` run `python3 ./generate_test_YE_sql.py -n 100 --basedate 2023-05-03 prems_sample.sql` (use 6 days ago as the date)
3. in `compose-cluster` run `python3 generate_compose_yaml.py --mssql --cards_project cards4prems --oak_filesystem --dev_docker_image --smtps --smtps_test_container --smtps_test_mail_path ~/cardsmail --composum --adminer --clarity`
4. edit `docker-compose.yml` and add `NIGHTLY_NOTIFICATIONS_SCHEDULE=0 * * * * ? *` to the cardsinitial environment to have emails sent every minute
5. in `compose-cluster` start cards with `docker-compose up`
6. at `http://localhost:1435/?mssql=mssql&username=sa&db=master&ns=path&import=` import the generated `prems_sample.sql` file
7. open `http://localhost:8080/Subjects.importClarity`
8. check that the patients have been imported correctly
9. check that Survey Events have been created
10. wait for one minute, check that patients with a visit 7 days ago have their Initial Notification question answered, patients with a visit 9 days ago have their Reminder1 Notification question answered, and 11 days ago Reminder 2 Notification
11. generate a token, log in, fill in and submit one of the visits, make sure that the Survey Events has an answer for the Responses Received question
