### PR TITLE
CARDS-2286: Allow to configure token life time for each survey

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics-hints.json
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics-hints.json
@@ -1,0 +1,3 @@
+{
+  "nbOfDaysRelativeToEventToCompleteSurvey": "Use a negative number when patient responses are due a number of days before the event, 0 for the day of the event, and a positive number when their responses are expected after the event."
+}

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics-hints.json
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics-hints.json
@@ -1,3 +1,3 @@
 {
-  "nbOfDaysRelativeToEventToCompleteSurvey": "Use a negative number when patient responses are due a number of days before the event, 0 for the day of the event, and a positive number when their responses are expected after the event."
+  "daysRelativeToEventWhileSurveyIsValid": "Use a negative number when patient responses are due a number of days before the event, 0 for the day of the event, and a positive number when their responses are expected after the event."
 }

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.json
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.json
@@ -5,5 +5,6 @@
   "survey": "string",
   "emergencyContact": "string",
   "description": "string",
+  "tokenLifetime": "long",
   "//REQUIRED": ["clinicName", "displayName", "sidebarLabel", "survey"]
 }

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.json
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.json
@@ -5,6 +5,6 @@
   "survey": "string",
   "emergencyContact": "string",
   "description": "string",
-  "tokenLifetime": "double",
+  "allowedPostVisitCompletionTime": "double",
   "//REQUIRED": ["clinicName", "displayName", "sidebarLabel", "survey"]
 }

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.json
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.json
@@ -5,6 +5,6 @@
   "survey": "string",
   "emergencyContact": "string",
   "description": "string",
-  "tokenLifetime": "long",
+  "tokenLifetime": "double",
   "//REQUIRED": ["clinicName", "displayName", "sidebarLabel", "survey"]
 }

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.json
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.json
@@ -5,6 +5,6 @@
   "survey": "string",
   "emergencyContact": "string",
   "description": "string",
-  "allowedPostVisitCompletionTime": "double",
+  "nbOfDaysRelativeToEventToCompleteSurvey": "double",
   "//REQUIRED": ["clinicName", "displayName", "sidebarLabel", "survey"]
 }

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.json
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.json
@@ -5,6 +5,6 @@
   "survey": "string",
   "emergencyContact": "string",
   "description": "string",
-  "nbOfDaysRelativeToEventToCompleteSurvey": "double",
+  "daysRelativeToEventWhileSurveyIsValid": "double",
   "//REQUIRED": ["clinicName", "displayName", "sidebarLabel", "survey"]
 }

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
@@ -44,7 +44,7 @@ function Clinics(props) {
     "sidebarLabel": "Sidebar Entry",
     "survey": "Surveys",
     "emergencyContact": "Emergency Contact",
-    "allowedPostVisitCompletionTime": "Allowed Post Visit Completion Time"
+    "allowedPostVisitCompletionTime": "Relatively to the associated event, patients can fill out surveys within"
   }
 
   let columns = Object.keys(clinicsSpecs).filter((stat) => !Array.isArray(clinicsSpecs[stat]))

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
@@ -88,6 +88,13 @@ function OnboardNewClinicDialog(props) {
 
   let clinicsSpecs = require('./Clinics.json');
 
+  let hints = null;
+  try {
+    hints = require(`./Clinics-hints.json`);
+  } catch (e) {
+    // do nothing
+  }
+
   let reset = () => {
     // reset all fields
     setError();
@@ -149,7 +156,7 @@ function OnboardNewClinicDialog(props) {
             {
               // We don't want to load the Fields component until we are fully initialized
               // since otherwise the default values will be empty and cannot be assigned
-              initialized && <Fields data={{}} JSON={clinicsSpecs} edit />
+              initialized && <Fields data={{}} JSON={clinicsSpecs} hints={hints} edit />
             }
           </Grid>
         </DialogContent>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
@@ -44,7 +44,7 @@ function Clinics(props) {
     "sidebarLabel": "Sidebar Entry",
     "survey": "Surveys",
     "emergencyContact": "Emergency Contact",
-    "tokenLifetime": "Token Lifetime"
+    "allowedPostVisitCompletionTime": "Allowed Post Visit Completion Time"
   }
 
   let columns = Object.keys(clinicsSpecs).filter((stat) => !Array.isArray(clinicsSpecs[stat]))

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
@@ -38,20 +38,11 @@ function Clinics(props) {
 
   let clinicsSpecs = require('./Clinics.json');
 
-  let formattedNames = {
-    "clinicName": "ID",
-    "displayName": "Name",
-    "sidebarLabel": "Sidebar Entry",
-    "survey": "Surveys",
-    "emergencyContact": "Emergency Contact",
-    "allowedPostVisitCompletionTime": "Relatively to the associated event, patients can fill out surveys within"
-  }
-
   let columns = Object.keys(clinicsSpecs).filter((stat) => !Array.isArray(clinicsSpecs[stat]))
     .map((stat) => {
       return {
         key: stat,
-        label: (stat in formattedNames) ? formattedNames[stat] : camelCaseToWords(stat),
+        label: camelCaseToWords(stat),
         format: clinicsSpecs[stat]
       };
     });

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
@@ -43,7 +43,8 @@ function Clinics(props) {
     "displayName": "Name",
     "sidebarLabel": "Sidebar Entry",
     "survey": "Surveys",
-    "emergencyContact": "Emergency Contact"
+    "emergencyContact": "Emergency Contact",
+    "tokenLifetime": "Token Lifetime"
   }
 
   let columns = Object.keys(clinicsSpecs).filter((stat) => !Array.isArray(clinicsSpecs[stat]))

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
@@ -34,7 +34,7 @@ export const PATIENT_ACCESS_CONFIG_PATH = "/Survey/PatientAccess";
 export const DEFAULT_PATIENT_ACCESS_CONFIG = {
     tokenlessAuthEnabled: false,
     PIIAuthRequired: false,
-    allowedPostVisitCompletionTime: "0",
+    nbOfDaysRelativeToEventToCompleteSurvey: "0",
     draftLifetime: "-1"
 };
 
@@ -62,7 +62,7 @@ function PatientAccessConfiguration() {
   const LABELS = {
     tokenlessAuthEnabled: "Patients can answer surveys without a personalized link",
     PIIAuthRequired: "Patients must confirm their identity by providing their date of birth and either MRN or HCN",
-    allowedPostVisitCompletionTime: [
+    nbOfDaysRelativeToEventToCompleteSurvey: [
       "Relatively to the associated event, patients can fill out surveys within:",
       "Use a negative number when patient responses are due a number of days before the event, 0 for the day of the event, and a positive number when their responses are expected after the event."
     ],
@@ -141,7 +141,7 @@ function PatientAccessConfiguration() {
           <List>
             { renderConfigCheckbox("tokenlessAuthEnabled") }
             { renderConfigCheckbox("PIIAuthRequired", patientAccessConfig?.tokenlessAuthEnabled) }
-            { renderConfigInput("allowedPostVisitCompletionTime", "days") }
+            { renderConfigInput("nbOfDaysRelativeToEventToCompleteSurvey", "days") }
             { renderConfigInput("draftLifetime", "days") }
           </List>
       </AdminConfigScreen>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
@@ -34,7 +34,7 @@ export const PATIENT_ACCESS_CONFIG_PATH = "/Survey/PatientAccess";
 export const DEFAULT_PATIENT_ACCESS_CONFIG = {
     tokenlessAuthEnabled: false,
     PIIAuthRequired: false,
-    nbOfDaysRelativeToEventToCompleteSurvey: "0",
+    daysRelativeToEventWhileSurveyIsValid: "0",
     draftLifetime: "-1"
 };
 
@@ -62,7 +62,7 @@ function PatientAccessConfiguration() {
   const LABELS = {
     tokenlessAuthEnabled: "Patients can answer surveys without a personalized link",
     PIIAuthRequired: "Patients must confirm their identity by providing their date of birth and either MRN or HCN",
-    nbOfDaysRelativeToEventToCompleteSurvey: [
+    daysRelativeToEventWhileSurveyIsValid: [
       "Relatively to the associated event, patients can fill out surveys within:",
       "Use a negative number when patient responses are due a number of days before the event, 0 for the day of the event, and a positive number when their responses are expected after the event."
     ],
@@ -141,7 +141,7 @@ function PatientAccessConfiguration() {
           <List>
             { renderConfigCheckbox("tokenlessAuthEnabled") }
             { renderConfigCheckbox("PIIAuthRequired", patientAccessConfig?.tokenlessAuthEnabled) }
-            { renderConfigInput("nbOfDaysRelativeToEventToCompleteSurvey", "days") }
+            { renderConfigInput("daysRelativeToEventWhileSurveyIsValid", "days") }
             { renderConfigInput("draftLifetime", "days") }
           </List>
       </AdminConfigScreen>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -114,6 +114,7 @@ function QuestionnaireSet(props) {
   // Questionnaire set title and intro text, to display to the patient user
   const [ title, setTitle ] = useState();
   const [ intro, setIntro ] = useState();
+  const [ tokenLifetime, setTokenLifetime ] = useState();
   // Map questionnaire id -> title, path and optional time estimate (in minutes) for filling it out
   const [ questionnaires, setQuestionnaires ] = useState();
   // The ids of the questionnaires in this set, in the order they must be filled in
@@ -320,6 +321,7 @@ function QuestionnaireSet(props) {
     // Extract the title and intro
     setTitle(json.name);
     setIntro(json.intro || "");
+    setTokenLifetime(json.tokenLifetime);
     // If the questionnaire set specifies a value for `enableReviewScreen`, overwrite the curently stored value
     typeof(json.enableReviewScreen) != "undefined" && setEnableReviewScreen(json.enableReviewScreen);
 
@@ -586,7 +588,7 @@ function QuestionnaireSet(props) {
     let date = getVisitDate();
     if (date?.isValid) {
       // Compute the moment the token expired: the configured number of days after the visit, at midnight
-      date = date.plus({days: config?.allowedPostVisitCompletionTime || 0}).endOf('day');
+      date = date.plus({days: tokenLifetime || config?.allowedPostVisitCompletionTime || 0}).endOf('day');
 
       // Get the date difference in the format: X days, Y hours and Z minutes,
       // skipping any time division that has a value of 0

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -291,7 +291,7 @@ function QuestionnaireSet(props) {
             .then((response) => response.ok ? response.json() : Promise.reject(response))
             .then((json) => {
               setId(json["survey"]);
-              setTokenLifetime(json.allowedPostVisitCompletionTime);
+              setTokenLifetime(json.nbOfDaysRelativeToEventToCompleteSurvey);
             });
         }
         selectDataForQuestionnaireSet(json, questionnaires, questionnaireSetIds);
@@ -588,7 +588,7 @@ function QuestionnaireSet(props) {
     let date = getVisitDate();
     if (date?.isValid) {
       // Compute the moment the token expired: the configured number of days after the visit, at midnight
-      date = date.plus({days: tokenLifetime ?? config?.allowedPostVisitCompletionTime ?? 0}).endOf('day');
+      date = date.plus({days: tokenLifetime ?? config?.nbOfDaysRelativeToEventToCompleteSurvey ?? 0}).endOf('day');
 
       // Get the date difference in the format: X days, Y hours and Z minutes,
       // skipping any time division that has a value of 0

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -291,7 +291,7 @@ function QuestionnaireSet(props) {
             .then((response) => response.ok ? response.json() : Promise.reject(response))
             .then((json) => {
               setId(json["survey"]);
-              setTokenLifetime(json.nbOfDaysRelativeToEventToCompleteSurvey);
+              setTokenLifetime(json.daysRelativeToEventWhileSurveyIsValid);
             });
         }
         selectDataForQuestionnaireSet(json, questionnaires, questionnaireSetIds);
@@ -588,7 +588,7 @@ function QuestionnaireSet(props) {
     let date = getVisitDate();
     if (date?.isValid) {
       // Compute the moment the token expired: the configured number of days after the visit, at midnight
-      date = date.plus({days: tokenLifetime ?? config?.nbOfDaysRelativeToEventToCompleteSurvey ?? 0}).endOf('day');
+      date = date.plus({days: tokenLifetime ?? config?.daysRelativeToEventWhileSurveyIsValid ?? 0}).endOf('day');
 
       // Get the date difference in the format: X days, Y hours and Z minutes,
       // skipping any time division that has a value of 0

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -291,7 +291,7 @@ function QuestionnaireSet(props) {
             .then((response) => response.ok ? response.json() : Promise.reject(response))
             .then((json) => {
               setId(json["survey"]);
-              setTokenLifetime(json.tokenLifetime);
+              setTokenLifetime(json.allowedPostVisitCompletionTime);
             });
         }
         selectDataForQuestionnaireSet(json, questionnaires, questionnaireSetIds);

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -291,6 +291,7 @@ function QuestionnaireSet(props) {
             .then((response) => response.ok ? response.json() : Promise.reject(response))
             .then((json) => {
               setId(json["survey"]);
+              setTokenLifetime(json.tokenLifetime);
             });
         }
         selectDataForQuestionnaireSet(json, questionnaires, questionnaireSetIds);
@@ -321,7 +322,6 @@ function QuestionnaireSet(props) {
     // Extract the title and intro
     setTitle(json.name);
     setIntro(json.intro || "");
-    setTokenLifetime(json.tokenLifetime);
     // If the questionnaire set specifies a value for `enableReviewScreen`, overwrite the curently stored value
     typeof(json.enableReviewScreen) != "undefined" && setEnableReviewScreen(json.enableReviewScreen);
 

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -588,7 +588,7 @@ function QuestionnaireSet(props) {
     let date = getVisitDate();
     if (date?.isValid) {
       // Compute the moment the token expired: the configured number of days after the visit, at midnight
-      date = date.plus({days: tokenLifetime || config?.allowedPostVisitCompletionTime || 0}).endOf('day');
+      date = date.plus({days: tokenLifetime ?? config?.allowedPostVisitCompletionTime ?? 0}).endOf('day');
 
       // Get the date difference in the format: X days, Y hours and Z minutes,
       // skipping any time division that has a value of 0

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ClinicsServlet.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ClinicsServlet.java
@@ -84,6 +84,8 @@ public class ClinicsServlet extends SlingAllMethodsServlet
 
     private final ThreadLocal<String> emergencyContact = new ThreadLocal<>();
 
+    private final ThreadLocal<Double> tokenLifetime = new ThreadLocal<>();
+
     private final ThreadLocal<String> description = new ThreadLocal<>();
 
     private final ThreadLocal<String> idHash = new ThreadLocal<>();
@@ -150,6 +152,7 @@ public class ClinicsServlet extends SlingAllMethodsServlet
         this.sidebarLabel.set(request.getParameter("sidebarLabel"));
         this.surveyID.set(request.getParameter("survey"));
         this.emergencyContact.set(request.getParameter("emergencyContact"));
+        this.tokenLifetime.set(Double.parseDouble(request.getParameter("tokenLifetime")));
         this.description.set(request.getParameter("description"));
         this.idHash.set(Integer.toString(this.clinicName.get().hashCode()));
         return true;
@@ -240,6 +243,7 @@ public class ClinicsServlet extends SlingAllMethodsServlet
             "sidebarLabel", this.sidebarLabel.get(),
             "survey", this.surveyID.get(),
             "emergencyContact", this.emergencyContact.get(),
+            "tokenLifetime", this.tokenLifetime.get(),
             ClinicsServlet.DESCRIPTION_FIELD, this.description.get(),
             ClinicsServlet.PRIMARY_TYPE_FIELD, "cards:ClinicMapping"));
     }
@@ -330,6 +334,7 @@ public class ClinicsServlet extends SlingAllMethodsServlet
         this.description.remove();
         this.displayName.remove();
         this.emergencyContact.remove();
+        this.tokenLifetime.remove();
         this.idHash.remove();
         this.sidebarLabel.remove();
         this.surveyID.remove();

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ClinicsServlet.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ClinicsServlet.java
@@ -154,7 +154,8 @@ public class ClinicsServlet extends SlingAllMethodsServlet
         this.sidebarLabel.set(request.getParameter("sidebarLabel"));
         this.surveyID.set(request.getParameter("survey"));
         this.emergencyContact.set(request.getParameter("emergencyContact"));
-        String tokenLifetimeParam = StringUtils.defaultString(request.getParameter("allowedPostVisitCompletionTime"), "");
+        String tokenLifetimeParam =
+            StringUtils.defaultString(request.getParameter("allowedPostVisitCompletionTime"), "");
         if (StringUtils.isNotBlank(tokenLifetimeParam)) {
             this.tokenLifetime.set(Double.valueOf(tokenLifetimeParam));
         }

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ClinicsServlet.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ClinicsServlet.java
@@ -155,7 +155,7 @@ public class ClinicsServlet extends SlingAllMethodsServlet
         this.surveyID.set(request.getParameter("survey"));
         this.emergencyContact.set(request.getParameter("emergencyContact"));
         String tokenLifetimeParam =
-            StringUtils.defaultString(request.getParameter("allowedPostVisitCompletionTime"), "");
+            StringUtils.defaultString(request.getParameter("nbOfDaysRelativeToEventToCompleteSurvey"), "");
         if (StringUtils.isNotBlank(tokenLifetimeParam)) {
             this.tokenLifetime.set(Double.valueOf(tokenLifetimeParam));
         }
@@ -252,7 +252,7 @@ public class ClinicsServlet extends SlingAllMethodsServlet
         params.put(ClinicsServlet.DESCRIPTION_FIELD, this.description.get());
         params.put(ClinicsServlet.PRIMARY_TYPE_FIELD, "cards:ClinicMapping");
         if (this.tokenLifetime.get() != null) {
-            params.put("allowedPostVisitCompletionTime", this.tokenLifetime.get());
+            params.put("nbOfDaysRelativeToEventToCompleteSurvey", this.tokenLifetime.get());
         }
         resolver.create(parentResource, this.idHash.get(), params);
     }

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ClinicsServlet.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ClinicsServlet.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.Arrays;
 import java.util.Dictionary;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Iterator;
@@ -241,14 +242,14 @@ public class ClinicsServlet extends SlingAllMethodsServlet
     {
         final Resource parentResource = resolver.getResource("/Survey/ClinicMapping");
 
-        Map<String, Object> params = Map.of(
-            "clinicName", this.clinicName.get(),
-            "displayName", this.displayName.get(),
-            "sidebarLabel", this.sidebarLabel.get(),
-            "survey", this.surveyID.get(),
-            "emergencyContact", this.emergencyContact.get(),
-            ClinicsServlet.DESCRIPTION_FIELD, this.description.get(),
-            ClinicsServlet.PRIMARY_TYPE_FIELD, "cards:ClinicMapping");
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("clinicName", this.clinicName.get());
+        params.put("displayName", this.displayName.get());
+        params.put("sidebarLabel", this.sidebarLabel.get());
+        params.put("survey", this.surveyID.get());
+        params.put("emergencyContact", this.emergencyContact.get());
+        params.put(ClinicsServlet.DESCRIPTION_FIELD, this.description.get());
+        params.put(ClinicsServlet.PRIMARY_TYPE_FIELD, "cards:ClinicMapping");
         if (this.tokenLifetime.get() != null) {
             params.put("tokenLifetime", this.tokenLifetime.get());
         }

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ClinicsServlet.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ClinicsServlet.java
@@ -155,7 +155,7 @@ public class ClinicsServlet extends SlingAllMethodsServlet
         this.surveyID.set(request.getParameter("survey"));
         this.emergencyContact.set(request.getParameter("emergencyContact"));
         String tokenLifetimeParam =
-            StringUtils.defaultString(request.getParameter("nbOfDaysRelativeToEventToCompleteSurvey"), "");
+            StringUtils.defaultString(request.getParameter("daysRelativeToEventWhileSurveyIsValid"), "");
         if (StringUtils.isNotBlank(tokenLifetimeParam)) {
             this.tokenLifetime.set(Double.valueOf(tokenLifetimeParam));
         }
@@ -252,7 +252,7 @@ public class ClinicsServlet extends SlingAllMethodsServlet
         params.put(ClinicsServlet.DESCRIPTION_FIELD, this.description.get());
         params.put(ClinicsServlet.PRIMARY_TYPE_FIELD, "cards:ClinicMapping");
         if (this.tokenLifetime.get() != null) {
-            params.put("nbOfDaysRelativeToEventToCompleteSurvey", this.tokenLifetime.get());
+            params.put("daysRelativeToEventWhileSurveyIsValid", this.tokenLifetime.get());
         }
         resolver.create(parentResource, this.idHash.get(), params);
     }

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ClinicsServlet.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ClinicsServlet.java
@@ -38,6 +38,7 @@ import javax.json.Json;
 import javax.json.stream.JsonGenerator;
 import javax.servlet.Servlet;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.user.Group;
 import org.apache.jackrabbit.api.security.user.UserManager;
@@ -152,7 +153,10 @@ public class ClinicsServlet extends SlingAllMethodsServlet
         this.sidebarLabel.set(request.getParameter("sidebarLabel"));
         this.surveyID.set(request.getParameter("survey"));
         this.emergencyContact.set(request.getParameter("emergencyContact"));
-        this.tokenLifetime.set(Double.parseDouble(request.getParameter("tokenLifetime")));
+        String tokenLifetimeParam = StringUtils.defaultString(request.getParameter("tokenLifetime"), "");
+        if (StringUtils.isNotBlank(tokenLifetimeParam)) {
+            this.tokenLifetime.set(Double.valueOf(tokenLifetimeParam));
+        }
         this.description.set(request.getParameter("description"));
         this.idHash.set(Integer.toString(this.clinicName.get().hashCode()));
         return true;
@@ -237,15 +241,18 @@ public class ClinicsServlet extends SlingAllMethodsServlet
     {
         final Resource parentResource = resolver.getResource("/Survey/ClinicMapping");
 
-        resolver.create(parentResource, this.idHash.get(), Map.of(
+        Map<String, Object> params = Map.of(
             "clinicName", this.clinicName.get(),
             "displayName", this.displayName.get(),
             "sidebarLabel", this.sidebarLabel.get(),
             "survey", this.surveyID.get(),
             "emergencyContact", this.emergencyContact.get(),
-            "tokenLifetime", this.tokenLifetime.get(),
             ClinicsServlet.DESCRIPTION_FIELD, this.description.get(),
-            ClinicsServlet.PRIMARY_TYPE_FIELD, "cards:ClinicMapping"));
+            ClinicsServlet.PRIMARY_TYPE_FIELD, "cards:ClinicMapping");
+        if (this.tokenLifetime.get() != null) {
+            params.put("tokenLifetime", this.tokenLifetime.get());
+        }
+        resolver.create(parentResource, this.idHash.get(), params);
     }
 
     /**

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ClinicsServlet.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ClinicsServlet.java
@@ -154,7 +154,7 @@ public class ClinicsServlet extends SlingAllMethodsServlet
         this.sidebarLabel.set(request.getParameter("sidebarLabel"));
         this.surveyID.set(request.getParameter("survey"));
         this.emergencyContact.set(request.getParameter("emergencyContact"));
-        String tokenLifetimeParam = StringUtils.defaultString(request.getParameter("tokenLifetime"), "");
+        String tokenLifetimeParam = StringUtils.defaultString(request.getParameter("allowedPostVisitCompletionTime"), "");
         if (StringUtils.isNotBlank(tokenLifetimeParam)) {
             this.tokenLifetime.set(Double.valueOf(tokenLifetimeParam));
         }
@@ -251,7 +251,7 @@ public class ClinicsServlet extends SlingAllMethodsServlet
         params.put(ClinicsServlet.DESCRIPTION_FIELD, this.description.get());
         params.put(ClinicsServlet.PRIMARY_TYPE_FIELD, "cards:ClinicMapping");
         if (this.tokenLifetime.get() != null) {
-            params.put("tokenLifetime", this.tokenLifetime.get());
+            params.put("allowedPostVisitCompletionTime", this.tokenLifetime.get());
         }
         resolver.create(parentResource, this.idHash.get(), params);
     }

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ValidateCredentialsServlet.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ValidateCredentialsServlet.java
@@ -62,7 +62,6 @@ import io.uhndata.cards.auth.token.TokenManager;
 import io.uhndata.cards.forms.api.FormUtils;
 import io.uhndata.cards.forms.api.QuestionnaireUtils;
 import io.uhndata.cards.patients.api.PatientAccessConfiguration;
-import io.uhndata.cards.patients.emailnotifications.AppointmentUtils;
 import io.uhndata.cards.subjects.api.SubjectTypeUtils;
 import io.uhndata.cards.subjects.api.SubjectUtils;
 
@@ -408,13 +407,8 @@ public class ValidateCredentialsServlet extends SlingAllMethodsServlet
             "time", p -> {
                 try {
                     Calendar limit = (Calendar) p.getDate().clone();
-                    final int defaultTokenLifetime =
-                        this.patientAccessConfiguration.getAllowedPostVisitCompletionTime();
-                    Node visitSubject = this.formUtils.getSubject(visitInformationForm, "/SubjectTypes/Patient/Visit");
-                    final int tokenLifetime = AppointmentUtils.getTokenLifetime(
-                        this.formUtils,
-                        visitSubject,
-                        defaultTokenLifetime);
+                    final int tokenLifetime =
+                        this.patientAccessConfiguration.getAllowedPostVisitCompletionTime(visitInformationForm);
                     limit.add(Calendar.DATE, tokenLifetime);
                     atMidnight(limit);
                     return Calendar.getInstance().before(limit);

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ValidateCredentialsServlet.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ValidateCredentialsServlet.java
@@ -62,6 +62,7 @@ import io.uhndata.cards.auth.token.TokenManager;
 import io.uhndata.cards.forms.api.FormUtils;
 import io.uhndata.cards.forms.api.QuestionnaireUtils;
 import io.uhndata.cards.patients.api.PatientAccessConfiguration;
+import io.uhndata.cards.patients.emailnotifications.AppointmentUtils;
 import io.uhndata.cards.subjects.api.SubjectTypeUtils;
 import io.uhndata.cards.subjects.api.SubjectUtils;
 
@@ -407,7 +408,16 @@ public class ValidateCredentialsServlet extends SlingAllMethodsServlet
             "time", p -> {
                 try {
                     Calendar limit = (Calendar) p.getDate().clone();
-                    limit.add(Calendar.DATE, this.patientAccessConfiguration.getAllowedPostVisitCompletionTime());
+                    final int postVisitCompletionTime =
+                        this.patientAccessConfiguration.getAllowedPostVisitCompletionTime();
+                    Node visitSubject = this.formUtils.getSubject(visitInformationForm, "/SubjectTypes/Patient/Visit");
+                    final int tokenLifetime = AppointmentUtils.getTokenLifetime(
+                        this.formUtils,
+                        visitSubject,
+                        "/Questionnaires/Visit information/surveys",
+                        "tokenLifetime",
+                        postVisitCompletionTime);
+                    limit.add(Calendar.DATE, tokenLifetime);
                     atMidnight(limit);
                     return Calendar.getInstance().before(limit);
                 } catch (RepositoryException e) {

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ValidateCredentialsServlet.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ValidateCredentialsServlet.java
@@ -414,8 +414,7 @@ public class ValidateCredentialsServlet extends SlingAllMethodsServlet
                     final int tokenLifetime = AppointmentUtils.getTokenLifetime(
                         this.formUtils,
                         visitSubject,
-                        "/Questionnaires/Visit information/surveys",
-                        "tokenLifetime",
+                        "/Questionnaires/Visit information/clinic",
                         postVisitCompletionTime);
                     limit.add(Calendar.DATE, tokenLifetime);
                     atMidnight(limit);

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ValidateCredentialsServlet.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ValidateCredentialsServlet.java
@@ -408,14 +408,13 @@ public class ValidateCredentialsServlet extends SlingAllMethodsServlet
             "time", p -> {
                 try {
                     Calendar limit = (Calendar) p.getDate().clone();
-                    final int postVisitCompletionTime =
+                    final int defaultTokenLifetime =
                         this.patientAccessConfiguration.getAllowedPostVisitCompletionTime();
                     Node visitSubject = this.formUtils.getSubject(visitInformationForm, "/SubjectTypes/Patient/Visit");
                     final int tokenLifetime = AppointmentUtils.getTokenLifetime(
                         this.formUtils,
                         visitSubject,
-                        "/Questionnaires/Visit information/clinic",
-                        postVisitCompletionTime);
+                        defaultTokenLifetime);
                     limit.add(Calendar.DATE, tokenLifetime);
                     atMidnight(limit);
                     return Calendar.getInstance().before(limit);

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ValidateCredentialsServlet.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/ValidateCredentialsServlet.java
@@ -408,7 +408,7 @@ public class ValidateCredentialsServlet extends SlingAllMethodsServlet
                 try {
                     Calendar limit = (Calendar) p.getDate().clone();
                     final int tokenLifetime =
-                        this.patientAccessConfiguration.getAllowedPostVisitCompletionTime(visitInformationForm);
+                        this.patientAccessConfiguration.getDaysRelativeToEventWhileSurveyIsValid(visitInformationForm);
                     limit.add(Calendar.DATE, tokenLifetime);
                     atMidnight(limit);
                     return Calendar.getInstance().before(limit);

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/api/PatientAccessConfiguration.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/api/PatientAccessConfiguration.java
@@ -50,17 +50,17 @@ public interface PatientAccessConfiguration
      *
      * @return A number of days
      */
-    int getDefaultAllowedPostVisitCompletionTime();
+    int getAllowedPostVisitCompletionTime();
 
     /**
      * Returns the token lifetime associated with the clinic linked to the Subject
      * related to the visitInformationNode Resource or default if it cannot be found.
      *
-     * @param visitInformationNode the JCR visit Information Node
+     * @param visitInformationForm the JCR Visit Information Node
      *
      * @return A number of days
      */
-    int getAllowedPostVisitCompletionTime(Node visitInformationNode);
+    int getAllowedPostVisitCompletionTime(Node visitInformationForm);
 
     /**
      * Get the configured amount of time, in days, that patient's draft responses are kept in the database and the

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/api/PatientAccessConfiguration.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/api/PatientAccessConfiguration.java
@@ -18,6 +18,8 @@
  */
 package io.uhndata.cards.patients.api;
 
+import javax.jcr.Node;
+
 /**
  * Configuration for how the patient can access the patient-facing UI.
  *
@@ -48,7 +50,17 @@ public interface PatientAccessConfiguration
      *
      * @return A number of days
      */
-    int getAllowedPostVisitCompletionTime();
+    int getDefaultAllowedPostVisitCompletionTime();
+
+    /**
+     * Returns the token lifetime associated with the clinic linked to the Subject
+     * related to the visitInformationNode Resource or default if it cannot be found.
+     *
+     * @param visitInformationNode the JCR visit Information Node
+     *
+     * @return A number of days
+     */
+    int getAllowedPostVisitCompletionTime(Node visitInformationNode);
 
     /**
      * Get the configured amount of time, in days, that patient's draft responses are kept in the database and the

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/api/PatientAccessConfiguration.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/api/PatientAccessConfiguration.java
@@ -50,7 +50,7 @@ public interface PatientAccessConfiguration
      *
      * @return A number of days
      */
-    int getAllowedPostVisitCompletionTime();
+    int getDaysRelativeToEventWhileSurveyIsValid();
 
     /**
      * Returns the token lifetime associated with the clinic linked to the Subject
@@ -60,7 +60,7 @@ public interface PatientAccessConfiguration
      *
      * @return A number of days
      */
-    int getAllowedPostVisitCompletionTime(Node visitInformationForm);
+    int getDaysRelativeToEventWhileSurveyIsValid(Node visitInformationForm);
 
     /**
      * Get the configured amount of time, in days, that patient's draft responses are kept in the database and the

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
@@ -167,7 +167,8 @@ abstract class AbstractEmailNotification
         String patientFullName = AppointmentUtils.getPatientFullName(this.formUtils, patientSubject);
         Calendar visitDate = (Calendar) this.formUtils.getValue(appointmentDate);
         Calendar tokenExpiryDate = (Calendar) visitDate.clone();
-        final int tokenLifetime = this.patientAccessConfiguration.getAllowedPostVisitCompletionTime(appointmentForm);
+        final int tokenLifetime =
+            this.patientAccessConfiguration.getDaysRelativeToEventWhileSurveyIsValid(appointmentForm);
         tokenExpiryDate.add(Calendar.DATE, tokenLifetime);
         atMidnight(tokenExpiryDate);
         final String token = this.tokenManager.create(

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
@@ -126,7 +126,8 @@ abstract class AbstractEmailNotification
                 Node patientSubject = this.formUtils.getSubject(appointmentForm, "/SubjectTypes/Patient");
 
                 try {
-                    Email email = renderTemplate(template, appointmentDate, visitSubject, patientSubject, session);
+                    Email email = renderTemplate(template, appointmentDate, appointmentForm, visitSubject,
+                        patientSubject, session);
                     if (email == null) {
                         continue;
                     }
@@ -152,7 +153,7 @@ abstract class AbstractEmailNotification
 
     protected abstract String getNotificationType();
 
-    private Email renderTemplate(final EmailTemplate template, final Node appointmentDate,
+    private Email renderTemplate(final EmailTemplate template, final Node appointmentDate, final Node appointmentForm,
         final Node visitSubject, final Node patientSubject, final Session session) throws RepositoryException
     {
         String patientEmailAddress =
@@ -164,11 +165,7 @@ abstract class AbstractEmailNotification
         String patientFullName = AppointmentUtils.getPatientFullName(this.formUtils, patientSubject);
         Calendar visitDate = (Calendar) this.formUtils.getValue(appointmentDate);
         Calendar tokenExpiryDate = (Calendar) visitDate.clone();
-        final int defaultTokenLifetime = this.patientAccessConfiguration.getAllowedPostVisitCompletionTime();
-        final int tokenLifetime = AppointmentUtils.getTokenLifetime(
-            this.formUtils,
-            visitSubject,
-            defaultTokenLifetime);
+        final int tokenLifetime = this.patientAccessConfiguration.getAllowedPostVisitCompletionTime(appointmentForm);
         tokenExpiryDate.add(Calendar.DATE, tokenLifetime);
         atMidnight(tokenExpiryDate);
         final String token = this.tokenManager.create(

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
@@ -118,7 +118,7 @@ abstract class AbstractEmailNotification
                 Node appointmentDate = appointmentResults.nextNode();
                 Node appointmentForm = this.formUtils.getForm(appointmentDate);
                 Node visitSubject = this.formUtils.getSubject(appointmentForm, "/SubjectTypes/Patient/Visit");
-                if (appointmentForm == null || AppointmentUtils.getVisitSurveysComplete(this.formUtils, visitSubject)) {
+                if (appointmentForm == null || AppointmentUtils.isVisitSurveyComplete(this.formUtils, visitSubject)) {
                     continue;
                 }
 
@@ -164,12 +164,11 @@ abstract class AbstractEmailNotification
         String patientFullName = AppointmentUtils.getPatientFullName(this.formUtils, patientSubject);
         Calendar visitDate = (Calendar) this.formUtils.getValue(appointmentDate);
         Calendar tokenExpiryDate = (Calendar) visitDate.clone();
-        final int postVisitCompletionTime = this.patientAccessConfiguration.getAllowedPostVisitCompletionTime();
+        final int defaultTokenLifetime = this.patientAccessConfiguration.getAllowedPostVisitCompletionTime();
         final int tokenLifetime = AppointmentUtils.getTokenLifetime(
             this.formUtils,
             visitSubject,
-            "/Questionnaires/Visit information/clinic",
-            postVisitCompletionTime);
+            defaultTokenLifetime);
         tokenExpiryDate.add(Calendar.DATE, tokenLifetime);
         atMidnight(tokenExpiryDate);
         final String token = this.tokenManager.create(

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
@@ -169,7 +169,6 @@ abstract class AbstractEmailNotification
             this.formUtils,
             visitSubject,
             "/Questionnaires/Visit information/clinic",
-            "tokenLifetime",
             postVisitCompletionTime);
         tokenExpiryDate.add(Calendar.DATE, tokenLifetime);
         atMidnight(tokenExpiryDate);

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
@@ -22,7 +22,6 @@ package io.uhndata.cards.patients.emailnotifications;
 import java.text.DateFormat;
 import java.util.Calendar;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -118,10 +117,11 @@ abstract class AbstractEmailNotification
             while (appointmentResults.hasNext()) {
                 Node appointmentDate = appointmentResults.nextNode();
                 Node appointmentForm = this.formUtils.getForm(appointmentDate);
-                if (appointmentForm == null || isSurveyCompleted(appointmentForm, session)) {
+                Node visitSubject = this.formUtils.getSubject(appointmentForm, "/SubjectTypes/Patient/Visit");
+                if (appointmentForm == null || AppointmentUtils.getVisitSurveysComplete(this.formUtils, visitSubject)) {
                     continue;
                 }
-                Node visitSubject = this.formUtils.getSubject(appointmentForm, "/SubjectTypes/Patient/Visit");
+
                 // Get the Patient Subject associated with this appointment Form
                 Node patientSubject = this.formUtils.getSubject(appointmentForm, "/SubjectTypes/Patient");
 
@@ -160,12 +160,18 @@ abstract class AbstractEmailNotification
         if (StringUtils.isBlank(patientEmailAddress)) {
             return null;
         }
+
         String patientFullName = AppointmentUtils.getPatientFullName(this.formUtils, patientSubject);
         Calendar visitDate = (Calendar) this.formUtils.getValue(appointmentDate);
         Calendar tokenExpiryDate = (Calendar) visitDate.clone();
-        tokenExpiryDate.add(
-            Calendar.DATE,
-            this.patientAccessConfiguration.getAllowedPostVisitCompletionTime());
+        final int postVisitCompletionTime = this.patientAccessConfiguration.getAllowedPostVisitCompletionTime();
+        final int tokenLifetime = AppointmentUtils.getTokenLifetime(
+            this.formUtils,
+            visitSubject,
+            "/Questionnaires/Visit information/surveys",
+            "tokenLifetime",
+            postVisitCompletionTime);
+        tokenExpiryDate.add(Calendar.DATE, tokenLifetime);
         atMidnight(tokenExpiryDate);
         final String token = this.tokenManager.create(
             "patient",
@@ -185,18 +191,6 @@ abstract class AbstractEmailNotification
         return template.getEmailBuilderForSubject(visitSubject, valuesMap, this.formUtils)
             .withRecipient(patientEmailAddress, patientFullName)
             .build();
-    }
-
-    private boolean isSurveyCompleted(final Node appointmentForm, final Session session) throws RepositoryException
-    {
-        Node surveysCompleteQuestion = session.getNode("/Questionnaires/Visit information/surveys_complete");
-        // Skip the email if there are no incomplete surveys for the patient
-        return this.formUtils
-            .findAllFormRelatedAnswers(appointmentForm, surveysCompleteQuestion,
-                EnumSet.of(FormUtils.SearchType.FORM))
-            .stream()
-            .map(n -> this.formUtils.getValue(n))
-            .anyMatch(v -> Long.valueOf(1).equals(v));
     }
 
     private void atMidnight(final Calendar c)

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
@@ -168,7 +168,7 @@ abstract class AbstractEmailNotification
         final int tokenLifetime = AppointmentUtils.getTokenLifetime(
             this.formUtils,
             visitSubject,
-            "/Questionnaires/Visit information/surveys",
+            "/Questionnaires/Visit information/clinic",
             "tokenLifetime",
             postVisitCompletionTime);
         tokenExpiryDate.add(Calendar.DATE, tokenLifetime);

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
@@ -117,6 +117,7 @@ abstract class AbstractEmailNotification
             while (appointmentResults.hasNext()) {
                 Node appointmentDate = appointmentResults.nextNode();
                 Node appointmentForm = this.formUtils.getForm(appointmentDate);
+                // This will have to be changed later, since we will have different visit information forms for the same subject
                 Node visitSubject = this.formUtils.getSubject(appointmentForm, "/SubjectTypes/Patient/Visit");
                 if (appointmentForm == null || AppointmentUtils.isVisitSurveyComplete(this.formUtils, visitSubject)) {
                     continue;

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
@@ -117,7 +117,8 @@ abstract class AbstractEmailNotification
             while (appointmentResults.hasNext()) {
                 Node appointmentDate = appointmentResults.nextNode();
                 Node appointmentForm = this.formUtils.getForm(appointmentDate);
-                // This will have to be changed later, since we will have different visit information forms for the same subject
+                // This will have to be changed later,
+                // since we will have different visit information forms for the same subject
                 Node visitSubject = this.formUtils.getSubject(appointmentForm, "/SubjectTypes/Patient/Visit");
                 if (appointmentForm == null || AppointmentUtils.isVisitSurveyComplete(this.formUtils, visitSubject)) {
                     continue;

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentUtils.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentUtils.java
@@ -48,6 +48,8 @@ public final class AppointmentUtils
 
     private static final String TOKEN_LIFETIME = "tokenLifetime";
 
+    private static final String CLINIC_PATH = "/Questionnaires/Visit information/clinic";
+
     // Hide the utility class constructor
     private AppointmentUtils()
     {
@@ -109,7 +111,7 @@ public final class AppointmentUtils
                 "cards:BooleanAnswer",
                 0L);
             Node visitClinic = session.getNode(getQuestionAnswerForSubject(formUtils, visitSubject,
-                "/Questionnaires/Visit information/clinic", TEXT_ANSWER, EMPTY));
+                CLINIC_PATH, TEXT_ANSWER, EMPTY));
 
             if (visitClinic == null) {
                 return null;
@@ -232,14 +234,13 @@ public final class AppointmentUtils
      *
      * @param formUtils form utilities service
      * @param formRelatedSubject the JCR Subject Resource for which the Clinic is associated with
-     * @param clinicIdLink the question linking the Subject to a clinic (eg. /Questionnaires/Visit information/clinic)
      * @param defaultLifetime the default to return
      * @return the token lifetime in days
      */
     public static int getTokenLifetime(FormUtils formUtils, Node formRelatedSubject,
-        String clinicIdLink, int defaultLifetime)
+        int defaultLifetime)
     {
-        Node clinicNode = getValidClinicNode(formUtils, formRelatedSubject, clinicIdLink);
+        Node clinicNode = getValidClinicNode(formUtils, formRelatedSubject, CLINIC_PATH);
         if (clinicNode == null) {
             return defaultLifetime;
         }
@@ -260,7 +261,7 @@ public final class AppointmentUtils
      * @param visitSubject the JCR Resource for the visit whose survey completion status we wish to obtain
      * @return the boolean survey completion status for the visit
      */
-    public static boolean getVisitSurveysComplete(FormUtils formUtils, Node visitSubject)
+    public static boolean isVisitSurveyComplete(FormUtils formUtils, Node visitSubject)
     {
         long isComplete = getQuestionAnswerForSubject(
             formUtils,
@@ -305,7 +306,7 @@ public final class AppointmentUtils
             final String hasSurveysUUID =
                 session.getNode("/Questionnaires/Visit information/has_surveys").getIdentifier();
             final String clinicUUID =
-                session.getNode("/Questionnaires/Visit information/clinic").getIdentifier();
+                session.getNode(CLINIC_PATH).getIdentifier();
             final Calendar lowerBoundDate = (Calendar) dateToQuery.clone();
             lowerBoundDate.set(Calendar.HOUR_OF_DAY, 0);
             lowerBoundDate.set(Calendar.MINUTE, 0);

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentUtils.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentUtils.java
@@ -46,6 +46,8 @@ public final class AppointmentUtils
 
     private static final String EMPTY = "";
 
+    private static final String TOKEN_LIFETIME = "tokenLifetime";
+
     // Hide the utility class constructor
     private AppointmentUtils()
     {
@@ -231,20 +233,19 @@ public final class AppointmentUtils
      * @param formUtils form utilities service
      * @param formRelatedSubject the JCR Subject Resource for which the Clinic is associated with
      * @param clinicIdLink the question linking the Subject to a clinic (eg. /Questionnaires/Visit information/clinic)
-     * @param tokenLifetimeProperty the JCR node property holding the token lifetime (eg. "tokenLifetime")
      * @param defaultLifetime the default to return
      * @return the token lifetime in days
      */
     public static int getTokenLifetime(FormUtils formUtils, Node formRelatedSubject,
-        String clinicIdLink, String tokenLifetimeProperty, int defaultLifetime)
+        String clinicIdLink, int defaultLifetime)
     {
         Node clinicNode = getValidClinicNode(formUtils, formRelatedSubject, clinicIdLink);
         if (clinicNode == null) {
             return defaultLifetime;
         }
         try {
-            if (clinicNode.hasProperty(tokenLifetimeProperty)) {
-                return (int) clinicNode.getProperty(tokenLifetimeProperty).getLong();
+            if (clinicNode.hasProperty(TOKEN_LIFETIME)) {
+                return (int) clinicNode.getProperty(TOKEN_LIFETIME).getLong();
             }
         } catch (RepositoryException e) {
             // TODO Auto-generated catch block

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentUtils.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentUtils.java
@@ -202,7 +202,7 @@ public final class AppointmentUtils
      *
      * @param formUtils form utilities service
      * @param formRelatedSubject the JCR Subject Resource for which the Clinic is associated with
-     * @param clinicIdLink the question linking the Subject to a clinic (eg. /Questionnaires/Visit information/surveys)
+     * @param clinicIdLink the question linking the Subject to a clinic (eg. /Questionnaires/Visit information/clinic)
      * @param clinicEmailProperty the JCR node property holding the email address (eg. "emergencyContact")
      * @return the contact email address associated with a subject
      */
@@ -230,7 +230,7 @@ public final class AppointmentUtils
      *
      * @param formUtils form utilities service
      * @param formRelatedSubject the JCR Subject Resource for which the Clinic is associated with
-     * @param clinicIdLink the question linking the Subject to a clinic (eg. /Questionnaires/Visit information/surveys)
+     * @param clinicIdLink the question linking the Subject to a clinic (eg. /Questionnaires/Visit information/clinic)
      * @param tokenLifetimeProperty the JCR node property holding the token lifetime (eg. "tokenLifetime")
      * @param defaultLifetime the default to return
      * @return the token lifetime in days

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentUtils.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentUtils.java
@@ -35,9 +35,11 @@ import org.slf4j.LoggerFactory;
 
 import io.uhndata.cards.forms.api.FormUtils;
 
-@SuppressWarnings("MultipleStringLiterals")
 public final class AppointmentUtils
 {
+    /** Clinic ID Link. */
+    public static final String CLINIC_PATH = "/Questionnaires/Visit information/clinic";
+
     /** Default log. */
     private static final Logger LOGGER = LoggerFactory.getLogger(AppointmentUtils.class);
 
@@ -45,10 +47,6 @@ public final class AppointmentUtils
     private static final String TEXT_ANSWER = "cards:TextAnswer";
 
     private static final String EMPTY = "";
-
-    private static final String TOKEN_LIFETIME = "tokenLifetime";
-
-    private static final String CLINIC_PATH = "/Questionnaires/Visit information/clinic";
 
     // Hide the utility class constructor
     private AppointmentUtils()
@@ -226,32 +224,6 @@ public final class AppointmentUtils
             // TODO Auto-generated catch block
         }
         return null;
-    }
-
-    /**
-     * Returns the token lifetime associated (through the clinicEmailProperty String) with the clinic linked to the
-     * formRelatedSubject Resource or default if it cannot be found.
-     *
-     * @param formUtils form utilities service
-     * @param formRelatedSubject the JCR Subject Resource for which the Clinic is associated with
-     * @param defaultLifetime the default to return
-     * @return the token lifetime in days
-     */
-    public static int getTokenLifetime(FormUtils formUtils, Node formRelatedSubject,
-        int defaultLifetime)
-    {
-        Node clinicNode = getValidClinicNode(formUtils, formRelatedSubject, CLINIC_PATH);
-        if (clinicNode == null) {
-            return defaultLifetime;
-        }
-        try {
-            if (clinicNode.hasProperty(TOKEN_LIFETIME)) {
-                return (int) clinicNode.getProperty(TOKEN_LIFETIME).getLong();
-            }
-        } catch (RepositoryException e) {
-            // TODO Auto-generated catch block
-        }
-        return defaultLifetime;
     }
 
     /**

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentUtils.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentUtils.java
@@ -173,16 +173,14 @@ public final class AppointmentUtils
      *
      * @param formUtils form utilities service
      * @param formRelatedSubject the JCR Subject Resource for which the Clinic is associated with
-     * @param clinicIdLink the question linking the Subject to a clinic (eg. /Questionnaires/Visit information/surveys)
      * @return the associated cards:QuestionnaireSet JCR Resource or null
      */
-    public static Node getValidClinicNode(FormUtils formUtils, Node formRelatedSubject,
-        String clinicIdLink)
+    public static Node getValidClinicNode(FormUtils formUtils, Node formRelatedSubject)
     {
         String clinicNodePath = getQuestionAnswerForSubject(
             formUtils,
             formRelatedSubject,
-            clinicIdLink,
+            CLINIC_PATH,
             TEXT_ANSWER,
             EMPTY);
 
@@ -204,14 +202,13 @@ public final class AppointmentUtils
      *
      * @param formUtils form utilities service
      * @param formRelatedSubject the JCR Subject Resource for which the Clinic is associated with
-     * @param clinicIdLink the question linking the Subject to a clinic (eg. /Questionnaires/Visit information/clinic)
      * @param clinicEmailProperty the JCR node property holding the email address (eg. "emergencyContact")
      * @return the contact email address associated with a subject
      */
     public static String getValidClinicEmail(FormUtils formUtils, Node formRelatedSubject,
-        String clinicIdLink, String clinicEmailProperty)
+        String clinicEmailProperty)
     {
-        Node clinicNode = getValidClinicNode(formUtils, formRelatedSubject, clinicIdLink);
+        Node clinicNode = getValidClinicNode(formUtils, formRelatedSubject);
         if (clinicNode == null) {
             return null;
         }

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentUtils.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentUtils.java
@@ -166,38 +166,16 @@ public final class AppointmentUtils
     }
 
     /**
-     * Gets the clinic name associated with a Visit Subject Resource, or null if the clinic name cannot be found.
-     *
-     * @param formUtils form utilities service
-     * @param visitSubject the JCR Resource for the visit whose clinic name we wish to obtain
-     * @return the clinic name associated with the Visit or null
-     */
-    public static String getVisitClinic(FormUtils formUtils, Node visitSubject)
-    {
-        String clinicId = getQuestionAnswerForSubject(
-            formUtils,
-            visitSubject,
-            "/Questionnaires/Visit information/surveys",
-            TEXT_ANSWER,
-            EMPTY);
-        if (EMPTY.equals(clinicId)) {
-            return null;
-        }
-        return clinicId;
-    }
-
-    /**
      * Returns the cards:QuestionnaireSet JCR Resource associated with the formRelatedSubject or null if no such
      * associated Resource can be found.
      *
      * @param formUtils form utilities service
      * @param formRelatedSubject the JCR Subject Resource for which the Clinic is associated with
      * @param clinicIdLink the question linking the Subject to a clinic (eg. /Questionnaires/Visit information/surveys)
-     * @param clinicsJcrPath the JCR path for information on the clinics (eg. /Survey)
      * @return the associated cards:QuestionnaireSet JCR Resource or null
      */
     public static Node getValidClinicNode(FormUtils formUtils, Node formRelatedSubject,
-        String clinicIdLink, String clinicsJcrPath)
+        String clinicIdLink)
     {
         String clinicNodePath = getQuestionAnswerForSubject(
             formUtils,
@@ -225,14 +203,13 @@ public final class AppointmentUtils
      * @param formUtils form utilities service
      * @param formRelatedSubject the JCR Subject Resource for which the Clinic is associated with
      * @param clinicIdLink the question linking the Subject to a clinic (eg. /Questionnaires/Visit information/surveys)
-     * @param clinicsJcrPath clinicsJcrPath the JCR path for information on the clinics (eg. /Survey)
      * @param clinicEmailProperty the JCR node property holding the email address (eg. "emergencyContact")
      * @return the contact email address associated with a subject
      */
     public static String getValidClinicEmail(FormUtils formUtils, Node formRelatedSubject,
-        String clinicIdLink, String clinicsJcrPath, String clinicEmailProperty)
+        String clinicIdLink, String clinicEmailProperty)
     {
-        Node clinicNode = getValidClinicNode(formUtils, formRelatedSubject, clinicIdLink, clinicsJcrPath);
+        Node clinicNode = getValidClinicNode(formUtils, formRelatedSubject, clinicIdLink);
         if (clinicNode == null) {
             return null;
         }
@@ -245,6 +222,34 @@ public final class AppointmentUtils
             // TODO Auto-generated catch block
         }
         return null;
+    }
+
+    /**
+     * Returns the token lifetime associated (through the clinicEmailProperty String) with the clinic linked to the
+     * formRelatedSubject Resource or default if it cannot be found.
+     *
+     * @param formUtils form utilities service
+     * @param formRelatedSubject the JCR Subject Resource for which the Clinic is associated with
+     * @param clinicIdLink the question linking the Subject to a clinic (eg. /Questionnaires/Visit information/surveys)
+     * @param tokenLifetimeProperty the JCR node property holding the token lifetime (eg. "tokenLifetime")
+     * @param defaultLifetime the default to return
+     * @return the token lifetime in days
+     */
+    public static int getTokenLifetime(FormUtils formUtils, Node formRelatedSubject,
+        String clinicIdLink, String tokenLifetimeProperty, int defaultLifetime)
+    {
+        Node clinicNode = getValidClinicNode(formUtils, formRelatedSubject, clinicIdLink);
+        if (clinicNode == null) {
+            return defaultLifetime;
+        }
+        try {
+            if (clinicNode.hasProperty(tokenLifetimeProperty)) {
+                return (int) clinicNode.getProperty(tokenLifetimeProperty).getLong();
+            }
+        } catch (RepositoryException e) {
+            // TODO Auto-generated catch block
+        }
+        return defaultLifetime;
     }
 
     /**

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/EmailAlertEventListener.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/EmailAlertEventListener.java
@@ -64,8 +64,6 @@ public final class EmailAlertEventListener implements EventListener
 
     private String clinicIdLink;
 
-    private String clinicsJcrPath;
-
     private String clinicEmailProperty;
 
     private String emailFromAddress;
@@ -86,7 +84,6 @@ public final class EmailAlertEventListener implements EventListener
         this.triggerOperand = listenerParams.get("triggerOperand");
         this.alertDescription = listenerParams.get("alertDescription");
         this.clinicIdLink = listenerParams.get("clinicIdLink");
-        this.clinicsJcrPath = listenerParams.get("clinicsJcrPath");
         this.clinicEmailProperty = listenerParams.get("clinicEmailProperty");
         this.emailFromAddress = listenerParams.get("emailFromAddress");
 
@@ -150,7 +147,7 @@ public final class EmailAlertEventListener implements EventListener
                  * associated with this visit.
                  */
                 String clinicAlertEmail = AppointmentUtils.getValidClinicEmail(this.formUtils,
-                    formRelatedSubject, this.clinicIdLink, this.clinicsJcrPath, this.clinicEmailProperty);
+                    formRelatedSubject, this.clinicIdLink, this.clinicEmailProperty);
                 if (clinicAlertEmail == null) {
                     continue;
                 }

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/EmailAlertEventListener.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/EmailAlertEventListener.java
@@ -62,8 +62,6 @@ public final class EmailAlertEventListener implements EventListener
 
     private String alertDescription;
 
-    private String clinicIdLink;
-
     private String clinicEmailProperty;
 
     private String emailFromAddress;
@@ -83,7 +81,6 @@ public final class EmailAlertEventListener implements EventListener
         this.triggerOperator = listenerParams.get("triggerOperator");
         this.triggerOperand = listenerParams.get("triggerOperand");
         this.alertDescription = listenerParams.get("alertDescription");
-        this.clinicIdLink = listenerParams.get("clinicIdLink");
         this.clinicEmailProperty = listenerParams.get("clinicEmailProperty");
         this.emailFromAddress = listenerParams.get("emailFromAddress");
 
@@ -147,7 +144,7 @@ public final class EmailAlertEventListener implements EventListener
                  * associated with this visit.
                  */
                 String clinicAlertEmail = AppointmentUtils.getValidClinicEmail(this.formUtils,
-                    formRelatedSubject, this.clinicIdLink, this.clinicEmailProperty);
+                    formRelatedSubject, this.clinicEmailProperty);
                 if (clinicAlertEmail == null) {
                     continue;
                 }

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/PatientAccessConfigurationImpl.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/PatientAccessConfigurationImpl.java
@@ -54,10 +54,10 @@ public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements
     private static final String PATIENT_IDENTIFICATION_REQUIRED_PROP = "PIIAuthRequired";
 
     /** Default property on config node for the number of days a token is valid for. */
-    private static final String DEFAULT_TOKEN_LIFETIME_PROP = "nbOfDaysRelativeToEventToCompleteSurvey";
+    private static final String DEFAULT_TOKEN_LIFETIME_PROP = "daysRelativeToEventWhileSurveyIsValid";
 
     /** Clinic property for the number of days a token is valid for. */
-    private static final String TOKEN_LIFETIME_PROP = "nbOfDaysRelativeToEventToCompleteSurvey";
+    private static final String TOKEN_LIFETIME_PROP = "daysRelativeToEventWhileSurveyIsValid";
 
     /** Property on config node for the number of days draft responses from patients are kept. */
     private static final String DRAFT_LIFETIME_PROP = "draftLifetime";
@@ -129,7 +129,7 @@ public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements
     }
 
     @Override
-    public int getAllowedPostVisitCompletionTime()
+    public int getDaysRelativeToEventWhileSurveyIsValid()
     {
         try
         {
@@ -141,9 +141,9 @@ public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements
     }
 
     @Override
-    public int getAllowedPostVisitCompletionTime(Node visitInformationNode)
+    public int getDaysRelativeToEventWhileSurveyIsValid(Node visitInformationNode)
     {
-        final int defaultTokenLifetime = getAllowedPostVisitCompletionTime();
+        final int defaultTokenLifetime = getDaysRelativeToEventWhileSurveyIsValid();
         try
         {
             Node visitSubject = this.formUtils.getSubject(visitInformationNode, "/SubjectTypes/Patient/Visit");

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/PatientAccessConfigurationImpl.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/PatientAccessConfigurationImpl.java
@@ -54,10 +54,10 @@ public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements
     private static final String PATIENT_IDENTIFICATION_REQUIRED_PROP = "PIIAuthRequired";
 
     /** Default property on config node for the number of days a token is valid for. */
-    private static final String DEFAULT_TOKEN_LIFETIME_PROP = "allowedPostVisitCompletionTime";
+    private static final String DEFAULT_TOKEN_LIFETIME_PROP = "nbOfDaysRelativeToEventToCompleteSurvey";
 
     /** Clinic property for the number of days a token is valid for. */
-    private static final String TOKEN_LIFETIME_PROP = "allowedPostVisitCompletionTime";
+    private static final String TOKEN_LIFETIME_PROP = "nbOfDaysRelativeToEventToCompleteSurvey";
 
     /** Property on config node for the number of days draft responses from patients are kept. */
     private static final String DRAFT_LIFETIME_PROP = "draftLifetime";

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/PatientAccessConfigurationImpl.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/PatientAccessConfigurationImpl.java
@@ -57,7 +57,7 @@ public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements
     private static final String DEFAULT_TOKEN_LIFETIME_PROP = "allowedPostVisitCompletionTime";
 
     /** Clinic property for the number of days a token is valid for. */
-    private static final String TOKEN_LIFETIME_PROP = "tokenLifetime";
+    private static final String TOKEN_LIFETIME_PROP = "allowedPostVisitCompletionTime";
 
     /** Property on config node for the number of days draft responses from patients are kept. */
     private static final String DRAFT_LIFETIME_PROP = "draftLifetime";

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/PatientAccessConfigurationImpl.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/PatientAccessConfigurationImpl.java
@@ -129,7 +129,7 @@ public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements
     }
 
     @Override
-    public int getDefaultAllowedPostVisitCompletionTime()
+    public int getAllowedPostVisitCompletionTime()
     {
         try
         {
@@ -143,12 +143,11 @@ public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements
     @Override
     public int getAllowedPostVisitCompletionTime(Node visitInformationNode)
     {
-        final int defaultTokenLifetime = getDefaultAllowedPostVisitCompletionTime();
+        final int defaultTokenLifetime = getAllowedPostVisitCompletionTime();
         try
         {
             Node visitSubject = this.formUtils.getSubject(visitInformationNode, "/SubjectTypes/Patient/Visit");
-            Node clinicNode = AppointmentUtils.getValidClinicNode(this.formUtils, visitSubject,
-                AppointmentUtils.CLINIC_PATH);
+            Node clinicNode = AppointmentUtils.getValidClinicNode(this.formUtils, visitSubject);
 
             if (clinicNode != null && clinicNode.hasProperty(TOKEN_LIFETIME_PROP)) {
                 return (int) clinicNode.getProperty(TOKEN_LIFETIME_PROP).getLong();

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
@@ -88,7 +88,7 @@ public class UnsubmittedFormsCleanupTask implements Runnable
                 (String) resolver.getResource("/Questionnaires/Visit information/time").getValueMap().get("jcr:uuid");
             final String submitted = (String) resolver
                 .getResource("/Questionnaires/Visit information/surveys_submitted").getValueMap().get("jcr:uuid");
-            final int patientTokenLifetime = this.patientAccessConfiguration.getDefaultAllowedPostVisitCompletionTime();
+            final int patientTokenLifetime = this.patientAccessConfiguration.getAllowedPostVisitCompletionTime();
 
             // Find all clinics to iterate over
             final Iterator<Resource> results = resolver.findResources(

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
@@ -88,7 +88,7 @@ public class UnsubmittedFormsCleanupTask implements Runnable
                 (String) resolver.getResource("/Questionnaires/Visit information/time").getValueMap().get("jcr:uuid");
             final String submitted = (String) resolver
                 .getResource("/Questionnaires/Visit information/surveys_submitted").getValueMap().get("jcr:uuid");
-            final int patientTokenLifetime = this.patientAccessConfiguration.getAllowedPostVisitCompletionTime();
+            final int patientTokenLifetime = this.patientAccessConfiguration.getDaysRelativeToEventWhileSurveyIsValid();
 
             // Find all clinics to iterate over
             final Iterator<Resource> results = resolver.findResources(
@@ -99,8 +99,8 @@ public class UnsubmittedFormsCleanupTask implements Runnable
                 final String clinicPath = clinicNode.getPath();
                 // Get clinic token lifetime or default to the global patient token lifetime
                 int delay = patientTokenLifetime;
-                if (clinicNode.hasProperty("nbOfDaysRelativeToEventToCompleteSurvey")) {
-                    delay = (int) clinicNode.getProperty("nbOfDaysRelativeToEventToCompleteSurvey").getLong();
+                if (clinicNode.hasProperty("daysRelativeToEventWhileSurveyIsValid")) {
+                    delay = (int) clinicNode.getProperty("daysRelativeToEventWhileSurveyIsValid").getLong();
                 }
 
                 // Get all data forms for the specific clinic

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
@@ -99,8 +99,8 @@ public class UnsubmittedFormsCleanupTask implements Runnable
                 final String clinicPath = clinicNode.getPath();
                 // Get clinic token lifetime or default to the global patient token lifetime
                 int delay = patientTokenLifetime;
-                if (clinicNode.hasProperty("allowedPostVisitCompletionTime")) {
-                    delay = (int) clinicNode.getProperty("allowedPostVisitCompletionTime").getLong();
+                if (clinicNode.hasProperty("nbOfDaysRelativeToEventToCompleteSurvey")) {
+                    delay = (int) clinicNode.getProperty("nbOfDaysRelativeToEventToCompleteSurvey").getLong();
                 }
 
                 // Get all data forms for the specific clinic

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
@@ -110,14 +110,17 @@ public class UnsubmittedFormsCleanupTask implements Runnable
                         + "  from [cards:Form] as dataForm"
                         // belonging to a visit
                         + "  inner join [cards:Form] as visitInformation on visitInformation.subject = dataForm.subject"
-                        + " inner join [cards:DateAnswer] as visitDate on visitDate.form = visitInformation.[jcr:uuid]"
+                        + "    inner join [cards:ResourceAnswer] as clinic"
+                        + "       on clinic.form = visitInformation.[jcr:uuid]"
+                        + "    inner join [cards:DateAnswer] as visitDate"
+                        + "       on visitDate.form=visitInformation.[jcr:uuid]"
                         + "    inner join [cards:BooleanAnswer] as submitted"
                         + "      on submitted.form = visitInformation.[jcr:uuid]"
                         + " where"
                         // link to the correct Visit Information questionnaire
                         + "  visitInformation.questionnaire = '%1$s'"
                         // link to the exact clinic in Visit Information form
-                        + "  and visitInformation.clinic = '%5$s'"
+                        + "  and clinic.value = '%5$s'"
                         // the visit date is in the past
                         + "  and visitDate.question = '%2$s'"
                         + "  and visitDate.value < '%4$s'"

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
@@ -99,8 +99,8 @@ public class UnsubmittedFormsCleanupTask implements Runnable
                 final String clinicPath = clinicNode.getPath();
                 // Get clinic token lifetime or default to the global patient token lifetime
                 int delay = patientTokenLifetime;
-                if (clinicNode.hasProperty("tokenLifetime")) {
-                    delay = (int) clinicNode.getProperty("tokenLifetime").getLong();
+                if (clinicNode.hasProperty("allowedPostVisitCompletionTime")) {
+                    delay = (int) clinicNode.getProperty("allowedPostVisitCompletionTime").getLong();
                 }
 
                 // Get all data forms for the specific clinic

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
@@ -88,7 +88,7 @@ public class UnsubmittedFormsCleanupTask implements Runnable
                 (String) resolver.getResource("/Questionnaires/Visit information/time").getValueMap().get("jcr:uuid");
             final String submitted = (String) resolver
                 .getResource("/Questionnaires/Visit information/surveys_submitted").getValueMap().get("jcr:uuid");
-            final int patientTokenLifetime = this.patientAccessConfiguration.getAllowedPostVisitCompletionTime();
+            final int patientTokenLifetime = this.patientAccessConfiguration.getDefaultAllowedPostVisitCompletionTime();
 
             // Find all clinics to iterate over
             final Iterator<Resource> results = resolver.findResources(

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
@@ -24,6 +24,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.Map;
 
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
 import javax.jcr.query.Query;
 
 import org.apache.sling.api.resource.LoginException;
@@ -86,42 +88,60 @@ public class UnsubmittedFormsCleanupTask implements Runnable
                 (String) resolver.getResource("/Questionnaires/Visit information/time").getValueMap().get("jcr:uuid");
             final String submitted = (String) resolver
                 .getResource("/Questionnaires/Visit information/surveys_submitted").getValueMap().get("jcr:uuid");
-            final int delay = this.patientAccessConfiguration.getAllowedPostVisitCompletionTime();
-            // Query:
-            final Iterator<Resource> resources = resolver.findResources(String.format(
-                // select the data forms
-                "select distinct dataForm.*"
-                    + "  from [cards:Form] as dataForm"
-                    // belonging to a visit
-                    + "  inner join [cards:Form] as visitInformation on visitInformation.subject = dataForm.subject"
-                    + "    inner join [cards:DateAnswer] as visitDate on visitDate.form = visitInformation.[jcr:uuid]"
-                    + "    inner join [cards:BooleanAnswer] as submitted"
-                    + "      on submitted.form = visitInformation.[jcr:uuid]"
-                    + " where"
-                    // link to the correct Visit Information questionnaire
-                    + "  visitInformation.questionnaire = '%1$s'"
-                    // the visit date is in the past
-                    + "  and visitDate.question = '%2$s'"
-                    + "  and visitDate.value < '%4$s'"
-                    // the visit is not submitted
-                    + "  and submitted.question = '%3$s'"
-                    + "  and (submitted.value <> 1 OR submitted.value IS NULL)"
-                    // exclude the Visit Information form itself
-                    + "  and dataForm.questionnaire <> '%1$s'"
-                    // use the fast index for the query
-                    + " option (index tag cards)",
-                visitInformationQuestionnaire, time, submitted,
-                ZonedDateTime.now().minusDays(delay)
-                    .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSxxx"))),
-                Query.JCR_SQL2);
-            resources.forEachRemaining(form -> {
-                try {
-                    resolver.delete(form);
-                } catch (final PersistenceException e) {
-                    LOGGER.warn("Failed to delete expired form {}: {}", form.getPath(), e.getMessage());
+            final int patientToken = this.patientAccessConfiguration.getAllowedPostVisitCompletionTime();
+
+            // Find all clinics to iterate over
+            final Iterator<Resource> results = resolver.findResources(
+                "select * from [cards:QuestionnaireSet] as clinic", Query.JCR_SQL2);
+            while (results.hasNext()) {
+                Resource resource = results.next();
+                final Node clinicNode = resource.adaptTo(Node.class);
+                final String clinicPath = clinicNode.getPath();
+                // Get clinic token lifetime or default to the global patient token lifetime
+                int delay = patientToken;
+                if (clinicNode.hasProperty("tokenLifetime")) {
+                    delay = (int) clinicNode.getProperty("tokenLifetime").getLong();
                 }
-            });
-            resolver.commit();
+
+                // Get all data forms for the specific clinic
+                final Iterator<Resource> resources = resolver.findResources(String.format(
+                    // select the data forms
+                    "select distinct dataForm.*"
+                        + "  from [cards:Form] as dataForm"
+                        // belonging to a visit
+                        + "  inner join [cards:Form] as visitInformation on visitInformation.subject = dataForm.subject"
+                        + " inner join [cards:DateAnswer] as visitDate on visitDate.form = visitInformation.[jcr:uuid]"
+                        + "    inner join [cards:BooleanAnswer] as submitted"
+                        + "      on submitted.form = visitInformation.[jcr:uuid]"
+                        + " where"
+                        // link to the correct Visit Information questionnaire
+                        + "  visitInformation.questionnaire = '%1$s'"
+                        // link to the exact clinic in Visit Information form
+                        + "  and visitInformation.clinic = '%5$s'"
+                        // the visit date is in the past
+                        + "  and visitDate.question = '%2$s'"
+                        + "  and visitDate.value < '%4$s'"
+                        // the visit is not submitted
+                        + "  and submitted.question = '%3$s'"
+                        + "  and (submitted.value <> 1 OR submitted.value IS NULL)"
+                        // exclude the Visit Information form itself
+                        + "  and dataForm.questionnaire <> '%1$s'"
+                        + " option (index tag cards)",
+                    visitInformationQuestionnaire, time, submitted,
+                    ZonedDateTime.now().minusDays(delay)
+                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSxxx")), clinicPath),
+                    Query.JCR_SQL2);
+                resources.forEachRemaining(form -> {
+                    try {
+                        resolver.delete(form);
+                    } catch (final PersistenceException e) {
+                        LOGGER.warn("Failed to delete expired form {}: {}", form.getPath(), e.getMessage());
+                    }
+                });
+                resolver.commit();
+            }
+        } catch (RepositoryException e) {
+            LOGGER.warn("Failed to fetch forms: {}", e.getMessage());
         } catch (final LoginException e) {
             LOGGER.warn("Invalid setup, service rights not set up for the expired forms cleanup task");
         } catch (final PersistenceException e) {

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
@@ -88,17 +88,17 @@ public class UnsubmittedFormsCleanupTask implements Runnable
                 (String) resolver.getResource("/Questionnaires/Visit information/time").getValueMap().get("jcr:uuid");
             final String submitted = (String) resolver
                 .getResource("/Questionnaires/Visit information/surveys_submitted").getValueMap().get("jcr:uuid");
-            final int patientToken = this.patientAccessConfiguration.getAllowedPostVisitCompletionTime();
+            final int patientTokenLifetime = this.patientAccessConfiguration.getAllowedPostVisitCompletionTime();
 
             // Find all clinics to iterate over
             final Iterator<Resource> results = resolver.findResources(
-                "select * from [cards:QuestionnaireSet] as clinic", Query.JCR_SQL2);
+                "select * from [cards:ClinicMapping] as clinic", Query.JCR_SQL2);
             while (results.hasNext()) {
                 Resource resource = results.next();
                 final Node clinicNode = resource.adaptTo(Node.class);
                 final String clinicPath = clinicNode.getPath();
                 // Get clinic token lifetime or default to the global patient token lifetime
-                int delay = patientToken;
+                int delay = patientTokenLifetime;
                 if (clinicNode.hasProperty("tokenLifetime")) {
                     delay = (int) clinicNode.getProperty("tokenLifetime").getLong();
                 }

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/surveytracker/SurveyTracker.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/surveytracker/SurveyTracker.java
@@ -48,7 +48,6 @@ import org.slf4j.LoggerFactory;
 import io.uhndata.cards.forms.api.FormUtils;
 import io.uhndata.cards.forms.api.QuestionnaireUtils;
 import io.uhndata.cards.patients.api.PatientAccessConfiguration;
-import io.uhndata.cards.patients.emailnotifications.AppointmentUtils;
 import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 import io.uhndata.cards.subjects.api.SubjectTypeUtils;
 import io.uhndata.cards.subjects.api.SubjectUtils;
@@ -236,12 +235,7 @@ public class SurveyTracker implements ResourceChangeListener, EventHandler
                 session.getNode("/Questionnaires/Survey events/survey_expiry"));
             if (expirationDateAnswer != null) {
                 Calendar expirationDate = (Calendar) eventDate.clone();
-                final int defaultTokenLifetime = this.accessConfiguration.getAllowedPostVisitCompletionTime();
-                Node visitSubject = this.formUtils.getSubject(form, "/SubjectTypes/Patient/Visit");
-                final int tokenLifetime = AppointmentUtils.getTokenLifetime(
-                    this.formUtils,
-                    visitSubject,
-                    defaultTokenLifetime);
+                final int tokenLifetime = this.accessConfiguration.getAllowedPostVisitCompletionTime(form);
                 expirationDate.add(Calendar.DATE, tokenLifetime + 1);
                 expirationDate.add(Calendar.DATE, 1);
                 expirationDate.set(Calendar.HOUR_OF_DAY, 0);

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/surveytracker/SurveyTracker.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/surveytracker/SurveyTracker.java
@@ -237,7 +237,6 @@ public class SurveyTracker implements ResourceChangeListener, EventHandler
                 Calendar expirationDate = (Calendar) eventDate.clone();
                 final int tokenLifetime = this.accessConfiguration.getAllowedPostVisitCompletionTime(form);
                 expirationDate.add(Calendar.DATE, tokenLifetime + 1);
-                expirationDate.add(Calendar.DATE, 1);
                 expirationDate.set(Calendar.HOUR_OF_DAY, 0);
                 expirationDate.set(Calendar.MINUTE, 0);
                 expirationDate.set(Calendar.SECOND, 0);

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/surveytracker/SurveyTracker.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/surveytracker/SurveyTracker.java
@@ -241,8 +241,7 @@ public class SurveyTracker implements ResourceChangeListener, EventHandler
                 final int tokenLifetime = AppointmentUtils.getTokenLifetime(
                     this.formUtils,
                     visitSubject,
-                    "/Questionnaires/Visit information/surveys",
-                    "tokenLifetime",
+                    "/Questionnaires/Visit information/clinic",
                     postVisitCompletionTime);
                 expirationDate.add(Calendar.DATE, tokenLifetime + 1);
                 expirationDate.add(Calendar.DATE, 1);

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/surveytracker/SurveyTracker.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/surveytracker/SurveyTracker.java
@@ -182,8 +182,8 @@ public class SurveyTracker implements ResourceChangeListener, EventHandler
                 return;
             }
             final Node node = session.getNode(path);
+            final Node form = this.formUtils.getForm(node);
             if (isAnswerForHasSurveys(node) && hasSurveys(node)) {
-                final Node form = this.formUtils.getForm(node);
                 // Also update the expiration date, since this cannot be copied from the visit
                 ensureSurveyStatusFormExists(session.getNode("/Questionnaires/Survey events"),
                     this.formUtils.getSubject(form), session);
@@ -192,7 +192,7 @@ public class SurveyTracker implements ResourceChangeListener, EventHandler
             } else if (isAnswerForSurveysSubmitted(node) && isSubmitted(node)) {
                 updateSurveySubmittedDate(node, session);
             } else if (isAnswerForVisitTime(node)) {
-                updateSurveyExpirationDate(node, node, session);
+                updateSurveyExpirationDate(form, node, session);
             }
         } catch (final LoginException e) {
             LOGGER.warn("Failed to get service session: {}", e.getMessage());

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/surveytracker/SurveyTracker.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/surveytracker/SurveyTracker.java
@@ -235,7 +235,7 @@ public class SurveyTracker implements ResourceChangeListener, EventHandler
                 session.getNode("/Questionnaires/Survey events/survey_expiry"));
             if (expirationDateAnswer != null) {
                 Calendar expirationDate = (Calendar) eventDate.clone();
-                final int tokenLifetime = this.accessConfiguration.getAllowedPostVisitCompletionTime(form);
+                final int tokenLifetime = this.accessConfiguration.getDaysRelativeToEventWhileSurveyIsValid(form);
                 expirationDate.add(Calendar.DATE, tokenLifetime + 1);
                 expirationDate.set(Calendar.HOUR_OF_DAY, 0);
                 expirationDate.set(Calendar.MINUTE, 0);

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/surveytracker/SurveyTracker.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/surveytracker/SurveyTracker.java
@@ -236,13 +236,12 @@ public class SurveyTracker implements ResourceChangeListener, EventHandler
                 session.getNode("/Questionnaires/Survey events/survey_expiry"));
             if (expirationDateAnswer != null) {
                 Calendar expirationDate = (Calendar) eventDate.clone();
-                final int postVisitCompletionTime = this.accessConfiguration.getAllowedPostVisitCompletionTime();
+                final int defaultTokenLifetime = this.accessConfiguration.getAllowedPostVisitCompletionTime();
                 Node visitSubject = this.formUtils.getSubject(form, "/SubjectTypes/Patient/Visit");
                 final int tokenLifetime = AppointmentUtils.getTokenLifetime(
                     this.formUtils,
                     visitSubject,
-                    "/Questionnaires/Visit information/clinic",
-                    postVisitCompletionTime);
+                    defaultTokenLifetime);
                 expirationDate.add(Calendar.DATE, tokenLifetime + 1);
                 expirationDate.add(Calendar.DATE, 1);
                 expirationDate.set(Calendar.HOUR_OF_DAY, 0);

--- a/modules/patient-portal/src/main/resources/SLING-INF/nodetypes/patient-portal.cnd
+++ b/modules/patient-portal/src/main/resources/SLING-INF/nodetypes/patient-portal.cnd
@@ -179,7 +179,7 @@
   - ignoreEmailConsent (boolean)
 
   // Specifies the token life time - number of days before expiration
-  - allowedPostVisitCompletionTime (double)
+  - nbOfDaysRelativeToEventToCompleteSurvey (double)
 
 //-----------------------------------------------------------------------------
 // The holder for all clinic mappings. This is mostly empty, but used so the

--- a/modules/patient-portal/src/main/resources/SLING-INF/nodetypes/patient-portal.cnd
+++ b/modules/patient-portal/src/main/resources/SLING-INF/nodetypes/patient-portal.cnd
@@ -179,7 +179,7 @@
   - ignoreEmailConsent (boolean)
 
   // Specifies the token life time - number of days before expiration
-  - nbOfDaysRelativeToEventToCompleteSurvey (double)
+  - daysRelativeToEventWhileSurveyIsValid (double)
 
 //-----------------------------------------------------------------------------
 // The holder for all clinic mappings. This is mostly empty, but used so the

--- a/modules/patient-portal/src/main/resources/SLING-INF/nodetypes/patient-portal.cnd
+++ b/modules/patient-portal/src/main/resources/SLING-INF/nodetypes/patient-portal.cnd
@@ -178,6 +178,9 @@
   // If TRUE, the email_ok question in Patient Information is ignored
   - ignoreEmailConsent (boolean)
 
+  // Specifies the token life time - number of days before expiration
+  - tokenLifetime (long)
+
 //-----------------------------------------------------------------------------
 // The holder for all clinic mappings. This is mostly empty, but used so the
 // pagination servlet can understand it

--- a/modules/patient-portal/src/main/resources/SLING-INF/nodetypes/patient-portal.cnd
+++ b/modules/patient-portal/src/main/resources/SLING-INF/nodetypes/patient-portal.cnd
@@ -179,7 +179,7 @@
   - ignoreEmailConsent (boolean)
 
   // Specifies the token life time - number of days before expiration
-  - tokenLifetime (double)
+  - allowedPostVisitCompletionTime (double)
 
 //-----------------------------------------------------------------------------
 // The holder for all clinic mappings. This is mostly empty, but used so the

--- a/modules/patient-portal/src/main/resources/SLING-INF/nodetypes/patient-portal.cnd
+++ b/modules/patient-portal/src/main/resources/SLING-INF/nodetypes/patient-portal.cnd
@@ -179,7 +179,7 @@
   - ignoreEmailConsent (boolean)
 
   // Specifies the token life time - number of days before expiration
-  - tokenLifetime (long)
+  - tokenLifetime (double)
 
 //-----------------------------------------------------------------------------
 // The holder for all clinic mappings. This is mostly empty, but used so the

--- a/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
+++ b/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
@@ -29,7 +29,7 @@ if (time.hasNext()) {
     if (time.hasProperty("value")) {
         time = time.getProperty("value").getDate();
         var config = sling.getService(Packages.io.uhndata.cards.patients.api.PatientAccessConfiguration);
-        var days = config.getAllowedPostVisitCompletionTime();
+        var days = config.getAllowedPostVisitCompletionTime(time.getParent());
         time.add(java.util.Calendar.DATE, days + 1);
         time.set(java.util.Calendar.HOUR_OF_DAY, 0);
         time.set(java.util.Calendar.MINUTE, 0);

--- a/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
+++ b/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
@@ -27,9 +27,10 @@ var time = currentSession.getWorkspace().getQueryManager().createQuery("select t
 if (time.hasNext()) {
     time = time.next();
     if (time.hasProperty("value")) {
+        var visitInformationForm = time.getParent();
         time = time.getProperty("value").getDate();
         var config = sling.getService(Packages.io.uhndata.cards.patients.api.PatientAccessConfiguration);
-        var days = config.getDaysRelativeToEventWhileSurveyIsValid(time.getParent());
+        var days = config.getDaysRelativeToEventWhileSurveyIsValid(visitInformationForm);
         time.add(java.util.Calendar.DATE, days + 1);
         time.set(java.util.Calendar.HOUR_OF_DAY, 0);
         time.set(java.util.Calendar.MINUTE, 0);

--- a/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
+++ b/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
@@ -29,7 +29,7 @@ if (time.hasNext()) {
     if (time.hasProperty("value")) {
         time = time.getProperty("value").getDate();
         var config = sling.getService(Packages.io.uhndata.cards.patients.api.PatientAccessConfiguration);
-        var days = config.getAllowedPostVisitCompletionTime(time.getParent());
+        var days = config.getDaysRelativeToEventWhileSurveyIsValid(time.getParent());
         time.add(java.util.Calendar.DATE, days + 1);
         time.set(java.util.Calendar.HOUR_OF_DAY, 0);
         time.set(java.util.Calendar.MINUTE, 0);

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/PatientAccess.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/PatientAccess.xml
@@ -30,7 +30,7 @@
         <type>Boolean</type>
     </property>
     <property>
-        <name>nbOfDaysRelativeToEventToCompleteSurvey</name>
+        <name>daysRelativeToEventWhileSurveyIsValid</name>
         <value>30</value>
         <type>Long</type>
     </property>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/PatientAccess.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/PatientAccess.xml
@@ -30,7 +30,7 @@
         <type>Boolean</type>
     </property>
     <property>
-        <name>allowedPostVisitCompletionTime</name>
+        <name>nbOfDaysRelativeToEventToCompleteSurvey</name>
         <value>30</value>
         <type>Long</type>
     </property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/PatientAccess.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/PatientAccess.xml
@@ -30,7 +30,7 @@
         <type>Boolean</type>
     </property>
     <property>
-        <name>nbOfDaysRelativeToEventToCompleteSurvey</name>
+        <name>daysRelativeToEventWhileSurveyIsValid</name>
         <value>0</value>
         <type>Long</type>
     </property>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/PatientAccess.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/PatientAccess.xml
@@ -30,7 +30,7 @@
         <type>Boolean</type>
     </property>
     <property>
-        <name>allowedPostVisitCompletionTime</name>
+        <name>nbOfDaysRelativeToEventToCompleteSurvey</name>
         <value>0</value>
         <type>Long</type>
     </property>


### PR DESCRIPTION
Testing "daysRelativeToEventWhileSurveyIsValid": "Relatively to the associated event, patients can fill out surveys within":
* Start in prems
* create a clinic A with a valid `survey` and leave  the `daysRelativeToEventWhileSurveyIsValid` field blank
* create a clinic B with a valid `survey` and set the `daysRelativeToEventWhileSurveyIsValid` field to 2
* create 2 patient visits for 2 different patients, one at clinic A and one at clinic B
  * check the autocreated Survey events forms, make sure the link expiry date field reflects the token lifetime value (for the clinic A visit, it should be in 29 days (if visit date is yesterday), for the clinic B visit it should be tomorrow (if the visit date is yesterday)
  * generate tokens for both visits and go to the respective survey links to check the link expiration message displayed on the start screen - it should say that the link will expire in 29 days for clinic A and in 1 day for clinic B
* From /bin/browser, edit the daysRelativeToEventWhileSurveyIsValid of clinic B to be 0
  * generate another token for the visit to clinic B and go to the survey link - it should say the link has expired
* testing emailed links - TBD
* Unsubmitted forms cleanup
  * reconfigure the unsubmitted forms cleanup task to run every 2min
  * test that it deletes the forms for clinic B, but NOT for clinic A