### PR TITLE
CARDS-2307: Listener that observes when the clinic field of the Visit information form changes and automatically adds any missing surveys to the visit subject

### DIFF
--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
@@ -82,6 +82,8 @@ public class VisitChangeListener implements ResourceChangeListener
 
     private static final String[] STRING_ARRAY = {};
 
+    private static final String STATUS_FLAGS = "statusFlags";
+
     /** Provides access to resources. */
     @Reference
     private volatile ResourceResolverFactory resolverFactory;
@@ -554,10 +556,10 @@ public class VisitChangeListener implements ResourceChangeListener
     {
         boolean incomplete = false;
         try {
-            if (this.formUtils.isForm(form) && form.hasProperty("statusFlags")) {
-                final Property statusProp = form.getProperty("statusFlags");
+            if (this.formUtils.isForm(form) && form.hasProperty(STATUS_FLAGS)) {
+                final Property statusProp = form.getProperty(STATUS_FLAGS);
                 if (statusProp.isMultiple()) {
-                    final Value[] statuses = form.getProperty("statusFlags").getValues();
+                    final Value[] statuses = form.getProperty(STATUS_FLAGS).getValues();
                     for (final Value status : statuses) {
                         final String str = status.getString();
                         if ("INCOMPLETE".equals(str)) {
@@ -583,8 +585,8 @@ public class VisitChangeListener implements ResourceChangeListener
         try {
             boolean checkinNeeded = checkoutIfNeeded(visitInformationForm, session);
             Set<String> flags = new TreeSet<>();
-            if (visitInformationForm.hasProperty("statusFlags")) {
-                Set.of(visitInformationForm.getProperty("statusFlags").getValues()).forEach(v -> {
+            if (visitInformationForm.hasProperty(STATUS_FLAGS)) {
+                Set.of(visitInformationForm.getProperty(STATUS_FLAGS).getValues()).forEach(v -> {
                     try {
                         String flag = v.getString();
                         if (!"SUBMITTED".equals(flag)) {
@@ -595,7 +597,7 @@ public class VisitChangeListener implements ResourceChangeListener
                     }
                 });
             }
-            visitInformationForm.setProperty("statusFlags", flags.toArray(STRING_ARRAY));
+            visitInformationForm.setProperty(STATUS_FLAGS, flags.toArray(STRING_ARRAY));
             try {
                 session.save();
             } catch (VersionException e) {

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
@@ -440,7 +440,7 @@ public class VisitChangeListener implements ResourceChangeListener
         // Check if the clinics match between the triggering visit and the current visit.
         // If the clinics match or if the questionnaire set does not care if clinics match,
         // remove any found questionnaires that are within the frequency range.
-        if (questionnaires.isEmpty() && (
+        if (!questionnaires.isEmpty() && (
             (!StringUtils.isBlank(visitClinic) && visitInformation.getClinicPath().equals(visitClinic))
             || questionnaireSetInfo.shouldIgnoreClinic())) {
             removeQuestionnairesFromVisit(visitInformation, visitDate, questionnaires, questionnaireSetInfo);


### PR DESCRIPTION
To test use [the test branch](https://github.com/data-team-uhn/cards/tree/CARDS-2307-test) or remove the following lines from `EIDP.xml`:
 
```
   <property>
        <name>conflictMode</name>
        <value>any</value>
        <type>String</type>
    </property>
```
Set the  `AIP` as a clinic in Visit information form and submit it as patient.
As admin change the `clinic` in Visit information form from `AIP` to `EIDP`. Observe the new questionnaire appeared and surveys_complete/surveys_submitted fields set to `false` in Visit information form. Also Visit information form’s `SUBMITTED` status flag should be removed. Switching back and forth in between those two clinics should not add any new duplicate questionnaires.