### PR TITLE
[misc] trivy_to_slack.py improvements

### DIFF
--- a/Utilities/SecurityScanning/trivy-utils/trivy_to_slack.py
+++ b/Utilities/SecurityScanning/trivy-utils/trivy_to_slack.py
@@ -56,12 +56,16 @@ class TrivyToSlackConverter:
 	def __init__(self, software_package_emoji=':package:'):
 		self.software_package_emoji = software_package_emoji
 		self.vulnerability_lists = {}
+		self.vulnerability_lists['EOSL'] = []
 		self.vulnerability_lists['CRITICAL'] = []
 		self.vulnerability_lists['HIGH'] = []
 		self.vulnerability_lists['MEDIUM'] = []
 		self.vulnerability_lists['LOW'] = []
 
-	def processVulnerabilities(self, detected_vulnerabilities):
+	def processVulnerabilities(self, detected_vulnerabilities, eosl=False):
+		if eosl:
+			self.vulnerability_lists['EOSL'].append((":no_entry:    Security support is no longer available.    :no_entry:", ":no_entry:    Security support is no longer available.    :no_entry:"))
+
 		for vulnerabilityIndex in range(0, len(detected_vulnerabilities)):
 			pkgName = detected_vulnerabilities[vulnerabilityIndex]['PkgName']
 			installedVersion = detected_vulnerabilities[vulnerabilityIndex]['InstalledVersion']
@@ -78,7 +82,7 @@ class TrivyToSlackConverter:
 
 	def getSortedVulnerabilityList(self):
 		ordered_vulnerabilities = []
-		for severity in ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']:
+		for severity in ['EOSL', 'CRITICAL', 'HIGH', 'MEDIUM', 'LOW']:
 			ordered_vulnerabilities += self.vulnerability_lists[severity]
 		return ordered_vulnerabilities
 
@@ -123,12 +127,22 @@ if __name__ == '__main__':
 	args = argparser.parse_args()
 
 	trivy_report = json.load(sys.stdin)
+
+	# Were there detected vulnerabilities?
 	if 'Vulnerabilities' in trivy_report['Results'][0]:
 		detected_vulnerabilities = trivy_report['Results'][0]['Vulnerabilities']
 	else:
 		detected_vulnerabilities = []
+
+	# Is this OS no longer getting security updates?
+	eosl = False
+	if 'Metadata' in trivy_report:
+		if 'OS' in trivy_report['Metadata']:
+			if 'EOSL' in trivy_report['Metadata']['OS']:
+				eosl = trivy_report['Metadata']['OS']['EOSL']
+
 	trivy_to_slack_converter = TrivyToSlackConverter(software_package_emoji=args.package_emoji)
-	trivy_to_slack_converter.processVulnerabilities(detected_vulnerabilities)
+	trivy_to_slack_converter.processVulnerabilities(detected_vulnerabilities, eosl=eosl)
 
 	if args.markdown_report_file:
 		with open(args.markdown_report_file, 'w') as f_markdown_report:

--- a/Utilities/SecurityScanning/trivy-utils/trivy_to_slack.py
+++ b/Utilities/SecurityScanning/trivy-utils/trivy_to_slack.py
@@ -120,7 +120,10 @@ if __name__ == '__main__':
 	args = argparser.parse_args()
 
 	trivy_report = json.load(sys.stdin)
-	detected_vulnerabilities = trivy_report['Results'][0]['Vulnerabilities']
+	if 'Vulnerabilities' in trivy_report['Results'][0]:
+		detected_vulnerabilities = trivy_report['Results'][0]['Vulnerabilities']
+	else:
+		detected_vulnerabilities = []
 	trivy_to_slack_converter = TrivyToSlackConverter(software_package_emoji=args.package_emoji)
 	trivy_to_slack_converter.processVulnerabilities(detected_vulnerabilities)
 

--- a/Utilities/SecurityScanning/trivy-utils/trivy_to_slack.py
+++ b/Utilities/SecurityScanning/trivy-utils/trivy_to_slack.py
@@ -106,7 +106,10 @@ class TrivyToSlackConverter:
 		return slack_block
 
 	def getMarkdownReportMessages(self):
-		return [v[1] for v in self.getSortedVulnerabilityList()]
+		if len(self.getSortedVulnerabilityList()) > 0:
+			return [v[1] for v in self.getSortedVulnerabilityList()]
+		else:
+			return [":heavy_check_mark:    No vulnerabilities detected!    :heavy_check_mark:"]
 
 if __name__ == '__main__':
 	import sys


### PR DESCRIPTION
This PR adds several improvements to the `trivy_to_slack.py` script, namely:

- If a base container OS (eg. Alpine Linux) for a CARDS Docker image has reached _end-of-service-life_ (EOSL) and thus is no longer receiving security updates, an alert will be shown on both the Slack and GitHub reports.
- The case where no vulnerabilities are detected is now properly handled - including a message on Slack and GitHub notifying of this condition.

Testing can be done by following the instructions under `Utilities/SecurityScanning/README.md`.