### PR TITLE
CARDS-2302: As a patient, I cannot edit surveys I have already submitted

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -176,7 +176,7 @@ function QuestionnaireSet(props) {
   }
 
   const isFormSubmitted = (questionnaireId) => {
-    return subjectData?.[questionnaireId] && subjectData[questionnaireId].statusFlags?.includes("SUBMITTED");
+    return subjectData?.[questionnaireId]?.statusFlags?.includes("SUBMITTED");
   }
 
   // If the `enableReviewScreen` state is not already defined, initialize it with the value passed via config

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -399,7 +399,7 @@ function QuestionnaireSet(props) {
   let findNextStep = (step) => {
     let next = step + 1
     // Skip if the corresponding questionnaire has already been filled out:
-    while (next < questionnaireIds.length && (isFormComplete(questionnaireIds[next]) || isFormSubmitted(questionnaireIds[next]))) ++next;
+    while (next < questionnaireIds.length && isFormComplete(questionnaireIds[next])) ++next;
     return next;
   }
 

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -175,6 +175,10 @@ function QuestionnaireSet(props) {
     return subjectData?.[questionnaireId] && !subjectData[questionnaireId].statusFlags?.includes("INCOMPLETE");
   }
 
+  const isFormSubmitted = (questionnaireId) => {
+    return subjectData?.[questionnaireId] && subjectData[questionnaireId].statusFlags?.includes("SUBMITTED");
+  }
+
   // If the `enableReviewScreen` state is not already defined, initialize it with the value passed via config
   useEffect(() => {
     typeof(enableReviewScreen) == "undefined" && setEnableReviewScreen(config?.enableReviewScreen);
@@ -395,7 +399,7 @@ function QuestionnaireSet(props) {
   let findNextStep = (step) => {
     let next = step + 1
     // Skip if the corresponding questionnaire has already been filled out:
-    while (next < questionnaireIds.length && isFormComplete(questionnaireIds[next])) ++next;
+    while (next < questionnaireIds.length && (isFormComplete(questionnaireIds[next]) || isFormSubmitted(questionnaireIds[next]))) ++next;
     return next;
   }
 
@@ -629,7 +633,8 @@ function QuestionnaireSet(props) {
         <ListItemAvatar>{isFormComplete(q) ? doneIndicator : questionnaireIds.length == 1 ? surveyIndicator : stepIndicator(i)}</ListItemAvatar>
         <ListItemText
           primary={questionnaires[q]?.title}
-          secondary={!isFormComplete(q) && (displayEstimate(q)
+          secondary={isFormSubmitted(q) ? "Submitted" :
+            !isFormComplete(q) && (displayEstimate(q)
             + (["patient", "guest-patient"].includes(subjectData?.[q]?.["jcr:lastModifiedBy"]) ? " (in progress)" : ""))}
         />
       </ListItem>
@@ -665,7 +670,7 @@ function QuestionnaireSet(props) {
     <Typography variant="h4" key="review-title">Please review and submit your answers</Typography>,
     <FormattedText paragraph key="review-desc">You can update the response for each question in the survey by using the **Update this Survey** button below. After reviewing, please click on **Submit my answers** to send your responses.</FormattedText>,
     <Grid container direction="column" spacing={8} key="review-list">
-      {(questionnaireIds || []).map((q, i) => (
+      {(questionnaireIds || []).filter(q => !isFormSubmitted(q)).map((q, i) => (
       <Grid item key={q+"Review"}>
       { previews?.[subjectData?.[q]?.["@name"]] ?
         <Grid container direction="column" spacing={4}>
@@ -739,7 +744,7 @@ function QuestionnaireSet(props) {
             <ListItemAvatar>{isFormComplete(q) ? doneIndicator : incompleteIndicator}</ListItemAvatar>
             <ListItemText
               primary={questionnaires[q]?.title}
-              secondary={!isFormComplete(q) && "Incomplete"}
+              secondary={!isFormComplete(q) && "Incomplete" || isFormSubmitted(q) && "Submitted"}
             />
           </ListItem>
         ))}


### PR DESCRIPTION
To test with existing setup:

- start in `prems`
- as admin create a patient, a visit, set clinic to ED
- as patient, fill out the ED survey and submit it
- as admin, edit the visit information form and change clinic from ED to ED + Inpatient, and the surveyes_completed / surveys_submitted flags to NO
- manually add the Inpatient survey to the visit 
- as patient, to back to the survey link:
  - on the welcome screen, the ED survey should be marked as “Submitted”
  - when clicking “Begin”, the Inpatient survey should be displayed
  - when completing the inpatient survey and advancing to the “Review” screen, only the Inpatient survey should displayed for review