### PR TITLE
CARDS-2266: Quick search never returns when the total number of results is requested and more than 5 results are found

### DIFF
--- a/modules/data-entry/src/main/java/io/uhndata/cards/QueryBuilder.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/QueryBuilder.java
@@ -420,12 +420,13 @@ public class QueryBuilder implements Use
         final JsonArrayBuilder builder = Json.createArrayBuilder();
 
         while (searchResults.hasNext()) {
+            final JsonObject next = searchResults.next();
             // Skip results up to the offset provided
             if (offsetCounter > 0) {
                 --offsetCounter;
                 // Count up to our limit
             } else if (limitCounter > 0) {
-                builder.add(searchResults.next());
+                builder.add(next);
                 --limitCounter;
                 ++returnedRows;
             } else if (!this.showTotalRows) {


### PR DESCRIPTION
To test:
- start in prems mode
- create 7 patients with identifiers between 11 and 17
- type `1` in the search bar
- in dev this never returns
- expected: 5 patients are listed, clicking to see all results display all 7 of them