### PR TITLE
[misc] Switch the free text comments question display from one line input to larger textbox

### DIFF
--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/IC.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/IC.xml
@@ -722,6 +722,11 @@
 			<type>String</type>
 		</property>
 		<property>
+			<name>displayMode</name>
+			<value>textbox</value>
+			<type>String</type>
+		</property>
+		<property>
 			<name>minAnswers</name>
 			<value>0</value>
 			<type>Long</type>


### PR DESCRIPTION
To test:
- start in prems mode
- create a new Integrated Care form
- go to lipsum.org and generate a few paragraphs, copy
- paste the lipsum text into the last question, save and view