### PR TITLE
CARDS-1461: Can't filter for Subjects containing "-" in their ID

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/SubjectFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/SubjectFilter.jsx
@@ -58,8 +58,8 @@ const SubjectFilter = forwardRef((props, ref) => {
 
   let constructQuery = (query, requestID) => {
     let url = new URL("/query", window.location.origin);
-    let formattedQuery = query.replace(/\s*\/\s*/g, " / ");
-    let sqlquery = "SELECT s.* FROM [cards:Subject] as s" + (query.search ? ` WHERE CONTAINS(s.'fullIdentifier', '*${formattedQuery}*')` : "");
+    let formattedQuery = query?.toLowerCase()?.replace(/\s*\/\s*/g, " / ");
+    let sqlquery = "SELECT s.* FROM [cards:Subject] as s" + (query.search ? ` WHERE lower(s.'fullIdentifier') LIKE '%25${formattedQuery}%25'` : "");
     sqlquery += " order by s.'fullIdentifier'";
     url.searchParams.set("query", sqlquery);
     url.searchParams.set("limit", query.pageSize);

--- a/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/subjects.json
+++ b/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/subjects.json
@@ -20,6 +20,17 @@
                     "ordered": true,
                     "propertyIndex": true
                 },
+                "fullIdentifier": {
+                    "analyzed": false,
+                    "boost": 20,
+                    "ordered": true,
+                    "propertyIndex": true
+                },
+                "lowerFullIdentifier": {
+                    "function": "lower([fullIdentifier])",
+                    "ordered": true,
+                    "propertyIndex": true
+                },
                 "type": {
                     "type": "String",
                     "propertyIndex": true


### PR DESCRIPTION
To test:

- start in proms mode
- create a Patient named `P-001` and a visit named `p-100` (first with upper P second with lower p)
- create a Patient named `S-001` and a visit named `s-100` (first with upper S second with lower s)
- go to the dashboard, add a filter for Subject
- enter `-`, make sure 4 show up
- enter `P`, make sure 2 show up
- enter `p`, make sure 2 show up
- enter `P-`, make sure 2 show up
- enter `p-`, make sure 2 show up
- enter `p-0`, make sure 1 shows up
- enter `s-1`, make sure 1 shows up
