### PR TITLE
CARDS-2196: Bare and simple JSONs should not include the form property

### DIFF
--- a/modules/utils/src/main/java/io/uhndata/cards/serialize/internal/BareProcessor.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/serialize/internal/BareProcessor.java
@@ -90,9 +90,9 @@ public class BareProcessor implements ResourceJsonProcessor
         try {
             final String name = property.getName();
             JsonValue result = input;
-            result = removeSlingProperties(name, result);
-            result = removeJcrProperties(node, name, result);
-            result = removeFormProperty(name, result);
+            result = removeTechnicalProperties(name, result, "sling:");
+            result = removeTechnicalProperties(name, result, "jcr:");
+            result = removeProperty(name, result, "form");
             return result;
         } catch (RepositoryException e) {
             // Really shouldn't happen
@@ -123,27 +123,21 @@ public class BareProcessor implements ResourceJsonProcessor
         addFileContent(node, json);
     }
 
-    private JsonValue removeSlingProperties(final String propertyName, final JsonValue input)
+    private JsonValue removeTechnicalProperties(final String propertyName, final JsonValue input,
+        final String prefix)
+        throws RepositoryException
     {
-        if (propertyName.startsWith("sling:")) {
+        if (propertyName.startsWith(prefix)) {
             return null;
         }
         return input;
     }
 
-    private JsonValue removeJcrProperties(final Node node, final String propertyName, final JsonValue input)
+    private JsonValue removeProperty(final String propertyName, final JsonValue input,
+        final String name)
         throws RepositoryException
     {
-        if (propertyName.startsWith("jcr:")) {
-            return null;
-        }
-        return input;
-    }
-
-    private JsonValue removeFormProperty(final String propertyName, final JsonValue input)
-        throws RepositoryException
-    {
-        if (propertyName.equals("form")) {
+        if (propertyName.equals(name)) {
             return null;
         }
         return input;

--- a/modules/utils/src/main/java/io/uhndata/cards/serialize/internal/BareProcessor.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/serialize/internal/BareProcessor.java
@@ -92,6 +92,7 @@ public class BareProcessor implements ResourceJsonProcessor
             JsonValue result = input;
             result = removeSlingProperties(name, result);
             result = removeJcrProperties(node, name, result);
+            result = removeFormProperty(name, result);
             return result;
         } catch (RepositoryException e) {
             // Really shouldn't happen
@@ -134,6 +135,15 @@ public class BareProcessor implements ResourceJsonProcessor
         throws RepositoryException
     {
         if (propertyName.startsWith("jcr:")) {
+            return null;
+        }
+        return input;
+    }
+
+    private JsonValue removeFormProperty(final String propertyName, final JsonValue input)
+        throws RepositoryException
+    {
+        if (propertyName.equals("form")) {
             return null;
         }
         return input;

--- a/modules/utils/src/main/java/io/uhndata/cards/serialize/internal/SimpleProcessor.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/serialize/internal/SimpleProcessor.java
@@ -67,7 +67,7 @@ public class SimpleProcessor implements ResourceJsonProcessor
             final String name = property.getName();
             JsonValue result = input;
             result = removeSlingProperties(name, result);
-            result = removeJcrProperties(node, name, result);
+            result = removeJcrProperties(name, result);
             result = removeFormProperty(name, result);
             return result;
         } catch (RepositoryException e) {
@@ -84,7 +84,7 @@ public class SimpleProcessor implements ResourceJsonProcessor
         return input;
     }
 
-    private JsonValue removeJcrProperties(final Node node, final String propertyName, final JsonValue input)
+    private JsonValue removeJcrProperties(final String propertyName, final JsonValue input)
         throws RepositoryException
     {
         // Only keep important JCR properties

--- a/modules/utils/src/main/java/io/uhndata/cards/serialize/internal/SimpleProcessor.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/serialize/internal/SimpleProcessor.java
@@ -68,6 +68,7 @@ public class SimpleProcessor implements ResourceJsonProcessor
             JsonValue result = input;
             result = removeSlingProperties(name, result);
             result = removeJcrProperties(node, name, result);
+            result = removeFormProperty(name, result);
             return result;
         } catch (RepositoryException e) {
             // Really shouldn't happen
@@ -88,6 +89,15 @@ public class SimpleProcessor implements ResourceJsonProcessor
     {
         // Only keep important JCR properties
         if (propertyName.startsWith("jcr:") && !KEEP_JCR_PROPERTIES.contains(propertyName)) {
+            return null;
+        }
+        return input;
+    }
+
+    private JsonValue removeFormProperty(final String propertyName, final JsonValue input)
+        throws RepositoryException
+    {
+        if ("form".equals(propertyName)) {
             return null;
         }
         return input;


### PR DESCRIPTION
Here in [CARDS-2196](https://phenotips.atlassian.net/browse/CARDS-2196) testing instructions:

Create any form with filled answers. Go to `/Forms/<form id>.simple.deep.json` and `/Forms/<form id>.bare.deep.json`, observe the output json and compare with `dev`. There should be no `form` property in the PR json answers parts.

[CARDS-2196]: https://phenotips.atlassian.net/browse/CARDS-2196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ