### PR TITLE
CARDS-2294: CARDS Webhook Backup module is broken due to incorrect date format used in JCR-SQL queries

### DIFF
--- a/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupEndpoint.java
+++ b/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupEndpoint.java
@@ -67,8 +67,24 @@ public class WebhookBackupEndpoint extends SlingSafeMethodsServlet
             return;
         }
 
-        final LocalDateTime dateLowerBound = this.strToDateTime(request.getParameter("dateLowerBound"));
-        final LocalDateTime dateUpperBound = this.strToDateTime(request.getParameter("dateUpperBound"));
+        try {
+            final LocalDateTime dateLowerBound = this.strToDateTime(request.getParameter("dateLowerBound"));
+        } catch (DateTimeParseException e) {
+            // Wasn't able to parse the passed DateTime
+            response.setStatus(400);
+            out.write("Error: Invalid date/time specified for dateLowerBound");
+            return;
+        }
+
+        try {
+            final LocalDateTime dateUpperBound = this.strToDateTime(request.getParameter("dateUpperBound"));
+        } catch (DateTimeParseException e) {
+            // Wasn't able to parse the passed DateTime
+            response.setStatus(400);
+            out.write("Error: Invalid date/time specified for dateUpperBound");
+            return;
+        }
+
         final String exportRunMode = (dateLowerBound != null && dateUpperBound != null)
             ? "manualBetween"
             : (dateLowerBound != null && dateUpperBound == null) ? "manualAfter" : "manualToday";
@@ -81,16 +97,10 @@ public class WebhookBackupEndpoint extends SlingSafeMethodsServlet
         out.write("Webhook Backup export started");
     }
 
-    private LocalDateTime strToDateTime(final String date)
+    private LocalDateTime strToDateTime(final String date) throws DateTimeParseException
     {
         LOGGER.warn("strToDateTime attempting to parse: {}", date);
         if (date == null) {
-            return null;
-        }
-        try {
-            return LocalDateTime.parse(date);
-        } catch (DateTimeParseException e) {
-            LOGGER.warn("strToDateTime failed to parse {} due to {}", date, e);
             return null;
         }
     }

--- a/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupEndpoint.java
+++ b/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupEndpoint.java
@@ -68,22 +68,14 @@ public class WebhookBackupEndpoint extends SlingSafeMethodsServlet
         }
 
         final LocalDateTime dateLowerBound;
-        try {
-            dateLowerBound = this.strToDateTime(request.getParameter("dateLowerBound"));
-        } catch (DateTimeParseException e) {
-            // Wasn't able to parse the passed DateTime
-            response.setStatus(400);
-            out.write("Error: Invalid date/time specified for dateLowerBound");
-            return;
-        }
-
         final LocalDateTime dateUpperBound;
         try {
+            dateLowerBound = this.strToDateTime(request.getParameter("dateLowerBound"));
             dateUpperBound = this.strToDateTime(request.getParameter("dateUpperBound"));
         } catch (DateTimeParseException e) {
             // Wasn't able to parse the passed DateTime
             response.setStatus(400);
-            out.write("Error: Invalid date/time specified for dateUpperBound");
+            out.write("Error: Invalid date/time specified");
             return;
         }
 

--- a/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupEndpoint.java
+++ b/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupEndpoint.java
@@ -67,8 +67,9 @@ public class WebhookBackupEndpoint extends SlingSafeMethodsServlet
             return;
         }
 
+        final LocalDateTime dateLowerBound;
         try {
-            final LocalDateTime dateLowerBound = this.strToDateTime(request.getParameter("dateLowerBound"));
+            dateLowerBound = this.strToDateTime(request.getParameter("dateLowerBound"));
         } catch (DateTimeParseException e) {
             // Wasn't able to parse the passed DateTime
             response.setStatus(400);
@@ -76,8 +77,9 @@ public class WebhookBackupEndpoint extends SlingSafeMethodsServlet
             return;
         }
 
+        final LocalDateTime dateUpperBound;
         try {
-            final LocalDateTime dateUpperBound = this.strToDateTime(request.getParameter("dateUpperBound"));
+            dateUpperBound = this.strToDateTime(request.getParameter("dateUpperBound"));
         } catch (DateTimeParseException e) {
             // Wasn't able to parse the passed DateTime
             response.setStatus(400);

--- a/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupEndpoint.java
+++ b/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupEndpoint.java
@@ -105,5 +105,6 @@ public class WebhookBackupEndpoint extends SlingSafeMethodsServlet
         if (date == null) {
             return null;
         }
+        return LocalDateTime.parse(date);
     }
 }

--- a/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupTask.java
+++ b/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupTask.java
@@ -151,8 +151,10 @@ public class WebhookBackupTask implements Runnable
         LOGGER.info("Executing NightlyExport");
         LocalDateTime startOfToday = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
         LocalDateTime startOfYesterday = startOfToday.minusDays(1);
-        String requestStartString = startOfYesterday.format(DateTimeFormatter.ofPattern(DATE_TIME_JCR_FORMAT));
-        String requestEndString = startOfToday.format(DateTimeFormatter.ofPattern(DATE_TIME_JCR_FORMAT));
+        String requestStartString = startOfYesterday.atZone(ZoneId.systemDefault())
+            .format(DateTimeFormatter.ofPattern(DATE_TIME_JCR_FORMAT));
+        String requestEndString = startOfToday.atZone(ZoneId.systemDefault())
+            .format(DateTimeFormatter.ofPattern(DATE_TIME_JCR_FORMAT));
         LOGGER.warn("Exporting data modified between [{}, {})", requestStartString, requestEndString);
         doManualExport(startOfYesterday, startOfToday);
     }
@@ -315,9 +317,11 @@ public class WebhookBackupTask implements Runnable
             taskUpdateMessage += "after " + lower.format(DateTimeFormatter.ofPattern(DATE_TIME_JCR_FORMAT));
         } else {
             taskUpdateMessage += "between ";
-            taskUpdateMessage += lower.format(DateTimeFormatter.ofPattern(DATE_TIME_JCR_FORMAT));
+            taskUpdateMessage += lower.atZone(ZoneId.systemDefault())
+                .format(DateTimeFormatter.ofPattern(DATE_TIME_JCR_FORMAT));
             taskUpdateMessage += " and ";
-            taskUpdateMessage += upper.format(DateTimeFormatter.ofPattern(DATE_TIME_JCR_FORMAT));
+            taskUpdateMessage += upper.atZone(ZoneId.systemDefault())
+                .format(DateTimeFormatter.ofPattern(DATE_TIME_JCR_FORMAT));
         }
         taskUpdateMessage += ". " + emojii;
         return taskUpdateMessage;

--- a/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupTask.java
+++ b/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupTask.java
@@ -21,6 +21,7 @@ package io.uhndata.cards.webhookbackup;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -94,9 +95,11 @@ public class WebhookBackupTask implements Runnable
 
     public void doManualExport(LocalDateTime lower, LocalDateTime upper)
     {
-        String requestDateStringLower = lower.toString();
+        String requestDateStringLower = lower.atZone(ZoneId.systemDefault())
+            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSxxx"));
+
         String requestDateStringUpper = (upper != null)
-            ? upper.toString()
+            ? upper.atZone(ZoneId.systemDefault()).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSxxx"))
             : null;
 
         // Notify that we are now beginning the backup

--- a/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupTask.java
+++ b/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupTask.java
@@ -46,7 +46,7 @@ import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 public class WebhookBackupTask implements Runnable
 {
-    private static final String DATE_TIME_JCR_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
+    private static final String DATE_TIME_JCR_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSxxx";
 
     /** Default log. */
     private static final Logger LOGGER = LoggerFactory.getLogger(WebhookBackupTask.class);
@@ -96,10 +96,10 @@ public class WebhookBackupTask implements Runnable
     public void doManualExport(LocalDateTime lower, LocalDateTime upper)
     {
         String requestDateStringLower = lower.atZone(ZoneId.systemDefault())
-            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSxxx"));
+            .format(DateTimeFormatter.ofPattern(DATE_TIME_JCR_FORMAT));
 
         String requestDateStringUpper = (upper != null)
-            ? upper.atZone(ZoneId.systemDefault()).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSxxx"))
+            ? upper.atZone(ZoneId.systemDefault()).format(DateTimeFormatter.ofPattern(DATE_TIME_JCR_FORMAT))
             : null;
 
         // Notify that we are now beginning the backup

--- a/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupTask.java
+++ b/modules/webhook-backup/src/main/java/io/uhndata/cards/webhookbackup/WebhookBackupTask.java
@@ -314,7 +314,8 @@ public class WebhookBackupTask implements Runnable
     {
         String taskUpdateMessage = emojii + " Backup " + status + " for data modified ";
         if (upper == null) {
-            taskUpdateMessage += "after " + lower.format(DateTimeFormatter.ofPattern(DATE_TIME_JCR_FORMAT));
+            taskUpdateMessage += "after " + lower.atZone(ZoneId.systemDefault())
+                .format(DateTimeFormatter.ofPattern(DATE_TIME_JCR_FORMAT));
         } else {
             taskUpdateMessage += "between ";
             taskUpdateMessage += lower.atZone(ZoneId.systemDefault())


### PR DESCRIPTION
This Pull Request fixes the _CARDS Webhook Backup_ module that got broken with the introduction of CARDS-2253 which, due to the introduction of a Lucene index, caused `WebhookBackupTask` tasks to fail with a `java.lang.IllegalArgumentException: Not a date string:` error. This Pull Request fixes the bug by specifying the expected date/time string format when executing the JCR-SQL query.

Testing Instructions
--------------------------

1. Build this (`CARDS-2294`) branch including a Docker image with `mvn clean install -Pdocker`.
2. `cd compose-cluster`
3. `mkdir ~/cards-2294_backup_test`
4. `python3 generate_compose_yaml.py --dev_docker_image --oak_filesystem --composum --cards_project cards4heracles --enable_backup_server --backup_server_path ~/cards-2294_backup_test`
5. `docker-compose build && docker-compose up -d`
6. Visit http://localhost:8080 and login as `admin`:`admin`
7. Create a new _Demographics_ Form and an associated random patient subject. Fill in and save the _Demographics_ Form.
8. Visit http://localhost:8080/Subjects.webhookbackup and verify that no new files are created under `~/cards-2294_backup_test/Forms` or `~/cards-2294_backup_test/Subjects`
9. Visit http://localhost:8080/Subjects.webhookbackup?dateLowerBound=2023-07-01T:00:00:00 and verify that JSON files are created under `~/cards-2294_backup_test/Forms` and `~/cards-2294_backup_test/Subjects`. Delete those files.
10. Visit http://localhost:8080/Subjects.webhookbackup?dateLowerBound=2100-07-01T:00:00:00 and verify that no files are created under `~/cards-2294_backup_test/Forms` or `~/cards-2294_backup_test/Subjects`
11. Visit http://localhost:8080/Subjects.webhookbackup?dateLowerBound=2023-07-01T00:00:00&dateUpperBound=2023-07-02T:00:00:00 and verify that no files are created under `~/cards-2294_backup_test/Forms` or `~/cards-2294_backup_test/Subjects`.
12. Visit http://localhost:8080/Subjects.webhookbackup?dateLowerBound=2023-07-01T00:00:00&dateUpperBound=2100-07-01T:00:00:00 and verify that JSON files are created under `~/cards-2294_backup_test/Forms` and `~/cards-2294_backup_test/Subjects`.
13. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`
14. Delete everything under `~/cards-2294_backup_test`
15. `python3 generate_compose_yaml.py --dev_docker_image --oak_filesystem --composum --cards_project cards4heracles --enable_backup_server --backup_server_path ~/cards-2294_backup_test`
16. Edit `docker-compose.yml` and add the `NIGHTLY_WEBHOOK_BACKUP_SCHEDULE=0 * * ? * *` environment variable to the `cardsinitial` container
17. `docker-compose build && docker-compose up -d`
18. Visit http://localhost:8080 and login as `admin`:`admin`
19. Create a new _Demographics_ Form and an associated random patient subject. Fill in and save the _Demographics_ Form.
20. Wait for at least one minute and ensure that no files are created under `~/cards-2294_backup_test/Subjects` or `~/cards-2294_backup_test/Forms`
21. Set the system clock to tomorrow.
22. Wait for at least a minute and verify that JSON files are created under `~/cards-2294_backup_test/Forms` and `~/cards-2294_backup_test/Subjects`.
23. Set the system clock to the day after tomorrow.
24. Delete the files under `~/cards-2294_backup_test/Forms` and `~/cards-2294_backup_test/Subjects`.
25. Wait for at least a minute and verify that no files are created under `~/cards-2294_backup_test/Forms` and `~/cards-2294_backup_test/Subjects`.
26. `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`