### PR TITLE
CARDS-2231: Add support for the --behind_ssl_termination flag to generate_compose_yaml.py

### DIFF
--- a/compose-cluster/proxy/terminated-ssl_000-default.conf
+++ b/compose-cluster/proxy/terminated-ssl_000-default.conf
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+Include /apache_common_conf/apache_ssl_headers.conf
+Include /apache_common_conf/apache_common.conf
+
+<VirtualHost *:80>
+
+	<Location "/">
+		ProxyPass http://cardsinitial:8080/
+		ProxyPassReverse http://cardsinitial:8080/
+	</Location>
+
+	Include /apache_common_conf/apache_non_cards_all_user_routes.conf
+</VirtualHost>
+
+<VirtualHost *:90>
+	Include /apache_common_conf/apache_user_port_rules.conf
+</VirtualHost>

--- a/compose-cluster/proxy/terminated-ssl_saml_000-default.conf
+++ b/compose-cluster/proxy/terminated-ssl_saml_000-default.conf
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+Include /apache_common_conf/apache_ssl_headers.conf
+Include /apache_common_conf/apache_common.conf
+
+<VirtualHost *:80>
+
+	<Location "/">
+		Header edit Location ${SAML_IDP_DESTINATION}.* https://${CARDS_HOST_AND_PORT}/login "expr=(%{REQUEST_STATUS} == 302) && (%{REQUEST_URI} != '/fetch_requires_saml_login.html') && (%{REQUEST_URI} != '/goto_saml_login')"
+		Header set Cache-Control no-store "expr=(%{REQUEST_URI} == '/fetch_requires_saml_login.html') || (%{REQUEST_URI} == '/goto_saml_login')"
+		ProxyPass http://cardsinitial:8080/
+		ProxyPassReverse http://cardsinitial:8080/
+	</Location>
+
+	Include /apache_common_conf/apache_non_cards_all_user_routes.conf
+	Include /apache_common_conf/apache_saml_admin_port_rules.conf
+
+</VirtualHost>
+
+<VirtualHost *:90>
+	Include /apache_common_conf/apache_user_port_rules.conf
+</VirtualHost>


### PR DESCRIPTION
This Pull Request adds support for the `--behind_ssl_termination` flag to `generate_compose_yaml.py`, which, when set, configures all HTTP headers for working in an SSL-protected environment (just like `--ssl_proxy` does) but only listens for unencrypted HTTP connections and not for SSL-protected HTTPS connections.

Testing Instructions
--------------------------

#### Comparing `terminated-ssl_*.conf` files to their non-SSL-terminated counterparts

When reviewing this PR, it may be helpful to compare `compose-cluster/proxy/terminated-ssl_000-default.conf` to `compose-cluster/proxy/https_000-default.conf` and `compose-cluster/proxy/terminated-ssl_saml_000-default.conf` to `compose-cluster/proxy/https_saml_000-default.conf` since the files are almost identical with the exception that `terminated-ssl_*` versions listen on plaintext TCP (ports 80 and 90) instead of SSL (ports 443 and 444).

#### Local SSL-Terminating Reverse Proxy

In order to test this PR, we'll need to setup and environment similar to what would be in production where an upstream reverse proxy (that we do not control) provides SSL termination. To do so:

1. Allow `socat` to bind to privileged ports (ie. ports < `1024`) - `sudo setcap 'cap_net_bind_service=+ep' $(which socat)`
2. Generate a self-signed SSL certificate - `openssl req -x509 -newkey rsa:4096 -keyout cards-2231_certificatekey.key -out cards-2231_certificate.crt -days 365 -nodes`, then `cat cards-2231_certificatekey.key cards-2231_certificate.crt > cards-2231_private_cert.pem`
3. In one terminal, start a _socat_ instance with `socat -d -d OPENSSL-LISTEN:443,cert=cards-2231_private_cert.pem,verify=0,fork TCP-CONNECT:127.0.0.1:8080`
4. In another terminal, start another _socat_ instance with `socat -d -d OPENSSL-LISTEN:444,cert=cards-2231_private_cert.pem,verify=0,fork TCP-CONNECT:127.0.0.1:8090`

#### CARDS

1. Build this (`CARDS-2231`) branch including a _development_ Docker image with `mvn clean install -Pdocker`.
5. `cd compose-cluster`
6. `python3 generate_compose_yaml.py --oak_filesystem --dev_docker_image --cards_project cards4proms --composum --behind_ssl_termination --web_port_admin 8080 --web_port_user 8090 --web_port_user_root_redirect https://localhost:444/Survey.html`
7. `docker-compose build && docker-compose up -d`
8. Wait for CARDS to be available on https://localhost and https://localhost:444 (you'll need to accept the self-signed SSL certificate)
9. `cd ../Utilities/Development`
10. `python3 test_proxy_configuration.py --https` - all tests should pass
11. `cd ../../compose-cluster`
12. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`
13. `python3 generate_compose_yaml.py --oak_filesystem --dev_docker_image --cards_project cards4proms --composum --behind_ssl_termination --web_port_admin 8080 --web_port_user 8090 --web_port_user_root_redirect https://localhost:444/Survey.html --saml --saml_cloud_iam_demo --server_address localhost`
14. `docker-compose build && docker-compose up -d`
15. Wait for CARDS to be available on https://localhost and https://localhost:444 (you'll need to accept the self-signed SSL certificate)
16. `cd ../Utilities/Development`
17. `python3 test_proxy_configuration.py --https --saml` - all tests should pass
18. `cd ../../compose-cluster`
19. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`