### PR TITLE
CARDS-2242: Optimize the unsubmitted forms restriction for faster execution

### DIFF
--- a/proms-resources/permissions/pom.xml
+++ b/proms-resources/permissions/pom.xml
@@ -43,10 +43,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.sling</groupId>
-      <artifactId>org.apache.sling.api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>

--- a/proms-resources/permissions/src/main/java/io/uhndata/cards/proms/permissions/UnsubmittedFormsRestrictionFactory.java
+++ b/proms-resources/permissions/src/main/java/io/uhndata/cards/proms/permissions/UnsubmittedFormsRestrictionFactory.java
@@ -21,14 +21,9 @@ package io.uhndata.cards.proms.permissions;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionPattern;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
-import io.uhndata.cards.forms.api.FormUtils;
 import io.uhndata.cards.forms.api.QuestionnaireUtils;
 import io.uhndata.cards.permissions.spi.RestrictionFactory;
 
@@ -43,24 +38,13 @@ public class UnsubmittedFormsRestrictionFactory implements RestrictionFactory
     /** @see #getName */
     public static final String NAME = "cards:unsubmittedForms";
 
-    /**
-     * This is needed to get access to the current session, which knows if there is a subject bound to it.
-     */
-    @Reference(fieldOption = FieldOption.REPLACE,
-        cardinality = ReferenceCardinality.OPTIONAL,
-        policyOption = ReferencePolicyOption.GREEDY)
-    private ResourceResolverFactory rrf;
-
-    @Reference
-    private FormUtils formUtils;
-
     @Reference
     private QuestionnaireUtils questionnaireUtils;
 
     @Override
     public RestrictionPattern forValue(final PropertyState value)
     {
-        return new UnsubmittedFormsRestrictionPattern(this.rrf, this.formUtils, this.questionnaireUtils);
+        return new UnsubmittedFormsRestrictionPattern(this.questionnaireUtils);
     }
 
     @Override


### PR DESCRIPTION
To test:
- start in proms mode
- as admin, create two patients each with a visit set for later today (fill in the names as well)
- as admin, fill in the forms for one patient; the forms should not appear as submitted
- as the other patient, fill in and submit the surveys
- as admin, create a new user and add it to the Trusted group
- log in as the new user
- check that on the regular dashboard you can see the submitted forms for one user, and only the meta-forms for the other one (patient info, visit info, survey events)
- check that on the clinic dashboard you can see both visits in the Appointments table, and only the submitted forms in the other tables, including the patient name