### PR TITLE
[misc] Docker Improvements

### DIFF
--- a/Utilities/Packaging/Docker/build_self_contained.sh
+++ b/Utilities/Packaging/Docker/build_self_contained.sh
@@ -46,7 +46,7 @@ CARDS_VERSION=$(cat ${CARDS_DIRECTORY}/pom.xml | grep --max-count=1 '<version>' 
 # If building in production mode, we want to ensure that the Docker cache is
 # disabled so that we are using the latest Alpine Linux packages
 MAVEN_BUILD_ARGS=""
-(echo "$CARDS_VERSION" | grep -e '-SNAPSHOT$' -q) || MAVEN_BUILD_ARGS="-Prelease -Dgpg.skip -Dmaven.javadoc.skip -Ddocker.buildOptions.noCache=true -Ddocker.verbose=true"
+(echo "$CARDS_VERSION" | grep -e '-SNAPSHOT$' -q) || MAVEN_BUILD_ARGS="-Prelease -Dgpg.skip -Dmaven.javadoc.skip -Ddocker.noCache=true -Ddocker.verbose=true"
 
 # Build CARDS including a Docker image
 mvn clean install -Pdocker $MAVEN_BUILD_ARGS || { echo "Failed to build CARDS Docker image. Exiting."; exit -1; }

--- a/Utilities/Packaging/Docker/build_self_contained.sh
+++ b/Utilities/Packaging/Docker/build_self_contained.sh
@@ -46,7 +46,7 @@ CARDS_VERSION=$(cat ${CARDS_DIRECTORY}/pom.xml | grep --max-count=1 '<version>' 
 # If building in production mode, we want to ensure that the Docker cache is
 # disabled so that we are using the latest Alpine Linux packages
 MAVEN_BUILD_ARGS=""
-(echo "$CARDS_VERSION" | grep -e '-SNAPSHOT$' -q) || MAVEN_BUILD_ARGS="-Prelease -Dgpg.skip -Dmaven.javadoc.skip -Ddocker.buildOptions.noCache=true"
+(echo "$CARDS_VERSION" | grep -e '-SNAPSHOT$' -q) || MAVEN_BUILD_ARGS="-Prelease -Dgpg.skip -Dmaven.javadoc.skip -Ddocker.buildOptions.noCache=true -Ddocker.verbose=true"
 
 # Build CARDS including a Docker image
 mvn clean install -Pdocker $MAVEN_BUILD_ARGS || { echo "Failed to build CARDS Docker image. Exiting."; exit -1; }

--- a/Utilities/Packaging/Docker/build_self_contained.sh
+++ b/Utilities/Packaging/Docker/build_self_contained.sh
@@ -43,8 +43,10 @@ cd $CARDS_DIRECTORY
 CARDS_VERSION=$(cat ${CARDS_DIRECTORY}/pom.xml | grep --max-count=1 '<version>' | cut '-d>' -f2 | cut '-d<' -f1)
 
 # If this is a release, build in production mode, otherwise build in dev mode
+# If building in production mode, we want to ensure that the Docker cache is
+# disabled so that we are using the latest Alpine Linux packages
 MAVEN_BUILD_ARGS=""
-(echo "$CARDS_VERSION" | grep -e '-SNAPSHOT$' -q) || MAVEN_BUILD_ARGS="-Prelease -Dgpg.skip -Dmaven.javadoc.skip"
+(echo "$CARDS_VERSION" | grep -e '-SNAPSHOT$' -q) || MAVEN_BUILD_ARGS="-Prelease -Dgpg.skip -Dmaven.javadoc.skip -Ddocker.buildOptions.noCache=true"
 
 # Build CARDS including a Docker image
 mvn clean install -Pdocker $MAVEN_BUILD_ARGS || { echo "Failed to build CARDS Docker image. Exiting."; exit -1; }

--- a/Utilities/SecurityScanning/build_package_listing_docker_image.sh
+++ b/Utilities/SecurityScanning/build_package_listing_docker_image.sh
@@ -20,7 +20,7 @@
 INPUT_DOCKER_IMAGE=$1
 OUTPUT_DOCKER_IMAGE=$2
 
-docker build -t $OUTPUT_DOCKER_IMAGE - << EOF
+docker build --no-cache -t $OUTPUT_DOCKER_IMAGE - << EOF
 FROM scratch
 COPY --from=$INPUT_DOCKER_IMAGE /etc/os-release /etc/os-release
 COPY --from=$INPUT_DOCKER_IMAGE /etc/apk /etc/apk

--- a/distribution/Dockerfile
+++ b/distribution/Dockerfile
@@ -44,8 +44,10 @@ RUN if [[ "$build_jars" == "true" ]] ; then cp /cards/aggregated-frontend/src/ma
 # Production Image: Start from a small Alpine Linux base image
 FROM alpine:3.17
 
-# Install utilities for patching the JAR file, if such is necessary
+# Install dependency Alpine Linux packages and apply any available package upgrades
 RUN apk update
+RUN apk add --upgrade apk-tools
+RUN apk upgrade --available
 RUN apk add \
   openjdk11-jre \
   tzdata


### PR DESCRIPTION
This Pull Request improves the building and vulnerability scanning of generated Docker images. Specifically:

- All Alpine Linux packages are upgraded to their latest version upon building the CARDS Docker image - provided that this is not blocked by Docker's build layer caching.
- _Production_ Docker images are built with Docker's build layer caching disabled thus ensuring the latest packages will be installed.
- Verbose Docker build logging is enabled for _Production_ images for more meaningful build logs and easier debugging.
- The `--no-cache` flag has been added to the `docker build` command in the `build_package_listing_docker_image.sh` to ensure that accurate APK package listing Docker images are generated for use with the Trivy security scanner.

Testing Instructions
--------------------------

1. On this (`misc-docker-improvements`) branch, make a fake release (`mvn release:prepare -DreleaseVersion=0.9.fake -DdevelopmentVersion=0.9-SNAPSHOT -Dtag=cards-0.9.fake`)
2. `git checkout cards-0.9.fake`
3. `cd Utilities/Packaging/Docker`
4. Run `./build_self_contained.sh cards/cards:0.9.fake | tee ~/improved_docker_test.log` and ensure that the script runs successfully.
5. Inspect the `~/improved_docker_test.log` files and search for the line `RUN apk update` and verify that `apk update` actually runs and doesn't use a cached layer.
6. `cd ../../SecurityScanning`
7. `./build_package_listing_docker_image.sh cards/cards:0.9.fake cards/cards-apk-listing:0.9.fake`
8. `docker save --output ~/cards-apk-scan.tar cards/cards-apk-listing:0.9.fake`
9. `docker run --rm -v $(realpath ~/cards-apk-scan.tar):/image.tar:ro aquasec/trivy image --input /image.tar` and verify that no vulnerabilities are detected.
10. `cd ../../compose-cluster`
11. `python3 generate_compose_yaml.py --oak_filesystem`
12. `docker-compose build && docker-compose up -d`
13. Ensure that CARDS starts and is available at http://localhost:8080
14. Clean up with `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`