### PR TITLE
CARDS-2264: Speed up the quick search

### DIFF
--- a/modules/data-entry/src/main/java/io/uhndata/cards/spi/QuickSearchEngine.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/spi/QuickSearchEngine.java
@@ -31,6 +31,39 @@ import org.apache.sling.api.resource.ResourceResolver;
  */
 public interface QuickSearchEngine
 {
+    interface Results
+    {
+        boolean hasNext();
+
+        void skip();
+
+        JsonObject next();
+
+        static Results emptyResults()
+        {
+            return new Results()
+            {
+                @Override
+                public boolean hasNext()
+                {
+                    return false;
+                }
+
+                @Override
+                public void skip()
+                {
+                    // Nothing to skip
+                }
+
+                @Override
+                public JsonObject next()
+                {
+                    return null;
+                }
+            };
+        }
+    }
+
     /**
      * List the node types supported by this query engine.
      *
@@ -55,7 +88,7 @@ public interface QuickSearchEngine
      *
      * @param query the query configuration to use for searching
      * @param resourceResolver the resource resolver for this session
-     * @param output aggregator of search results
+     * @return a supplier of results
      */
-    void quickSearch(SearchParameters query, ResourceResolver resourceResolver, List<JsonObject> output);
+    Results quickSearch(SearchParameters query, ResourceResolver resourceResolver);
 }

--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
@@ -59,6 +59,15 @@
                     "notNullCheckEnabled": true,
                     "nullCheckEnabled": true,
                     "jcr:primaryType": "nt:unstructured"
+                },
+                "lowervalue": {
+                    "function": "lower([value])",
+                    "ordered": true,
+                    "propertyIndex": true
+                },
+                "lowernote": {
+                    "function": "lower([note])",
+                    "propertyIndex": true
                 }
             }
         },

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormsQuickSearchEngine.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormsQuickSearchEngine.java
@@ -27,6 +27,7 @@ import javax.jcr.Session;
 import javax.jcr.query.Query;
 import javax.jcr.query.RowIterator;
 import javax.json.JsonObject;
+import javax.json.JsonValue;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -54,8 +55,6 @@ public class FormsQuickSearchEngine implements QuickSearchEngine
 
     private static final List<String> SUPPORTED_TYPES = Collections.singletonList("cards:Form");
 
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
-
     @Reference
     private FormUtils formUtils;
 
@@ -66,48 +65,18 @@ public class FormsQuickSearchEngine implements QuickSearchEngine
     }
 
     @Override
-    public void quickSearch(final SearchParameters query, final ResourceResolver resourceResolver,
-        final List<JsonObject> output)
+    public QuickSearchEngine.Results quickSearch(final SearchParameters query,
+        final ResourceResolver resourceResolver)
     {
         try {
-            if (output.size() >= query.getMaxResults() && !query.showTotalResults()) {
-                return;
-            }
-
             final String sqlQuery = getQuery(query.getQuery());
             final RowIterator queryResults = resourceResolver.adaptTo(Session.class).getWorkspace().getQueryManager()
                 .createQuery(sqlQuery.toString(), Query.JCR_SQL2).execute().getRows();
-
-            while (queryResults.hasNext()) {
-                try {
-                    // No need to go through results list if we do not want total number of matches
-                    if (output.size() == query.getMaxResults() && !query.showTotalResults()) {
-                        break;
-                    }
-                    Node item = queryResults.nextRow().getNode();
-
-                    Pair<String, Boolean> match = getMatch(query.getQuery(), item);
-
-                    String questionText = null;
-                    String questionPath = "";
-                    final Node questionNode = getQuestion(item);
-                    questionText = questionNode.getProperty("text").getString();
-                    questionPath = questionNode.getPath();
-
-                    if (match != null && questionText != null) {
-                        final Resource parent = getForm(item, resourceResolver);
-
-                        output.add(SearchUtils.addMatchMetadata(
-                            match.getLeft(), query.getQuery(), questionText, parent.adaptTo(JsonObject.class),
-                            match.getRight(), questionPath));
-                    }
-                } catch (RepositoryException e) {
-                    this.logger.warn("Failed to process search results: {}", e.getMessage(), e);
-                }
-            }
-        } catch (RepositoryException e) {
+            return new FormsResults(query.getQuery(), queryResults, resourceResolver);
+        } catch (final RepositoryException e) {
             LOGGER.warn("Failed to search for subjects: {}", e.getMessage(), e);
         }
+        return QuickSearchEngine.Results.emptyResults();
     }
 
     private String getQuery(final String textQuery)
@@ -124,54 +93,107 @@ public class FormsQuickSearchEngine implements QuickSearchEngine
         return sqlQuery.toString();
     }
 
-    /**
-     * Get the question node that a matched answer node answers.
-     *
-     * @param answer an answer node matched by the query
-     * @return the question node, non-null if the database is well formed
-     * @throws RepositoryException if accessing the question node fails (shouldn't happen in practice)
-     */
-    private Node getQuestion(Node answer) throws RepositoryException
+    private final class FormsResults implements QuickSearchEngine.Results
     {
-        return answer.getProperty("question").getNode();
-    }
+        private final RowIterator queryResults;
 
-    /**
-     * Get the ancestor {@code cards:Form} node that a matched answer node belongs to.
-     *
-     * @param answer an answer node matched by the query
-     * @return the form node, non-null if the database is well formed
-     * @throws RepositoryException if accessing the repository fails
-     */
-    private Resource getForm(final Node answer, final ResourceResolver resourceResolver) throws RepositoryException
-    {
-        return resourceResolver.getResource(this.formUtils.getForm(answer).getPath());
-    }
+        private final String query;
 
-    /**
-     * Find the value that was matched by the query. This is either one of the answe'r values, or its notes.
-     *
-     * @param query the user-entered query text to look for
-     * @param answer the matched answer node
-     * @return a pair, with the matched value (or notes field) in the left side, and a boolean indicating whether the
-     *         match was in an answer value ({@code false}) or in the notes ({@code true}), or {@code null} if the query
-     *         text couldn't be found in the answer
-     * @throws RepositoryException if accessing the repository fails
-     */
-    private Pair<String, Boolean> getMatch(final String query, final Node answer) throws RepositoryException
-    {
-        Object answerValues = this.formUtils.getValue(answer);
-        String matchedValue = SearchUtils.getMatch(answerValues, query);
+        private final ResourceResolver resolver;
 
-        // As a fallback for when the match isn't in the value field, attempt to use the note field
-        boolean matchedNotes = false;
-        if (matchedValue == null && answer.hasProperty("note")) {
-            String noteValue = answer.getProperty("note").getString();
-            if (StringUtils.containsIgnoreCase(noteValue, query)) {
-                matchedValue = noteValue;
-                matchedNotes = true;
-            }
+        FormsResults(final String query, final RowIterator queryResults, final ResourceResolver resolver)
+        {
+            this.query = query;
+            this.queryResults = queryResults;
+            this.resolver = resolver;
         }
-        return matchedValue == null ? null : Pair.of(matchedValue, matchedNotes);
+
+        @Override
+        public boolean hasNext()
+        {
+            return this.queryResults.hasNext();
+        }
+
+        @Override
+        public void skip()
+        {
+            this.queryResults.nextRow();
+        }
+
+        @Override
+        public JsonObject next()
+        {
+            try {
+                final Node item = this.queryResults.nextRow().getNode();
+                final Pair<String, Boolean> match = getMatch(this.query, item);
+                String questionText = null;
+                String questionPath = "";
+                final Node questionNode = getQuestion(item);
+                questionText = questionNode.getProperty("text").getString();
+                questionPath = questionNode.getPath();
+
+                if (match != null && questionText != null) {
+                    final Resource parent = getForm(item);
+
+                    return SearchUtils.addMatchMetadata(
+                        match.getLeft(), this.query, questionText, parent.adaptTo(JsonObject.class),
+                        match.getRight(), questionPath);
+                }
+            } catch (final RepositoryException e) {
+                LOGGER.warn("Failed to process search results: {}", e.getMessage(), e);
+            }
+            return JsonValue.EMPTY_JSON_OBJECT;
+        }
+
+        /**
+         * Get the ancestor {@code cards:Form} node that a matched answer node belongs to.
+         *
+         * @param answer an answer node matched by the query
+         * @return the form node, non-null if the database is well formed
+         * @throws RepositoryException if accessing the repository fails
+         */
+        private Resource getForm(final Node answer) throws RepositoryException
+        {
+            return this.resolver.getResource(FormsQuickSearchEngine.this.formUtils.getForm(answer).getPath());
+        }
+
+        /**
+         * Get the question node that a matched answer node answers.
+         *
+         * @param answer an answer node matched by the query
+         * @return the question node, non-null if the database is well formed
+         * @throws RepositoryException if accessing the question node fails (shouldn't happen in practice)
+         */
+        private Node getQuestion(final Node answer) throws RepositoryException
+        {
+            return answer.getProperty("question").getNode();
+        }
+
+        /**
+         * Find the value that was matched by the query. This is either one of the answe'r values, or its notes.
+         *
+         * @param query the user-entered query text to look for
+         * @param answer the matched answer node
+         * @return a pair, with the matched value (or notes field) in the left side, and a boolean indicating whether
+         *         the match was in an answer value ({@code false}) or in the notes ({@code true}), or {@code null} if
+         *         the query text couldn't be found in the answer
+         * @throws RepositoryException if accessing the repository fails
+         */
+        private Pair<String, Boolean> getMatch(final String query, final Node answer) throws RepositoryException
+        {
+            final Object answerValues = FormsQuickSearchEngine.this.formUtils.getValue(answer);
+            String matchedValue = SearchUtils.getMatch(answerValues, query);
+
+            // As a fallback for when the match isn't in the value field, attempt to use the note field
+            boolean matchedNotes = false;
+            if (matchedValue == null && answer.hasProperty("note")) {
+                final String noteValue = answer.getProperty("note").getString();
+                if (StringUtils.containsIgnoreCase(noteValue, query)) {
+                    matchedValue = noteValue;
+                    matchedNotes = true;
+                }
+            }
+            return matchedValue == null ? null : Pair.of(matchedValue, matchedNotes);
+        }
     }
 }

--- a/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/subjects.json
+++ b/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/subjects.json
@@ -20,6 +20,11 @@
                     "ordered": true,
                     "propertyIndex": true
                 },
+                "loweridentifier": {
+                    "function": "lower([identifier])",
+                    "ordered": true,
+                    "propertyIndex": true
+                },
                 "fullIdentifier": {
                     "analyzed": false,
                     "boost": 20,

--- a/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectQuickSearchEngine.java
+++ b/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectQuickSearchEngine.java
@@ -24,6 +24,7 @@ import java.util.List;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.query.Query;
 import javax.jcr.query.RowIterator;
 import javax.json.JsonObject;
 
@@ -63,13 +64,13 @@ public class SubjectQuickSearchEngine implements QuickSearchEngine
                 return;
             }
 
-            final StringBuilder xpathQuery = new StringBuilder();
-            xpathQuery.append("/jcr:root/Subjects//*[jcr:like(fn:lower-case(@identifier),'%");
-            xpathQuery.append(SearchUtils.escapeLikeText(query.getQuery().toLowerCase()));
-            xpathQuery.append("%')]");
+            final StringBuilder sqlQuery = new StringBuilder()
+                .append("select [jcr:path] from [cards:Subject] as a where lower([identifier]) like '%")
+                .append(SearchUtils.escapeLikeText(query.getQuery().toLowerCase()))
+                .append("%' order by [identifier] option(index tag cards)");
 
-            RowIterator queryResults = resourceResolver.adaptTo(Session.class).getWorkspace().getQueryManager()
-                .createQuery(xpathQuery.toString(), "xpath").execute().getRows();
+            final RowIterator queryResults = resourceResolver.adaptTo(Session.class).getWorkspace().getQueryManager()
+                .createQuery(sqlQuery.toString(), Query.JCR_SQL2).execute().getRows();
 
             while (queryResults.hasNext()) {
                 // No need to go through results list if we do not want total number of matches

--- a/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectQuickSearchEngine.java
+++ b/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectQuickSearchEngine.java
@@ -27,6 +27,7 @@ import javax.jcr.Session;
 import javax.jcr.query.Query;
 import javax.jcr.query.RowIterator;
 import javax.json.JsonObject;
+import javax.json.JsonValue;
 
 import org.apache.sling.api.resource.ResourceResolver;
 import org.osgi.service.component.annotations.Component;
@@ -56,39 +57,71 @@ public class SubjectQuickSearchEngine implements QuickSearchEngine
     }
 
     @Override
-    public void quickSearch(final SearchParameters query, final ResourceResolver resourceResolver,
-        final List<JsonObject> output)
+    public QuickSearchEngine.Results quickSearch(final SearchParameters query, final ResourceResolver resourceResolver)
     {
         try {
-            if (output.size() == query.getMaxResults() && !query.showTotalResults()) {
-                return;
-            }
-
             final StringBuilder sqlQuery = new StringBuilder()
                 .append("select [jcr:path] from [cards:Subject] as a where lower([identifier]) like '%")
                 .append(SearchUtils.escapeLikeText(query.getQuery().toLowerCase()))
                 .append("%' order by [identifier] option(index tag cards)");
 
-            final RowIterator queryResults = resourceResolver.adaptTo(Session.class).getWorkspace().getQueryManager()
-                .createQuery(sqlQuery.toString(), Query.JCR_SQL2).execute().getRows();
-
-            while (queryResults.hasNext()) {
-                // No need to go through results list if we do not want total number of matches
-                if (output.size() == query.getMaxResults() && !query.showTotalResults()) {
-                    break;
-                }
-                Node item = queryResults.nextRow().getNode();
-
-                String resourceValue = item.getProperty("identifier").getString();
-
-                if (resourceValue != null) {
-                    output.add(SearchUtils.addMatchMetadata(
-                        resourceValue, query.getQuery(), "identifier",
-                        resourceResolver.getResource(item.getPath()).adaptTo(JsonObject.class), false, ""));
-                }
-            }
-        } catch (RepositoryException e) {
+            return new SubjectsResults(query.getQuery(),
+                resourceResolver.adaptTo(Session.class).getWorkspace().getQueryManager()
+                    .createQuery(sqlQuery.toString(), Query.JCR_SQL2).execute().getRows(),
+                resourceResolver);
+        } catch (final RepositoryException e) {
             LOGGER.warn("Failed to search for subjects: {}", e.getMessage(), e);
         }
+        return QuickSearchEngine.Results.emptyResults();
+    }
+
+    private final class SubjectsResults implements QuickSearchEngine.Results
+    {
+        private final String query;
+
+        private final RowIterator queryResults;
+
+        private final ResourceResolver resolver;
+
+        SubjectsResults(final String query, final RowIterator queryResults,
+            final ResourceResolver resolver)
+        {
+            this.query = query;
+            this.queryResults = queryResults;
+            this.resolver = resolver;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return this.queryResults.hasNext();
+        }
+
+        @Override
+        public void skip()
+        {
+            this.queryResults.next();
+        }
+
+        @Override
+        public JsonObject next()
+        {
+            try {
+                // No need to go through results list if we do not want total number of matches
+                final Node item = this.queryResults.nextRow().getNode();
+
+                final String resourceValue = item.getProperty("identifier").getString();
+
+                if (resourceValue != null) {
+                    return SearchUtils.addMatchMetadata(
+                        resourceValue, this.query, "identifier",
+                        this.resolver.getResource(item.getPath()).adaptTo(JsonObject.class), false, "");
+                }
+            } catch (final RepositoryException e) {
+                LOGGER.warn("Failed to process search results: {}", e.getMessage(), e);
+            }
+            return JsonValue.EMPTY_JSON_OBJECT;
+        }
+
     }
 }


### PR DESCRIPTION
This changes how quick search in forms is done, now it only looks in text answers.

Before: a few seconds matching subjects with 1.5k subjects, half a minute matching forms with 3k forms.

Now: 0.1 seconds matching both forms and subjects.

To test:

- build with `mvn clean install -Pdocker`
- in `compose-cluster` run `python3 generate_compose_yaml.py --mssql --cards_project cards4prems --oak_filesystem --dev_docker_image --composum --adminer`
- in `compose-cluster/mssql` run `python3 generate_test_YE_sql.py -n 1000 prems_sample.sql`
- in `compose-cluster` start with `docker-compose build && docker-compose up`
- at `http://localhost:1435/?mssql=mssql&username=sa&db=master&ns=path&import=` import the generated `prems_sample.sql` file
- open `http://localhost:8080/Subjects.importClarity` to start the import, wait 10 minutes for the import to finish
- enable quick searching in questionnaires as well, in Administration / Quick Search Widget 
- use quicksearch to check that it returns results in under one second
- make sure the "all results" page works, including switching pages and page sizes, and going to the last page
- stop docker-compose and run `docker-compose rm -vf && ./cleanup.sh` to clean up