### PR TITLE
CARDS-2253: Add index for SubjectType nodes

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
@@ -83,7 +83,7 @@ function SubjectView(props) {
 
   let fetchSubjectTypes = () => {
     let url = new URL("/query", window.location.origin);
-    url.searchParams.set("query", `SELECT * FROM [cards:SubjectType] as n order by n.'cards:defaultOrder'`);
+    url.searchParams.set("query", `SELECT * FROM [cards:SubjectType] as n order by n.'cards:defaultOrder' option (index tag cards)`);
     return fetchWithReLogin(globalLoginDisplay, url)
       .then(response => response.json())
       .then(result => {

--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
@@ -378,6 +378,7 @@
                     "ordered": true,
                     "propertyIndex": true,
                     "nodeScopeIndex": false,
+                    "type": "Date",
                     "jcr:primaryType": "nt:unstructured"
                 },
                 "lastModified": {
@@ -385,6 +386,7 @@
                     "ordered": true,
                     "propertyIndex": true,
                     "nodeScopeIndex": false,
+                    "type": "Date",
                     "jcr:primaryType": "nt:unstructured"
                 },
                 "statusFlags": {

--- a/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/subjectTypes.json
+++ b/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/subjectTypes.json
@@ -4,15 +4,15 @@
     "compatVersion": 2,
     "async": "async",
     "evaluatePathRestrictions": true,
-    "includedPaths": ["/Subjects"],
+    "includedPaths": ["/SubjectTypes"],
     "tags": ["cards"],
     "indexRules" : {
         "jcr:primaryType": "nt:unstructured",
-        "cards:Subject" : {
+        "cards:SubjectType" : {
             "jcr:primaryType": "nt:unstructured",
             "properties": {
                 "jcr:primaryType": "nt:unstructured",
-                "identifier": {
+                "label": {
                     "analyzed": false,
                     "boost": 100,
                     "nodeScopeIndex": true,
@@ -20,8 +20,9 @@
                     "ordered": true,
                     "propertyIndex": true
                 },
-                "type": {
-                    "type": "String",
+                "order": {
+                    "name": "cards:defaultOrder",
+                    "type": "Long",
                     "propertyIndex": true
                 },
                 "uuid": {


### PR DESCRIPTION
To test:

- start in prems mode
- load the dashboard
- does the Subjects table tabs load quickly?
