### PR TITLE
CARDS-1620: Upgrade mongo version used in compose-cluster to 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ docker-compose up -d
 
 5.1. To inspect the data split between the MongoDB shards:
 ```bash
-docker-compose exec router mongo
+docker-compose exec router mongosh
 sh.status()
 exit
 ```

--- a/Utilities/ContainerManagement/upgrade_mongo_image.sh
+++ b/Utilities/ContainerManagement/upgrade_mongo_image.sh
@@ -18,7 +18,7 @@
 # under the License.
 
 MONGO_CONTAINER_INSTANCE=$1
-MONGO_IMAGE="mongo:4.2-bionic"
+MONGO_IMAGE="mongo:6.0-jammy"
 TAG_BACKUP_PATH=~/.docker_tags_backup/singular_mongo_slingstore.txt
 
 # Check if jq is installed. Exit if it is not.

--- a/Utilities/Development/Backup_Size_Estimation.md
+++ b/Utilities/Development/Backup_Size_Estimation.md
@@ -1,7 +1,7 @@
 1. Start a simple Mongo DB Docker container
 
 ```bash
-docker run --rm -p 27017:27017 -it mongo:4.2-bionic
+docker run --rm -p 27017:27017 -it mongo:6.0-jammy
 ```
 
 2. Build a Docker Compose environment using the Mongo DB container as a storage backend

--- a/compose-cluster/TEMPLATE_shard/Dockerfile
+++ b/compose-cluster/TEMPLATE_shard/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM mongo:4.2-bionic
+FROM mongo:6.0-jammy
 
 COPY mongo-shard.conf /etc/mongo.conf
 ENTRYPOINT mongod --config /etc/mongo.conf --wiredTigerCacheSizeGB $WIRED_TIGER_CACHE_SIZE_GB

--- a/compose-cluster/configdb/Dockerfile
+++ b/compose-cluster/configdb/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM mongo:4.2-bionic
+FROM mongo:6.0-jammy
 
 COPY mongo-configdb.conf /etc/mongo.conf
 ENTRYPOINT mongod --config /etc/mongo.conf

--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -574,7 +574,7 @@ if args.mongo_singular:
   # Create the single-container MongoDB
   print("Configuring service: mongo")
   yaml_obj['services']['mongo'] = {}
-  yaml_obj['services']['mongo']['image'] = "mongo:4.2-bionic"
+  yaml_obj['services']['mongo']['image'] = "mongo:6.0-jammy"
   yaml_obj['services']['mongo']['networks'] = {}
   yaml_obj['services']['mongo']['networks']['internalnetwork'] = {}
   yaml_obj['services']['mongo']['networks']['internalnetwork']['aliases'] = ['mongo']

--- a/compose-cluster/initializer/Dockerfile
+++ b/compose-cluster/initializer/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM mongo:4.2-bionic
+FROM mongo:6.0-jammy
 
 COPY initialize_all.sh /initialize_all.sh
 RUN chmod +x /initialize_all.sh

--- a/compose-cluster/initializer/mongo_add_shard.sh
+++ b/compose-cluster/initializer/mongo_add_shard.sh
@@ -20,4 +20,4 @@
 MONGO_HOST=$1
 SHARD_CONFIG=$2
 
-/usr/bin/mongo --host $MONGO_HOST --port 27017 --eval "sh.addShard(\"$SHARD_CONFIG\");"
+/usr/bin/mongosh --host $MONGO_HOST --port 27017 --eval "sh.addShard(\"$SHARD_CONFIG\");"

--- a/compose-cluster/initializer/mongo_rs_initiate.sh
+++ b/compose-cluster/initializer/mongo_rs_initiate.sh
@@ -20,4 +20,4 @@
 MONGO_HOST=$1
 INIT_DOCUMENT=$2
 
-/usr/bin/mongo --host $MONGO_HOST --port 27017 --eval "rs.initiate($INIT_DOCUMENT);"
+/usr/bin/mongosh --host $MONGO_HOST --port 27017 --eval "rs.initiate($INIT_DOCUMENT);"

--- a/compose-cluster/initializer/wait_for_mongo.sh
+++ b/compose-cluster/initializer/wait_for_mongo.sh
@@ -19,6 +19,6 @@
 
 MONGO_HOST=$1
 
-until /usr/bin/mongo --host $MONGO_HOST --port 27017 --quiet --eval 'db.getMongo()'; do
+until /usr/bin/mongosh --host $MONGO_HOST --port 27017 --quiet --eval 'db.getMongo()'; do
 	sleep 1
 done

--- a/compose-cluster/mongos/Dockerfile
+++ b/compose-cluster/mongos/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM mongo:4.2-bionic
+FROM mongo:6.0-jammy
 
 #Need netcat to signal CARDS to start
 RUN apt-get update

--- a/compose-cluster/mongos/initialize_mongos.sh
+++ b/compose-cluster/mongos/initialize_mongos.sh
@@ -22,11 +22,11 @@
 MONGOS_PID=$!
 
 #Wait for it to be ready...
-until /usr/bin/mongo --quiet --eval 'db.getMongo()'; do
+until /usr/bin/mongosh --quiet --eval 'db.getMongo()'; do
 	sleep 1
 done
 
-/usr/bin/mongo <<EOF
+/usr/bin/mongosh <<EOF
   use sling;
   
   db.createCollection("blobs");


### PR DESCRIPTION
This _Pull Request_ upgrades the `mongo` Docker images used within `compose-cluster` from `:4.2-bionic` (which is no longer supported) to `:6.0-jammy` (which is supported).

Testing Instructions
--------------------------

1. Build this `CARDS-1620` branch, including a Docker image, with `mvn clean install -Pdocker`.
2. `cd compose-cluster`
3. `python3 generate_compose_yaml.py --mongo_cluster --shards 2 --replicas 3 --dev_docker_image --cards_project cards4prems`
4. `docker-compose build && docker-compose up -d`
5. Visit http://localhost:8080, login as `admin`:`admin`, and create some _Forms_ and _Subjects_.
6. `docker-compose down && docker-compose rm`
7. `docker-compose up -d`
8. Visit http://localhost:8080, login as `admin`:`admin`, and ensure that the previously created _Forms_ and _Subjects_ are still present.
9. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`
10. `mkdir ~/cards-1620-mongo-data`
11. `python3 generate_compose_yaml.py --mongo_singular --data_db_mount ~/cards-1620-mongo-data/ --dev_docker_image --cards_project cards4prems`
12. `docker-compose build && docker-compose up -d`
13. Visit http://localhost:8080, login as `admin`:`admin`, and create some _Forms_ and _Subjects_.
14. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`
15. `python3 generate_compose_yaml.py --mongo_singular --data_db_mount ~/cards-1620-mongo-data/ --dev_docker_image --cards_project cards4prems`
16. `docker-compose build && docker-compose up -d`
17. Visit http://localhost:8080, login as `admin`:`admin`, and ensure that the previously created _Forms_ and _Subjects_ are still present.
18. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`
19. `sudo rm -rf ~/cards-1620-mongo-data`