### PR TITLE
CARDS-2360: Display startup warning if the GOOGLE_APIKEY environment variable is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ By default, the app will run with username `admin` and password `admin`.
 
 In order to use "Vocabularies" section and load vocabularies from BioPortal (bioontology.org) `BIOPORTAL_APIKEY` environment variable should be set to a valid BioPortal API key. You can [request a new account](https://bioportal.bioontology.org/accounts/new) if you don't already have one, and the API key can be found [in your profile](https://bioportal.bioontology.org/account).
 
+A Google API key enables access to Google services such as address autocomplete. `GOOGLE_APIKEY` environment variable should be set to a valid Google API key. You can [can obtain an API key at]( https://developers.google.com/maps/documentation/javascript/get-api-key) if you don't already have one. Follow [these steps](https://help.stockist.co/article/43-verifying-your-google-maps-api-key) to ensure the necessary services such as Places service are enabled for your key.
+
 ## Running with Docker
 
 If Docker is installed, then the build can also create a new image named `cards/cards:latest` if building with `mvn install -Pdocker`.

--- a/environment.md
+++ b/environment.md
@@ -21,6 +21,7 @@ The following environment variables are read by CARDS and thus can be used in bo
 | `SLACK_PERFORMANCE_URL` | The Slack incoming webhook URL which the performance logger (`io.uhndata.cards.patients.slacknotifications`) can write its performance update messages to | `https://hooks.slack.com/services/ery8974/342rUYEiue/KJHkggI8973130DddE3r` |
 | `SLACK_BACKUP_NOTIFICATIONS_URL` | The Slack incoming webhook URL which the Webhook backup task (`io.uhndata.cards.webhookbackup`) uses to log its backup task status (_started_/_completed_/_failed_) messages | `https://hooks.slack.com/services/ery8974/342rUYEiue/KJHkggI8973130DddE3r` |
 | `BIOPORTAL_APIKEY` | API key [for Bioportal vocabularies](https://data.bioontology.org/documentation) | |
+| `GOOGLE_APIKEY` | API key [for Google Maps Place services](https://developers.google.com/maps/documentation/places/web-service/get-api-key) | |
 | `NIGHTLY_WEBHOOK_BACKUP_SCHEDULE` | Crontab-readable schedule (Quartz Job Scheduler) for performing Webhook backups of CARDS | `0 0 6 * * ? *` |
 | `BACKUP_WEBHOOK_URL` | Webhook URL to perform backups of CARDS to | `http://localhost:8012` |
 | `CLARITY_SQL_SERVER` | The MS-SQL server and port number to import clarity data from | `mssql:1433` |

--- a/environment.md
+++ b/environment.md
@@ -21,7 +21,7 @@ The following environment variables are read by CARDS and thus can be used in bo
 | `SLACK_PERFORMANCE_URL` | The Slack incoming webhook URL which the performance logger (`io.uhndata.cards.patients.slacknotifications`) can write its performance update messages to | `https://hooks.slack.com/services/ery8974/342rUYEiue/KJHkggI8973130DddE3r` |
 | `SLACK_BACKUP_NOTIFICATIONS_URL` | The Slack incoming webhook URL which the Webhook backup task (`io.uhndata.cards.webhookbackup`) uses to log its backup task status (_started_/_completed_/_failed_) messages | `https://hooks.slack.com/services/ery8974/342rUYEiue/KJHkggI8973130DddE3r` |
 | `BIOPORTAL_APIKEY` | API key [for Bioportal vocabularies](https://data.bioontology.org/documentation) | |
-| `GOOGLE_APIKEY` | API key [for Google Maps Place services](https://developers.google.com/maps/documentation/places/web-service/get-api-key) | |
+| `GOOGLE_APIKEY` | API key [for Google Maps Places services](https://developers.google.com/maps/documentation/places/web-service/get-api-key) | |
 | `NIGHTLY_WEBHOOK_BACKUP_SCHEDULE` | Crontab-readable schedule (Quartz Job Scheduler) for performing Webhook backups of CARDS | `0 0 6 * * ? *` |
 | `BACKUP_WEBHOOK_URL` | Webhook URL to perform backups of CARDS to | `http://localhost:8012` |
 | `CLARITY_SQL_SERVER` | The MS-SQL server and port number to import clarity data from | `mssql:1433` |

--- a/start_cards.sh
+++ b/start_cards.sh
@@ -136,11 +136,11 @@ function message_bioportal_apikey_missing() {
 }
 
 function message_google_apikey_missing() {
-  echo -e "${TERMINAL_RED}*******************************${TERMINAL_NOCOLOR}"
-  echo -e "${TERMINAL_RED}*                             *${TERMINAL_NOCOLOR}"
-  echo -e "${TERMINAL_RED}* GOOGLE_APIKEY not specified *${TERMINAL_NOCOLOR}"
-  echo -e "${TERMINAL_RED}*                             *${TERMINAL_NOCOLOR}"
-  echo -e "${TERMINAL_RED}*******************************${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*******************************${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*                             *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}* GOOGLE_APIKEY not specified *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*                             *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*******************************${TERMINAL_NOCOLOR}"
 }
 
 function message_hancestro_install_ok() {

--- a/start_cards.sh
+++ b/start_cards.sh
@@ -135,6 +135,14 @@ function message_bioportal_apikey_missing() {
   echo -e "${TERMINAL_RED}********************************************************************${TERMINAL_NOCOLOR}"
 }
 
+function message_google_apikey_missing() {
+  echo -e "${TERMINAL_RED}*******************************${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_RED}*                             *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_RED}* GOOGLE_APIKEY not specified *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_RED}*                             *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_RED}*******************************${TERMINAL_NOCOLOR}"
+}
+
 function message_hancestro_install_ok() {
   echo -e "${TERMINAL_GREEN}***********************${TERMINAL_NOCOLOR}"
   echo -e "${TERMINAL_GREEN}*                     *${TERMINAL_NOCOLOR}"
@@ -512,6 +520,12 @@ then
   else
     message_bioportal_apikey_missing
   fi
+fi
+
+#Check if a GOOGLE_APIKEY is present
+if [ -z $BIOPORTAL_APIKEY ]
+then
+  message_google_apikey_missing
 fi
 
 #Check if we are using the Cloud-IAM.com demo

--- a/start_cards.sh
+++ b/start_cards.sh
@@ -523,7 +523,7 @@ then
 fi
 
 #Check if a GOOGLE_APIKEY is present
-if [ -z $BIOPORTAL_APIKEY ]
+if [ -z $GOOGLE_APIKEY ]
 then
   message_google_apikey_missing
 fi

--- a/start_cards.sh
+++ b/start_cards.sh
@@ -136,11 +136,12 @@ function message_bioportal_apikey_missing() {
 }
 
 function message_google_apikey_missing() {
-  echo -e "${TERMINAL_YELLOW}*******************************${TERMINAL_NOCOLOR}"
-  echo -e "${TERMINAL_YELLOW}*                             *${TERMINAL_NOCOLOR}"
-  echo -e "${TERMINAL_YELLOW}* GOOGLE_APIKEY not specified *${TERMINAL_NOCOLOR}"
-  echo -e "${TERMINAL_YELLOW}*                             *${TERMINAL_NOCOLOR}"
-  echo -e "${TERMINAL_YELLOW}*******************************${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*********************************************************${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*                                                       *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}* GOOGLE_APIKEY not specified                           *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}* Certain question types may have limited functionality *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*                                                       *${TERMINAL_NOCOLOR}"
+  echo -e "${TERMINAL_YELLOW}*********************************************************${TERMINAL_NOCOLOR}"
 }
 
 function message_hancestro_install_ok() {


### PR DESCRIPTION
Testing:
* start without defining the `GOOGLE_APIKEY` environment variable, check that the warning message is displayed
* stop cards
* set the `GOOGLE_APIKEY` environment variable
* start cards, check that the warning message is no longer displayed