### PR TITLE
CARDS-2234: Disable the default Sling HTML and Text output for nodes without a custom render

### DIFF
--- a/distribution/src/main/features/core/base-configuration.json
+++ b/distribution/src/main/features/core/base-configuration.json
@@ -23,6 +23,13 @@
             "servlet.post.autoCheckout":true,
             "servlet.post.checkinNewVersionableNodes":true
         },
+        // Disable the default HTML/TXT output
+        "org.apache.sling.servlets.get.DefaultGetServlet":{
+            "enable.html": false,
+            "enable.txt": false,
+            "enable.xml": false,
+            "enable.json": true
+        },
         "org.apache.sling.engine.parameters":{
             "sling.default.parameter.encoding":"UTF-8",
             "request.max.file.count": 1000000


### PR DESCRIPTION
To test:
- access `http://localhost:8080/Questionnaires/` and `http://localhost:8080/Questionnaires.txt` and make sure the old HTML resource dump is not visible
- access `http://localhost:8080/` and `http://localhost:8080/Survey` and make sure they still load properly
