### PR TITLE
CARDS-2239: Create a Python script for exporting questionnaire schemas

### DIFF
--- a/Utilities/Administration/export_schemas.py
+++ b/Utilities/Administration/export_schemas.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import json
+import string
+import argparse
+import urllib.parse
+import requests
+from requests.auth import HTTPBasicAuth
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('--download_dir', help='Directory to where exported JSON schema files should be saved', required=True)
+argparser.add_argument('--verbose', help='Enable verbose debug logging', action='store_true')
+args = argparser.parse_args()
+
+CARDS_URL = "http://localhost:8080"
+if "CARDS_URL" in os.environ:
+  CARDS_URL = os.environ["CARDS_URL"].rstrip('/')
+
+ADMIN_PASSWORD = "admin"
+if "ADMIN_PASSWORD" in os.environ:
+  ADMIN_PASSWORD = os.environ["ADMIN_PASSWORD"]
+
+SAFE_FILE_NAME_CHARS = string.ascii_letters + string.digits + "_-. "
+def sanitizeFileName(file_name):
+  clean_file_name = ""
+  for c in str(file_name):
+    if c in SAFE_FILE_NAME_CHARS:
+      clean_file_name += c
+  return clean_file_name
+
+def getQuestionnaireNames():
+  r = requests.get(CARDS_URL + "/Questionnaires.paginate?limit=10000", auth=HTTPBasicAuth("admin", ADMIN_PASSWORD))
+  if r.status_code != 200:
+    raise Exception("/Questionnaires.paginate?limit=10000 did not return HTTP 200")
+  questionnaire_names = [row['@name'] for row in r.json()['rows']]
+  return questionnaire_names
+
+def getQuestionnaireSchema(questionnaire_name):
+  r = requests.get(CARDS_URL + "/Questionnaires/" + urllib.parse.quote(questionnaire_name) + ".bare.deep.-identify.json", auth=HTTPBasicAuth("admin", ADMIN_PASSWORD))
+  if r.status_code != 200:
+    raise Exception("Could not get questionnaire schema for {}".format(questionnaire_name))
+  return r.json()
+
+questionnaire_names = getQuestionnaireNames()
+
+for questionnaire_name in questionnaire_names:
+  schema = getQuestionnaireSchema(questionnaire_name)
+  output_path = os.path.join(args.download_dir, sanitizeFileName(questionnaire_name) + ".json")
+  with open(output_path, 'w') as f_json:
+    json.dump(schema, f_json, indent=2)
+  if args.verbose:
+    print("Saved {} to {}".format(questionnaire_name, output_path))
+
+if args.verbose:
+  print("Done")


### PR DESCRIPTION
This Pull Request introduces the `Utilities/Administration/export_schemas.py` script which dumps the questionnaire schemas from a running CARDS instance as a set of JSON files. The script is written in Python and uses only the _requests_ module, therefore it should run cross-platform.

Testing Instructions
--------------------------

To run the original script (`export_schemas_test/original_script.sh`), please ensure that the following packages are installed:
  - `python3-json-pointer`
  - `perl` (for the `json_pp` utility)

1. Build the `CARDS-2239_test` branch - `git checkout CARDS-2239_test` then `mvn clean install`.
2. Start CARDS in _Cards4Heracles_ mode with `./start_cards.sh --project cards4heracles`. Wait for the _Started CARDS_ message.
3. In a new terminal, `cd Utilities/Administration/`
4. `python3 export_schemas.py --download_dir export_schemas_test/NEW_SCRIPT_OUTPUT/ --verbose`
5. `cd export_schemas_test/ORIGINAL_SCRIPT_OUTPUT`
6. `../original_script.sh`
7. `cd ..`
8. `python3 compare_outputs.py` and ensure that the command returns _SUCCESS_.