### PR TITLE
CARDS-2240: Clear the cards_auth_token cookie when landing on the Survey Patient Portal page

### DIFF
--- a/Utilities/Development/test_proxy_configuration.py
+++ b/Utilities/Development/test_proxy_configuration.py
@@ -257,6 +257,15 @@ def check_clears_cards_auth_token_cookie(path):
   assert is_cookie_invalidated(r.headers['Set-Cookie'], "cards_auth_token"), "FAIL: Visiting {} on the user port did not invalidate the cards_auth_token cookie".format(path)
   print("PASS: Request to {} on the user port invalidated the cards_auth_token cookie".format(path))
 
+def check_doesnt_set_cookies(path):
+  r = testClient.adminGET(path, allow_redirects=False)
+  assert 'Set-Cookie' not in r.headers, "FAIL: Set-Cookie was present in response header"
+  print("PASS: Response to GET {} on admin port did not set any cookies as expected.".format(path))
+
+  r = testClient.userGET(path, allow_redirects=False)
+  assert 'Set-Cookie' not in r.headers, "FAIL: Set-Cookie was present in response header"
+  print("PASS: Response to GET {} on user port did not set any cookies as expected.".format(path))
+
 withSaml = args.saml
 withHttps = args.https
 
@@ -272,7 +281,13 @@ check_session_cookie_auth()
 check_ncr_routing()
 check_root_redirect(withSaml=withSaml)
 check_clears_cards_auth_token_cookie("/Survey")
+check_clears_cards_auth_token_cookie("/Survey/")
 check_clears_cards_auth_token_cookie("/Survey.html")
+check_clears_cards_auth_token_cookie("/Survey.html/")
+check_doesnt_set_cookies("/Survey?foo=bar")
+check_doesnt_set_cookies("/Survey/?foo=bar")
+check_doesnt_set_cookies("/Survey.html?foo=bar")
+check_doesnt_set_cookies("/Survey.html/?foo=bar")
 
 if withSaml:
   # Run the SAML-specific tests

--- a/compose-cluster/proxy/apache_common_conf/apache_common.conf
+++ b/compose-cluster/proxy/apache_common_conf/apache_common.conf
@@ -17,6 +17,7 @@
 
 Header unset WWW-Authenticate
 Header always set X-Frame-Options "DENY"
+Header always set Set-Cookie "cards_auth_token=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; HttpOnly" "expr=((%{QUERY_STRING} == '') && ((%{REQUEST_URI} == '/Survey') || (%{REQUEST_URI} == '/Survey/') || (%{REQUEST_URI} == '/Survey.html') || (%{REQUEST_URI} == '/Survey.html/')))"
 ProxyPreserveHost On
 
 DocumentRoot "/var/www/html"

--- a/compose-cluster/proxy/apache_common_conf/apache_common.conf
+++ b/compose-cluster/proxy/apache_common_conf/apache_common.conf
@@ -17,6 +17,7 @@
 
 Header unset WWW-Authenticate
 Header always set X-Frame-Options "DENY"
+Header unset Set-Cookie "expr=((%{QUERY_STRING} == '') && ((%{REQUEST_URI} == '/Survey') || (%{REQUEST_URI} == '/Survey/') || (%{REQUEST_URI} == '/Survey.html') || (%{REQUEST_URI} == '/Survey.html/')))"
 Header always set Set-Cookie "cards_auth_token=; Path=/; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; HttpOnly" "expr=((%{QUERY_STRING} == '') && ((%{REQUEST_URI} == '/Survey') || (%{REQUEST_URI} == '/Survey/') || (%{REQUEST_URI} == '/Survey.html') || (%{REQUEST_URI} == '/Survey.html/')))"
 ProxyPreserveHost On
 


### PR DESCRIPTION
When a client visits `/Survey`, `/Survey/`, `/Survey.html`, or `/Survey.html/` without any query parameters (eg. `?auth_token=12345678`) the `cards_auth_token` cookie should be cleared so that the browser is ready to receive a new `cards_auth_token` cookie when the user enters their _date of birth_ and (_MRN_ or _Health Card number_). This fixes the bug in _Cards4PROMs_ where completing a set of surveys as one patient and then logging out and attempting to complete a new set of surveys as a new patient would result in failed authentication thus requiring the user to manually delete their cookies for `datapro.uhn.ca`.

Testing Instructions
--------------------------

Before performing any of the below tests, ensure that you have built this `CARDS-2240` branch including a `cards/cards:latest` Docker image (`mvn clean install -Pdocker`).

#### Testing HTTP

1. `cd compose-cluster`
2. `python3 generate_compose_yaml.py --oak_filesystem --dev_docker_image --composum --cards_project cards4proms --web_port_admin 8080 --web_port_user 8090 --web_port_user_root_redirect /Survey.html`
3. `docker-compose build && docker-compose up -d`
4. Wait for CARDS to be available on port 8080
5. `cd ../Utilities/Development`
6. `python3 test_proxy_configuration.py` - verify that all tests pass
7. `cd ../../compose-cluster`
8. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`

#### Testing HTTP+SAML

1. `cd compose-cluster`
2. `python3 generate_compose_yaml.py --oak_filesystem --dev_docker_image --composum --cards_project cards4proms --web_port_admin 8080 --web_port_user 8090 --web_port_user_root_redirect /Survey.html --saml --saml_cloud_iam_demo` - use `localhost:8080` when prompted for the _public-facing server address_.
3. `docker-compose build && docker-compose up -d`
4. Wait for CARDS to be available on port 8080
5. `cd ../Utilities/Development`
6. `python3 test_proxy_configuration.py --saml` - verify that all tests pass
7. `cd ../../compose-cluster`
8. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`

#### Testing HTTPS

1. `cd compose-cluster`
2. `python3 generate_compose_yaml.py --oak_filesystem --dev_docker_image --composum --cards_project cards4proms --web_port_admin 443 --web_port_user 444 --web_port_user_root_redirect /Survey.html --ssl_proxy --self_signed_ssl_proxy`
3. `docker-compose build && docker-compose up -d`
4. Wait for CARDS to be available on SSL port 443
5. `cd ../Utilities/Development`
6. `python3 test_proxy_configuration.py --https` - verify that all tests pass
7. `cd ../../compose-cluster`
8. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`

#### Testing HTTPS+SAML

1. `cd compose-cluster`
2. `python3 generate_compose_yaml.py --oak_filesystem --dev_docker_image --composum --cards_project cards4proms --web_port_admin 443 --web_port_user 444 --web_port_user_root_redirect /Survey.html --ssl_proxy --self_signed_ssl_proxy --saml --saml_cloud_iam_demo` - use `localhost` when prompted for the _public-facing server address_.
3. `docker-compose build && docker-compose up -d`
4. Wait for CARDS to be available on SSL port 443
5. `cd ../Utilities/Development`
6. `python3 test_proxy_configuration.py --https --saml` - verify that all tests pass
7. `cd ../../compose-cluster`
8. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`

#### Testing Cards4PROMs

1. `cd compose-cluster`
2. `python3 generate_compose_yaml.py --oak_filesystem --dev_docker_image --composum --cards_project cards4proms --web_port_admin 8080 --web_port_user 8090 --web_port_user_root_redirect /Survey.html --mssql --adminer`
9. `docker-compose build && docker-compose up -d`
10. `cd mssql`
11. `python3 generate_test_proms_sql.py cards-2240-test_proms.sql`
12. `cd ..`
13. Visit http://localhost:1435 and login to the test MS SQL server with the following credentials
    - _System_: `MS SQL (beta)`
    - _Server_: `mssql`
    - _Username_: `sa`
    - _Password_: `testPassword_`
    - _Database_: `master`
14. _Import_ the `cards-2240-test_proms.sql` file.
15. Visit http://localhost:8080 and login as `admin`:`admin`
16. Run the _Clarity Import_ by visiting http://localhost:8080/Subjects.importClarity
17. Logout of CARDS.
18. Visit http://localhost:8090/Survey.html and login using a _date of birth_ and _MRN_ number from the `cards-2240-test_proms.sql` file. Complete the surveys.
19. Once the surveys have been completed, visit http://localhost:8090/Survey.html and ensure that you are able to login using a _different_ _date of birth_ and _MRN_ number from the `cards-2240-test_proms.sql` file.
20. Stop and cleanup with `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`

#### Testing Cards4PREMs

1. `cd compose-cluster`
2. `python3 generate_compose_yaml.py --oak_filesystem --dev_docker_image --composum --cards_project cards4prems --web_port_admin 8080 --web_port_user 8090 --web_port_user_root_redirect /Survey.html --mssql --adminer`
3. `docker-compose build && docker-compose up -d`
4. `cd mssql`
5. `python3 generate_test_YE_sql.py cards-2240-test_prems.sql`
6. `cd ..`
7. Visit http://localhost:1435 and login to the test MS SQL server with the following credentials
    - _System_: `MS SQL (beta)`
    - _Server_: `mssql`
    - _Username_: `sa`
    - _Password_: `testPassword_`
    - _Database_: `master`
8. _Import_ the `cards-2240-test_prems.sql` file.
9. Visit http://localhost:8080 and login as `admin`:`admin`
10. Run the _Clarity Import_ by visiting http://localhost:8080/Subjects.importClarity
11. Make a list of authentication tokens for at least _two_ different _Visit_ subjects. To do so, on the main CARDS _Dashboard_, click on a _Visit_ Subject, remove the `content.html/` part of the URL and append `.token.html` to the end of the URL. For example, `http://localhost:8080/content.html/Subjects/7104369/1` would become `http://localhost:8080/Subjects/7104369/1.token.html`. Visit that URL and make note of the returned token.
12. Logout of CARDS.
13. Visit `http://localhost:8090/Survey.html?auth_token=VALUE FROM PREVIOUS STEP` and ensure that you are able to complete the set of surveys.
14. Once the surveys have been completed, visit `http://localhost:8090/Survey.html?auth_token=AUTH TOKEN FOR A DIFFERENT VISIT` and ensure that you are able to complete the surveys.
15. Stop and cleanup with `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`