### PR TITLE
CARDS-2299: Non-admin users cannot add user filters for any users other than themselves

### DIFF
--- a/distribution/src/main/features/base-repoinit.txt
+++ b/distribution/src/main/features/base-repoinit.txt
@@ -86,3 +86,8 @@ end
 # SLING-10597 - Simplify setup of resource resolution mappings
 create path (sling:Folder) /etc/map
 create path (sling:Folder) /etc/map/http
+
+# CARDS-2299: allow everyone to see all users
+set ACL on /home/users
+    allow jcr:read for everyone
+end


### PR DESCRIPTION
Q: Users still cannot see groups. For example, if `A` belongs to `TrustedUsers` but `B` doesn't, then `B` cannot see the `A` belongs to `TrustedUsers`. A more illustrative example: if `John Buck` belongs to `Cardiology Department` and `Doctors`, and `Jane Doe` belongs to `Cardiology Department` and `Nurses`, `Jane Doe` sees that `John Buck` belongs only to `Cardiology Department`, because they are both part of the same group. Should we also allow read access to all groups?

To test:

- start in proms mode
- as admin, create two users, `a` and `b`
- log in as `b`
- open `http://localhost:8080/home/users.json`, check that all users are listed, including `a`, `b`, `admin` and `patient`