### PR TITLE
[misc] Throw an error when an invalid condition is present in the configuration of a clarity processor

### DIFF
--- a/modules/clarity-integration/pom.xml
+++ b/modules/clarity-integration/pom.xml
@@ -120,6 +120,11 @@
       <artifactId>org.osgi.service.metatype.annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
+      <version>1.6.1</version>
+    </dependency>
+    <dependency>
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>
       <version>11.2.1.jre11</version>

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/internal/AbstractConditionalClarityDataProcessor.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/internal/AbstractConditionalClarityDataProcessor.java
@@ -27,6 +27,7 @@ import java.util.function.BiFunction;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.osgi.service.cm.ConfigurationException;
 
 import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
 
@@ -41,7 +42,7 @@ public abstract class AbstractConditionalClarityDataProcessor implements Clarity
 
     protected final List<ConditionDefinition> conditions;
 
-    AbstractConditionalClarityDataProcessor(int priority, String[] conditionStrings)
+    AbstractConditionalClarityDataProcessor(int priority, String[] conditionStrings) throws ConfigurationException
     {
         this.priority = priority;
         this.conditions = new ArrayList<>(conditionStrings.length);
@@ -49,6 +50,8 @@ public abstract class AbstractConditionalClarityDataProcessor implements Clarity
             ConditionDefinition def = new ConditionDefinition(conditionString);
             if (def.isValid()) {
                 this.conditions.add(def);
+            } else {
+                throw new ConfigurationException("condition", "Invalid condition " + conditionString);
             }
         }
     }

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/internal/ConfiguredCohortMapper.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/internal/ConfiguredCohortMapper.java
@@ -21,6 +21,7 @@ package io.uhndata.cards.clarity.importer.internal;
 
 import java.util.Map;
 
+import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
@@ -76,7 +77,7 @@ public class ConfiguredCohortMapper extends AbstractConditionalClarityDataProces
     private final String id;
 
     @Activate
-    public ConfiguredCohortMapper(Config configuration)
+    public ConfiguredCohortMapper(Config configuration) throws ConfigurationException
     {
         super(configuration.priority(), configuration.conditions());
         this.cohort = configuration.clinic();

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/internal/ConfiguredDiscardFilter.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/internal/ConfiguredDiscardFilter.java
@@ -21,6 +21,7 @@ package io.uhndata.cards.clarity.importer.internal;
 
 import java.util.Map;
 
+import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
@@ -69,7 +70,7 @@ public class ConfiguredDiscardFilter extends AbstractConditionalClarityDataProce
     private final String id;
 
     @Activate
-    public ConfiguredDiscardFilter(Config configuration)
+    public ConfiguredDiscardFilter(Config configuration) throws ConfigurationException
     {
         super(configuration.priority(), configuration.conditions());
         String pid = configuration.service_pid();

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/internal/ConfiguredGenericMapper.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/internal/ConfiguredGenericMapper.java
@@ -21,6 +21,7 @@ package io.uhndata.cards.clarity.importer.internal;
 
 import java.util.Map;
 
+import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
@@ -79,7 +80,7 @@ public class ConfiguredGenericMapper extends AbstractConditionalClarityDataProce
     private final String id;
 
     @Activate
-    public ConfiguredGenericMapper(Config configuration)
+    public ConfiguredGenericMapper(Config configuration) throws ConfigurationException
     {
         super(configuration.priority(), configuration.conditions());
         this.column = configuration.column();


### PR DESCRIPTION
This just prints a stacktrace in the console, I'm not sure we should do something more drastic than that.