### PR TITLE
CARDS-2362: New Integrated Care Survey questions

### DIFF
--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/IC.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/IC.xml
@@ -67,7 +67,11 @@
 		</property>
 		<property>
 			<name>text</name>
-			<value>As you look to fill out this survey, you were likely discharged from your stay at a UHN hospital site within the last 30 days. We would like you to reflect on your experience with the Integrated Care Program as you transitioned home and to provide us with some feedback on supports that you may have received. We appreciate any insights you can provide and will look to make improvements based on your feedback. </value>
+			<value>
+### As you look to fill out this survey, you were likely discharged from your stay at a UHN hospital site within the last 30 days.
+
+We would like you to reflect on your experience with the Integrated Care Program as you transitioned home and to provide us with some feedback on supports that you may have received. We appreciate any insights you can provide and will look to make improvements based on your feedback.
+			</value>
 			<type>String</type>
 		</property>
 	</node>
@@ -143,6 +147,25 @@
 		<name>ic_1</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
+			<name>dataType</name>
+			<value>boolean</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>text</name>
+			<value>During this hospital stay, did you get information in writing about what symptoms or health problems to look out for after you left hospital?</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>minAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+	</node>
+	<node>
+		<name>ic_2</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
 			<name>maxAnswers</name>
 			<value>1</value>
 			<type>Long</type>
@@ -207,7 +230,7 @@
 		</node>
 	</node>
 	<node>
-		<name>ic_2</name>
+		<name>ic_3</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
 			<name>maxAnswers</name>
@@ -274,7 +297,7 @@
 		</node>
 	</node>
 	<node>
-		<name>ic_3</name>
+		<name>ic_4</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
 			<name>maxAnswers</name>
@@ -360,7 +383,7 @@
 		</node>
 	</node>
 	<node>
-		<name>ic_4</name>
+		<name>ic_5</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
 			<name>maxAnswers</name>
@@ -456,7 +479,7 @@
 		</node>
 	</node>
 	<node>
-		<name>ic_5</name>
+		<name>ic_6</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
 			<name>maxAnswers</name>
@@ -580,7 +603,7 @@
 		</node>
 	</node>
 	<node>
-		<name>ic_6</name>
+		<name>ic_7</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
 			<name>maxAnswers</name>
@@ -704,7 +727,7 @@
 		</node>
 	</node>
 	<node>
-		<name>ic_7</name>
+		<name>ic_8</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
 			<name>maxAnswers</name>
@@ -731,5 +754,243 @@
 			<value>0</value>
 			<type>Long</type>
 		</property>
+	</node>
+	<node>
+		<name>ic_feedback</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>label</name>
+			<value>##### If you would like to provide further input into your experience, please provide your name or that of your family caregiver, and a way to reach you (phone or email). A member of the quality improvement team will reach out to you for interview. Interviews would be maximum 30 minutes and in appreciation of your time, you would receive compensation.</value>
+			<type>String</type>
+		</property>
+		<node>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<name>ic_contact_name</name>
+			<property>
+				<name>text</name>
+				<value>Name</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+		</node>
+		<node>
+			<name>ic_contact_mode</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>I would like to be contacted by</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>list</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>1</value>
+				<type>Long</type>
+			</property>
+			<node>
+				<name>Phone</name>
+				<primaryNodeType>cards:AnswerOption</primaryNodeType>
+				<property>
+					<name>label</name>
+					<value>Phone call</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>value</name>
+					<value>Phone</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>defaultOrder</name>
+					<value>1</value>
+					<type>Long</type>
+				</property>
+			</node>
+			<node>
+				<name>Text</name>
+				<primaryNodeType>cards:AnswerOption</primaryNodeType>
+				<property>
+					<name>label</name>
+					<value>Text</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>value</name>
+					<value>Text</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>defaultOrder</name>
+					<value>2</value>
+					<type>Long</type>
+				</property>
+			</node>
+			<node>
+				<name>Email</name>
+				<primaryNodeType>cards:AnswerOption</primaryNodeType>
+				<property>
+					<name>label</name>
+					<value>Email</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>value</name>
+					<value>Email</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>defaultOrder</name>
+					<value>3</value>
+					<type>Long</type>
+				</property>
+			</node>
+		</node>
+		<node>
+			<name>ic_contact_phone_section</name>
+			<primaryNodeType>cards:Section</primaryNodeType>
+			<node>
+				<name>condition1</name>
+				<primaryNodeType>cards:Conditional</primaryNodeType>
+				<property>
+					<name>comparator</name>
+					<value>=</value>
+					<type>String</type>
+				</property>
+				<node>
+					<name>operandA</name>
+					<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+					<property>
+						<name>value</name>
+						<values>
+							<value>ic_contact_mode</value>
+						</values>
+						<type>String</type>
+					</property>
+					<property>
+						<name>isReference</name>
+						<value>True</value>
+						<type>Boolean</type>
+					</property>
+				</node>
+				<node>
+					<name>operandB</name>
+					<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+					<property>
+						<name>value</name>
+						<values>
+							<value>Phone</value>
+							<value>Text</value>
+						</values>
+						<type>String</type>
+					</property>
+					<property>
+						<name>isReference</name>
+						<value>False</value>
+						<type>Boolean</type>
+					</property>
+				</node>
+			</node>
+			<node>
+				<primaryNodeType>cards:Question</primaryNodeType>
+				<name>ic_contact_phone</name>
+				<property>
+					<name>text</name>
+					<value>Phone number</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>dataType</name>
+					<value>phone</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>onlyCountries</name>
+					<value>ca</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>maxAnswers</name>
+					<value>1</value>
+					<type>Long</type>
+				</property>
+			</node>
+		</node>
+		<node>
+			<name>ic_contact_email_section</name>
+			<primaryNodeType>cards:Section</primaryNodeType>
+			<node>
+				<name>condition1</name>
+				<primaryNodeType>cards:Conditional</primaryNodeType>
+				<property>
+					<name>comparator</name>
+					<value>=</value>
+					<type>String</type>
+				</property>
+				<node>
+					<name>operandA</name>
+					<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+					<property>
+						<name>value</name>
+						<values>
+							<value>ic_contact_mode</value>
+						</values>
+						<type>String</type>
+					</property>
+					<property>
+						<name>isReference</name>
+						<value>True</value>
+						<type>Boolean</type>
+					</property>
+				</node>
+				<node>
+					<name>operandB</name>
+					<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+					<property>
+						<name>value</name>
+						<values>
+							<value>Email</value>
+						</values>
+						<type>String</type>
+					</property>
+					<property>
+						<name>isReference</name>
+						<value>False</value>
+						<type>Boolean</type>
+					</property>
+				</node>
+			</node>
+			<node>
+				<primaryNodeType>cards:Question</primaryNodeType>
+				<name>ic_contact_email</name>
+				<property>
+					<name>text</name>
+					<value>Email address</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>validationRegexp</name>
+					<value>^([a-zA-Z0-9._%-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})$</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>validationErrorText</name>
+					<value>Please enter a valid email address</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>maxAnswers</name>
+					<value>1</value>
+					<type>Long</type>
+				</property>
+			</node>
+		</node>
 	</node>
 </node>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/IC.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/IC.xml
@@ -70,7 +70,7 @@
 			<value>
 ### As you look to fill out this survey, you were likely discharged from your stay at a UHN hospital site within the last 30 days.
 
-We would like you to reflect on your experience with the Integrated Care Program as you transitioned home and to provide us with some feedback on supports that you may have received. We appreciate any insights you can provide and will look to make improvements based on your feedback.
+We would like you to reflect on your experience with the Integrated Care Program in the last month when you were discharged from the hospital and transitioned home and to provide us with some feedback on supports that you may have received. We appreciate any insights you can provide and will look to make improvements based on your feedback.
 			</value>
 			<type>String</type>
 		</property>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/IC.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/IC.xml
@@ -1000,7 +1000,7 @@ A member of the quality improvement team will reach out to you for an interview.
 				</property>
 				<property>
 					<name>validationRegexp</name>
-					<value>^([a-zA-Z0-9._%-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})$</value>
+					<value>^([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})$</value>
 					<type>String</type>
 				</property>
 				<property>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/IC.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/IC.xml
@@ -864,6 +864,11 @@ A member of the quality improvement team will reach out to you for an interview.
 					<value>4</value>
 					<type>Long</type>
 				</property>
+				<property>
+					<name>noneOfTheAbove</name>
+					<value>True</value>
+					<type>Boolean</type>
+				</property>
 			</node>
 		</node>
 		<node>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/IC.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/IC.xml
@@ -70,7 +70,7 @@
 			<value>
 ### As you look to fill out this survey, you were likely discharged from your stay at a UHN hospital site within the last 30 days.
 
-We would like you to reflect on your experience with the Integrated Care Program in the last month when you were discharged from the hospital and transitioned home and to provide us with some feedback on supports that you may have received. We appreciate any insights you can provide and will look to make improvements based on your feedback.
+We would like you to reflect on your experience with the Integrated Care Program in the last month when you were discharged from the hospital and transitioned home, and to provide us with some feedback on supports that you may have received. We appreciate any insights you can provide and will look to make improvements based on your feedback.
 			</value>
 			<type>String</type>
 		</property>
@@ -758,11 +758,19 @@ We would like you to reflect on your experience with the Integrated Care Program
 	<node>
 		<name>ic_feedback</name>
 		<primaryNodeType>cards:Section</primaryNodeType>
-		<property>
-			<name>label</name>
-			<value>##### If you would like to provide further input into your experience, please provide your name or that of your family caregiver, and a way to reach you (phone or email). A member of the quality improvement team will reach out to you for interview. Interviews would be maximum 30 minutes and in appreciation of your time, you would receive compensation.</value>
-			<type>String</type>
-		</property>
+		<node>
+			<name>ic_feedback_intro</name>
+			<primaryNodeType>cards:Information</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>
+### If you would like to provide further input into your experience, please provide your name or that of your family caregiver, and a way to reach you (phone or email).
+
+A member of the quality improvement team will reach out to you for an interview. Interviews would be maximum 30 minutes and in appreciation of your time, you would receive compensation.
+				</value>
+				<type>String</type>
+			</property>
+		</node>
 		<node>
 			<name>ic_contact_mode</name>
 			<primaryNodeType>cards:Question</primaryNodeType>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/IC.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/IC.xml
@@ -764,20 +764,6 @@ We would like you to reflect on your experience with the Integrated Care Program
 			<type>String</type>
 		</property>
 		<node>
-			<primaryNodeType>cards:Question</primaryNodeType>
-			<name>ic_contact_name</name>
-			<property>
-				<name>text</name>
-				<value>Name</value>
-				<type>String</type>
-			</property>
-			<property>
-				<name>maxAnswers</name>
-				<value>1</value>
-				<type>Long</type>
-			</property>
-		</node>
-		<node>
 			<name>ic_contact_mode</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
@@ -852,6 +838,25 @@ We would like you to reflect on your experience with the Integrated Care Program
 					<type>Long</type>
 				</property>
 			</node>
+			<node>
+				<name>No</name>
+				<primaryNodeType>cards:AnswerOption</primaryNodeType>
+				<property>
+					<name>label</name>
+					<value>I do not want to be contacted</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>value</name>
+					<value>No</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>defaultOrder</name>
+					<value>4</value>
+					<type>Long</type>
+				</property>
+			</node>
 		</node>
 		<node>
 			<name>ic_contact_phone_section</name>
@@ -915,6 +920,11 @@ We would like you to reflect on your experience with the Integrated Care Program
 					<name>onlyCountries</name>
 					<value>ca</value>
 					<type>String</type>
+				</property>
+				<property>
+					<name>minAnswers</name>
+					<value>1</value>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>maxAnswers</name>
@@ -984,6 +994,77 @@ We would like you to reflect on your experience with the Integrated Care Program
 					<name>validationErrorText</name>
 					<value>Please enter a valid email address</value>
 					<type>String</type>
+				</property>
+				<property>
+					<name>minAnswers</name>
+					<value>1</value>
+					<type>Long</type>
+				</property>
+				<property>
+					<name>maxAnswers</name>
+					<value>1</value>
+					<type>Long</type>
+				</property>
+			</node>
+		</node>
+		<node>
+			<name>ic_contact_name_section</name>
+			<primaryNodeType>cards:Section</primaryNodeType>
+			<node>
+				<name>condition1</name>
+				<primaryNodeType>cards:Conditional</primaryNodeType>
+				<property>
+					<name>comparator</name>
+					<value>=</value>
+					<type>String</type>
+				</property>
+				<node>
+					<name>operandA</name>
+					<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+					<property>
+						<name>value</name>
+						<values>
+							<value>ic_contact_mode</value>
+						</values>
+						<type>String</type>
+					</property>
+					<property>
+						<name>isReference</name>
+						<value>True</value>
+						<type>Boolean</type>
+					</property>
+				</node>
+				<node>
+					<name>operandB</name>
+					<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+					<property>
+						<name>value</name>
+						<values>
+							<value>Phone</value>
+							<value>Text</value>
+							<value>Email</value>
+						</values>
+						<type>String</type>
+					</property>
+					<property>
+						<name>isReference</name>
+						<value>False</value>
+						<type>Boolean</type>
+					</property>
+				</node>
+			</node>
+			<node>
+				<primaryNodeType>cards:Question</primaryNodeType>
+				<name>ic_contact_name</name>
+				<property>
+					<name>text</name>
+					<value>Name</value>
+					<type>String</type>
+				</property>
+				<property>
+					<name>minAnswers</name>
+					<value>1</value>
+					<type>Long</type>
 				</property>
 				<property>
 					<name>maxAnswers</name>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/EDIC.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/EDIC.xml
@@ -29,7 +29,7 @@
         <name>intro</name>
         <value>
 We’d like to hear about your experience while you were a patient in UHN’s Emergency Department.
-We would also like you to reflect on your experience with the Integrated Care Program as you transitioned home and to provide us with some feedback on supports that you may have received.
+We would also like you to reflect on your experience with the Integrated Care Program in the last month when you were discharged from the hospital and transitioned home, and to provide us with some feedback on supports that you may have received.
 We appreciate any insights you can provide and will look to make improvements based on your feedback.
         </value>
         <type>String</type>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/EDIC.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/EDIC.xml
@@ -126,7 +126,7 @@ We appreciate any insights you can provide and will look to make improvements ba
       "link" : "dashboard+path"
     },
     {
-      "key": "ic_6",
+      "key": "ic_7",
       "label": "Overall experience",
       "link" : "string"
     }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/EDIPIC.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/EDIPIC.xml
@@ -29,7 +29,7 @@
         <name>intro</name>
         <value>
 We’d like to hear about your experience while you were a patient at UHN.
-We would also like you to reflect on your experience with the Integrated Care Program as you transitioned home and to provide us with some feedback on supports that you may have received.
+We would also like you to reflect on your experience with the Integrated Care Program in the last month when you were discharged from the hospital and transitioned home, and to provide us with some feedback on supports that you may have received.
 We appreciate any insights you can provide and will look to make improvements based on your feedback.
         </value>
         <type>String</type>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/EDIPIC.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/EDIPIC.xml
@@ -174,7 +174,7 @@ We appreciate any insights you can provide and will look to make improvements ba
       "link" : "dashboard+path"
     },
     {
-      "key": "ic_6",
+      "key": "ic_7",
       "label": "Overall experience",
       "link" : "string"
     }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/IC.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/IC.xml
@@ -77,7 +77,7 @@ We appreciate any insights you can provide and will look to make improvements ba
       "link" : "dashboard+path"
     },
     {
-      "key": "ic_6",
+      "key": "ic_7",
       "label": "Overall experience",
       "link" : "string"
     }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/IC.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/IC.xml
@@ -28,7 +28,7 @@
     <property>
         <name>intro</name>
         <value>
-We would like you to reflect on your experience with the Integrated Care Program as you transitioned home and to provide us with some feedback on supports that you may have received.
+We would like you to reflect on your experience with the Integrated Care Program in the last month when you were discharged from the hospital and transitioned home, and to provide us with some feedback on supports that you may have received.
 We appreciate any insights you can provide and will look to make improvements based on your feedback.
         </value>
         <type>String</type>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/IPIC.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/IPIC.xml
@@ -29,7 +29,7 @@
         <name>intro</name>
         <value>
 We’d like to hear about your experience while you were an inpatient at UHN.
-We would also like you to reflect on your experience with the Integrated Care Program as you transitioned home and to provide us with some feedback on supports that you may have received.
+We would also like you to reflect on your experience with the Integrated Care Program in the last month when you were discharged from the hospital and transitioned home, and to provide us with some feedback on supports that you may have received.
 We appreciate any insights you can provide and will look to make improvements based on your feedback.
         </value>
         <type>String</type>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/IPIC.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/IPIC.xml
@@ -126,7 +126,7 @@ We appreciate any insights you can provide and will look to make improvements ba
       "link" : "dashboard+path"
     },
     {
-      "key": "ic_6",
+      "key": "ic_7",
       "label": "Overall experience",
       "link" : "string"
     }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -17,7 +17,7 @@
       team and answering will not impact future care you receive at UHN.
     </p>
     <p>
-      The survey consists of two questionnaires containing 19 questions and will take 10-15 minutes to complete.
+      The survey consists of two questionnaires containing 20 questions and will take 10-15 minutes to complete.
     </p>
     <p>
       <strong>The survey will be available until ${expirationDate}. Please do not delay.</strong>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -17,7 +17,7 @@
       team and answering will not impact future care you receive at UHN.
     </p>
     <p>
-      The survey consists of two questionnaires containing 18 questions and will take 10-15 minutes to complete.
+      The survey consists of two questionnaires containing 19 questions and will take 10-15 minutes to complete.
     </p>
     <p>
       <strong>The survey will be available until ${expirationDate}. Please do not delay.</strong>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -2,8 +2,8 @@
     <p>
       You are receiving this email because of your recent visit at a University Health Network (UHN) hospital within the last 30 days.
       We’d like to hear about your experience while you were a patient in UHN’s Emergency Department.
-      We would also like you to reflect on your experience with the Integrated Care Program as you transitioned home and to provide us
-      with some feedback on supports that you may have received.
+      We would also like you to reflect on your experience with the Integrated Care Program in the last month when you were discharged from
+      the hospital and transitioned home, and to provide us with some feedback on supports that you may have received.
     </p>
     <p>
       Your opinions are valuable to us.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -13,7 +13,7 @@ be used to help UHN continuously improve the quality of care patients receive.
 Completing this survey is voluntary. Your responses will not be shared with
 the care team and answering will not impact future care you receive at UHN.
 
-The survey consists of two questionnaires containing 18 questions and will take
+The survey consists of two questionnaires containing 19 questions and will take
 10-15 minutes to complete.
 
 To begin the survey, click the following link:

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -4,8 +4,9 @@ You are receiving this email because of your recent visit at a University
 Health Network (UHN) hospital within the last 30 days. We’d like to
 hear about your experience while you were a patient in UHN’s Emergency
 Department. We would also like you to reflect on your experience with
-the Integrated Care Program as you transitioned home and to provide us
-with some feedback on supports that you may have received.
+the Integrated Care Program in the last month when you were discharged
+from the hospital and transitioned home, and to provide us with some
+feedback on supports that you may have received.
 
 Your opinions are valuable to us. Your responses will be anonymous and will
 be used to help UHN continuously improve the quality of care patients receive.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -14,7 +14,7 @@ be used to help UHN continuously improve the quality of care patients receive.
 Completing this survey is voluntary. Your responses will not be shared with
 the care team and answering will not impact future care you receive at UHN.
 
-The survey consists of two questionnaires containing 19 questions and will take
+The survey consists of two questionnaires containing 20 questions and will take
 10-15 minutes to complete.
 
 To begin the survey, click the following link:

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -1,9 +1,12 @@
     <p>Dear ${first_name} ${last_name},</p>
     <p>
-      You are receiving this email because of your recent visit at a University Health Network (UHN) hospital within the last 30 days.
+      You are receiving this email because you have recently visited a University Health Network (UHN) hospital within the last 30 days
+      and our records indicate that we sent you a survey asking about your experience. However we have not heard back from you.
+    </p>
+    <p>
       We’d like to hear about your experience while you were a patient in UHN’s Emergency Department.
-      We would also like you to reflect on your experience with the Integrated Care Program as you transitioned home and to provide us
-      with some feedback on supports that you may have received, but we have not heard back from you.
+      We would also like you to reflect on your experience with the Integrated Care Program in the last month when you were discharged
+      from the hospital and transitioned home, and to provide us with some feedback on supports that you may have received.
     </p>
     <p>
       Your opinions are valuable to us.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -20,7 +20,7 @@
       team and answering will not impact future care you receive at UHN.
     </p>
     <p>
-      The survey consists of two questionnaires containing 19 questions and will take 10-15 minutes to complete.
+      The survey consists of two questionnaires containing 20 questions and will take 10-15 minutes to complete.
     </p>
     <p>
       <strong>The survey will be available until ${expirationDate}. Please do not delay.</strong>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -17,7 +17,7 @@
       team and answering will not impact future care you receive at UHN.
     </p>
     <p>
-      The survey consists of two questionnaires containing 18 questions and will take 10-15 minutes to complete.
+      The survey consists of two questionnaires containing 19 questions and will take 10-15 minutes to complete.
     </p>
     <p>
       <strong>The survey will be available until ${expirationDate}. Please do not delay.</strong>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -14,7 +14,7 @@ be used to help UHN continuously improve the quality of care patients receive.
 Completing this survey is voluntary. Your responses will not be shared with
 the care team and answering will not impact future care you receive at UHN.
 
-The survey consists of two questionnaires containing 18 questions and will take
+The survey consists of two questionnaires containing 19 questions and will take
 10-15 minutes to complete.
 
 To begin the survey, click the following link:

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -17,7 +17,7 @@ be used to help UHN continuously improve the quality of care patients receive.
 Completing this survey is voluntary. Your responses will not be shared with
 the care team and answering will not impact future care you receive at UHN.
 
-The survey consists of two questionnaires containing 19 questions and will take
+The survey consists of two questionnaires containing 20 questions and will take
 10-15 minutes to complete.
 
 To begin the survey, click the following link:

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -1,12 +1,15 @@
 Dear ${first_name} ${last_name},
 
-You are receiving this email because of your recent visit at a University
-Health Network (UHN) hospital within the last 30 days. We’d like to
-hear about your experience while you were a patient in UHN’s Emergency
-Department. We would also like you to reflect on your experience with
-the Integrated Care Program as you transitioned home and to provide us
-with some feedback on supports that you may have received, but we have
-not heard back from you.
+You are receiving this email because you have recently visited a
+University Health Network (UHN) hospital within the last 30 days
+and our records indicate that we sent you a survey asking about
+your experience. However we have not heard back from you.
+
+We’d like to hear about your experience while you were a patient in UHN’s
+Emergency Department. We would also like you to reflect on your experience
+with the Integrated Care Program in the last month when you were discharged
+from the hospital and transitioned home, and to provide us with some
+feedback on supports that you may have received.
 
 Your opinions are valuable to us. Your responses will be anonymous and will
 be used to help UHN continuously improve the quality of care patients receive.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -2,8 +2,8 @@
     <p>
       You are receiving this email because of your recent visit at a University Health Network (UHN) hospital within the last 30 days.
       We’d like to hear about your experience while you were a patient at UHN.
-      We would also like you to reflect on your experience with the Integrated Care Program as you transitioned home and to provide us
-      with some feedback on supports that you may have received.
+      We would also like you to reflect on your experience with the Integrated Care Program in the last month when you were discharged
+      from the hospital and transitioned home, and to provide us with some feedback on supports that you may have received.
     </p>
     <p>
       Your opinions are valuable to us.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -17,7 +17,7 @@
       team and answering will not impact future care you receive at UHN.
     </p>
     <p>
-      The survey consists of three questionnaires containing 31 questions and will take 15-20 minutes to complete.
+      The survey consists of three questionnaires containing 33 questions and will take 15-20 minutes to complete.
     </p>
     <p>
       <strong>The survey will be available until ${expirationDate}. Please do not delay.</strong>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -3,9 +3,10 @@ Dear ${first_name} ${last_name},
 You are receiving this email because of your recent visit at a University
 Health Network (UHN) hospital within the last 30 days. We’d like to
 hear about your experience while you were a patient at UHN.
-We would also like you to reflect on your experience with
-the Integrated Care Program as you transitioned home and to provide us
-with some feedback on supports that you may have received.
+We would also like you to reflect on your experience with the Integrated
+Care Program in the last month when you were discharged from the hospital
+and transitioned home, and to provide us with some feedback on supports
+that you may have received.
 
 Your opinions are valuable to us. Your responses will be anonymous and will
 be used to help UHN continuously improve the quality of care patients receive.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -13,7 +13,7 @@ be used to help UHN continuously improve the quality of care patients receive.
 Completing this survey is voluntary. Your responses will not be shared with
 the care team and answering will not impact future care you receive at UHN.
 
-The survey consists of three questionnaires containing 31 questions and will
+The survey consists of three questionnaires containing 33 questions and will
 take 15-20 minutes to complete.
 
 To begin the survey, click the following link:

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -1,9 +1,12 @@
     <p>Dear ${first_name} ${last_name},</p>
     <p>
-      You are receiving this email because of your recent visit at a University Health Network (UHN) hospital within the last 30 days.
+      You are receiving this email because you have recently visited a University Health Network (UHN) hospital within the last 30 days
+      and our records indicate that we sent you a survey asking about your experience. However we have not heard back from you.
+    </p>
+    <p>
       We’d like to hear about your experience while you were a patient at UHN.
-      We would also like you to reflect on your experience with the Integrated Care Program as you transitioned home and to provide us
-      with some feedback on supports that you may have received, but we have not heard back from you.
+      We would also like you to reflect on your experience with the Integrated Care Program in the last month when you were discharged
+      from the hospital and transitioned home, and to provide us with some feedback on supports that you may have received.
     </p>
     <p>
       Your opinions are valuable to us.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -17,7 +17,7 @@
       team and answering will not impact future care you receive at UHN.
     </p>
     <p>
-      The survey consists of three questionnaires containing 31 questions and will take 15-20 minutes to complete.
+      The survey consists of three questionnaires containing 33 questions and will take 15-20 minutes to complete.
     </p>
     <p>
       <strong>The survey will be available until ${expirationDate}. Please do not delay.</strong>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -1,12 +1,15 @@
 Dear ${first_name} ${last_name},
 
-You are receiving this email because of your recent visit at a University
-Health Network (UHN) hospital within the last 30 days. We’d like to
-hear about your experience while you were a patient at UHN.
-We would also like you to reflect on your experience with
-the Integrated Care Program as you transitioned home and to provide us
-with some feedback on supports that you may have received, but we have
-not heard back from you.
+You are receiving this email because you have recently visited a University
+Health Network (UHN) hospital within the last 30 days and our records indicate
+that we sent you a survey asking about your experience. However we have not
+heard back from you.
+
+We’d like to hear about your experience while you were a patient at UHN.
+We would also like you to reflect on your experience with the Integrated
+Care Program in the last month when you were discharged from the hospital
+and transitioned home, and to provide us with some feedback on supports
+that you may have received.
 
 Your opinions are valuable to us. Your responses will be anonymous and will
 be used to help UHN continuously improve the quality of care patients receive.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -14,7 +14,7 @@ be used to help UHN continuously improve the quality of care patients receive.
 Completing this survey is voluntary. Your responses will not be shared with
 the care team and answering will not impact future care you receive at UHN.
 
-The survey consists of three questionnaires containing 31 questions and will
+The survey consists of three questionnaires containing 33 questions and will
 take 15-20 minutes to complete.
 
 To begin the survey, click the following link:

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -2,8 +2,8 @@
     <p>
       You are receiving this email because of your recent visit at a University Health Network (UHN) hospital within the last 30 days.
       We’d like to hear about your experience while you were an inpatient at UHN.
-      We would also like you to reflect on your experience with the Integrated Care Program as you transitioned home and to provide us
-      with some feedback on supports that you may have received.
+      We would also like you to reflect on your experience with the Integrated Care Program in the last month when you were discharged
+      from the hospital and transitioned home, and to provide us with some feedback on supports that you may have received.
     </p>
     <p>
       Your opinions are valuable to us.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -17,7 +17,7 @@
       team and answering will not impact future care you receive at UHN.
     </p>
     <p>
-      The survey consists of two questionnaires containing 20 questions and will take about 10-15 minutes to complete.
+      The survey consists of two questionnaires containing 22 questions and will take about 10-15 minutes to complete.
     </p>
     <p>
       <strong>The survey will be available until ${expirationDate}. Please do not delay.</strong>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -13,7 +13,7 @@ be used to help UHN continuously improve the quality of care patients receive.
 Completing this survey is voluntary. Your responses will not be shared with
 the care team and answering will not impact future care you receive at UHN.
 
-The survey consists of two questionnaires containing 20 questions and will
+The survey consists of two questionnaires containing 22 questions and will
 take about 10-15 minutes to complete.
 
 To begin the survey, click the following link:

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -3,9 +3,10 @@ Dear ${first_name} ${last_name},
 You are receiving this email because of your recent visit at a University
 Health Network (UHN) hospital within the last 30 days. We’d like to
 hear about your experience while you were an inpatient at UHN.
-We would also like you to reflect on your experience with
-the Integrated Care Program as you transitioned home and to provide us
-with some feedback on supports that you may have received.
+We would also like you to reflect on your experience with the Integrated
+Care Program in the last month when you were discharged from the hospital
+and transitioned home, and to provide us with some feedback on supports
+that you may have received.
 
 Your opinions are valuable to us. Your responses will be anonymous and will
 be used to help UHN continuously improve the quality of care patients receive.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -1,9 +1,12 @@
     <p>Dear ${first_name} ${last_name},</p>
     <p>
-      You are receiving this email because of your recent visit at a University Health Network (UHN) hospital within the last 30 days.
+      You are receiving this email because you have recently visited a University Health Network (UHN) hospital within the last 30 days
+      and our records indicate that we sent you a survey asking about your experience. However we have not heard back from you.
+    </p>
+    <p>
       We’d like to hear about your experience while you were an inpatient at UHN.
-      We would also like you to reflect on your experience with the Integrated Care Program as you transitioned home and to provide us
-      with some feedback on supports that you may have received, but we have not heard back from you.
+      We would also like you to reflect on your experience with the Integrated Care Program in the last month when you were discharged
+      from the hospital and transitioned home, and to provide us with some feedback on supports that you may have received.
     </p>
     <p>
       Your opinions are valuable to us.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -17,7 +17,7 @@
       team and answering will not impact future care you receive at UHN.
     </p>
     <p>
-      The survey consists of two questionnaires containing 20 questions and will take about 10-15 minutes to complete.
+      The survey consists of two questionnaires containing 22 questions and will take about 10-15 minutes to complete.
     </p>
     <p>
       <strong>The survey will be available until ${expirationDate}. Please do not delay.</strong>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -14,7 +14,7 @@ be used to help UHN continuously improve the quality of care patients receive.
 Completing this survey is voluntary. Your responses will not be shared with
 the care team and answering will not impact future care you receive at UHN.
 
-The survey consists of two questionnaires containing 20 questions and will
+The survey consists of two questionnaires containing 22 questions and will
 take about 10-15 minutes to complete.
 
 To begin the survey, click the following link:

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -1,12 +1,15 @@
 Dear ${first_name} ${last_name},
 
-You are receiving this email because of your recent visit at a University
-Health Network (UHN) hospital within the last 30 days. We’d like to
-hear about your experience while you were an inpatient at UHN.
-We would also like you to reflect on your experience with
-the Integrated Care Program as you transitioned home and to provide us
-with some feedback on supports that you may have received, but we have
-not heard back from you.
+You are receiving this email because you have recently visited a University
+Health Network (UHN) hospital within your last 30 days and our records
+indicate that we sent you a survey asking about your experience. However
+we have not heard back from you.
+
+We’d like to hear about your experience while you were an inpatient at UHN.
+We would also like you to reflect on your experience with the Integrated
+Care Program in the last month when you were discharged from the hospital
+and transitioned home, and to provide us with some feedback on supports
+that you may have received.
 
 Your opinions are valuable to us. Your responses will be anonymous and will
 be used to help UHN continuously improve the quality of care patients receive.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -1,8 +1,8 @@
     <p>Dear ${first_name} ${last_name},</p>
     <p>
       You are receiving this email because of your recent visit at a University Health Network (UHN) hospital within the last 30 days.
-      We would like you to reflect on your experience with the Integrated Care Program as you transitioned home and to provide us
-      with some feedback on supports that you may have received.
+      We would like you to reflect on your experience with the Integrated Care Program in the last month when you were discharged from
+      the hospital and transitioned home, and to provide us with some feedback on supports that you may have received.
     </p>
     <p>
       Your opinions are valuable to us.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -16,7 +16,7 @@
       team and answering will not impact future care you receive at UHN.
     </p>
     <p>
-      The questionnaire contains 8 questions and will take about 5 minutes to complete.
+      The questionnaire contains 9 questions and will take about 5 minutes to complete.
     </p>
     <p>
       <strong>The survey will be available until ${expirationDate}. Please do not delay.</strong>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -16,7 +16,7 @@
       team and answering will not impact future care you receive at UHN.
     </p>
     <p>
-      The questionnaire contains 7 questions and will take about 5 minutes to complete.
+      The questionnaire contains 8 questions and will take about 5 minutes to complete.
     </p>
     <p>
       <strong>The survey will be available until ${expirationDate}. Please do not delay.</strong>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -2,9 +2,9 @@ Dear ${first_name} ${last_name},
 
 You are receiving this email because of your recent visit at a University
 Health Network (UHN) hospital within the last 30 days. We would like you
-to reflect on your experience with the Integrated Care Program as you
-transitioned home and to provide us with some feedback on supports that
-you may have received.
+to reflect on your experience with the Integrated Care Program in the last
+month when you were discharged from the hospital and transitioned home,
+and to provide us with some feedback on supports that you may have received.
 
 Your opinions are valuable to us. Your responses will be anonymous and will
 be used to help UHN continuously improve the quality of care patients receive.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -12,7 +12,7 @@ be used to help UHN continuously improve the quality of care patients receive.
 Completing this survey is voluntary. Your responses will not be shared with
 the care team and answering will not impact future care you receive at UHN.
 
-The questionnaire contains 8 questions and will take about 5 minutes to
+The questionnaire contains 9 questions and will take about 5 minutes to
 complete.
 
 To begin the survey, click the following link:

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -12,7 +12,7 @@ be used to help UHN continuously improve the quality of care patients receive.
 Completing this survey is voluntary. Your responses will not be shared with
 the care team and answering will not impact future care you receive at UHN.
 
-The questionnaire contains 7 questions and will take about 5 minutes to
+The questionnaire contains 8 questions and will take about 5 minutes to
 complete.
 
 To begin the survey, click the following link:

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -16,7 +16,7 @@
       team and answering will not impact future care you receive at UHN.
     </p>
     <p>
-      The questionnaire contains 7 questions and will take about 5 minutes to complete.
+      The questionnaire contains 8 questions and will take about 5 minutes to complete.
     </p>
     <p>
       <strong>The survey will be available until ${expirationDate}. Please do not delay.</strong>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -1,8 +1,12 @@
     <p>Dear ${first_name} ${last_name},</p>
     <p>
-      You are receiving this email because of your recent visit at a University Health Network (UHN) hospital within the last 30 days.
-      We would like you to reflect on your experience with the Integrated Care Program as you transitioned home and to provide us
-      with some feedback on supports that you may have received, but we have not heard back from you.
+      You are receiving this email because you have recently visited a University Health Network (UHN) hospital within the last 30 days
+      and our records indicate that we sent you a survey asking about your experience with the Integrated Care Program.
+      However we have not heard back from you.
+    </p>
+    <p>
+      We would like you to reflect on your experience with the Integrated Care Program in the last month when you were discharged
+      from the hospital and transitioned home, and to provide us with some feedback on supports that you may have received.
     </p>
     <p>
       Your opinions are valuable to us.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -20,7 +20,7 @@
       team and answering will not impact future care you receive at UHN.
     </p>
     <p>
-      The questionnaire contains 8 questions and will take about 5 minutes to complete.
+      The questionnaire contains 9 questions and will take about 5 minutes to complete.
     </p>
     <p>
       <strong>The survey will be available until ${expirationDate}. Please do not delay.</strong>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -1,10 +1,15 @@
 Dear ${first_name} ${last_name},
 
-You are receiving this email because of your recent visit at a University
-Health Network (UHN) hospital within the last 30 days. We would like you
-to reflect on your experience with the Integrated Care Program as you
-transitioned home and to provide us with some feedback on supports that
-you may have received, but we have not heard back from you.
+You are receiving this email because you have recently visited a
+University Health Network (UHN) hospital within the last 30 days
+and our records indicate that we sent you a survey asking about
+your experience with the Integrated Care Program. However we have
+not heard back from you.
+
+We would like you to reflect on your experience with the Integrated Care
+Program in the last month when you were discharged from the hospital and
+transitioned home, and to provide us with some feedback on supports that
+you may have received.
 
 Your opinions are valuable to us. Your responses will be anonymous and will
 be used to help UHN continuously improve the quality of care patients receive.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -17,7 +17,7 @@ be used to help UHN continuously improve the quality of care patients receive.
 Completing this survey is voluntary. Your responses will not be shared with
 the care team and answering will not impact future care you receive at UHN.
 
-The questionnaire contains 8 questions and will take about 5 minutes to
+The questionnaire contains 9 questions and will take about 5 minutes to
 complete.
 
 To begin the survey, click the following link:

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -12,7 +12,7 @@ be used to help UHN continuously improve the quality of care patients receive.
 Completing this survey is voluntary. Your responses will not be shared with
 the care team and answering will not impact future care you receive at UHN.
 
-The questionnaire contains 7 questions and will take about 5 minutes to
+The questionnaire contains 8 questions and will take about 5 minutes to
 complete.
 
 To begin the survey, click the following link:

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/config/CopyAnswers/Questionnaires/IC.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/config/CopyAnswers/Questionnaires/IC.json
@@ -1,6 +1,6 @@
 {
   "jcr:primaryType": "nt:unstructured",
-  "jcr:reference:ic_6": "/Questionnaires/IC/ic_6",
+  "jcr:reference:ic_7": "/Questionnaires/IC/ic_7",
   "jcr:reference:ic_department": "/Questionnaires/IC/ic_department",
   "jcr:reference:time": "/Questionnaires/Visit information/time",
   "jcr:reference:mrn": "/Questionnaires/Patient information/mrn"

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -303,11 +303,12 @@
       "export.schedule": "0 0 2 ? * SAT *",
       "questionnaires.to.be.exported": [
         "/Questionnaires/CPESIC",
+        "/Questionnaires/IC",
         "/Questionnaires/OAIP",
         "/Questionnaires/OED",
         "/Questionnaires/Rehab"
       ],
-      "selectors": ".labels.dataFilter:status=SUBMITTED.csvHeader:raw.questionnaireFilter.questionnaireFilter:exclude=/Questionnaires/CPESIC/OverallRatingofHospital/cpesic_hospital_overall",
+      "selectors": ".labels.dataFilter:status=SUBMITTED.csvHeader:raw.questionnaireFilter.questionnaireFilter:exclude=/Questionnaires/CPESIC/OverallRatingofHospital/cpesic_hospital_overall.questionnaireFilter.questionnaireFilter:exclude=/Questionnaires/IC/ic_feedback",
       "save.path": "/csv-export",
       "file.name.format": "{questionnaire}_labels.csv",
       "export.format": "csv"
@@ -318,11 +319,12 @@
       "export.schedule": "0 0 2 ? * SAT *",
       "questionnaires.to.be.exported": [
         "/Questionnaires/CPESIC",
+        "/Questionnaires/IC",
         "/Questionnaires/OAIP",
         "/Questionnaires/OED",
         "/Questionnaires/Rehab"
       ],
-      "selectors": ".dataFilter:status=SUBMITTED.csvHeader:raw.questionnaireFilter.questionnaireFilter:exclude=/Questionnaires/CPESIC/OverallRatingofHospital/cpesic_hospital_overall",
+      "selectors": ".dataFilter:status=SUBMITTED.csvHeader:raw.questionnaireFilter.questionnaireFilter:exclude=/Questionnaires/CPESIC/OverallRatingofHospital/cpesic_hospital_overall.questionnaireFilter.questionnaireFilter:exclude=/Questionnaires/IC/ic_feedback",
       "save.path": "/csv-export",
       "file.name.format": "{questionnaire}.csv",
       "export.format": "csv"
@@ -337,6 +339,18 @@
       "selectors": ".dataFilter:statusNot=INCOMPLETE.labels",
       "save.path": "/csv-export",
       "file.name.format": "{questionnaire}.csv",
+      "export.format": "csv"
+    },
+    "io.uhndata.cards.scheduledcsvexport.ExportConfig~UHN-IC-Survey-Contact":{
+      "name": "UHN-IC-Survey-Contact",
+      "frequency.in.days": 7,
+      "export.schedule": "0 0 2 ? * SAT *",
+      "questionnaires.to.be.exported": [
+        "/Questionnaires/IC"
+      ],
+      "selectors": ".labels.dataFilter:status=SUBMITTED.questionnaireFilter.questionnaireFilter:include=/Questionnaires/IC/ic_feedback",
+      "save.path": "/ic-export",
+      "file.name.format": "{questionnaire}_{period}_survey_contact.csv",
       "export.format": "csv"
     },
 


### PR DESCRIPTION
* Adding a new question at the beginning of the IC survey, and a second page with optional contact info for additional in-person feedback
* Also updating the email templates since the number of survey questions changed.
* Adding the IC survey to the csv exports (survey questions 1-8 only)
* Adding a new setting to export IC contact information to a separate location. **This new export destination is not yet set up in production.**