### PR TITLE
[misc] CopyAnswers logs excessively in proms mode

### DIFF
--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/AbstractAnswerCopyProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/AbstractAnswerCopyProcessor.java
@@ -20,6 +20,7 @@ package io.uhndata.cards.forms.internal.serialize;
 
 import java.util.function.Function;
 
+import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.PropertyIterator;
@@ -129,6 +130,8 @@ public abstract class AbstractAnswerCopyProcessor implements ResourceJsonProcess
                         json.add(key, this.formUtils.serializeProperty(value));
                     }
                 }
+            } catch (final ItemNotFoundException e) {
+                // This is expected when we don't allow access to certain questions
             } catch (final RepositoryException e) {
                 // Should not happen
                 LOGGER.warn("Failed to access answer {}: {}", key, e.getMessage(), e);


### PR DESCRIPTION
To test:
- start in proms mode
- create patient info and visit info forms
- log in as the patient
- notice that in dev `.cards-data/logs/error.log` has many huge stacktraces about missing nodes, while this branch has a cleaner log