### PR TITLE
CARDS-2265: Loading child subjects on the patient chart is too slow

### DIFF
--- a/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/subjects.json
+++ b/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/subjects.json
@@ -24,6 +24,11 @@
                     "type": "String",
                     "propertyIndex": true
                 },
+                "parents": {
+                    "propertyIndex": true,
+                    "notNullCheckEnabled": true,
+                    "type": "String"
+                },
                 "uuid": {
                     "name": "jcr:uuid",
                     "propertyIndex": true,


### PR DESCRIPTION
Seems that most of the slowdown was already fixed by CARDS-2233, but this makes it even faster.

To test:

- build with `mvn clean install -Pdocker`
- in `compose-cluster` run `python3 generate_compose_yaml.py --mssql --cards_project cards4prems --oak_filesystem --dev_docker_image --composum --adminer`
- in `compose-cluster/mssql` run `python3 generate_test_YE_sql.py -n 6000 prems_sample.sql`
- in `compose-cluster` start with `docker-compose build && docker-compose up`
- at `http://localhost:1435/?mssql=mssql&username=sa&db=master&ns=path&import=` import the generated `prems_sample.sql` file
- open `http://localhost:8080/Subjects.importClarity` to start the import, wait 20 minutes for the import to finish
- open some patients, make sure the list of visits (only 1 for imported data) loads quickly
- create a new patient with 10 visits, open it, make sure the list of visits loads
- check the logs, make sure no "traversed nodes" warnings are logged
- stop docker-compose and run `docker-compose rm -vf && ./cleanup.sh` to clean up