### PR TITLE
CARDS-2274: JS error when filtering the subjects of a new form and no matches are found

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -1001,7 +1001,7 @@ function SubjectSelectorList(props) {
       let latestRelatedSubjects = relatedSubjectsResp.rows;
 
       // Auto-select if there is only one subject available which has not execeeded maximum Forms per Subject
-      let atMax = (latestRelatedSubjects?.length && selectedQuestionnaire && (latestRelatedSubjects.filter((i) => (i["s.jcr:uuid"] == filteredData[0]["jcr:uuid"])).length >= (+(selectedQuestionnaire?.["maxPerSubject"]) || undefined)))
+      let atMax = (filteredData.length === 1 && latestRelatedSubjects?.length && selectedQuestionnaire && (latestRelatedSubjects.filter((i) => (i["s.jcr:uuid"] == filteredData[0]["jcr:uuid"])).length >= (+(selectedQuestionnaire?.["maxPerSubject"]) || undefined)))
       if (filteredData.length === 1 && !atMax) {
         handleSelection(filteredData[0]) && onSelect(filteredData[0]);
       }


### PR DESCRIPTION
- Start in Heracles mode
- create two Study Stream forms for patients `a` and `b`
- go to the dashboard
- start creating a new Study Stream form, and on the Patient selection dialog type `c` in the filter
- expected: no error, empty table; current: table is stuck loading while `a` and `b` are still displayed
- cancel, open the Study Stream for `a`
- edit it, from the More Action menu select Change Subject, filter by `c`, expect same results as above