### PR TITLE
CARDS-2212 - Your Experience: logos are not displayed properly on iPhone mobile view

### DIFF
--- a/modules/commons/src/main/frontend/src/components/Logo.jsx
+++ b/modules/commons/src/main/frontend/src/components/Logo.jsx
@@ -43,7 +43,6 @@ const useStyles = makeStyles(theme => ({
     "& > img" : {
       width: `calc(50% - ${theme.spacing(4)})`,
       minWidth: "100px",
-      height: "fit-content",
       margin: theme.spacing(1, 2),
     },
   },


### PR DESCRIPTION
Tentative fix by removing `height: fit-content` on double logo images.

Not tested on Safari. Doesn't appear to break anything in other browsers.