### PR TITLE
CARDS-2263: Store HERACLES S3 data export task performance metrics in the JCR

### DIFF
--- a/distribution/src/main/features/base-repoinit.txt
+++ b/distribution/src/main/features/base-repoinit.txt
@@ -35,15 +35,6 @@ set principal ACL for cards-metrics
     allow    jcr:read    on /LoggedEvents/
 end
 
-# error-tracking
-create path (sling:Folder) /LoggedEvents
-
-create service user error-tracking with path system/sling
-
-set principal ACL for error-tracking
-    allow   jcr:read,jcr:addChildNodes,jcr:modifyProperties,jcr:nodeTypeManagement   on /LoggedEvents/
-end
-
 create service user cards-exporter with path system/sling
 set principal ACL for cards-exporter
     allow   jcr:read    on /

--- a/distribution/src/main/features/base-repoinit.txt
+++ b/distribution/src/main/features/base-repoinit.txt
@@ -38,10 +38,15 @@ end
 # error-tracking
 create path (sling:Folder) /LoggedEvents
 
+create service user error-tracking with path system/sling
+
+set principal ACL for error-tracking
+    allow   jcr:read,jcr:addChildNodes,jcr:modifyProperties,jcr:nodeTypeManagement   on /LoggedEvents/
+end
+
 create service user cards-exporter with path system/sling
 set principal ACL for cards-exporter
     allow   jcr:read    on /
-    allow   jcr:addChildNodes,jcr:modifyProperties,jcr:nodeTypeManagement   on /LoggedEvents
 end
 
 # sling-xss

--- a/distribution/src/main/features/base-repoinit.txt
+++ b/distribution/src/main/features/base-repoinit.txt
@@ -32,6 +32,7 @@ set principal ACL for cards-metrics
     allow    jcr:write   on /Metrics/
     allow    jcr:addChildNodes    on /Metrics/
     allow    jcr:nodeTypeManagement    on /Metrics/
+    allow    jcr:read    on /LoggedEvents/
 end
 
 # error-tracking

--- a/distribution/src/main/features/base-repoinit.txt
+++ b/distribution/src/main/features/base-repoinit.txt
@@ -34,6 +34,15 @@ set principal ACL for cards-metrics
     allow    jcr:nodeTypeManagement    on /Metrics/
 end
 
+# error-tracking
+create path (sling:Folder) /LoggedEvents
+
+create service user cards-exporter with path system/sling
+set principal ACL for cards-exporter
+    allow   jcr:read    on /
+    allow   jcr:addChildNodes,jcr:modifyProperties,jcr:nodeTypeManagement   on /LoggedEvents
+end
+
 # sling-xss
 create service user sling-xss with path system/sling
 

--- a/distribution/src/main/features/base-repoinit.txt
+++ b/distribution/src/main/features/base-repoinit.txt
@@ -24,11 +24,6 @@ set principal ACL for sling-readall
     allow   jcr:read    on /
 end
 
-create service user cards-exporter with path system/sling
-set principal ACL for cards-exporter
-    allow   jcr:read    on /
-end
-
 # sling-xss
 create service user sling-xss with path system/sling
 

--- a/distribution/src/main/features/base-repoinit.txt
+++ b/distribution/src/main/features/base-repoinit.txt
@@ -24,17 +24,6 @@ set principal ACL for sling-readall
     allow   jcr:read    on /
 end
 
-# cards-metrics
-create service user cards-metrics with path system/sling
-
-set principal ACL for cards-metrics
-    allow    jcr:read    on /Metrics/
-    allow    jcr:write   on /Metrics/
-    allow    jcr:addChildNodes    on /Metrics/
-    allow    jcr:nodeTypeManagement    on /Metrics/
-    allow    jcr:read    on /LoggedEvents/
-end
-
 create service user cards-exporter with path system/sling
 set principal ACL for cards-exporter
     allow   jcr:read    on /

--- a/distribution/src/main/features/core/error-tracking.json
+++ b/distribution/src/main/features/core/error-tracking.json
@@ -16,23 +16,7 @@
 // under the License.
 
 {
-  "title": "CARDS - Error Tracking",
-  "description": "Feature enabling support for keeping track of errors by storing their stack traces in the JCR",
-  "bundles":[
-    {
-      "id":"org.apache.sling:org.apache.sling.api:2.27.0",
-      "start-order":"26"
-    },
-    {
-      "id":"${project.groupId}:${project.artifactId}:${project.version}",
-      "start-order":"26"
+    "prototype":{
+        "id": "io.uhndata.cards:cards-error-tracking:slingosgifeature:${project.version}"
     }
-  ],
-  "configurations":{
-    "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~error-tracking":{
-      "user.mapping":[
-        "io.uhndata.cards.error-tracking=[error-tracking]"
-      ]
-    }
-  }
 }

--- a/distribution/src/main/features/core/metrics.json
+++ b/distribution/src/main/features/core/metrics.json
@@ -16,17 +16,7 @@
 // under the License.
 
 {
-  "title": "CARDS - Metrics support",
-  "description": "Feature enabling support for performance metrics recording",
-  "bundles":[
-    {
-      "id":"org.apache.sling:org.apache.sling.api:2.27.0",
-      "start-order":"25"
-    },
-    {
-      "id":"${project.groupId}:${project.artifactId}:${project.version}",
-      "start-order":"25"
+    "prototype":{
+        "id": "io.uhndata.cards:cards-metrics:slingosgifeature:${project.version}"
     }
-  ],
-  "repoinit:TEXT|true": "@file"
 }

--- a/distribution/src/main/features/oak/oak_base.json
+++ b/distribution/src/main/features/oak/oak_base.json
@@ -187,7 +187,7 @@
             "enableAggregationFilter":true
         },
         "org.apache.jackrabbit.oak.spi.security.authorization.principalbased.impl.FilterProviderImpl":{
-            "path":"/home/users/system/sling"
+            "path":"/home/users/system"
         },
         "org.apache.jackrabbit.oak.security.internal.SecurityProviderRegistration":{
             "requiredServicePids":[

--- a/heracles-resources/backend/pom.xml
+++ b/heracles-resources/backend/pom.xml
@@ -90,6 +90,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.uhndata.cards</groupId>
+      <artifactId>cards-error-tracking</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.servlets.annotations</artifactId>
     </dependency>

--- a/heracles-resources/backend/pom.xml
+++ b/heracles-resources/backend/pom.xml
@@ -95,6 +95,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.uhndata.cards</groupId>
+      <artifactId>cards-metrics</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.servlets.annotations</artifactId>
     </dependency>

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
@@ -19,6 +19,8 @@
 
 package io.uhndata.cards.heracles.internal.export;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -49,6 +51,7 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import io.uhndata.cards.errortracking.ErrorTracking;
 import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 public class ExportTask implements Runnable
@@ -99,6 +102,11 @@ public class ExportTask implements Runnable
             }
         } catch (Exception e) {
             LOGGER.error("Failed to perform the nightly export", e.getMessage(), e);
+            // Create an nt:file node under /LoggedEvents/ storing the stack trace of this failure
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            e.printStackTrace(pw);
+            ErrorTracking.logError(this.resolverFactory, sw.toString());
         }
     }
 

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
@@ -104,7 +104,7 @@ public class ExportTask implements Runnable
         } catch (Exception e) {
             LOGGER.error("Failed to perform the nightly export", e.getMessage(), e);
 
-            // Create an nt:file node under /LoggedEvents/ storing the stack trace of this failure
+            // Store the stack trace of this failure
             StringWriter sw = new StringWriter();
             PrintWriter pw = new PrintWriter(sw);
             e.printStackTrace(pw);

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
@@ -49,7 +49,7 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import io.uhndata.cards.errortracking.ErrorTracking;
+import io.uhndata.cards.errortracking.StaticErrorLogger;
 import io.uhndata.cards.metrics.Metrics;
 import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
@@ -103,7 +103,7 @@ public class ExportTask implements Runnable
             LOGGER.error("Failed to perform the nightly export", e.getMessage(), e);
 
             // Store the stack trace of this failure
-            ErrorTracking.logError(e);
+            StaticErrorLogger.logError(e);
 
             // Increment the count of S3ExportFailures
             Metrics.increment(this.resolverFactory, "S3ExportFailures", 1);

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
@@ -26,6 +26,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -262,7 +263,8 @@ public class ExportTask implements Runnable
     private Set<SubjectIdentifier> getChangedSubjects(String requestDateStringLower,
         String requestDateStringUpper) throws LoginException
     {
-        try (ResourceResolver resolver = this.resolverFactory.getServiceResourceResolver(null)) {
+        try (ResourceResolver resolver =
+            this.resolverFactory.getServiceResourceResolver(Map.of(ResourceResolverFactory.SUBSERVICE, "S3Export"))) {
             Set<SubjectIdentifier> subjects = new HashSet<>();
             String query = String.format(
                 "SELECT subject.* FROM [cards:Form] AS form INNER JOIN [cards:Subject] AS subject"

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
@@ -19,8 +19,6 @@
 
 package io.uhndata.cards.heracles.internal.export;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -105,10 +103,7 @@ public class ExportTask implements Runnable
             LOGGER.error("Failed to perform the nightly export", e.getMessage(), e);
 
             // Store the stack trace of this failure
-            StringWriter sw = new StringWriter();
-            PrintWriter pw = new PrintWriter(sw);
-            e.printStackTrace(pw);
-            ErrorTracking.logError(sw.toString());
+            ErrorTracking.logError(e);
 
             // Increment the count of S3ExportFailures
             Metrics.increment(this.resolverFactory, "S3ExportFailures", 1);

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
@@ -52,6 +52,7 @@ import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import io.uhndata.cards.errortracking.ErrorTracking;
+import io.uhndata.cards.metrics.Metrics;
 import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 public class ExportTask implements Runnable
@@ -102,11 +103,15 @@ public class ExportTask implements Runnable
             }
         } catch (Exception e) {
             LOGGER.error("Failed to perform the nightly export", e.getMessage(), e);
+
             // Create an nt:file node under /LoggedEvents/ storing the stack trace of this failure
             StringWriter sw = new StringWriter();
             PrintWriter pw = new PrintWriter(sw);
             e.printStackTrace(pw);
             ErrorTracking.logError(this.resolverFactory, sw.toString());
+
+            // Increment the count of S3ExportFailures
+            Metrics.increment(this.resolverFactory, "S3ExportFailures", 1);
         }
     }
 

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
@@ -338,7 +338,10 @@ public class ExportTask implements Runnable
             .build();
         try {
             s3.putObject(s3BucketName, filename, input.getData());
-            input.getSummary().forEach(form -> LOGGER.info("Exported {}", form));
+            input.getSummary().forEach(form -> {
+                LOGGER.info("Exported {}", form);
+                Metrics.increment(this.resolverFactory, "S3ExportedForms", 1);
+            });
             LOGGER.info("Exported {} to {}", input.getUrl(), filename);
             Metrics.increment(this.resolverFactory, "S3ExportedSubjects", 1);
         } catch (Exception e) {

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
@@ -340,6 +340,7 @@ public class ExportTask implements Runnable
             s3.putObject(s3BucketName, filename, input.getData());
             input.getSummary().forEach(form -> LOGGER.info("Exported {}", form));
             LOGGER.info("Exported {} to {}", input.getUrl(), filename);
+            Metrics.increment(this.resolverFactory, "S3ExportedSubjects", 1);
         } catch (Exception e) {
             throw e;
         }

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
@@ -49,7 +49,7 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import io.uhndata.cards.errortracking.StaticErrorLogger;
+import io.uhndata.cards.errortracking.ErrorLogger;
 import io.uhndata.cards.metrics.Metrics;
 import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
@@ -103,7 +103,7 @@ public class ExportTask implements Runnable
             LOGGER.error("Failed to perform the nightly export", e.getMessage(), e);
 
             // Store the stack trace of this failure
-            StaticErrorLogger.logError(e);
+            ErrorLogger.logError(e);
 
             // Increment the count of S3ExportFailures
             Metrics.increment(this.resolverFactory, "S3ExportFailures", 1);

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/export/ExportTask.java
@@ -108,7 +108,7 @@ public class ExportTask implements Runnable
             StringWriter sw = new StringWriter();
             PrintWriter pw = new PrintWriter(sw);
             e.printStackTrace(pw);
-            ErrorTracking.logError(this.resolverFactory, sw.toString());
+            ErrorTracking.logError(sw.toString());
 
             // Increment the count of S3ExportFailures
             Metrics.increment(this.resolverFactory, "S3ExportFailures", 1);

--- a/heracles-resources/feature/src/main/features/feature.json
+++ b/heracles-resources/feature/src/main/features/feature.json
@@ -107,7 +107,7 @@
     },
     "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~heracles":{
       "user.mapping":[
-        "io.uhndata.cards.heracles-backend=[cards-exporter]",
+        "io.uhndata.cards.heracles-backend:S3Export=[cards-exporter]",
         "io.uhndata.cards.heracles-backend:PauseResumeEditor=[sling-readall]",
         "io.uhndata.cards.heracles-backend:MetricLogger=[cards-metrics]"
       ]

--- a/heracles-resources/feature/src/main/features/feature.json
+++ b/heracles-resources/feature/src/main/features/feature.json
@@ -80,10 +80,6 @@
     {
       "id":"${project.groupId}:heracles-resources-clinical-data:${project.version}",
       "start-order":"26"
-    },
-    {
-      "id":"${project.groupId}:cards-metrics:${project.version}",
-      "start-order":"25"
     }
   ],
   "configurations":{

--- a/heracles-resources/feature/src/main/features/feature.json
+++ b/heracles-resources/feature/src/main/features/feature.json
@@ -80,6 +80,10 @@
     {
       "id":"${project.groupId}:heracles-resources-clinical-data:${project.version}",
       "start-order":"26"
+    },
+    {
+      "id":"${project.groupId}:cards-error-tracking:${project.version}",
+      "start-order":"25"
     }
   ],
   "configurations":{
@@ -106,7 +110,7 @@
     },
     "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~heracles":{
       "user.mapping":[
-        "io.uhndata.cards.heracles-backend=[sling-readall]",
+        "io.uhndata.cards.heracles-backend=[cards-exporter]",
         "io.uhndata.cards.heracles-backend:PauseResumeEditor=[sling-readall]"
       ]
     }

--- a/heracles-resources/feature/src/main/features/feature.json
+++ b/heracles-resources/feature/src/main/features/feature.json
@@ -102,7 +102,7 @@
         "set properties on /Metrics/S3ExportedSubjects/prevTotal \n   default value{Long} to 0 \n end",
         "set properties on /Metrics/S3ExportFailures/name \n   default value{String} to \"{003} Number Of Failed S3 export jobs\" \n end",
         "set properties on /Metrics/S3ExportFailures/prevTotal \n   default value{Long} to 0 \n end",
-        "create service user cards-exporter \n set principal ACL for cards-exporter \n   allow jcr:read on / \n end"
+        "create service user cards-exporter with path system/cards \n set principal ACL for cards-exporter \n   allow jcr:read on / \n end"
       ]
     },
     "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~heracles":{

--- a/heracles-resources/feature/src/main/features/feature.json
+++ b/heracles-resources/feature/src/main/features/feature.json
@@ -101,7 +101,8 @@
         "set properties on /Metrics/S3ExportedSubjects/name \n   default value{String} to \"{002} Number Of Subjects Exported to S3 bucket\" \n end",
         "set properties on /Metrics/S3ExportedSubjects/prevTotal \n   default value{Long} to 0 \n end",
         "set properties on /Metrics/S3ExportFailures/name \n   default value{String} to \"{003} Number Of Failed S3 export jobs\" \n end",
-        "set properties on /Metrics/S3ExportFailures/prevTotal \n   default value{Long} to 0 \n end"
+        "set properties on /Metrics/S3ExportFailures/prevTotal \n   default value{Long} to 0 \n end",
+        "create service user cards-exporter \n set principal ACL for cards-exporter \n   allow jcr:read on / \n end"
       ]
     },
     "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~heracles":{

--- a/heracles-resources/feature/src/main/features/feature.json
+++ b/heracles-resources/feature/src/main/features/feature.json
@@ -84,6 +84,10 @@
     {
       "id":"${project.groupId}:cards-error-tracking:${project.version}",
       "start-order":"25"
+    },
+    {
+      "id":"${project.groupId}:cards-metrics:${project.version}",
+      "start-order":"25"
     }
   ],
   "configurations":{
@@ -111,7 +115,8 @@
     "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~heracles":{
       "user.mapping":[
         "io.uhndata.cards.heracles-backend=[cards-exporter]",
-        "io.uhndata.cards.heracles-backend:PauseResumeEditor=[sling-readall]"
+        "io.uhndata.cards.heracles-backend:PauseResumeEditor=[sling-readall]",
+        "io.uhndata.cards.heracles-backend:MetricLogger=[cards-metrics]"
       ]
     }
   }

--- a/heracles-resources/feature/src/main/features/feature.json
+++ b/heracles-resources/feature/src/main/features/feature.json
@@ -83,6 +83,27 @@
     }
   ],
   "configurations":{
+    "org.apache.sling.jcr.repoinit.RepositoryInitializer~HERACLES":{
+      "service.ranking:Integer":300,
+      "scripts": [
+        // A /Metrics sling:Folder for storing performance info to be sent periodically via Slack
+        "create path (sling:Folder) /Metrics/S3ExportedForms/name(nt:unstructured)",
+        "create path (sling:Folder) /Metrics/S3ExportedForms/prevTotal(nt:unstructured)",
+        "create path (sling:Folder) /Metrics/S3ExportedForms/total(nt:unstructured mixin mix:atomicCounter)",
+        "create path (sling:Folder) /Metrics/S3ExportedSubjects/name(nt:unstructured)",
+        "create path (sling:Folder) /Metrics/S3ExportedSubjects/prevTotal(nt:unstructured)",
+        "create path (sling:Folder) /Metrics/S3ExportedSubjects/total(nt:unstructured mixin mix:atomicCounter)",
+        "create path (sling:Folder) /Metrics/S3ExportFailures/name(nt:unstructured)",
+        "create path (sling:Folder) /Metrics/S3ExportFailures/prevTotal(nt:unstructured)",
+        "create path (sling:Folder) /Metrics/S3ExportFailures/total(nt:unstructured mixin mix:atomicCounter)",
+        "set properties on /Metrics/S3ExportedForms/name \n   default value{String} to \"{001} Number Of Forms Exported to S3 bucket\" \n end",
+        "set properties on /Metrics/S3ExportedForms/prevTotal \n   default value{Long} to 0 \n end",
+        "set properties on /Metrics/S3ExportedSubjects/name \n   default value{String} to \"{002} Number Of Subjects Exported to S3 bucket\" \n end",
+        "set properties on /Metrics/S3ExportedSubjects/prevTotal \n   default value{Long} to 0 \n end",
+        "set properties on /Metrics/S3ExportFailures/name \n   default value{String} to \"{003} Number Of Failed S3 export jobs\" \n end",
+        "set properties on /Metrics/S3ExportFailures/prevTotal \n   default value{Long} to 0 \n end"
+      ]
+    },
     "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~heracles":{
       "user.mapping":[
         "io.uhndata.cards.heracles-backend=[sling-readall]",

--- a/heracles-resources/feature/src/main/features/feature.json
+++ b/heracles-resources/feature/src/main/features/feature.json
@@ -82,10 +82,6 @@
       "start-order":"26"
     },
     {
-      "id":"${project.groupId}:cards-error-tracking:${project.version}",
-      "start-order":"25"
-    },
-    {
       "id":"${project.groupId}:cards-metrics:${project.version}",
       "start-order":"25"
     }

--- a/modules/error-tracking/pom.xml
+++ b/modules/error-tracking/pom.xml
@@ -46,6 +46,14 @@
       <artifactId>org.apache.sling.api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/modules/error-tracking/pom.xml
+++ b/modules/error-tracking/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.uhndata.cards</groupId>
+    <artifactId>cards-modules</artifactId>
+    <version>0.9-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>cards-error-tracking</artifactId>
+  <packaging>bundle</packaging>
+  <name>CARDS - Error Tracking</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/modules/error-tracking/src/main/features/feature-repoinit.txt
+++ b/modules/error-tracking/src/main/features/feature-repoinit.txt
@@ -1,0 +1,27 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+
+# error-tracking
+create path (sling:Folder) /LoggedEvents
+
+create service user error-tracking with path system/sling
+
+set principal ACL for error-tracking
+    allow   jcr:read,jcr:addChildNodes,jcr:modifyProperties,jcr:nodeTypeManagement   on /LoggedEvents/
+end

--- a/modules/error-tracking/src/main/features/feature-repoinit.txt
+++ b/modules/error-tracking/src/main/features/feature-repoinit.txt
@@ -20,7 +20,7 @@
 # error-tracking
 create path (sling:Folder) /LoggedEvents
 
-create service user error-tracking with path system/sling
+create service user error-tracking
 
 set principal ACL for error-tracking
     allow   jcr:read,jcr:addChildNodes,jcr:modifyProperties,jcr:nodeTypeManagement   on /LoggedEvents/

--- a/modules/error-tracking/src/main/features/feature-repoinit.txt
+++ b/modules/error-tracking/src/main/features/feature-repoinit.txt
@@ -20,7 +20,7 @@
 # error-tracking
 create path (sling:Folder) /LoggedEvents
 
-create service user error-tracking
+create service user error-tracking with path system/cards
 
 set principal ACL for error-tracking
     allow   jcr:read,jcr:addChildNodes,jcr:modifyProperties,jcr:nodeTypeManagement   on /LoggedEvents/

--- a/modules/error-tracking/src/main/features/feature.json
+++ b/modules/error-tracking/src/main/features/feature.json
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+{
+  "title": "CARDS - Error Tracking",
+  "description": "Feature enabling support for keeping track of errors by storing their stack traces in the JCR",
+  "bundles":[
+    {
+      "id":"org.apache.sling:org.apache.sling.api:2.27.0",
+      "start-order":"26"
+    },
+    {
+      "id":"${project.groupId}:${project.artifactId}:${project.version}",
+      "start-order":"26"
+    }
+  ]
+}

--- a/modules/error-tracking/src/main/features/feature.json
+++ b/modules/error-tracking/src/main/features/feature.json
@@ -34,5 +34,6 @@
         "io.uhndata.cards.error-tracking=[error-tracking]"
       ]
     }
-  }
+  },
+  "repoinit:TEXT|true": "@file"
 }

--- a/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLogger.java
+++ b/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLogger.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.errortracking;
+
+public interface ErrorLogger
+{
+    /*
+     * Stores in the JCR, under /LoggedEvents, a nt:file node containing the passed stack trace.
+     *
+     * @param loggedError the Throwable containing the stack trace of the error that was thrown resulting
+     * in the calling of this method
+     */
+    void logError(Throwable loggedError);
+}

--- a/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLogger.java
+++ b/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLogger.java
@@ -41,6 +41,8 @@ public final class ErrorLogger
      */
     public static void logError(final Throwable loggedError)
     {
-        errorLoggerService.logError(loggedError);
+        if (errorLoggerService != null) {
+            errorLoggerService.logError(loggedError);
+        }
     }
 }

--- a/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLogger.java
+++ b/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLogger.java
@@ -19,13 +19,33 @@
 
 package io.uhndata.cards.errortracking;
 
-public interface ErrorLogger
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ErrorLogger
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ErrorLogger.class);
+
+    private static ErrorLoggerService errorLoggerService;
+
+    // Hide the constructor
+    private ErrorLogger()
+    {
+    }
+
+    public static void setService(ErrorLoggerService service)
+    {
+        errorLoggerService = service;
+    }
+
     /*
      * Stores in the JCR, under /LoggedEvents, a nt:file node containing the passed stack trace.
      *
      * @param loggedError the Throwable containing the stack trace of the error that was thrown resulting
      * in the calling of this method
      */
-    void logError(Throwable loggedError);
+    public static void logError(final Throwable loggedError)
+    {
+        errorLoggerService.logError(loggedError);
+    }
 }

--- a/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLogger.java
+++ b/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLogger.java
@@ -28,7 +28,7 @@ public final class ErrorLogger
     {
     }
 
-    public static void setService(ErrorLoggerService service)
+    static void setService(ErrorLoggerService service)
     {
         errorLoggerService = service;
     }

--- a/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLogger.java
+++ b/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLogger.java
@@ -19,13 +19,8 @@
 
 package io.uhndata.cards.errortracking;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public final class ErrorLogger
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ErrorLogger.class);
-
     private static ErrorLoggerService errorLoggerService;
 
     // Hide the constructor

--- a/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLoggerImpl.java
+++ b/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLoggerImpl.java
@@ -50,7 +50,6 @@ public final class ErrorLoggerImpl implements ErrorLoggerService
     @Activate
     protected void activate(ComponentContext componentContext) throws Exception
     {
-        LOGGER.warn("ErrorTracking IS ACTIVATING!");
         ErrorLogger.setService(this);
     }
 

--- a/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLoggerImpl.java
+++ b/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLoggerImpl.java
@@ -53,12 +53,7 @@ public final class ErrorLoggerImpl implements ErrorLoggerService
         ErrorLogger.setService(this);
     }
 
-    /*
-     * Stores in the JCR, under /LoggedEvents, a nt:file node containing the passed stack trace.
-     *
-     * @param loggedError the Throwable containing the stack trace of the error that was thrown resulting
-     * in the calling of this method
-     */
+    @Override
     public void logError(final Throwable loggedError)
     {
         try (ResourceResolver resolver = this.rrf.getServiceResourceResolver(null)) {

--- a/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLoggerImpl.java
+++ b/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLoggerImpl.java
@@ -37,23 +37,21 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Component(immediate = true, service = ErrorTracking.class)
-public final class ErrorTracking
+@Component(immediate = true, service = ErrorLoggerImpl.class)
+public final class ErrorLoggerImpl implements ErrorLogger
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ErrorLoggerImpl.class);
+
     private static final String LOGGED_EVENTS_PATH = "/LoggedEvents/";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ErrorTracking.class);
-
-    private static ResourceResolverFactory rrf;
-
     @Reference
-    private ResourceResolverFactory originalRrf;
+    private ResourceResolverFactory rrf;
 
     @Activate
     protected void activate(ComponentContext componentContext) throws Exception
     {
         LOGGER.warn("ErrorTracking IS ACTIVATING!");
-        rrf = this.originalRrf;
+        StaticErrorLogger.setService(this);
     }
 
     /*
@@ -62,9 +60,9 @@ public final class ErrorTracking
      * @param loggedError the Throwable containing the stack trace of the error that was thrown resulting
      * in the calling of this method
      */
-    public static void logError(final Throwable loggedError)
+    public void logError(final Throwable loggedError)
     {
-        try (ResourceResolver resolver = rrf.getServiceResourceResolver(null)) {
+        try (ResourceResolver resolver = this.rrf.getServiceResourceResolver(null)) {
             if (resolver == null) {
                 return;
             }

--- a/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLoggerImpl.java
+++ b/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLoggerImpl.java
@@ -69,11 +69,7 @@ public final class ErrorLoggerImpl implements ErrorLoggerService
             final String newFileName = UUID.randomUUID().toString();
             final Map<String, Object> eventNodeProperties = new HashMap<>();
             eventNodeProperties.put("jcr:primaryType", "nt:file");
-            resolver.create(eventsFolderResource, newFileName, eventNodeProperties);
-            Resource thisEventResource = resolver.getResource(LOGGED_EVENTS_PATH + newFileName);
-            if (thisEventResource == null) {
-                return;
-            }
+            Resource thisEventResource = resolver.create(eventsFolderResource, newFileName, eventNodeProperties);
 
             final StringWriter sw = new StringWriter();
             final PrintWriter pw = new PrintWriter(sw);

--- a/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLoggerImpl.java
+++ b/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLoggerImpl.java
@@ -37,8 +37,8 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Component(immediate = true, service = ErrorLoggerImpl.class)
-public final class ErrorLoggerImpl implements ErrorLogger
+@Component(immediate = true, service = ErrorLoggerService.class)
+public final class ErrorLoggerImpl implements ErrorLoggerService
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(ErrorLoggerImpl.class);
 
@@ -51,7 +51,7 @@ public final class ErrorLoggerImpl implements ErrorLogger
     protected void activate(ComponentContext componentContext) throws Exception
     {
         LOGGER.warn("ErrorTracking IS ACTIVATING!");
-        StaticErrorLogger.setService(this);
+        ErrorLogger.setService(this);
     }
 
     /*

--- a/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLoggerService.java
+++ b/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLoggerService.java
@@ -19,34 +19,13 @@
 
 package io.uhndata.cards.errortracking;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-public final class StaticErrorLogger
+public interface ErrorLoggerService
 {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(StaticErrorLogger.class);
-
-    private static ErrorLogger errorLoggerService;
-
-    // Hide the constructor
-    private StaticErrorLogger()
-    {
-    }
-
-    public static void setService(ErrorLogger service)
-    {
-        errorLoggerService = service;
-    }
-
     /*
      * Stores in the JCR, under /LoggedEvents, a nt:file node containing the passed stack trace.
      *
      * @param loggedError the Throwable containing the stack trace of the error that was thrown resulting
      * in the calling of this method
      */
-    public static void logError(final Throwable loggedError)
-    {
-        errorLoggerService.logError(loggedError);
-    }
+    void logError(Throwable loggedError);
 }

--- a/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorTracking.java
+++ b/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorTracking.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.errortracking;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ErrorTracking
+{
+    private static final String LOGGED_EVENTS_PATH = "/LoggedEvents/";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ErrorTracking.class);
+
+    // Hide the utility class constructor
+    private ErrorTracking()
+    {
+    }
+
+    /*
+     * Stores in the JCR, under /LoggedEvents, a nt:file node containing the passed stack trace.
+     *
+     * @param resolverFactory a ResourceResolverFactory the can be used for obtaining a ResourceResolver
+     * with permissions to add child nodes to /LoggedEvents.
+     * @param stackTrace the String containing the stack trace of the error that was thrown resulting
+     * in the calling of this method
+     */
+    public static void logError(final ResourceResolverFactory resolverFactory, final String stackTrace)
+    {
+        try (ResourceResolver resolver = resolverFactory.getServiceResourceResolver(null)) {
+            Resource eventsFolderResource = resolver.getResource(LOGGED_EVENTS_PATH);
+            if (eventsFolderResource == null) {
+                return;
+            }
+
+            // Create the nt:file node under /LoggedEvents and get a reference to it
+            final String newFileName = UUID.randomUUID().toString();
+            final Map<String, Object> eventNodeProperties = new HashMap<>();
+            eventNodeProperties.put("jcr:primaryType", "nt:file");
+            resolver.create(eventsFolderResource, newFileName, eventNodeProperties);
+            Resource thisEventResource = resolver.getResource(LOGGED_EVENTS_PATH + newFileName);
+            if (thisEventResource == null) {
+                return;
+            }
+            final Map<String, Object> jcrContentProperties = new HashMap<>();
+            jcrContentProperties.put("jcr:primaryType", "nt:resource");
+            jcrContentProperties.put("jcr:mimeType", "text/plain");
+            jcrContentProperties.put("jcr:data", stackTrace);
+            resolver.create(thisEventResource, "jcr:content", jcrContentProperties);
+
+            // Commit these changes to JCR
+            resolver.commit();
+        } catch (LoginException | PersistenceException e) {
+            LOGGER.error("logError failed.", e);
+            return;
+        }
+    }
+}

--- a/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorTracking.java
+++ b/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorTracking.java
@@ -57,12 +57,10 @@ public final class ErrorTracking
     /*
      * Stores in the JCR, under /LoggedEvents, a nt:file node containing the passed stack trace.
      *
-     * @param resolverFactory a ResourceResolverFactory the can be used for obtaining a ResourceResolver
-     * with permissions to add child nodes to /LoggedEvents.
      * @param stackTrace the String containing the stack trace of the error that was thrown resulting
      * in the calling of this method
      */
-    public static void logError(final ResourceResolverFactory resolverFactory, final String stackTrace)
+    public static void logError(final String stackTrace)
     {
         try (ResourceResolver resolver = rrf.getServiceResourceResolver(null)) {
             if (resolver == null) {

--- a/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/StaticErrorLogger.java
+++ b/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/StaticErrorLogger.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.errortracking;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class StaticErrorLogger
+{
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StaticErrorLogger.class);
+
+    private static ErrorLogger errorLoggerService;
+
+    // Hide the constructor
+    private StaticErrorLogger()
+    {
+    }
+
+    public static void setService(ErrorLogger service)
+    {
+        errorLoggerService = service;
+    }
+
+    /*
+     * Stores in the JCR, under /LoggedEvents, a nt:file node containing the passed stack trace.
+     *
+     * @param loggedError the Throwable containing the stack trace of the error that was thrown resulting
+     * in the calling of this method
+     */
+    public static void logError(final Throwable loggedError)
+    {
+        errorLoggerService.logError(loggedError);
+    }
+}

--- a/modules/metrics/src/main/features/feature-repoinit.txt
+++ b/modules/metrics/src/main/features/feature-repoinit.txt
@@ -23,9 +23,6 @@ create path (sling:Folder) /Metrics
 create service user cards-metrics
 
 set principal ACL for cards-metrics
-    allow    jcr:read    on /Metrics/
-    allow    jcr:write   on /Metrics/
-    allow    jcr:addChildNodes    on /Metrics/
-    allow    jcr:nodeTypeManagement    on /Metrics/
+    allow    jcr:read,jcr:write,jcr:addChildNodes,jcr:nodeTypeManagement    on /Metrics/
     allow    jcr:read    on /LoggedEvents/
 end

--- a/modules/metrics/src/main/features/feature-repoinit.txt
+++ b/modules/metrics/src/main/features/feature-repoinit.txt
@@ -1,0 +1,31 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+
+# cards-metrics
+create path (sling:Folder) /Metrics
+
+create service user cards-metrics with path system/sling
+
+set principal ACL for cards-metrics
+    allow    jcr:read    on /Metrics/
+    allow    jcr:write   on /Metrics/
+    allow    jcr:addChildNodes    on /Metrics/
+    allow    jcr:nodeTypeManagement    on /Metrics/
+    allow    jcr:read    on /LoggedEvents/
+end

--- a/modules/metrics/src/main/features/feature-repoinit.txt
+++ b/modules/metrics/src/main/features/feature-repoinit.txt
@@ -20,7 +20,7 @@
 # cards-metrics
 create path (sling:Folder) /Metrics
 
-create service user cards-metrics with path system/sling
+create service user cards-metrics
 
 set principal ACL for cards-metrics
     allow    jcr:read    on /Metrics/

--- a/modules/metrics/src/main/features/feature-repoinit.txt
+++ b/modules/metrics/src/main/features/feature-repoinit.txt
@@ -20,7 +20,7 @@
 # cards-metrics
 create path (sling:Folder) /Metrics
 
-create service user cards-metrics
+create service user cards-metrics with path system/cards
 
 set principal ACL for cards-metrics
     allow    jcr:read,jcr:write,jcr:addChildNodes,jcr:nodeTypeManagement    on /Metrics/

--- a/modules/patient-portal/src/main/features/feature.json
+++ b/modules/patient-portal/src/main/features/feature.json
@@ -38,10 +38,6 @@
       "start-order":"25"
     },
     {
-      "id":"${project.groupId}:cards-metrics:${project.version}",
-      "start-order":"25"
-    },
-    {
       "id":"${project.groupId}:cards-http-requests:${project.version}",
       "start-order":"25"
     }

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -72,5 +72,6 @@
     <module>torch-import</module>
     <module>slack-notifications</module>
     <module>embedded-view</module>
+    <module>error-tracking</module>
   </modules>
 </project>

--- a/modules/slack-notifications/src/main/features/feature.json
+++ b/modules/slack-notifications/src/main/features/feature.json
@@ -22,10 +22,6 @@
       "start-order":"26"
     },
     {
-      "id":"${project.groupId}:cards-metrics:${project.version}",
-      "start-order":"25"
-    },
-    {
       "id":"${project.groupId}:cards-http-requests:${project.version}",
       "start-order":"25"
     }

--- a/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/SlackNotificationsTask.java
+++ b/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/SlackNotificationsTask.java
@@ -167,12 +167,12 @@ public class SlackNotificationsTask implements Runnable
                 slackNotificationString += "\n" + "```" + "\n" + stackTracesIter.next() + "\n" + "```";
             }
 
-            if (slackNotificationString.length() == 0) {
-                slackNotificationString = "*ERROR*: Could not gather any performance statistics";
-            }
-
-            postToSlack(SLACK_PERFORMANCE_URL, slackNotificationString,
-                (slackNotificationString.length() == 0 || errorStackTraces.size() > 0) ? "#f3db0e" : "#2eb886");
+            postToSlack(SLACK_PERFORMANCE_URL,
+                (slackNotificationString.length() == 0)
+                    ? "*ERROR*: Could not gather any performance statistics" : slackNotificationString,
+                (slackNotificationString.length() == 0 || errorStackTraces.size() > 0)
+                    ? "#f3db0e" : "#2eb886"
+            );
 
         } catch (LoginException e) {
             LOGGER.warn("Failed to results.next().getPath()");

--- a/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/SlackNotificationsTask.java
+++ b/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/SlackNotificationsTask.java
@@ -113,6 +113,23 @@ public class SlackNotificationsTask implements Runnable
         return errorStackTraces;
     }
 
+    private String generateStackTraceMessagePart(List<String> errorStackTraces)
+    {
+        String slackNotificationString = "";
+        Iterator<String> stackTracesIter = errorStackTraces.iterator();
+
+        // Include a separator message if there are any stack traces to be printed
+        if (stackTracesIter.hasNext()) {
+            slackNotificationString += "\n\n" + "The following errors were logged:";
+        }
+
+        // Include the stack traces text
+        while (stackTracesIter.hasNext()) {
+            slackNotificationString += "\n" + "```" + "\n" + stackTracesIter.next() + "\n" + "```";
+        }
+        return slackNotificationString;
+    }
+
     @Override
     public void run()
     {
@@ -162,10 +179,7 @@ public class SlackNotificationsTask implements Runnable
             }
 
             // Include any relevant stack traces
-            Iterator<String> stackTracesIter = errorStackTraces.iterator();
-            while (stackTracesIter.hasNext()) {
-                slackNotificationString += "\n" + "```" + "\n" + stackTracesIter.next() + "\n" + "```";
-            }
+            slackNotificationString += generateStackTraceMessagePart(errorStackTraces);
 
             postToSlack(SLACK_PERFORMANCE_URL,
                 (slackNotificationString.length() == 0)

--- a/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/SlackNotificationsTask.java
+++ b/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/SlackNotificationsTask.java
@@ -20,8 +20,10 @@
 package io.uhndata.cards.slacknotifications;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -71,16 +73,44 @@ public class SlackNotificationsTask implements Runnable
         return notificationLine;
     }
 
-    private void postToSlack(String slackUrl, String msg)
+    private void postToSlack(String slackUrl, String msg, String color)
     {
         try {
             JsonObject slackApiReq = Json.createObjectBuilder()
-                .add("text", msg)
+                .add("attachments", Json.createArrayBuilder()
+                    .add(Json.createObjectBuilder()
+                        .add("text", msg)
+                        .add("fallback", "Failed to generate a report :(")
+                        .add("color", color)
+                    )
+                )
                 .build();
             HttpRequests.getPostResponse(slackUrl, slackApiReq.toString(), "application/json");
         } catch (IOException e) {
             LOGGER.warn("Failed to send performance update to Slack");
         }
+    }
+
+    private List<String> getLoggedEvents(ResourceResolver resolver)
+    {
+        // Get all the nt:file nodes under /LoggedEvents/
+        Iterator<Resource> loggedEventsIter;
+        loggedEventsIter = resolver.findResources(
+            "SELECT n.* FROM [nt:file] AS n WHERE isdescendantnode(n, '/LoggedEvents')",
+            "JCR-SQL2"
+        );
+
+        List<String> errorStackTraces = new ArrayList<>();
+        while (loggedEventsIter.hasNext()) {
+            Resource thisResource = loggedEventsIter.next();
+            Resource jcrContentResource = thisResource.getChild("jcr:content");
+            if (jcrContentResource == null) {
+                continue;
+            }
+            String thisStackTrace = jcrContentResource.getValueMap().get("jcr:data", "");
+            errorStackTraces.add(thisStackTrace);
+        }
+        return errorStackTraces;
     }
 
     @Override
@@ -115,6 +145,9 @@ public class SlackNotificationsTask implements Runnable
                 gatheredStatistics.put(thisHumanName, thisMetricValue);
             }
 
+            // Get all the error stack traces under /LoggedEvents/
+            List<String> errorStackTraces = getLoggedEvents(resolver);
+
             resolver.close();
 
             // Build the notification update string to be sent to Slack
@@ -128,10 +161,18 @@ public class SlackNotificationsTask implements Runnable
                 );
             }
 
+            // Include any relevant stack traces
+            Iterator<String> stackTracesIter = errorStackTraces.iterator();
+            while (stackTracesIter.hasNext()) {
+                slackNotificationString += "\n" + "```" + "\n" + stackTracesIter.next() + "\n" + "```";
+            }
+
             if (slackNotificationString.length() == 0) {
                 slackNotificationString = "*ERROR*: Could not gather any performance statistics";
             }
-            postToSlack(SLACK_PERFORMANCE_URL, slackNotificationString);
+
+            postToSlack(SLACK_PERFORMANCE_URL, slackNotificationString,
+                (slackNotificationString.length() == 0 || errorStackTraces.size() > 0) ? "#f3db0e" : "#2eb886");
 
         } catch (LoginException e) {
             LOGGER.warn("Failed to results.next().getPath()");


### PR DESCRIPTION
This _Pull Request_ introduces 3 new performance metrics, all related to HERACLES S3 data exports, namely:

- `S3ExportedForms` counts the number of _Forms_ successfully pushed to the configured S3 bucket
- `S3ExportedSubjects` counts the number of Subjects successfully pushed to the configured S3 bucket
- `S3ExportFailures` counts the number of S3 export tasks that have terminated in error

Additionally, an `ErrorTracking` service is made available so that whenever `ErrorTracking.logError` is called, an `nt:file` node in the JCR under `/LoggedEvents` is created which holds the contents of the logged error. The `SlackNotificationsTask` is modified so that any logged errors under `/LoggedEvents` are sent in the periodic Slack alerts update along with the performance metrics recorded under `/Metrics`. As of the current implementation, all logged errors under `/LoggedEvents` will be sent to Slack, therefore once the errors have been resolved, these node under `/LoggedEvents` should be manually deleted so that alerts of these (now resolved) errors are no longer sent to Slack.

As the errors collected by `ErrorTracking.logError` can potentially be long, I needed to switch from using basic _text_ objects on the Slack API to using _attachment_ objects. This automatically adds a _Show more / Show less_ button for messages that would be too long to be sent to Slack using basic _text_ objects. This, however, slightly changes the appearance of the message of all our Slack alert messages.

For example, a nightly performance metric update message from _Cards4PREMs_ would now look like this,

![screenshot_2023_07_12-15-30-19](https://github.com/data-team-uhn/cards/assets/5349728/a2baba55-f1da-4032-8a05-8dc1f83b1af8)

instead of this,

![screenshot_2023_07_12-15-30-32](https://github.com/data-team-uhn/cards/assets/5349728/5224aa0d-9fd1-49a7-bb48-d1bb8a4d434b)

Testing Instructions
--------------------------

1. Build this (`CARDS-2263`) branch including a Docker image with `mvn clean install -Pdocker`.
2. `cd compose-cluster`
3. `python3 generate_compose_yaml.py --dev_docker_image --oak_filesystem --composum --cards_project cards4heracles --slack_notifications --s3_test_container`.
4. You will be prompted to enter a Slack webhook URL. Either create your own Slack channel and app with an _incoming webhook_ or DM me to be added to the _#cards-alerts-dev_ Slack channel and I will provide you with an incoming webhook.
5. Edit `docker-compose.yml` and add the environment variable `NIGHTLY_SLACK_NOTIFICATIONS_SCHEDULE=0 * * ? * *` to the `cardsinitial` container.
6. `docker-compose build && docker-compose up -d`
7. Every minute, a performance metric update containing **Number Of Forms Exported to S3 bucket**, **Number Of Subjects Exported to S3 bucket**, and **Number Of Failed S3 export jobs** should be sent to Slack.
8. Visit http://localhost:8080 and login as `admin`:`admin`
9. Create a _Demographics_ Form and a test _Patient_ Subject.
10. Visit http://localhost:8080/Subjects.s3push?dateLowerBound={TODAY}&dateUpperBound={TOMORROW}. For example, if today is July 12th 2023, you would visit http://localhost:8080/Subjects.s3push?dateLowerBound=2023-07-12&dateUpperBound=2023-07-13.
11. The next update in Slack should show **Number Of Failed S3 export jobs** incremented by 1 followed by a stack trace showing a `NoSuchBucket` error.
12. Visit http://localhost:8080/bin/browser.html and delete the `nt:file` node under `/LoggedEvents`
13. Visit http://localhost:9001 and login as `minioadmin`:`minioadmin`
14. Click on _Create bucket_ and create a new bucket called `uhn`.
15. Visit the `Subjects.s3push` URL once again (eg. http://localhost:8080/Subjects.s3push?dateLowerBound=2023-07-12&dateUpperBound=2023-07-13)
16. The next Slack update should increment both **Number Of Forms Exported to S3 bucket** and **Number Of Subjects Exported to S3 bucket** by 1.
17. Create a new _Baseline Health Information_ Form for the same test patient and visit the S3 push URL (eg. http://localhost:8080/Subjects.s3push?dateLowerBound=2023-07-12&dateUpperBound=2023-07-13) once again.
18. The next Slack update should increment **Number Of Forms Exported to S3 bucket** by 2 and **Number Of Subjects Exported to S3 bucket** by 1.
19. Visit http://localhost:8080/bin/browser.html and delete everything under `/Metrics`.
20. The next Slack update should show _**ERROR:** Could not gather any performance statistics_.
21. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`