### PR TITLE
CARDS-2241: Unable to upgrade to 9.11 due to referenced question

### DIFF
--- a/proms-resources/clinical-data/pom.xml
+++ b/proms-resources/clinical-data/pom.xml
@@ -41,7 +41,7 @@
           <instructions>
             <Include-Resource>{maven-resources},src/main/media</Include-Resource>
             <Sling-Initial-Content>
-              SLING-INF/content/Survey/Cardio.xml;path:=/Survey/Cardio;overwrite:=true;checkin:=true,
+              SLING-INF/content/Survey/Cardio.xml;path:=/Survey/Cardio;overwriteProperties:=true;checkin:=true,
               SLING-INF/content/Survey/ClinicMapping.xml;path:=/Survey/ClinicMapping;overwrite:=true,
               SLING-INF/content/Survey/PatientAccess.xml;path:=/Survey/PatientAccess;overwrite:=true,
               SLING-INF/content/Survey/TermsOfUse.xml;path:=/Survey/TermsOfUse;overwrite:=true,


### PR DESCRIPTION
To test:
- build with `mvn clean install -Pdocker`
- in `compose-cluster` run `python3 generate_compose_yaml.py --mongo_singular --dev_docker_image --cards_project cards4proms --composum --timezone America/Toronto`
- edit the generated `docker-compose.yml` and replace the image for `cardsinitial` from `cards/cards:latest` to `ghcr.io/data-team-uhn/cards:0.9.10`
- `docker-compose build && docker-compose up`
- create Patient Information and Visit Information forms, log in as the patient, fill in and submit the survey
- stop docker-compose
- run `docker run --rm -v $(realpath ./SLING):/sling -it alpine:3.14 sh -c 'cd /sling; find . -delete'`
- edit `docker-compose.yml` and put back the `cards/cards:latest` image
- `docker-compose build && docker-compose up`
- make sure cards starts properly, it has the right logo, and the submitted visit forms are still present