### PR TITLE
CARDS-2197: AUDITC interpretation should already take into account the sex when computing the results

### DIFF
--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/AUDITC.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/AUDITC.xml
@@ -112,12 +112,20 @@ disorder. AUDIT-C has been validated in mental health and primary care clinics.
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
 				<name>expression</name>
-				<value>return (
-					+@{audit_score:-0} >= 3 ? "For **men**, a total score of **4 or greater** indicates elevated risk for hazardous drinking or active alcohol use disorder. " +
-					                          "For **women**, a total score of **3 or greater** indicates elevated risk for hazardous drinking or active alcohol use disorder.\n\n" +
-					                          "Greater scores indicate greater risk posed to the patient’s health and safety."
-					                        : "No alcohol use disorder detected."
-				)</value>
+				<value><![CDATA[
+					var score = @{audit_score:-0};
+					var maleText = "A total score of **4 or greater** indicates elevated risk for hazardous drinking or active alcohol use disorder. Greater scores indicate greater risk posed to the patient’s health and safety.";
+					var femaleText = "A total score of **3 or greater** indicates elevated risk for hazardous drinking or active alcohol use disorder. Greater scores indicate greater risk posed to the patient’s health and safety.";
+					var result = "No alcohol use disorder detected.";
+					if ("male" === @{audit_sex:-""}.toLowerCase()) {
+						if (score >= 4) result = maleText;
+					} else if ("female" === @{audit_sex:-""}.toLowerCase()) {
+						if (score >= 3) result = femaleText;
+					} else if (score >= 3) {
+						result = "For **men**:\n\n" + maleText + "\n\n For **women**:\n\n" + femaleText;
+					}
+					return result;
+				]]></value>
 				<type>String</type>
 			</property>
 			<property>


### PR DESCRIPTION
To test:

- start in proms mode
- create 4 Patient Information forms, one `MALE`, one `female`, one `mermaid`, one leaving the sex question blank
- create 5 AUDIT forms, one for each of the 4 patients, and one for a new patient without a Patient Information form
- select answers to get scores of 0, 2, 3, 4, 7, and watch if the correct interpretation is displayed:
    - 0 and 2 displays "no disorder" in all cases
    - 3 displays the warning for female but not for male, and the longer "for male: ..." text for the ones without a valid sex
    - 4 and 7 display the warning in all cases
- create a new Patient Information (female, with DoB and MRN) and a Visit Information
- log in as the patient
- fill in the form, get a score greater than 3; the interpretation should not be displayed while filling in the form, but it should be displayed in the summary; submit
- log in as admin, check that the right interpretation is displayed in the submitted form in view mode