### PR TITLE
CARDS-2275: Filtering the subject selection dialog by `-` does not return results

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -964,7 +964,7 @@ function SubjectSelectorList(props) {
         conditions.push("(" + allowedTypes.map((type) => `n.'type' = '${type["jcr:uuid"]}'`).join(" OR ") + ")");
       }
       if (globalFilter) {
-        conditions.push(`CONTAINS(n.fullIdentifier, '*${escapeJQL(globalFilter)}*')`);
+        conditions.push(`lower(n.fullIdentifier) like '%25${escapeJQL(globalFilter.toLowerCase())}%25'`);
       }
       if (currentSubject) {
         let subjectID = currentSubject["jcr:uuid"];


### PR DESCRIPTION
- Create a new subject `a-b`
- Go to the dashboard
- Start creating a new form
- On the subject selection dialog, filtering by `a` or `b` displays the correct subject, but filtering by `a-` or `-` does not display anything