### PR TITLE
CARDS-2258: Automatic container restart policy in Docker Compose files generated by generate_compose_yaml.py should not auto-restart initializer containers

### DIFF
--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -975,7 +975,8 @@ for service_name in yaml_obj['services']:
     yaml_obj['services'][service_name]['environment'] = ["TZ={}".format(getTimezoneName())]
 
   # Automatic restart policy
-  yaml_obj['services'][service_name]['restart'] = "unless-stopped"
+  if service_name not in ["initializer"]:
+    yaml_obj['services'][service_name]['restart'] = "unless-stopped"
 
 #Save it
 with open(OUTPUT_FILENAME, 'w') as f_out:


### PR DESCRIPTION
This Pull Request causes `generate_compose_yaml.py` to skip over the `initializer` container when assigning the `restart: unless-stopped` policy as the `initializer` only needs to run once. Before this PR, the `initializer` container would run, successfully initialize the MongoDB cluster, terminate, and then automatically restart thus repeating this behavior ad-infinitum.

Testing Instructions
--------------------------

- `cd compose-cluster`
- `python3 generate_compose_yaml.py --mongo_cluster --shards 2 --replicas 3 --dev_docker_image --cards_project cards4prems`
- Inspect `docker-compose.yml` and verify that the `restart: unless-stopped` policy is applied to all Docker containers _except_ for `initializer`
- Clean up with `./cleanup.sh`