### PR TITLE
CARDS-2289: CSV export task fails due to invalid date string

### DIFF
--- a/Utilities/Development/PREMs-Testing/OED_responses.json
+++ b/Utilities/Development/PREMs-Testing/OED_responses.json
@@ -1,0 +1,14 @@
+{
+	"What else would you like to say about this experience?": ["Test Value 1234", "String"],
+	"Overall... (please answer on a scale where 0 is “I had a very poor experience” and 10 is “I had a very good experience”)": [7, "Long"],
+	"How often did care providers treat you with courtesy and respect?": [2, "Long"],
+	"Did you feel that there was good communication about your care between doctors, nurses and other hospital staff?": [2, "Long"],
+	"Would you recommend this hospital to your friends and family?": [7, "Long"],
+	"Did you receive enough information from hospital staff about what to do if you were worried about your condition or treatment after you left the hospital?": [2, "Long"],
+	"Did care providers do everything they could do to ease your discomfort or symptoms?": [2, "Long"],
+	"How often did care providers explain things in a way you could understand?": [2, "Long"],
+	"Hospital": ["TGH", "String"],
+	"If you had a long wait, were you told why?": [2, "Long"],
+	"Did you get the emotional support you needed to help you with any anxieties, fears or worries you had during this hospital visit?": [2, "Long"],
+	"Do you feel that you were treated with kindness and compassion?": [2, "Long"]
+}

--- a/Utilities/Development/create_prems_test_subject_visit_forms.py
+++ b/Utilities/Development/create_prems_test_subject_visit_forms.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+"""
+
+import sys
+import json
+
+import fill_form
+import create_subject_for_type
+
+IDENTIFIER_ID = sys.argv[1]
+
+with open("PREMs-Testing/OED_responses.json", 'r') as f_json:
+  OED_ANSWERS = json.load(f_json)
+
+VISIT_INFORMATION_ANSWERS = {}
+VISIT_INFORMATION_ANSWERS['Surveys completed'] = [1, "Long"]
+VISIT_INFORMATION_ANSWERS['Surveys submitted'] = [1, "Long"]
+
+patient_subject_path = create_subject_for_type.create_subject_for_type("/Subjects", "P" + IDENTIFIER_ID, "/SubjectTypes/Patient")
+visit_subject_path = create_subject_for_type.create_subject_for_type(patient_subject_path, "V" + IDENTIFIER_ID, "/SubjectTypes/Patient/Visit")
+
+fill_form.fill_form(visit_subject_path, "/Questionnaires/OED", OED_ANSWERS)
+fill_form.fill_form(visit_subject_path, "/Questionnaires/Visit information", VISIT_INFORMATION_ANSWERS)

--- a/Utilities/Development/create_prems_test_subject_visit_forms.py
+++ b/Utilities/Development/create_prems_test_subject_visit_forms.py
@@ -22,6 +22,7 @@
 
 import sys
 import json
+import time
 
 import fill_form
 import create_subject_for_type
@@ -38,5 +39,11 @@ VISIT_INFORMATION_ANSWERS['Surveys submitted'] = [1, "Long"]
 patient_subject_path = create_subject_for_type.create_subject_for_type("/Subjects", "P" + IDENTIFIER_ID, "/SubjectTypes/Patient")
 visit_subject_path = create_subject_for_type.create_subject_for_type(patient_subject_path, "V" + IDENTIFIER_ID, "/SubjectTypes/Patient/Visit")
 
+# Fill out the OED Form
 fill_form.fill_form(visit_subject_path, "/Questionnaires/OED", OED_ANSWERS)
+
+# A small delay to simulate the time between when the user fills out their surveys and when the submit button is clicked
+time.sleep(3)
+
+# Mark the surveys for this visit as completed and submitted
 fill_form.fill_form(visit_subject_path, "/Questionnaires/Visit information", VISIT_INFORMATION_ANSWERS)

--- a/Utilities/Development/fill_form.py
+++ b/Utilities/Development/fill_form.py
@@ -86,5 +86,4 @@ def fill_form(subject_path, questionnaire_path, provided_answers):
     apath = question_to_answer_nodes[qtext]
     avalue = provided_answers[qtext][0]
     atype = provided_answers[qtext][1]
-    #print("Answering question: {} to {} as {} [{}]".format(qtext, apath, avalue, atype))
     post_answer(apath, avalue, atype)

--- a/Utilities/Development/fill_form.py
+++ b/Utilities/Development/fill_form.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+"""
+
+import os
+import uuid
+import requests
+
+CARDS_URL = "http://localhost:8080"
+if "CARDS_URL" in os.environ:
+  CARDS_URL = os.environ["CARDS_URL"].rstrip('/')
+
+ADMIN_PASSWORD = "admin"
+if "ADMIN_PASSWORD" in os.environ:
+  ADMIN_PASSWORD = os.environ["ADMIN_PASSWORD"]
+
+def get_jcr_uuid_for_path(path):
+  resp = requests.get(CARDS_URL + path + ".json", auth=('admin', ADMIN_PASSWORD))
+  return resp.json()['jcr:uuid']
+
+def createFormNode(questionnaire_path, subject_path):
+  questionnaire_jcr_uuid = get_jcr_uuid_for_path(questionnaire_path)
+  subject_path_jcr_uuid = get_jcr_uuid_for_path(subject_path)
+
+  creation_form_data = []
+  creation_form_data.append(("jcr:primaryType", (None, "cards:Form")))
+
+  creation_form_data.append(("questionnaire", (None, questionnaire_jcr_uuid)))
+  creation_form_data.append(("questionnaire@TypeHint", (None, "Reference")))
+
+  creation_form_data.append(("subject", (None, subject_path_jcr_uuid)))
+  creation_form_data.append(("subject@TypeHint", (None, "Reference")))
+
+  new_form_jcr_path = "/Forms/" + str(uuid.uuid4())
+  resp = requests.post(CARDS_URL + new_form_jcr_path, files=tuple(creation_form_data), auth=('admin', ADMIN_PASSWORD))
+
+  if resp.status_code in range(200, 300):
+    return new_form_jcr_path
+  else:
+    raise Exception("ERROR: Cound not create {}".format(new_form_jcr_path))
+
+def find_answer_nodes(node, qa_map={}):
+  for key in node:
+    if type(node[key]) == dict:
+      if node[key]['jcr:primaryType'] == 'cards:AnswerSection':
+        find_answer_nodes(node[key], qa_map=qa_map)
+      elif node[key]['sling:resourceSuperType'] == 'cards/Answer':
+        answer_path = node[key]['@path']
+        question_text = node[key]['question']['text']
+        qa_map[question_text] = answer_path
+  return qa_map
+
+def post_answer(answer_node_path, value, value_type):
+  creation_form_data = []
+  creation_form_data.append(("value", (None, value)))
+  creation_form_data.append(("value@TypeHint", (None, value_type)))
+  resp = requests.post(CARDS_URL + answer_node_path, auth=('admin', ADMIN_PASSWORD), files=tuple(creation_form_data))
+  if resp.status_code != 200:
+    raise Exception("{} was returned upon answer submission".format(resp.status_code))
+
+def fill_form(subject_path, questionnaire_path, provided_answers):
+  form_path = createFormNode(questionnaire_path, subject_path)
+  form_structure = requests.get(CARDS_URL + form_path + ".deep.json", auth=('admin', ADMIN_PASSWORD)).json()
+  question_to_answer_nodes = find_answer_nodes(form_structure)
+  for qtext in question_to_answer_nodes:
+    if qtext not in provided_answers:
+      continue
+    apath = question_to_answer_nodes[qtext]
+    avalue = provided_answers[qtext][0]
+    atype = provided_answers[qtext][1]
+    #print("Answering question: {} to {} as {} [{}]".format(qtext, apath, avalue, atype))
+    post_answer(apath, avalue, atype)


### PR DESCRIPTION
This _Pull Request_ fixes the bug described by CARDS-2289 where CSV exports failed due to the `java.lang.IllegalArgumentException: Not a date string` exception being thrown during CSV exports.

Testing Instructions
--------------------------

1. Build this (`CARDS-2289`) branch including a Docker image with `mvn clean install -Pdocker`.
2. Set the system date to _9_ days ago.
3. `cd compose-cluster`.
4. `python3 generate_compose_yaml.py --dev_docker_image --oak_filesystem --composum --cards_project cards4prems`.
5. `docker-compose build && docker-compose up -d`.
6. Wait for CARDS to become available at http://localhost:8080.
7. `cd ../Utilities/Development`.
8. `python3 create_prems_test_subject_visit_forms.py 1`.
9. Set the system date to _8_ days ago.
10. `python3 create_prems_test_subject_visit_forms.py 2`.
11. Set the system date to _7_ days ago.
12. `python3 create_prems_test_subject_visit_forms.py 3`.
13. Set the system date to _6_ days ago.
14. `python3 create_prems_test_subject_visit_forms.py 4`.
15. Set the system date to _5_ days ago.
16. `python3 create_prems_test_subject_visit_forms.py 5`.
17. Set the system date to _4_ days ago.
18. `python3 create_prems_test_subject_visit_forms.py 6`.
19. Set the system date to _3_ days ago.
20. `python3 create_prems_test_subject_visit_forms.py 7`.
21. Set the system date to _2_ days ago.
22. `python3 create_prems_test_subject_visit_forms.py 8`.
23. Set the system date to _1_ day ago.
24. `python3 create_prems_test_subject_visit_forms.py 9`.
25. Set the system date to the current date/time.
26. `python3 create_prems_test_subject_visit_forms.py 10`.
27. `cd ../../compose-cluster`.
28. `docker-compose exec cardsinitial /bin/sh`.
29. `apk add nano`.
30. `cd /`.
31. `mkdir csv-export`.
32. `cd csv-export`.
33. Visit http://localhost:8080 and login as `admin`:`admin`.
34. Trigger a CSV export by visiting http://localhost:8080/Subjects.csvExport?config=UHN-Labeled-Forms,
35. Back in the `cardsinitial` shell, run `nano Questionnaires_OED_labels.csv`. Verify that CSV rows for `P3`, `P4`, `P5`, `P6`, `P7`, `P8`, and `P9` _are_ present while rows for `P1`, `P2`, and `P10` are not.