### PR TITLE
CARDS-2303 / CARDS-2309 : When importing data from Clarity, if the fields Status [FLO 44189] and Patient Eligibility [FLO 44190] are "New Patient" and "Enrolled", then the `status` answer in the Visit information should be set to `in-progress` instead of `discharged`

### DIFF
--- a/compose-cluster/mssql/generate_test_YE_sql.py
+++ b/compose-cluster/mssql/generate_test_YE_sql.py
@@ -81,6 +81,8 @@ CREATE TABLE [path].[CL_EP_IP_EMAIL_CONSENT_IN_LAST_7_DAYS] (
     DX_NAME varchar(1024) NULL,
     ID varchar(255) NULL,
     PAT_ENC_CSN_ID varchar(255) NULL,
+    UHN_ICC_STATUS varchar(255) NULL,
+    UHN_ICC_PATIENT_ELIGIBILITY varchar(255) NULL,
     PATIENT_CLASS varchar(255) NULL,
 );
 
@@ -193,13 +195,17 @@ for i in range(args.n):
     # LENGTH_OF_STAY_DAYS
     insertion_values['LENGTH_OF_STAY_DAYS'] = random.randint(1, 15)
 
+    # Integrated Care eligibility
+    insertion_values['UHN_ICC_STATUS'] = random.choices([None, 'New Patient'], [1, 2])[0]
+    insertion_values['UHN_ICC_PATIENT_ELIGIBILITY'] = random.choices([None, 'Enrolled'], [1, 2])[0]
+
     # Identifier columns
     insertion_values['ID'] = i
     insertion_values['PAT_ENC_CSN_ID'] = i
 
     args.file.write("INSERT INTO [path].[CL_EP_IP_EMAIL_CONSENT_IN_LAST_7_DAYS]")
-    args.file.write("\t(ID, PAT_ENC_CSN_ID, PAT_MRN, PAT_FIRST_NAME, PAT_LAST_NAME, EMAIL_ADDRESS, HOSP_DISCHARGE_DTTM, DISCH_DEPT_NAME, DISCH_LOC_NAME, EMAIL_CONSENT_YN, [MYCHART STATUS], DEATH_DATE, DISCH_DISPOSITION, LEVEL_OF_CARE, ED_IP_TRANSFER_YN, LENGTH_OF_STAY_DAYS, PATIENT_CLASS)\n")
+    args.file.write("\t(ID, PAT_ENC_CSN_ID, PAT_MRN, PAT_FIRST_NAME, PAT_LAST_NAME, EMAIL_ADDRESS, HOSP_DISCHARGE_DTTM, DISCH_DEPT_NAME, DISCH_LOC_NAME, EMAIL_CONSENT_YN, [MYCHART STATUS], DEATH_DATE, DISCH_DISPOSITION, LEVEL_OF_CARE, ED_IP_TRANSFER_YN, LENGTH_OF_STAY_DAYS, UHN_ICC_STATUS, UHN_ICC_PATIENT_ELIGIBILITY, PATIENT_CLASS)\n")
     args.file.write("\tVALUES\n")
-    args.file.write("\t({ID:07d}, {PAT_ENC_CSN_ID:07d}, {PAT_MRN:07d}, {PAT_FIRST_NAME}, {PAT_LAST_NAME}, {EMAIL_ADDRESS}, {HOSP_DISCHARGE_DTTM}, {DISCH_DEPT_NAME}, {DISCH_LOC_NAME}, {EMAIL_CONSENT_YN}, {MYCHART STATUS}, {DEATH_DATE}, {DISCH_DISPOSITION}, {LEVEL_OF_CARE}, {ED_IP_TRANSFER_YN}, {LENGTH_OF_STAY_DAYS}, 'Inpatient')\n".format(**convertToSqlType(insertion_values)))
+    args.file.write("\t({ID:07d}, {PAT_ENC_CSN_ID:07d}, {PAT_MRN:07d}, {PAT_FIRST_NAME}, {PAT_LAST_NAME}, {EMAIL_ADDRESS}, {HOSP_DISCHARGE_DTTM}, {DISCH_DEPT_NAME}, {DISCH_LOC_NAME}, {EMAIL_CONSENT_YN}, {MYCHART STATUS}, {DEATH_DATE}, {DISCH_DISPOSITION}, {LEVEL_OF_CARE}, {ED_IP_TRANSFER_YN}, {LENGTH_OF_STAY_DAYS}, {UHN_ICC_STATUS}, {UHN_ICC_PATIENT_ELIGIBILITY}, 'Inpatient')\n".format(**convertToSqlType(insertion_values)))
 
 args.file.close()

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clarityMapping.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clarityMapping.xml
@@ -368,6 +368,34 @@
                 <type>String</type>
               </property>
             </node>
+            <node>
+              <name>00000016</name>
+              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+              <property>
+                <name>column</name>
+                <value>UHN_ICC_STATUS</value>
+                <type>String</type>
+              </property>
+              <property>
+                <name>question</name>
+                <value></value>
+                <type>String</type>
+              </property>
+            </node>
+            <node>
+              <name>00000017</name>
+              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+              <property>
+                <name>column</name>
+                <value>UHN_ICC_PATIENT_ELIGIBILITY</value>
+                <type>String</type>
+              </property>
+              <property>
+                <name>question</name>
+                <value></value>
+                <type>String</type>
+              </property>
+            </node>
           </node>
         </node>
       </node>

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -305,6 +305,17 @@
       "priority": 20,
       "conditions": ["DISCH_DEPT_NAME in PM-PALLIATIVE CARE ONCOLOGY CLINIC; TW-PALLIATIVE CARE CLINIC; TG-PALLIATIVE CARE; PM-16P PALLIATIVE CARE"]
     },
+    // Patients eligible for Integrated Care surveys should have a different status
+    // The default status is set at priority 30 by DischargedFiller
+    "io.uhndata.cards.clarity.importer.internal.ConfiguredGenericMapper~IntegratedCareStatusInProgress":{
+      "priority": 35,
+      "column": "STATUS",
+      "value": "in-progress",
+      "conditions": [
+        "UHN_ICC_STATUS = New Patient",
+        "UHN_ICC_PATIENT_ELIGIBILITY = Enrolled"
+      ]
+    },
     // Assign patients from Toronto Rehab to the Rehab cohort
     "io.uhndata.cards.clarity.importer.internal.ConfiguredCohortMapper~CohortMapper-Rehab":{
       "priority": 40,


### PR DESCRIPTION
To test:

- build with `mvn clean install -Pdocker`
- `cd compose-cluster/mssql`
- `python3 generate_test_YE_sql.py -n 50 prems_sample.sql`
- `cd ..`
- `python3 generate_compose_yaml.py --mssql --cards_project cards4prems --oak_filesystem --dev_docker_image --composum --adminer`
- `docker-compose build && docker-compose up`
- open `http://localhost:1435/?mssql=mssql&username=sa&db=master&ns=path&import=` and upload the generated `prems_sample.sql` file
- open `http://localhost:8080/Subjects.importClarity`
- check that some visit information forms have status = `in-progress` (the ones where `UHN_ICC_STATUS=New Patient` and `UHN_ICC_PATIENT_ELIGIBILITY=Enrolled`), and some have `discharged` (all the other ones)
- stop docker and clean up with `docker-compose rm -v -f && ./cleanup.sh`