### PR TITLE
CARDS-2251: Proxy images in the compose-cluster environment should be based on Ubuntu 22.04 LTS

### DIFF
--- a/Utilities/ContainerManagement/upgrade_nginx_ubuntu_proxy.sh
+++ b/Utilities/ContainerManagement/upgrade_nginx_ubuntu_proxy.sh
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UBUNTU_IMAGE="ubuntu:18.04"
+UBUNTU_IMAGE="ubuntu:22.04"
 TAG_BACKUP_PATH=~/.docker_tags_backup/nginx_ubuntu_proxy.txt
 
 PROJECT_ROOT=$(realpath ../../)

--- a/compose-cluster/proxy/Dockerfile
+++ b/compose-cluster/proxy/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 RUN apt-get update
 RUN apt-get -y install \


### PR DESCRIPTION
This _Pull Request_ upgrades proxy images used in the `compose-cluster` environment so that they are based on Ubuntu 22.04 LTS and not Ubuntu 18.04 LTS which has reached E.O.L.

I have tested this _Pull Request_ based on the instructions in https://github.com/data-team-uhn/cards/pull/1513 - specifically the following:

Before performing any of the below tests, ensure that you have built this `CARDS-2251` branch including a `cards/cards:latest` Docker image (`mvn clean install -Pdocker`).

#### Testing HTTP

1. `cd compose-cluster`
2. `python3 generate_compose_yaml.py --oak_filesystem --dev_docker_image --composum --cards_project cards4proms --web_port_admin 8080 --web_port_user 8090 --web_port_user_root_redirect /Survey.html`
3. `docker-compose build && docker-compose up -d`
4. Wait for CARDS to be available on port 8080
5. `cd ../Utilities/Development`
6. `python3 test_proxy_configuration.py` - verify that all tests pass
7. `cd ../../compose-cluster`
8. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`

#### Testing HTTP+SAML

1. `cd compose-cluster`
2. `python3 generate_compose_yaml.py --oak_filesystem --dev_docker_image --composum --cards_project cards4proms --web_port_admin 8080 --web_port_user 8090 --web_port_user_root_redirect /Survey.html --saml --saml_cloud_iam_demo` - use `localhost:8080` when prompted for the _public-facing server address_.
3. `docker-compose build && docker-compose up -d`
4. Wait for CARDS to be available on port 8080
5. `cd ../Utilities/Development`
6. `python3 test_proxy_configuration.py --saml` - verify that all tests pass
7. `cd ../../compose-cluster`
8. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`

#### Testing HTTPS

1. `cd compose-cluster`
2. `python3 generate_compose_yaml.py --oak_filesystem --dev_docker_image --composum --cards_project cards4proms --web_port_admin 443 --web_port_user 444 --web_port_user_root_redirect /Survey.html --ssl_proxy --self_signed_ssl_proxy`
3. `docker-compose build && docker-compose up -d`
4. Wait for CARDS to be available on SSL port 443
5. `cd ../Utilities/Development`
6. `python3 test_proxy_configuration.py --https` - verify that all tests pass
7. `cd ../../compose-cluster`
8. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`

#### Testing HTTPS+SAML

1. `cd compose-cluster`
2. `python3 generate_compose_yaml.py --oak_filesystem --dev_docker_image --composum --cards_project cards4proms --web_port_admin 443 --web_port_user 444 --web_port_user_root_redirect /Survey.html --ssl_proxy --self_signed_ssl_proxy --saml --saml_cloud_iam_demo` - use `localhost` when prompted for the _public-facing server address_.
3. `docker-compose build && docker-compose up -d`
4. Wait for CARDS to be available on SSL port 443
5. `cd ../Utilities/Development`
6. `python3 test_proxy_configuration.py --https --saml` - verify that all tests pass
7. `cd ../../compose-cluster`
8. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`