### PR TITLE
CARDS-2349: Add support for an --external_cards_project flag to generate_compose_yaml.py

### DIFF
--- a/distribution/docker_entry.sh
+++ b/distribution/docker_entry.sh
@@ -17,6 +17,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Execute the /external_project/project_init.sh script if it is present
+# and if so, load its exported environment variables
+[ -e /external_project/project_init.sh ] && source /external_project/project_init.sh
+
 #If we are simply restarting...
 [ -z $CARDS_RELOAD ] || WAIT_FOR_CARDSINIT=''
 

--- a/distribution/docker_entry.sh
+++ b/distribution/docker_entry.sh
@@ -43,6 +43,7 @@ PROJECT_ARTIFACTID=$1
 PROJECT_VERSION=$2
 
 VALID_CARDS_PROJECTS="||cards4kids|cards4lfs|cards4proms|cards4prems|cards4heracles|"
+VALID_CARDS_PROJECTS="${VALID_CARDS_PROJECTS}$(cat /external_project/project_code.txt | head -n 1 | tr -d '\n')|"
 echo "${VALID_CARDS_PROJECTS}" | grep -q "|${CARDS_PROJECT}|" || { echo "Invalid project specified - defaulting to generic CARDS."; unset CARDS_PROJECT; }
 
 featureFlagString=""

--- a/distribution/docker_entry.sh
+++ b/distribution/docker_entry.sh
@@ -47,7 +47,7 @@ PROJECT_ARTIFACTID=$1
 PROJECT_VERSION=$2
 
 VALID_CARDS_PROJECTS="||cards4kids|cards4lfs|cards4proms|cards4prems|cards4heracles|"
-VALID_CARDS_PROJECTS="${VALID_CARDS_PROJECTS}$(cat /external_project/project_code.txt | head -n 1 | tr -d '\n')|"
+[ -e /external_project/project_code.txt ] && VALID_CARDS_PROJECTS="${VALID_CARDS_PROJECTS}$(cat /external_project/project_code.txt | head -n 1 | tr -d '\n')|"
 echo "${VALID_CARDS_PROJECTS}" | grep -q "|${CARDS_PROJECT}|" || { echo "Invalid project specified - defaulting to generic CARDS."; unset CARDS_PROJECT; }
 
 featureFlagString=""


### PR DESCRIPTION
This _Pull Request_ implements CARDS-2349 by adding support for the `--external_cards_project` argument for `generate_compose_yaml.py` so that CARDS projects not defined in the https://github.com/data-team-uhn/cards code base (eg. `cards4sparc`) can be launched in a Docker Compose environment.

To test this PR, follow the instructions in the _README.md_ file of the https://github.com/data-team-uhn/cards4sparc repository, on the _CARDS-2347_ branch (https://github.com/data-team-uhn/cards4sparc/tree/CARDS-2347).