### PR TITLE
CARDS-2292: Logo reverts to the default logo after an upgrade

### DIFF
--- a/modules/homepage/pom.xml
+++ b/modules/homepage/pom.xml
@@ -57,7 +57,6 @@
               SLING-INF/content/libs/cards/Homepage/;path:=/libs/cards/Homepage/;overwriteProperties:=true;uninstall:=true,
               SLING-INF/content/libs/cards/resources/assetDependencies.json;path:=/libs/cards/resources/assetDependencies;overwriteProperties:=true,
               SLING-INF/content/libs/cards/resources/media/default/;path:=/libs/cards/resources/media/default/;overwrite:=true;uninstall:=true,
-              SLING-INF/content/libs/cards/conf/Media.json;path:=/libs/cards/conf/Media;overwriteProperties:=true,
               SLING-INF/content/Extensions/;path:=/Extensions/;overwriteProperties:=true;uninstall:=true,
             </Sling-Initial-Content>
           </instructions>

--- a/modules/homepage/src/main/features/feature-repoinit.txt
+++ b/modules/homepage/src/main/features/feature-repoinit.txt
@@ -21,9 +21,16 @@ create path (cards:Homepage) /content
 create path (sling:Folder) /Extensions
 create path (sling:Folder) /Extensions/AdminDashboard
 create path (sling:Folder) /Extensions/Sidebar/AdminEntries
+create path (nt:unstructured) /libs/cards/conf/Media
 
 set ACL for everyone
     allow   jcr:read    on /content
     deny    jcr:all     on /Extensions/AdminDashboard
     deny    jcr:all     on /Extensions/Sidebar/AdminEntries
+end
+
+set properties on /libs/cards/conf/Media
+  default logoDark to "/libs/cards/resources/media/default/logo.png"
+  default logoLight to "/libs/cards/resources/media/default/logo_light_bg.png"
+  default sidebarBackground to "/libs/cards/resources/media/default/background.jpg"
 end

--- a/modules/homepage/src/main/resources/SLING-INF/content/libs/cards/conf/Media.json
+++ b/modules/homepage/src/main/resources/SLING-INF/content/libs/cards/conf/Media.json
@@ -1,6 +1,0 @@
-{
-  "jcr:primaryType": "nt:unstructured",
-  "logoDark": "/libs/cards/resources/media/default/logo.png",
-  "logoLight": "/libs/cards/resources/media/default/logo_light_bg.png",
-  "sidebarBackground": "/libs/cards/resources/media/default/background.jpg"
-}


### PR DESCRIPTION
@IntegralProgrammer Can you provide steps for reproducing the original problem? I tried different upgrade scenarios between 0.9.14->0.9.15 and couldn't get the wrong logo to show up.