### PR TITLE
CARDS-1857: Define and use synchronous property indexes during backend data creation and validation

### DIFF
--- a/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/Questionnaire/updateSelectedForms.html.esp
+++ b/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/Questionnaire/updateSelectedForms.html.esp
@@ -62,15 +62,22 @@ const questions = {
   "Participant Status": "Status/enrollment_status"
 };
 
+let toTitleCase = function(str) {
+  return str.substring(0, 1).toUpperCase() + str.substring(1);
+}
+
 // Compute a list of question UUIDs based on the `questions` map above and the selected questionnaire.
 let extraQuestionsUuid = [];
+let extraQuestionsType = [];
 if (typeof questions[currentNode.getName()] == "string") {
   // A single question
   extraQuestionsUuid.push(currentNode.getNode(questions[currentNode.getName()]).getIdentifier());
+  extraQuestionsType.push(toTitleCase(currentNode.getNode(questions[currentNode.getName()]).getProperty('dataType').getString()));
 } else if (typeof questions[currentNode.getName()] == "object") {
   // A list of questions
   for (let q of questions[currentNode.getName()]) {
     extraQuestionsUuid.push(currentNode.getNode(q).getIdentifier());
+    extraQuestionsType.push(toTitleCase(currentNode.getNode(q).getProperty('dataType').getString()));
   }
 }
 
@@ -91,9 +98,7 @@ let updateFormsForSubjectAndVisit = function(subject, identifiers) {
   let query = 'select f.* from [cards:Form] as f inner join [cards:Subject] as s on s.[jcr:uuid] = f.subject';
   for (let i = 0; i < extraQuestionsUuid.length; ++i) {
     if (identifiers[i]) {
-      query += ' inner join [cards:Answer] as va' + i +' on isdescendantnode(va' + i + ', f)';
-      // TODO: figure out the exact answer type for speedier queries
-      // TODO: change to `... on va.[form] = f.[jcr:uuid] for speedier queries
+      query += ' inner join [cards:' + extraQuestionsType[i] + 'Answer] as va' + i +' on va' + i + '.[form] = f.[jcr:uuid]';
     }
   }
   query += ' where f.questionnaire="' + questionnaireUuid + '"';

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -209,7 +209,7 @@ function NewFormDialog(props) {
 
   // get all the forms related to the selectedSubject, saved in the `relatedForms` state
   let filterQuestionnaire = () => {
-    fetchWithReLogin(globalLoginDisplay, `/query?rawResults=true&query=SELECT q.[jcr:uuid] FROM [cards:Questionnaire] AS q inner join [cards:Form] as f on f.'questionnaire'=q.'jcr:uuid' where f.'subject'='${(currentSubject || selectedSubject)?.['jcr:uuid']}'&limit=1000`)
+    fetchWithReLogin(globalLoginDisplay, `/query?rawResults=true&query=SELECT f.questionnaire FROM [cards:Form] as f where f.'subject'='${(currentSubject || selectedSubject)?.['jcr:uuid']}' OPTION (index tag property)&limit=1000`)
     .then((response) => response.ok ? response.json() : Promise.reject(response))
     .then((response) => {
       setRelatedForms(response.rows);
@@ -326,7 +326,7 @@ function NewFormDialog(props) {
   let isRowDisabled = (row) => (
     relatedForms?.length
       && (selectedSubject || currentSubject)
-      && (relatedForms.filter(f => f["q.jcr:uuid"] == row.original["jcr:uuid"]).length >= (+(row.original?.["maxPerSubject"]) || undefined))
+      && (relatedForms.filter(f => f["f.questionnaire"] == row.original["jcr:uuid"]).length >= (+(row.original?.["maxPerSubject"]) || undefined))
   );
 
   // On click, select the questionnaire row if eligible

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -182,7 +182,7 @@ function SubjectContainer(props) {
     setRelatedSubjects([]);
   };
 
-  let check_url = createQueryURL(` WHERE n.'parents'='${subject?.['jcr:uuid']}' order by n.'jcr:created'`, "cards:Subject");
+  let check_url = createQueryURL(` WHERE n.'parents'='${subject?.['jcr:uuid']}' order by n.'jcr:created' OPTION (index tag property)`, "cards:Subject");
   let fetchRelated = () => {
     fetchWithReLogin(globalLoginDisplay, check_url)
     .then((response) => response.ok ? response.json() : Promise.reject(response))

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -924,7 +924,7 @@ function SubjectSelectorList(props) {
 
   // if the number of related forms of a certain questionnaire/subject is at the maxPerSubject, an error is set
   let handleSelection = (rowData) => {
-    let atMax = (relatedSubjects?.length && selectedQuestionnaire && (relatedSubjects.filter((i) => (i["s.jcr:uuid"] == rowData["jcr:uuid"])).length >= (+(selectedQuestionnaire?.["maxPerSubject"]) || undefined)))
+    let atMax = (relatedSubjects?.length && selectedQuestionnaire && (relatedSubjects.filter((i) => (i["f.subject"] == rowData["jcr:uuid"])).length >= (+(selectedQuestionnaire?.["maxPerSubject"]) || undefined)))
     if (atMax) {
       onError(`${rowData?.["type"]["@name"]} ${rowData?.["identifier"]} already has ${selectedQuestionnaire?.["maxPerSubject"]} ${selectedQuestionnaire?.["title"]} form(s) filled out.`);
       disableProgress(true);
@@ -969,17 +969,16 @@ function SubjectSelectorList(props) {
       let filteredData = json["rows"];
       let querySubjectSubset = "";
       for (let i = 0; i < filteredData.length; i++) {
-        querySubjectSubset += "s.'jcr:uuid'='" + filteredData[i]['jcr:uuid'] + "'";
+        querySubjectSubset += "f.'subject'='" + filteredData[i]['jcr:uuid'] + "'";
         if ((i+1) != filteredData.length) {
           querySubjectSubset += " or ";
         }
       }
       let querySubjectSubsetClause = (querySubjectSubset.length > 0) ? (" and (" + querySubjectSubset + ") ") : " ";
       // fetch the Subjects of each form of this questionnaire type for all listed subjects
-      url = `/query?rawResults=true&query=SELECT s.[jcr:uuid] FROM [cards:Subject] AS s `
-          + `inner join [cards:Form] as f on f.'subject'=s.'jcr:uuid' `
+      url = `/query?rawResults=true&query=SELECT f.[subject] FROM [cards:Form] as f `
           + `where f.'questionnaire'='${selectedQuestionnaire?.['jcr:uuid']}'${querySubjectSubsetClause}`
-          + `order by s.'fullIdentifier'&limit=${selectedQuestionnaire?.["maxPerSubject"] * pagination.pageSize}`;
+          + `&limit=${selectedQuestionnaire?.["maxPerSubject"] * pagination.pageSize}`;
       const responseSubject = await fetchWithReLogin(globalLoginDisplay, url);
       const relatedSubjectsResp = await responseSubject.json();
 
@@ -987,7 +986,7 @@ function SubjectSelectorList(props) {
       let latestRelatedSubjects = relatedSubjectsResp.rows;
 
       // Auto-select if there is only one subject available which has not execeeded maximum Forms per Subject
-      let atMax = (filteredData.length === 1 && latestRelatedSubjects?.length && selectedQuestionnaire && (latestRelatedSubjects.filter((i) => (i["s.jcr:uuid"] == filteredData[0]["jcr:uuid"])).length >= (+(selectedQuestionnaire?.["maxPerSubject"]) || undefined)))
+      let atMax = (filteredData.length === 1 && latestRelatedSubjects?.length && selectedQuestionnaire && (latestRelatedSubjects.filter((i) => (i["f.subject"] == filteredData[0]["jcr:uuid"])).length >= (+(selectedQuestionnaire?.["maxPerSubject"]) || undefined)))
       if (filteredData.length === 1 && !atMax) {
         handleSelection(filteredData[0]) && onSelect(filteredData[0]);
       }
@@ -1043,7 +1042,7 @@ function SubjectSelectorList(props) {
           sx: {
             fontSize: '1rem',
             // grey out subjects that have already reached maxPerSubject
-            color: ((relatedSubjects?.length && selectedQuestionnaire && (relatedSubjects.filter((i) => (i["s.jcr:uuid"] == cell.row.original["jcr:uuid"])).length >= (+(selectedQuestionnaire?.["maxPerSubject"]) || undefined)))
+            color: ((relatedSubjects?.length && selectedQuestionnaire && (relatedSubjects.filter((i) => (i["f.subject"] == cell.row.original["jcr:uuid"])).length >= (+(selectedQuestionnaire?.["maxPerSubject"]) || undefined)))
             ? theme.palette.text.disabled
             : theme.palette.text.primary
             )

--- a/modules/data-entry/src/main/java/io/uhndata/cards/DataImportServlet.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/DataImportServlet.java
@@ -784,7 +784,7 @@ public class DataImportServlet extends SlingAllMethodsServlet
         } catch (RepositoryException ex) {
             // No change to query
         }
-        query += " OPTION (index tag property)"
+        query += " OPTION (index tag property)";
 
         try {
             Query queryObj = this.queryManager.get().createQuery(query, "JCR-SQL2");

--- a/modules/data-entry/src/main/java/io/uhndata/cards/DataImportServlet.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/DataImportServlet.java
@@ -379,9 +379,9 @@ public class DataImportServlet extends SlingAllMethodsServlet
             return this.cachedAnswers.get().get(question.getIdentifier());
         }
 
-        final String query =
-            String.format("select n from [cards:Answer] as n where n.question = '%s' and isdescendantnode(n,'%s')",
-                question.getIdentifier(), form.getPath());
+        final String query = String.format(
+            "select n from [cards:Answer] as n where n.question = '%s' and n.form = '%s' OPTION (index tag property)",
+            question.getIdentifier(), form.getValueMap().get("jcr:uuid"));
         Iterator<Resource> results = this.resolver.get().findResources(query, "JCR-SQL2");
         if (results.hasNext()) {
             return results.next();
@@ -678,7 +678,8 @@ public class DataImportServlet extends SlingAllMethodsServlet
     {
         try {
             final String query =
-                String.format("select n from [cards:Form] as n where n.subject = '%s' and n.questionnaire = '%s'",
+                String.format("select n from [cards:Form] as n where n.subject = '%s' and n.questionnaire = '%s'"
+                    + " OPTION (index tag property)",
                     subject.getIdentifier(), this.questionnaire.get().getIdentifier());
             final Iterator<Resource> results = this.resolver.get().findResources(query, "JCR-SQL2");
             if (results.hasNext()) {
@@ -770,8 +771,9 @@ public class DataImportServlet extends SlingAllMethodsServlet
             return cache.get(subjectKey);
         }
 
-        String query = String.format("select n from [cards:Subject] as n where n.identifier = '%s'",
-            SearchUtils.escapeQueryArgument(subjectId));
+        String query =
+            String.format("select n from [cards:Subject] as n where n.identifier = '%s'",
+                SearchUtils.escapeQueryArgument(subjectId));
         try {
             if (typeNode != null) {
                 query += " and n.type = '" + typeNode.getProperty("jcr:uuid").getValue() + "'";
@@ -782,6 +784,7 @@ public class DataImportServlet extends SlingAllMethodsServlet
         } catch (RepositoryException ex) {
             // No change to query
         }
+        query += " OPTION (index tag property)"
 
         try {
             Query queryObj = this.queryManager.get().createQuery(query, "JCR-SQL2");

--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/answerQuestion.json
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/answerQuestion.json
@@ -1,0 +1,12 @@
+{
+  "jcr:primaryType": "oak:QueryIndexDefinition",
+  "type": "property",
+  "tags": ["property"],
+  "jcr:name:propertyNames": [
+    "question",
+    "form"
+  ],
+  "jcr:name:declaringNodeTypes": [
+    "cards:Answer"
+  ]
+}

--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/answerValue.json
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/answerValue.json
@@ -1,7 +1,11 @@
 {
   "jcr:primaryType": "oak:QueryIndexDefinition",
+  "type": "property",
+  "tags": ["property"],
   "jcr:name:propertyNames": [
     "value"
   ],
-  "type": "property"
+  "jcr:name:declaringNodeTypes": [
+    "cards:Answer"
+  ]
 }

--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/formQuestionnaire.json
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/formQuestionnaire.json
@@ -1,7 +1,11 @@
 {
   "jcr:primaryType": "oak:QueryIndexDefinition",
+  "type": "property",
+  "tags": ["property"],
   "jcr:name:propertyNames": [
     "questionnaire"
   ],
-  "type": "property"
+  "jcr:name:declaringNodeTypes": [
+    "cards:Form"
+  ]
 }

--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/formRelatedSubjects.json
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/formRelatedSubjects.json
@@ -1,7 +1,11 @@
 {
   "jcr:primaryType": "oak:QueryIndexDefinition",
+  "type": "property",
+  "tags": ["property"],
   "jcr:name:propertyNames": [
     "relatedSubjects"
   ],
-  "type": "property"
+  "jcr:name:declaringNodeTypes": [
+    "cards:Form"
+  ]
 }

--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/formSubject.json
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/formSubject.json
@@ -1,7 +1,11 @@
 {
   "jcr:primaryType": "oak:QueryIndexDefinition",
+  "type": "property",
+  "tags": ["property"],
   "jcr:name:propertyNames": [
     "subject"
   ],
-  "type": "property"
+  "jcr:name:declaringNodeTypes": [
+    "cards:Form"
+  ]
 }

--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
@@ -17,6 +17,7 @@
                     "propertyIndex": true,
                     "type": "String",
                     "analyzed": false,
+                    "weight": 1,
                     "jcr:primaryType": "nt:unstructured"
                 },
                 "form": {
@@ -31,6 +32,7 @@
                     "analyzed": true,
                     "notNullCheckEnabled": true,
                     "nullCheckEnabled": true,
+                    "weight": 1,
                     "jcr:primaryType": "nt:unstructured"
                 }
             }
@@ -80,6 +82,7 @@
                     "propertyIndex": true,
                     "type": "String",
                     "analyzed": false,
+                    "weight": 10,
                     "jcr:primaryType": "nt:unstructured"
                 },
                 "form": {
@@ -94,6 +97,7 @@
                     "analyzed": false,
                     "notNullCheckEnabled": true,
                     "nullCheckEnabled": true,
+                    "weight": 10,
                     "jcr:primaryType": "nt:unstructured"
                 }
             }
@@ -188,6 +192,7 @@
                     "propertyIndex": true,
                     "type": "String",
                     "analyzed": false,
+                    "weight": 10000,
                     "jcr:primaryType": "nt:unstructured"
                 },
                 "form": {
@@ -202,6 +207,7 @@
                     "analyzed": true,
                     "notNullCheckEnabled": true,
                     "nullCheckEnabled": true,
+                    "weight": 10000,
                     "jcr:primaryType": "nt:unstructured"
                 }
             }
@@ -215,6 +221,7 @@
                     "propertyIndex": true,
                     "type": "String",
                     "analyzed": false,
+                    "weight": 100,
                     "jcr:primaryType": "nt:unstructured"
                 },
                 "form": {
@@ -229,6 +236,7 @@
                     "analyzed": true,
                     "notNullCheckEnabled": true,
                     "nullCheckEnabled": true,
+                    "weight": 100,
                     "jcr:primaryType": "nt:unstructured"
                 }
             }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/MaxFormsOfTypePerSubjectValidator.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/MaxFormsOfTypePerSubjectValidator.java
@@ -107,7 +107,7 @@ public class MaxFormsOfTypePerSubjectValidator extends DefaultValidator
         long count = 0;
         final Iterator<Resource> results = serviceResolver.findResources(
             "SELECT f.* FROM [cards:Form] AS f WHERE f.'subject'='" + subjectUUID + "'"
-                + " AND f.'questionnaire'='" + questionnaireUUID + "'",
+                + " AND f.'questionnaire'='" + questionnaireUUID + "' OPTION (index tag property)",
             "JCR-SQL2");
 
         while (results.hasNext()) {

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/DataProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/DataProcessor.java
@@ -260,6 +260,7 @@ public class DataProcessor implements ResourceJsonProcessor
             }
         });
         result.append(" order by n.'jcr:created' ASC");
+        result.append(" OPTION (index tag cards)");
         return result.toString();
     }
 }

--- a/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/subjectParents.json
+++ b/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/subjectParents.json
@@ -1,0 +1,11 @@
+{
+  "jcr:primaryType": "oak:QueryIndexDefinition",
+  "type": "property",
+  "tags": ["cards", "property"],
+  "jcr:name:propertyNames": [
+    "parents"
+  ],
+  "jcr:name:declaringNodeTypes": [
+    "cards:Subject"
+  ]
+}

--- a/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/subjectType.json
+++ b/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/subjectType.json
@@ -1,0 +1,11 @@
+{
+  "jcr:primaryType": "oak:QueryIndexDefinition",
+  "type": "property",
+  "tags": ["property"],
+  "jcr:name:propertyNames": [
+    "type"
+  ],
+  "jcr:name:declaringNodeTypes": [
+    "cards:Subject"
+  ]
+}

--- a/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/serialize/SubjectTypeInstanceCountProcessor.java
+++ b/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/serialize/SubjectTypeInstanceCountProcessor.java
@@ -110,7 +110,8 @@ public class SubjectTypeInstanceCountProcessor implements ResourceJsonProcessor
     private String generateDataQuery(final Node node)
         throws RepositoryException
     {
-        String query = String.format("select n from [cards:Subject] as n where n.type = '%s'",
+        String query = String.format(
+            "select n from [cards:Subject] as n where n.type = '%s' OPTION (index tag property)",
             node.getProperty("jcr:uuid").getString());
         return query;
     }

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ValidateCredentialsServlet.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ValidateCredentialsServlet.java
@@ -252,7 +252,7 @@ public class ValidateCredentialsServlet extends SlingAllMethodsServlet
             "SELECT f.* FROM [cards:TextAnswer] AS t "
                 + "  INNER JOIN [cards:Form] AS f ON t.form = f.[jcr:uuid] "
                 + "WHERE t.'question'='" + identifierQuestion + "' "
-                + "  AND t.'value'='" + presentedID.replaceAll("'", "''") + "'",
+                + "  AND t.'value'='" + presentedID.replaceAll("'", "''") + "' OPTION (index tag cards)",
             "JCR-SQL2");
         while (results.hasNext()) {
             Node patientInformationForm = results.next().adaptTo(Node.class);

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/DraftsAnswersCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/DraftsAnswersCleanupTask.java
@@ -114,7 +114,9 @@ public class DraftsAnswersCleanupTask implements Runnable
                     + "  and submitted.question = '%3$s'"
                     + "  and (submitted.value <> 1 OR submitted.value IS NULL)"
                     // exclude the Visit Information form itself
-                    + "  and dataForm.questionnaire <> '%1$s'",
+                    + "  and dataForm.questionnaire <> '%1$s'"
+                    // use the fast index for the query
+                    + " OPTION (index tag cards)",
                 visitInformationQuestionnaire, ZonedDateTime.now().minusDays(draftLifetime), submitted),
                 Query.JCR_SQL2);
             resources.forEachRemaining(form -> {

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/DraftsAnswersCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/DraftsAnswersCleanupTask.java
@@ -20,6 +20,7 @@
 package io.uhndata.cards.patients.internal;
 
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -117,7 +118,9 @@ public class DraftsAnswersCleanupTask implements Runnable
                     + "  and dataForm.questionnaire <> '%1$s'"
                     // use the fast index for the query
                     + " OPTION (index tag cards)",
-                visitInformationQuestionnaire, ZonedDateTime.now().minusDays(draftLifetime), submitted),
+                visitInformationQuestionnaire, ZonedDateTime.now().minusDays(draftLifetime)
+                    .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSxxx")),
+                submitted),
                 Query.JCR_SQL2);
             resources.forEachRemaining(form -> {
                 try {

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/SubmissionListener.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/SubmissionListener.java
@@ -132,7 +132,9 @@ public class SubmissionListener implements ResourceChangeListener
                     + "  FROM [cards:Form] AS form"
                     + " WHERE"
                     // link to the correct Visit subject
-                    + "  form.subject = '%1$s'",
+                    + "  form.subject = '%1$s'"
+                    // use the synchronous index to not miss recently created forms
+                    + " OPTION (index tag property)",
                 subjectId), "JCR-SQL2").execute().getNodes();
             while (forms.hasNext()) {
                 updateFormFlags(forms.nextNode());

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
@@ -108,6 +108,7 @@ public class UnsubmittedFormsCleanupTask implements Runnable
                     + "  and (submitted.value <> 1 OR submitted.value IS NULL)"
                     // exclude the Visit Information form itself
                     + "  and dataForm.questionnaire <> '%1$s'"
+                    // use the fast index for the query
                     + " option (index tag cards)",
                 visitInformationQuestionnaire, time, submitted,
                 ZonedDateTime.now().minusDays(delay)

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
@@ -112,7 +112,7 @@ public class UnsubmittedFormsCleanupTask implements Runnable
                     + " option (index tag cards)",
                 visitInformationQuestionnaire, time, submitted,
                 ZonedDateTime.now().minusDays(delay)
-                    .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"))),
+                    .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSxxx"))),
                 Query.JCR_SQL2);
             resources.forEachRemaining(form -> {
                 try {

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/submissioncounter/SubmissionEventListener.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/submissioncounter/SubmissionEventListener.java
@@ -100,6 +100,7 @@ public final class SubmissionEventListener implements EventListener
         for (String excludeQuestionnaireUUID : this.getExcludedQuestionnaireUUIDs()) {
             sqlQuery += " AND f.'questionnaire'<>'" + excludeQuestionnaireUUID + SINGLE_QUOTE;
         }
+        sqlQuery += " OPTION (index tag cards)";
 
         Iterator<Resource> results;
         results = this.resolver.findResources(sqlQuery, "JCR-SQL2");

--- a/modules/token-authentication/pom.xml
+++ b/modules/token-authentication/pom.xml
@@ -48,6 +48,7 @@
             <Sling-Initial-Content>
               SLING-INF/content/libs/cards/TokenExpired/;path:=/libs/cards/TokenExpired/;overwriteProperties:=true;uninstall:=true,
               SLING-INF/content/libs/cards/Subject/;path:=/libs/cards/Subject/;overwriteProperties:=true;uninstall:=true,
+              SLING-INF/content/oak%3Aindex/;path:=/oak:index/;overwriteProperties:=true;uninstall:=true,
             </Sling-Initial-Content>
           </instructions>
         </configuration>

--- a/modules/token-authentication/src/main/java/io/uhndata/cards/auth/token/impl/ExpiredTokensCleanupTask.java
+++ b/modules/token-authentication/src/main/java/io/uhndata/cards/auth/token/impl/ExpiredTokensCleanupTask.java
@@ -20,6 +20,7 @@
 package io.uhndata.cards.auth.token.impl;
 
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 
 import javax.jcr.query.Query;
@@ -48,7 +49,9 @@ public class ExpiredTokensCleanupTask implements Runnable
     {
         try (ResourceResolver resolver = this.rrf.getServiceResourceResolver(null)) {
             final Iterator<Resource> resources = resolver.findResources("SELECT * FROM [cards:Token] WHERE ["
-                + CardsTokenImpl.TOKEN_ATTRIBUTE_EXPIRY + "] < '" + ZonedDateTime.now() + "'", Query.JCR_SQL2);
+                + CardsTokenImpl.TOKEN_ATTRIBUTE_EXPIRY + "] < '"
+                + ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss.SSSxxx")) + "'",
+                Query.JCR_SQL2);
             resources.forEachRemaining(token -> {
                 try {
                     resolver.delete(token);

--- a/modules/token-authentication/src/main/java/io/uhndata/cards/auth/token/impl/ExpiredTokensCleanupTask.java
+++ b/modules/token-authentication/src/main/java/io/uhndata/cards/auth/token/impl/ExpiredTokensCleanupTask.java
@@ -50,7 +50,7 @@ public class ExpiredTokensCleanupTask implements Runnable
         try (ResourceResolver resolver = this.rrf.getServiceResourceResolver(null)) {
             final Iterator<Resource> resources = resolver.findResources("SELECT * FROM [cards:Token] WHERE ["
                 + CardsTokenImpl.TOKEN_ATTRIBUTE_EXPIRY + "] < '"
-                + ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss.SSSxxx")) + "'",
+                + ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSxxx")) + "'",
                 Query.JCR_SQL2);
             resources.forEachRemaining(token -> {
                 try {

--- a/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
+++ b/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
@@ -23,7 +23,7 @@ var get10MinExpiry = function() {
 }
 
 var visitTimeQuestionUuid = currentSession.getNode("/Questionnaires/Visit information/time").getIdentifier();
-var time = currentSession.getWorkspace().getQueryManager().createQuery("select t.* from [cards:Form] as f inner join [cards:DateAnswer] as t on ischildnode(t, f) where f.subject = '" + currentNode.getIdentifier() + "' and t.question = '" + visitTimeQuestionUuid + "' OPTION (index tag cards)", "JCR-SQL2").execute().getNodes();
+var time = currentSession.getWorkspace().getQueryManager().createQuery("select t.* from [cards:Form] as f inner join [cards:DateAnswer] as t on t.form = f.[jcr:uuid] where f.subject = '" + currentNode.getIdentifier() + "' and t.question = '" + visitTimeQuestionUuid + "' OPTION (index tag cards)", "JCR-SQL2").execute().getNodes();
 if (time.hasNext()) {
     time = time.next();
     if (time.hasProperty("value")) {

--- a/modules/token-authentication/src/main/resources/SLING-INF/content/oak%3Aindex/tokenExpiry.json
+++ b/modules/token-authentication/src/main/resources/SLING-INF/content/oak%3Aindex/tokenExpiry.json
@@ -1,0 +1,24 @@
+{
+    "jcr:primaryType": "oak:QueryIndexDefinition",
+    "type": "lucene",
+    "compatVersion": 2,
+    "async": "async",
+    "includedPaths": ["/jcr:system/cards:tokens"],
+    "tags": ["cards"],
+    "indexRules" : {
+        "jcr:primaryType": "nt:unstructured",
+        "cards:Token" : {
+            "jcr:primaryType": "nt:unstructured",
+            "properties": {
+                "jcr:primaryType": "nt:unstructured",
+                "expiry": {
+                    "name": "cards:token.exp",
+                    "ordered": true,
+                    "propertyIndex": true,
+                    "type": "Date",
+                    "sync": true
+                }
+            }
+        }
+    }
+}

--- a/modules/torch-import/src/main/java/io/uhndata/cards/torch/internal/PatientLocalStorage.java
+++ b/modules/torch-import/src/main/java/io/uhndata/cards/torch/internal/PatientLocalStorage.java
@@ -340,7 +340,8 @@ public class PatientLocalStorage
         throws RepositoryException, PersistenceException
     {
         final Iterator<Resource> subjectResourceIter = this.resolver.findResources(String.format(
-            "SELECT * FROM [cards:Subject] WHERE identifier = \"%s\"", identifier), PatientLocalStorage.JCR_SQL);
+            "SELECT * FROM [cards:Subject] WHERE identifier = \"%s\" OPTION (index tag property)", identifier),
+            PatientLocalStorage.JCR_SQL);
         if (subjectResourceIter.hasNext()) {
             final Resource subjectResource = subjectResourceIter.next();
             this.versionManager.checkout(subjectResource.getPath());
@@ -374,7 +375,7 @@ public class PatientLocalStorage
         final Resource formType = this.resolver.getResource(questionnairePath);
         final Node subjectNode = subject.adaptTo(Node.class);
         final Iterator<Resource> formResourceIter = this.resolver.findResources(String.format(
-            "SELECT * FROM [cards:Form] WHERE subject = \"%s\" AND questionnaire=\"%s\"",
+            "SELECT * FROM [cards:Form] WHERE subject = \"%s\" AND questionnaire=\"%s\" OPTION (index tag property)",
             subjectNode.getIdentifier(),
             formType.adaptTo(Node.class).getIdentifier()), PatientLocalStorage.JCR_SQL);
         if (formResourceIter.hasNext()) {

--- a/modules/ui-extension/pom.xml
+++ b/modules/ui-extension/pom.xml
@@ -49,6 +49,7 @@
               SLING-INF/content/libs/cards/Extension/;path:=/libs/cards/Extension/;overwriteProperties:=true;uninstall:=true,
               SLING-INF/content/libs/cards/ExtensionPoint/;path:=/libs/cards/ExtensionPoint/;overwriteProperties:=true;uninstall:=true,
               SLING-INF/content/libs/cards/ExtensionPointFinder/;path:=/libs/cards/ExtensionPointFinder/;overwriteProperties:=true;uninstall:=true,
+              SLING-INF/content/oak%3Aindex/;path:=/oak:index/;overwriteProperties:=true;uninstall:=true,
             </Sling-Initial-Content>
             <Sling-Nodetypes>SLING-INF/nodetypes/extension.cnd</Sling-Nodetypes>
           </instructions>

--- a/modules/ui-extension/src/main/java/io/uhndata/cards/uix/ExtensionsManager.java
+++ b/modules/ui-extension/src/main/java/io/uhndata/cards/uix/ExtensionsManager.java
@@ -91,7 +91,7 @@ public class ExtensionsManager implements Use
         LOGGER.debug("Looking for extensions for [{}]", extensionPointId);
         final Iterator<Resource> result = this.resourceResolver.findResources(
             "select n from [cards:Extension] as n where n.'cards:extensionPointId' = '" + extensionPointId
-            + "' order by n.'cards:defaultOrder'",
+            + "' order by n.'cards:defaultOrder' OPTION (index tag property)",
             "JCR-SQL2");
         result.forEachRemaining(extension -> this.matchingExtensions.add(extension));
         LOGGER.debug("Found [{}] extensions", this.matchingExtensions.size());

--- a/modules/ui-extension/src/main/resources/SLING-INF/content/libs/cards/ExtensionPointFinder/extensionQuery.js
+++ b/modules/ui-extension/src/main/resources/SLING-INF/content/libs/cards/ExtensionPointFinder/extensionQuery.js
@@ -24,7 +24,7 @@ use(function(){
     }
     uixp = uixp.getString();
     var queryManager = currentSession.getWorkspace().getQueryManager();
-    var q = "select * from [cards:ExtensionPoint] as n WHERE n.'cards:extensionPointId' = $path and ISDESCENDANTNODE(n, '/apps/cards/ExtensionPoints/')";
+    var q = "select * from [cards:ExtensionPoint] as n WHERE n.'cards:extensionPointId' = $path and ISDESCENDANTNODE(n, '/apps/cards/ExtensionPoints/') OPTION (index tag property)";
     var query = queryManager.createQuery(q, "JCR-SQL2");
     query.bindValue("path", currentSession.getValueFactory().createValue(uixp));
     var queryResults = query.execute().getNodes();

--- a/modules/ui-extension/src/main/resources/SLING-INF/content/oak%3Aindex/extensionId.json
+++ b/modules/ui-extension/src/main/resources/SLING-INF/content/oak%3Aindex/extensionId.json
@@ -1,0 +1,11 @@
+{
+  "jcr:primaryType": "oak:QueryIndexDefinition",
+  "type": "property",
+  "tags": ["property"],
+  "jcr:name:propertyNames": [
+    "cards:extensionPointId"
+  ],
+  "jcr:name:declaringNodeTypes": [
+    "cards:Extension"
+  ]
+}

--- a/modules/ui-extension/src/main/resources/SLING-INF/content/oak%3Aindex/extensionPointId.json
+++ b/modules/ui-extension/src/main/resources/SLING-INF/content/oak%3Aindex/extensionPointId.json
@@ -1,0 +1,11 @@
+{
+  "jcr:primaryType": "oak:QueryIndexDefinition",
+  "type": "property",
+  "tags": ["property"],
+  "jcr:name:propertyNames": [
+    "cards:extensionPointId"
+  ],
+  "jcr:name:declaringNodeTypes": [
+    "cards:ExtensionPoint"
+  ]
+}


### PR DESCRIPTION
Also includes a few other query optimizations.

Reviewing commit by commit is easier.

To test:
- maxPerSubject correctly detected when creating new forms, both from the dashboard and the subject page
- loading child subjects (and grandchildren in LFS)
- csv import with multiple forms per patient
- csv import with `:patch=true` updates existing forms
- patient UI, submitting a survey correctly marks all visit forms as submitted
- manual token generation still works