### PR TITLE
CARDS-2247: Custom error page fails to render in projects other than prems - QUICK FIX

### DIFF
--- a/modules/commons/src/main/resources/SLING-INF/content/apps/sling/servlet/errorhandler/default.esp
+++ b/modules/commons/src/main/resources/SLING-INF/content/apps/sling/servlet/errorhandler/default.esp
@@ -76,8 +76,8 @@ if ("application/json".equals(request.getHeader("Accept"))) {
     <meta name="statusCode" content="${statusCode}">
     <meta name="statusMessage" content="${statusMessage}">
     <meta name="themeColor" content="${colors['ThemeColor']}">
-    <meta name="primaryColor" content="${colors['PrimaryColor']}">
-    <meta name="secondaryColor" content="${colors['SecondaryColor']}">
+    <meta name="primaryColor" content="${colors['PrimaryColor'] || ''}">
+    <meta name="secondaryColor" content="${colors['SecondaryColor'] || ''}">
 <%
       let mediaProps = media.getProperties();
       for (let i in mediaProps) {


### PR DESCRIPTION
**Details on Jira**: https://phenotips.atlassian.net/browse/CARDS-2247

Introduced by #1500 .

**To test**:
- start any one of `proms`, `lfs`, or `heracles` (the bug does **not** affect `prems`)
- navigate to http://localhost:8080/libs/cards/
- Result:
  - in this branch: Error page (**403 Forbidden**) is displayed
  - in `dev`: Blank page + js console error

**Note**:
- A better fix is to lowercase the field names in the ThemeColor json config and iterate through them when generating the meta tags, but that implies changing many files and should be done by someone with more time and patience. This should do for now.