### PR TITLE
CARDS-2338: Put back the breadcrumb on the Patient chart to enable navigation to the previous hierarchy level - Patients page

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -28,7 +28,7 @@ import NewFormDialog from "../dataHomepage/NewFormDialog";
 import { QUESTION_TYPES, SECTION_TYPES, ENTRY_TYPES } from "./FormEntry.jsx";
 import { usePageNameWriterContext } from "../themePage/Page.jsx";
 import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
-import { getSubjectIdFromPath, getHierarchyAsList, getTextHierarchy } from "./SubjectIdentifier";
+import { getSubjectIdFromPath, getHierarchyAsList, getTextHierarchy, getHomepageLink } from "./SubjectIdentifier";
 import MaterialReactTable from 'material-react-table';
 import { Box } from '@mui/material';
 
@@ -313,7 +313,7 @@ function SubjectHeader(props) {
                />
             </div>
   );
-  let parentDetails = (subject?.data?.['parents'] && getHierarchyAsList(subject.data['parents'], true));
+  let parentDetails = (subject?.data?.['parents'] && getHierarchyAsList(subject.data['parents'], true) || [getHomepageLink(subject?.data)]);;
 
   return (
     subject?.data &&

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectIdentifier.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectIdentifier.jsx
@@ -26,7 +26,7 @@ function defaultCreator (node) {
 
 // Extract the subject id from the subject path
 // returns null if the parameter is not a valid subject path (expected format: Subjects/<id>)
-function getHomepageLink (subjectNode) {
+export function getHomepageLink (subjectNode) {
   let props = defaultCreator({"@path": `/Subjects#subjects:activeTab=${subjectNode?.type?.["@name"]}`});
   return (<Link {...props} underline="hover">{subjectNode?.type?.subjectListLabel || "Subjects"}</Link>);
 }


### PR DESCRIPTION
https://phenotips.atlassian.net/browse/CARDS-2338

Regression introduced by https://github.com/data-team-uhn/cards/commit/c93a9caba1f670e3ee1830b1ecc0c06c0acf938c#diff-8abd711cb3808388093456509d843732e1ba62974461644f36d718ac320ff89fL368