### PR TITLE
CARDS-2339: More specific time of the last save displayed on Form pages

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -516,10 +516,10 @@ function Form (props) {
           }
           {
             lastSaveTimestamp ?
-            <Typography variant="overline">{saveInProgress ? "Saving ... " : "Saved " + DateTime.fromISO(lastSaveTimestamp.toISOString()).toRelativeCalendar()}</Typography>
+            <Typography variant="overline">{saveInProgress ? "Saving ... " : "Saved " + DateTime.fromISO(lastSaveTimestamp.toISOString()).toRelative()}</Typography>
             :
             data && data['jcr:lastModified'] ?
-            <Typography variant="overline">{"Last modified " + DateTime.fromISO(data['jcr:lastModified']).toRelativeCalendar()}</Typography>
+            <Typography variant="overline">{"Last modified " + DateTime.fromISO(data['jcr:lastModified']).toRelative()}</Typography>
             : ""
           }
           </Breadcrumbs>
@@ -615,7 +615,7 @@ function Form (props) {
         <Typography variant="h6">Your changes were not saved.</Typography>
         <Typography variant="body1" paragraph>Server responded with response code {errorCode}: {errorMessage}</Typography>
         {lastSaveTimestamp &&
-          <Typography variant="body1" paragraph>Time of the last successful save: {DateTime.fromISO(lastSaveTimestamp.toISOString()).toRelativeCalendar()}</Typography>
+          <Typography variant="body1" paragraph>Time of the last successful save: {DateTime.fromISO(lastSaveTimestamp.toISOString()).toRelative()}</Typography>
         }
       </ErrorDialog>
     </form>


### PR DESCRIPTION
To test:
* edit a form and save the changes at various moments, then check how the last save timestamp is displayed in the header
* switch to offline from the browser devtools/network, try to save, and check how the "Failed to save" message is displayed