### PR TITLE
CARDS-2268: Loading table pages far from the first takes longer and longer

### DIFF
--- a/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
@@ -947,7 +947,8 @@ public class PaginationServlet extends SlingSafeMethodsServlet
         // How many results were returned by the query
         long itemsInBatch = 0;
 
-        query.setLimit(batchSize + 1);
+        // For the first query, request offset + regular batch size
+        query.setLimit(resultOffset + batchSize + 1);
         do {
             query.setOffset(batchStart);
 
@@ -974,10 +975,12 @@ public class PaginationServlet extends SlingSafeMethodsServlet
                         ++counts[3];
                     }
                 }
-                batchStart += batchSize;
+                batchStart += itemsInBatch;
             } catch (RepositoryException e) {
                 //
             }
+            // Reset batch size to the regular window
+            query.setLimit(batchSize + 1);
         } while (counts[3] < totalLimit && itemsInBatch > batchSize);
 
         if (itemsInBatch > batchSize) {


### PR DESCRIPTION
To test:

- build with `mvn clean install -Pdocker`
- in `compose-cluster` run `python3 generate_compose_yaml.py --mssql --cards_project cards4prems --oak_filesystem --dev_docker_image --composum --adminer`
- in `compose-cluster/mssql` run `python3 generate_test_YE_sql.py -n 1000 prems_sample.sql`
- in `compose-cluster` start with `docker-compose build && docker-compose up`
- at `http://localhost:1435/?mssql=mssql&username=sa&db=master&ns=path&import=` import the generated `prems_sample.sql` file
- open `http://localhost:8080/Subjects.importClarity` to start the import, wait 10 minutes for the import to finish
- on the dashboard, with the developer tools open on the network page, navigate forms to the next pages, and check if the page load time increases as you go further right
- load `http://localhost:8080/Forms.paginate?descending=true&includeallstatus=true&offset=1000&limit=1&req=0` and check that it loads super quickly, under 0.1 seconds
- stop docker-compose and run `docker-compose rm -vf && ./cleanup.sh` to clean up