### PR TITLE
CARDS-2151: Wrong label displayed for Resource answers without a value

### DIFF
--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/labels/ResourceLabelProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/labels/ResourceLabelProcessor.java
@@ -30,6 +30,7 @@ import javax.json.Json;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonValue;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -83,13 +84,13 @@ public class ResourceLabelProcessor extends AbstractResourceLabelProcessor imple
             if (valueProperty.isMultiple()) {
                 List<String> labels = new ArrayList<>();
                 for (Value item : valueProperty.getValues()) {
-                    String label = getLabelForResource(item.getString(), resolver, labelPropertyName);
-                    labels.add(label);
+                    if (StringUtils.isNotBlank(item.getString())) {
+                        labels.add(getLabelForResource(item.getString(), resolver, labelPropertyName));
+                    }
                 }
                 return createJsonArrayFromList(labels);
-            } else {
-                String label = getLabelForResource(valueProperty.getString(), resolver, labelPropertyName);
-                return Json.createValue(label);
+            } else if (StringUtils.isNotBlank(valueProperty.getString())) {
+                return Json.createValue(getLabelForResource(valueProperty.getString(), resolver, labelPropertyName));
             }
         } catch (final RepositoryException ex) {
             // Shouldn't be happening


### PR DESCRIPTION
To test:

- start with `./start_cards.sh -P prems --dev`
- create a new Visit Information form, leave the Clinic question empty
- save and view, make sure the Clinic answer is not shown and doesn't display `apps` as the value
- open `/bin/browser.html`, navigate to the created form, check it out, open the first question, add a new property of type String named `value` and no actual value
- open the Visit Information form in the regular UI in view mode, make sure the Clinic answer is still missing
- edit the form, select an actual clinic, save and view, make sure the clinic name is displayed