### PR TITLE
CARDS-2353: Move the @reference JSON processor in its own module and disable it by default

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -582,7 +582,6 @@ function SubjectMemberInternal (props) {
                         entryPath={row.original["@path"]}
                         entryName={getEntityIdentifier(row.original)}
                         entryType="Form"
-                        warning={row.original ? row.original["@referenced"] : false}
                         onComplete={fetchTableData}
                       />
                     </Box>

--- a/modules/utils/src/main/java/io/uhndata/cards/serialize/internal/ReferencedProcessor.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/serialize/internal/ReferencedProcessor.java
@@ -25,24 +25,24 @@ import javax.jcr.RepositoryException;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonValue;
 
-import org.apache.sling.api.resource.Resource;
 import org.osgi.service.component.annotations.Component;
 
 import io.uhndata.cards.serialize.spi.ResourceJsonProcessor;
 
 /**
- * Identify a node by including {@code @path} and {@code @name} properties. The name of this processor is
- * {@code identify}.
+ * Report if a node is referenced by adding a {@code @referenced=true|false} property. The name of this processor is
+ * {@code referenced}.
  *
  * @version $Id$
+ * @since 0.9.17
  */
 @Component(immediate = true)
-public class IdentificationProcessor implements ResourceJsonProcessor
+public class ReferencedProcessor implements ResourceJsonProcessor
 {
     @Override
     public String getName()
     {
-        return "identify";
+        return "referenced";
     }
 
     @Override
@@ -52,19 +52,11 @@ public class IdentificationProcessor implements ResourceJsonProcessor
     }
 
     @Override
-    public boolean isEnabledByDefault(Resource resource)
-    {
-        return true;
-    }
-
-    @Override
     public void leave(final Node node, final JsonObjectBuilder json,
         final Function<Node, JsonValue> serializeNode)
     {
-        // Add a few properties identifying the resource
         try {
-            json.add("@path", node.getPath());
-            json.add("@name", node.getName());
+            json.add("@referenced", node.getReferences().hasNext());
         } catch (RepositoryException e) {
             // Unlikely, and not critical, just make sure the serialization doesn't fail
         }


### PR DESCRIPTION
To test:
- create a new form
- access the form's `.deep.json` and check that there are no `@referenced` properties for any of the nodes
- access the subject's `.json` and check that there are no `@referenced` properties for any of the nodes
- access the form's `.deep.referenced.json` and check that `@referenced` properties are present