### PR TITLE
MISC: Fix deprecated tzlocal call in generate_compose_yaml

### DIFF
--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -130,7 +130,7 @@ def getTimezoneName():
   if args.timezone:
     return args.timezone
   else:
-    return tzlocal.get_localzone().zone
+    return tzlocal.get_localzone_name()
 
 #Validate before doing anything else
 


### PR DESCRIPTION
With version 5.0 of tzlocal `get_localzone` no longer returns a shim to the deprecated `pytz` so the call to retrieve the time zone string needed to be changed