### PR TITLE
CARDS-2273: JS error logged when editing certain Heracles questionnaires

### DIFF
--- a/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/6MWT.xml
+++ b/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/6MWT.xml
@@ -126,6 +126,11 @@
 				<type>String</type>
 			</property>
 			<property>
+				<name>displayMode</name>
+				<value>plain</value>
+				<type>String</type>
+			</property>
+			<property>
 				<name>question</name>
 				<value>/Questionnaires/Study Stream/study_stream</value>
 				<type>String</type>

--- a/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/CPET - External File.xml
+++ b/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/CPET - External File.xml
@@ -118,6 +118,11 @@
 			<type>String</type>
 		</property>
 		<property>
+			<name>displayMode</name>
+			<value>plain</value>
+			<type>String</type>
+		</property>
+		<property>
 			<name>question</name>
 			<value>/Questionnaires/Study Stream/study_stream</value>
 			<type>String</type>

--- a/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/CPET Interpretation.xml
+++ b/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/CPET Interpretation.xml
@@ -69,6 +69,11 @@
 				<type>String</type>
 			</property>
 			<property>
+				<name>displayMode</name>
+				<value>plain</value>
+				<type>String</type>
+			</property>
+			<property>
 				<name>question</name>
 				<value>/Questionnaires/Study Stream/study_stream</value>
 				<type>String</type>

--- a/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Laboratory Results.xml
+++ b/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Laboratory Results.xml
@@ -61,6 +61,11 @@
 			<type>String</type>
 		</property>
 		<property>
+			<name>displayMode</name>
+			<value>plain</value>
+			<type>String</type>
+		</property>
+		<property>
 			<name>question</name>
 			<value>/Questionnaires/Study Stream/study_stream</value>
 			<type>String</type>


### PR DESCRIPTION
Affects the questionnaires with a Study Stream reference answer, in both view and edit mode, and when viewing the questionnaire in the administration.