### PR TITLE
CARDS-2315: Exporting and re-importing Smoking Cessation form fails

### DIFF
--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/QuestionnaireToCsvProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/QuestionnaireToCsvProcessor.java
@@ -213,7 +213,7 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
         } else if ("cards:Question".equals(nodeType)) {
             String label = nodeJson.getString("@name");
             rawColumns.add(label);
-            if (nodeJson.containsKey("text")) {
+            if (nodeJson.containsKey("text") && !"".equals(nodeJson.getString("text"))) {
                 label = nodeJson.getString("text");
             }
             columns.add(label);


### PR DESCRIPTION
This _Pull Request_ fixes the bug described by CARDS-2315 by fixing the `processHeaderElement` method so that when deciding to use either the Questionnaire's question node name or its _text_ as a CSV column header, not only does the code check that the "text" property of the question node is present but it also checks that it is not empty.

### Testing Instructions

1. Start CARDS in `cards4proms` (DATA-PRO) mode and create a new _Patient_ + _Visit_ + _Smoking cessation_ Form.
2. Export the _Smoking Secession_ Forms by going to _Administration_ --> _Questionnaires_ and clicking the _Export forms_ button for the _Smoking cessation_ questionnaire. Select `.tsv` for the _file format_. Leave all other settings as-is.
3. Through the CARDS web UI, delete the newly created _Smoking cessation_ Form.
4. Import the exported TSV file back into CARDS by running `curl -u admin:admin http://localhost:8080/Forms/ -X POST -F ":data=@path/to/exported/tsv/file" -F ":questionnaire=/Questionnaires/SC" -F ":subjectType=/SubjectTypes/Patient" -F ":subjectType=/SubjectTypes/Patient/Visit"`
5. Ensure that the Form is re-imported without error.