### PR TITLE
[misc] Trivy security scanning hostname lookup failure fix

### DIFF
--- a/Utilities/SecurityScanning/slack_vulnerability_report_job.sh
+++ b/Utilities/SecurityScanning/slack_vulnerability_report_job.sh
@@ -20,6 +20,10 @@
 DEPLOYMENT_HOSTNAME=$1
 OS_PACKAGE_LISTING_DOCKER_IMAGE=$2
 
+resolve_ip () {
+	HOSTNAME=$1 python3 -c 'import os; import socket; print(os.environ["HOSTNAME"] + ":" + socket.gethostbyname(os.environ["HOSTNAME"]))'
+}
+
 # Pull the aquasec/trivy Docker image and update it's cache
 mkdir ~/trivy-cache
 ./trivy-utils/update_trivy_cache.sh
@@ -34,6 +38,9 @@ CARDS_IMAGE_REPO_DIGEST=$(python3 github_get_docker_image_digest.py --deployment
 cd trivy-utils
 docker run \
 	--rm \
+	--add-host $(resolve_ip ghcr.io) \
+	--add-host $(resolve_ip index.docker.io) \
+	--add-host $(resolve_ip production.cloudflare.docker.com) \
 	-v $(realpath ~/trivy-cache):/root/.cache \
 	aquasec/trivy image --security-checks vuln \
 	--ignore-unfixed $OS_PACKAGE_LISTING_DOCKER_IMAGE:$CARDS_IMAGE_REPO_DIGEST \


### PR DESCRIPTION
This Pull Request applies the same type of fix that was applied in https://github.com/data-team-uhn/cards/pull/1487 to the part of the `slack_vulnerability_report_job.sh` script that scans the CARDS Docker image for OS package vulnerabilities.

This Pull Request fixes an issue that I was having when running the Trivy security scanner in a Qubes OS Qube. For an unknown reason, when running the `./slack_vulnerability_report_job.sh` script, it would fail due to it not being able to resolve the `index.docker.io` hostname. This Pull request provides a work-around to that problem by resolving the `ghcr.io`, `index.docker.io`, and `production.cloudflare.docker.com` hosts before starting the `aquasec/trivy` Docker container.

If you would like to test this PR, please see the instructions under `Utilities/SecurityScanning/README.md`