### PR TITLE
CARDS-2252: Refactor the ThemeColor config for better extensibility

### DIFF
--- a/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/conf/ThemeColor.json
+++ b/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/conf/ThemeColor.json
@@ -1,4 +1,4 @@
 {
   "jcr:primaryType": "nt:unstructured",
-  "ThemeColor": "bronze"
+  "themeColor": "bronze"
 }

--- a/kids-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/conf/ThemeColor.json
+++ b/kids-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/conf/ThemeColor.json
@@ -1,4 +1,4 @@
 {
   "jcr:primaryType": "nt:unstructured",
-  "ThemeColor": "red"
+  "themeColor": "red"
 }

--- a/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/conf/ThemeColor.json
+++ b/lfs-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/conf/ThemeColor.json
@@ -1,4 +1,4 @@
 {
   "jcr:primaryType": "nt:unstructured",
-  "ThemeColor": "blue"
+  "themeColor": "blue"
 }

--- a/modules/commons/src/main/resources/SLING-INF/content/apps/sling/servlet/errorhandler/default.esp
+++ b/modules/commons/src/main/resources/SLING-INF/content/apps/sling/servlet/errorhandler/default.esp
@@ -75,10 +75,13 @@ if ("application/json".equals(request.getHeader("Accept"))) {
     <title>${appName}</title>
     <meta name="statusCode" content="${statusCode}">
     <meta name="statusMessage" content="${statusMessage}">
-    <meta name="themeColor" content="${colors['ThemeColor']}">
-    <meta name="primaryColor" content="${colors['PrimaryColor'] || ''}">
-    <meta name="secondaryColor" content="${colors['SecondaryColor'] || ''}">
 <%
+      let colorProps = colors.getProperties();
+      for (let i in colorProps) {
+        if (!i.startsWith("jcr:")) {
+          out.println('    <meta name="' + i + '" content="' + colorProps[i] + '"/>');
+        }
+      }
       let mediaProps = media.getProperties();
       for (let i in mediaProps) {
         if (!i.startsWith("jcr:")) {

--- a/modules/commons/src/main/resources/SLING-INF/content/libs/cards/Resource/header.html
+++ b/modules/commons/src/main/resources/SLING-INF/content/libs/cards/Resource/header.html
@@ -34,9 +34,9 @@
       <title>${config.AppName}</title>
     </sly>
     <sly data-sly-use.config="/libs/cards/conf/ThemeColor">
-      <meta name="themeColor" content="${config['ThemeColor']}">
-      <meta name="primaryColor" content="${config['PrimaryColor']}">
-      <meta name="secondaryColor" content="${config['SecondaryColor']}">
+      <sly data-sly-repeat="${config.valueMap.entrySet.iterator}">
+        <meta name="${item.key}" content="${item.value}">
+      </sly>
     </sly>
     <sly data-sly-use.config="/libs/cards/conf/Media">
       <sly data-sly-repeat="${config.valueMap.entrySet.iterator}">

--- a/modules/commons/src/main/resources/SLING-INF/content/libs/sling/servlet/errorhandler/404.html
+++ b/modules/commons/src/main/resources/SLING-INF/content/libs/sling/servlet/errorhandler/404.html
@@ -36,9 +36,9 @@
       <title>${config.AppName}</title>
     </sly>
     <sly data-sly-use.config="/libs/cards/conf/ThemeColor">
-      <meta name="themeColor" content="${config['ThemeColor']}">
-      <meta name="primaryColor" content="${config['PrimaryColor']}">
-      <meta name="secondaryColor" content="${config['SecondaryColor']}">
+      <sly data-sly-repeat="${config.valueMap.entrySet.iterator}">
+        <meta name="${item.key}" content="${item.value}">
+      </sly>
     </sly>
     <sly data-sly-use.config="/libs/cards/conf/Media">
       <sly data-sly-repeat="${config.valueMap.entrySet.iterator}">

--- a/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/TokenExpired/html.html
+++ b/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/TokenExpired/html.html
@@ -36,9 +36,9 @@
       <title>${config.AppName}</title>
     </sly>
     <sly data-sly-use.config="/libs/cards/conf/ThemeColor">
-      <meta name="themeColor" content="${config['ThemeColor']}">
-      <meta name="primaryColor" content="${config['PrimaryColor']}">
-      <meta name="secondaryColor" content="${config['SecondaryColor']}">
+      <sly data-sly-repeat="${config.valueMap.entrySet.iterator}">
+        <meta name="${item.key}" content="${item.value}">
+      </sly>
     </sly>
     <sly data-sly-use.config="/libs/cards/conf/Media">
       <sly data-sly-repeat="${config.valueMap.entrySet.iterator}">

--- a/modules/utils/src/main/resources/SLING-INF/content/libs/cards/conf/ThemeColor.json
+++ b/modules/utils/src/main/resources/SLING-INF/content/libs/cards/conf/ThemeColor.json
@@ -1,4 +1,4 @@
 {
   "jcr:primaryType": "nt:unstructured",
-  "ThemeColor": "blue"
+  "themeColor": "blue"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/conf/ThemeColor.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/conf/ThemeColor.json
@@ -1,6 +1,6 @@
 {
   "jcr:primaryType": "nt:unstructured",
-  "PrimaryColor": "#106DB5",
-  "SecondaryColor": "#c6934b",
-  "ThemeColor": "bronze"
+  "primaryColor": "#106DB5",
+  "secondaryColor": "#c6934b",
+  "themeColor": "bronze"
 }

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/conf/ThemeColor.json
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/conf/ThemeColor.json
@@ -1,4 +1,4 @@
 {
   "jcr:primaryType": "nt:unstructured",
-  "ThemeColor": "red"
+  "themeColor": "red"
 }


### PR DESCRIPTION
To test:

- check that the correct color is used on the login page, the dashboard, the token expired page (`/Expired.html`), the Not Found page (`/Forms/nothere.json`), the generic error page (`/libs`).
- repeat for `prems`, `proms`, `kids`, `heracles`