### PR TITLE
[misc] Update io.netty version

### DIFF
--- a/heracles-resources/feature/src/main/features/feature.json
+++ b/heracles-resources/feature/src/main/features/feature.json
@@ -26,39 +26,39 @@
       "start-order":"26"
     },
     {
-      "id":"io.netty:netty-tcnative-classes:2.0.59.Final",
+      "id":"io.netty:netty-tcnative-classes:2.0.61.Final",
       "start-order":"26"
     },
     {
-      "id":"io.netty:netty-codec-http:4.1.89.Final",
+      "id":"io.netty:netty-codec-http:4.1.94.Final",
       "start-order":"26"
     },
     {
-      "id":"io.netty:netty-codec:4.1.89.Final",
+      "id":"io.netty:netty-codec:4.1.94.Final",
       "start-order":"26"
     },
     {
-      "id":"io.netty:netty-handler:4.1.89.Final",
+      "id":"io.netty:netty-handler:4.1.94.Final",
       "start-order":"26"
     },
     {
-      "id":"io.netty:netty-buffer:4.1.89.Final",
+      "id":"io.netty:netty-buffer:4.1.94.Final",
       "start-order":"26"
     },
     {
-      "id":"io.netty:netty-common:4.1.89.Final",
+      "id":"io.netty:netty-common:4.1.94.Final",
       "start-order":"26"
     },
     {
-      "id":"io.netty:netty-transport:4.1.89.Final",
+      "id":"io.netty:netty-transport:4.1.94.Final",
       "start-order":"26"
     },
     {
-      "id":"io.netty:netty-transport-native-unix-common:4.1.89.Final",
+      "id":"io.netty:netty-transport-native-unix-common:4.1.94.Final",
       "start-order":"26"
     },
     {
-      "id":"io.netty:netty-resolver:4.1.89.Final",
+      "id":"io.netty:netty-resolver:4.1.94.Final",
       "start-order":"26"
     },
     {

--- a/modules/webhook-backup/src/main/features/feature.json
+++ b/modules/webhook-backup/src/main/features/feature.json
@@ -22,35 +22,35 @@
       "start-order":"25"
     },
     {
-      "id":"io.netty:netty-codec-http:4.1.89.Final",
+      "id":"io.netty:netty-codec-http:4.1.94.Final",
       "start-order":"25"
     },
     {
-      "id":"io.netty:netty-codec:4.1.89.Final",
+      "id":"io.netty:netty-codec:4.1.94.Final",
       "start-order":"25"
     },
     {
-      "id":"io.netty:netty-handler:4.1.89.Final",
+      "id":"io.netty:netty-handler:4.1.94.Final",
       "start-order":"25"
     },
     {
-      "id":"io.netty:netty-buffer:4.1.89.Final",
+      "id":"io.netty:netty-buffer:4.1.94.Final",
       "start-order":"25"
     },
     {
-      "id":"io.netty:netty-common:4.1.89.Final",
+      "id":"io.netty:netty-common:4.1.94.Final",
       "start-order":"25"
     },
     {
-      "id":"io.netty:netty-transport:4.1.89.Final",
+      "id":"io.netty:netty-transport:4.1.94.Final",
       "start-order":"25"
     },
     {
-      "id":"io.netty:netty-transport-native-unix-common:4.1.89.Final",
+      "id":"io.netty:netty-transport-native-unix-common:4.1.94.Final",
       "start-order":"25"
     },
     {
-      "id":"io.netty:netty-resolver:4.1.89.Final",
+      "id":"io.netty:netty-resolver:4.1.94.Final",
       "start-order":"25"
     },
     {
@@ -62,7 +62,7 @@
       "start-order":"25"
     },
     {
-      "id":"io.netty:netty-tcnative-classes:2.0.59.Final",
+      "id":"io.netty:netty-tcnative-classes:2.0.61.Final",
       "start-order":"25"
     },
     {


### PR DESCRIPTION
This Pull Request upgrades the version of the `io.netty` packages from `4.1.89.Final` to `4.1.94.Final` to address the CVE-2023-34462 issue.

Testing Instructions
--------------------------

1. Build this (`misc-netty-4.1.94.Final-upgrade`) branch, including a Docker image, with `mvn clean install -Pdocker`.
2. `mkdir ~/netty-upgrade-test`
3. `cd compose-cluster`
4. `python3 generate_compose_yaml.py --dev_docker_image --oak_filesystem --composum --cards_project cards4heracles --enable_backup_server --backup_server_path ~/netty-upgrade-test --s3_test_container`
5. `docker-compose build && docker-compose up -d`
6. Visit http://localhost:9001, login as `minioadmin`:`minioadmin` and create a bucket named `uhn`
7. Visit http://localhost:8080, login as `admin`:`admin`, create a new _Demographics_ Form and an associated test Patient
8. Visit http://localhost:8080/Subjects.webhookbackup?dateLowerBound=1970-01-01T00:00:00. Verify that files are created under `~/netty-upgrade-test/Forms` and under `~/netty-upgrade-test/Subjects`
9. Visit http://localhost:8080/Subjects.s3push?dateLowerBound=1970-01-01.
10. Visit http://localhost:9001 and verify that a JSON file for the newly created HERACLES Patient exists in the `uhn` bucket.