### PR TITLE
CARDS-2243: Improve the performance of the clinic dashboard tables

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/ClinicForms.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/ClinicForms.jsx
@@ -55,16 +55,15 @@ function ClinicForms(props) {
       "inner join [cards:DateAnswer] as visitDate on visitDate.form = visitInformation.[jcr:uuid] " +
       "inner join [cards:ResourceAnswer] as visitClinic on visitClinic.form = visitInformation.[jcr:uuid] " +
       "inner join [cards:TextAnswer] as visitStatus on visitStatus.form = visitInformation.[jcr:uuid] " +
-      "inner join [cards:BooleanAnswer] as patientSubmitted on patientSubmitted.form = visitInformation.[jcr:uuid] " +
     "inner join [cards:Form] as dataForm on visitSubject.[jcr:uuid] = dataForm.subject " +
   "where " +
     `visitInformation.questionnaire = '${visitInfo?.["jcr:uuid"]}' ` +
       `and visitDate.question = '${visitInfo?.time?.["jcr:uuid"]}' and __DATE_FILTER_PLACEHOLDER__ ` +
       `and visitClinic.question = '${visitInfo?.clinic?.["jcr:uuid"]}' and visitClinic.value = '/Survey/ClinicMapping/${clinicId}' ` +
       `and visitStatus.question = '${visitInfo?.status?.["jcr:uuid"]}' and visitStatus.value <> 'cancelled' and visitStatus.value <> 'entered-in-error' ` +
-      `and patientSubmitted.question = '${visitInfo?.surveys_submitted?.["jcr:uuid"]}' and patientSubmitted.value = 1 ` +
     `and dataForm.questionnaire = '${questionnaireId}' ` +
-  "order by visitDate.value __SORT_ORDER_PLACEHOLDER__"
+      `and dataForm.statusFlags = 'SUBMITTED' ` +
+  "order by visitDate.value __SORT_ORDER_PLACEHOLDER__ option (index tag cards)"
   )
 
   return (

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/ClinicVisits.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/ClinicVisits.jsx
@@ -62,7 +62,7 @@ function ClinicVisits(props) {
       `and visitDate.question = '${visitInfo?.time?.["jcr:uuid"]}' and __DATE_FILTER_PLACEHOLDER__ ` +
       `and visitClinic.question = '${visitInfo?.clinic?.["jcr:uuid"]}' and visitClinic.value = '/Survey/ClinicMapping/${clinicId}' ` +
       `and visitStatus.question = '${visitInfo?.status?.["jcr:uuid"]}' and visitStatus.value <> 'cancelled' and visitStatus.value <> 'entered-in-error' ` +
-  "order by visitDate.value __SORT_ORDER_PLACEHOLDER__"
+  "order by visitDate.value __SORT_ORDER_PLACEHOLDER__ option (index tag cards)"
 )
 
   let columns = [


### PR DESCRIPTION
To test:
- **on the `CARDS-2243-test` branch**
- build with `mvn clean install -Pdocker`
- in `compose-cluster/mssql` run `python3 generate_test_proms_sql.py -n 1000 proms_sample.sql`
- in `compose-cluster` run `python3 generate_compose_yaml.py --mssql --cards_project cards4proms --oak_filesystem --dev_docker_image --smtps --smtps_test_container --smtps_test_mail_path ~/cardsmail --composum --adminer --timezone America/Toronto`
- run `docker-compose build ; docker-compose up`
- at `http://localhost:1435/?mssql=mssql&username=sa&db=master&ns=path&import=` import the generated `proms_sample.sql` file
- open `http://localhost:8080/Subjects.importClarity`
- wait for about 30 minutes for the import to finish and all the Survey events to be generated
- log in as one or two of the patients and fill in and submit the surveys
- log in as another one of the patients and fill in, but DON'T submit the surveys
- as admin, open the clinic dashboard and check that the tables load in just a few seconds, showing around 900 visits for today and the submitted forms
- create a new user and add it to the trusted users group
- log in as the new user, open the clinic dashboard and check that it loads and looks just like for admin