### PR TITLE
CARDS-2204: Patient portal access tokens are slow to use on large instances

### DIFF
--- a/modules/token-authentication/src/main/java/io/uhndata/cards/auth/token/impl/TokenManagerImpl.java
+++ b/modules/token-authentication/src/main/java/io/uhndata/cards/auth/token/impl/TokenManagerImpl.java
@@ -148,7 +148,7 @@ public class TokenManagerImpl implements TokenManager
     /**
      * Create a new token node below the specified {@code parent}.
      *
-     * @param parent the parent node, must be {@code /path/to/someUserProfile/.tokens/}
+     * @param parent the parent node, must be {@code /jcr:system/cards:tokens/<username>}
      * @param expiration the expiration time of the new token
      * @param userId the username of the user that the token will authenticate
      * @param extraData additional attributes of the token to be created, which will also be stored in the session when

--- a/modules/token-authentication/src/main/java/io/uhndata/cards/auth/token/impl/oak/CardsTokenProvider.java
+++ b/modules/token-authentication/src/main/java/io/uhndata/cards/auth/token/impl/oak/CardsTokenProvider.java
@@ -108,7 +108,7 @@ public class CardsTokenProvider implements TokenProvider, TokenConstants
             return false;
         }
         // The expected path is /jcr:system/cards:tokens/<userId>/<tokenNode>
-        return CardsTokenImpl.TOKENS_NODE_PATH.equals(tokenTree.getParent().getParent().getPath())
+        return tokenTree.getPath().startsWith(CardsTokenImpl.TOKENS_NODE_PATH + "/")
             && "cards:Token".equals(TreeUtil.getPrimaryTypeName(tokenTree));
     }
 
@@ -120,6 +120,16 @@ public class CardsTokenProvider implements TokenProvider, TokenConstants
      */
     private String getUser(final Tree tokenTree)
     {
-        return tokenTree.getParent().getName();
+        Tree crt = tokenTree;
+        String name = null;
+        // Tokens are stored under /jcr:system/cards:tokens/<username>/<01>/<23>/<45>/<token node>
+        // They also used to be stored directly under /jcr:system/cards:tokens/<username>/<token node>
+        // To support both kinds of locations, we simply go up until we reach the cards:tokens node
+        // and return the name of the node right before that point
+        while (!CardsTokenImpl.TOKENS_NODE_PATH.equals(crt.getPath())) {
+            name = crt.getName();
+            crt = crt.getParent();
+        }
+        return name;
     }
 }


### PR DESCRIPTION
To test:
- in prems mode
- create a visit
- generate a token
- log in as the patient with that token, fill in the forms

And:

- in proms mode
- create two visits for the same patient one year apart
- log in without a token, make sure both visits are listed, pick one and fill it in
- create one visit for another patient
- log in without a token, fill in and submit the survey
- create one visit for another patient
- generate a token, log in with it, fill in and submit the survey