### PR TITLE
CARDS-2372: Add support for data migrators

### DIFF
--- a/distribution/src/main/features/core/migrators.json
+++ b/distribution/src/main/features/core/migrators.json
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+{
+    "prototype":{
+        "id": "io.uhndata.cards:cards-data-model-migrators:slingosgifeature:${project.version}"
+    }
+}

--- a/heracles-resources/backend/pom.xml
+++ b/heracles-resources/backend/pom.xml
@@ -51,6 +51,10 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.framework</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
@@ -97,6 +101,11 @@
     <dependency>
       <groupId>io.uhndata.cards</groupId>
       <artifactId>cards-metrics</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.uhndata.cards</groupId>
+      <artifactId>cards-data-model-migrators</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/migrators/Cards2336BikeMigration.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/migrators/Cards2336BikeMigration.java
@@ -52,12 +52,6 @@ public class Cards2336BikeMigration implements DataMigrator
     }
 
     @Override
-    public int getPriority()
-    {
-        return 0;
-    }
-
-    @Override
     public boolean shouldRun(Version previousVersion, Version currentVersion, Session session)
     {
         return previousVersion.compareTo(Version.valueOf("0.9.18")) < 0;

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/migrators/Cards2336BikeMigration.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/migrators/Cards2336BikeMigration.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.heracles.internal.migrators;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.query.Query;
+import javax.jcr.version.VersionManager;
+
+import org.osgi.framework.Version;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.uhndata.cards.forms.api.FormUtils;
+import io.uhndata.cards.migrators.spi.DataMigrator;
+
+@Component(immediate = true)
+public class Cards2336BikeMigration implements DataMigrator
+{
+    private static final String QUESTION_PATH = "/Questionnaires/CPET Interpretation/CardiacStressTest/cpet_prot";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Cards2336BikeMigration.class);
+
+    @Reference
+    private FormUtils formUtils;
+
+    @Override
+    public String getName()
+    {
+        return "CARDS-2336: Migrate CPET Interpretation Protocol's  \"Bike\" answer to \"Bike 50 rpm\"";
+    }
+
+    @Override
+    public int getPriority()
+    {
+        return 0;
+    }
+
+    @Override
+    public boolean shouldRun(Version previousVersion, Version currentVersion, Session session)
+    {
+        return previousVersion.compareTo(Version.valueOf("0.9.18")) < 0;
+    }
+
+    @Override
+    public void run(Version previousVersion, Version currentVersion, Session session)
+    {
+        try {
+            if (!session.nodeExists(QUESTION_PATH)) {
+                return;
+            }
+
+            VersionManager versionManager = session.getWorkspace().getVersionManager();
+            final List<String> formsToCheckin = new ArrayList<>();
+
+            final String id = session.getNode(QUESTION_PATH).getIdentifier();
+            final NodeIterator answers = session.getWorkspace().getQueryManager().createQuery(
+                "select answer.* from [cards:TextAnswer] as answer"
+                    + " where answer.question = '" + id + "' and answer.value = 'Bike'",
+                Query.JCR_SQL2).execute().getNodes();
+
+            while (answers.hasNext()) {
+                Node answer = answers.nextNode();
+                Node form = this.formUtils.getForm(answer);
+                final boolean wasCheckedOut = versionManager.isCheckedOut(form.getPath());
+                if (!wasCheckedOut) {
+                    versionManager.checkout(form.getPath());
+                    formsToCheckin.add(form.getPath());
+                }
+                answer.setProperty("value", "Bike 50 rpm");
+            }
+            session.save();
+            formsToCheckin.forEach(f -> {
+                try {
+                    versionManager.checkin(f);
+                } catch (RepositoryException e) {
+                    LOGGER.warn("Failed to checkin {}: {}", f, e);
+                }
+            });
+        } catch (RepositoryException e) {
+            LOGGER.error("Failed to run migrator {}: {}", getName(), e.getMessage(), e);
+        }
+    }
+}

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/migrators/Cards2336BikeMigration.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/migrators/Cards2336BikeMigration.java
@@ -54,7 +54,7 @@ public class Cards2336BikeMigration implements DataMigrator
     @Override
     public boolean shouldRun(Version previousVersion, Version currentVersion, Session session)
     {
-        return previousVersion.compareTo(Version.valueOf("0.9.18")) < 0;
+        return previousVersion != null && previousVersion.compareTo(Version.valueOf("0.9.18")) < 0;
     }
 
     @Override

--- a/modules/data-model/migrators/pom.xml
+++ b/modules/data-model/migrators/pom.xml
@@ -70,5 +70,10 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>cards-resolver-provider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/modules/data-model/migrators/pom.xml
+++ b/modules/data-model/migrators/pom.xml
@@ -22,17 +22,45 @@
 
   <parent>
     <groupId>io.uhndata.cards</groupId>
-    <artifactId>cards-modules</artifactId>
+    <artifactId>cards-data-model</artifactId>
     <version>0.9-SNAPSHOT</version>
   </parent>
 
-  <artifactId>cards-data-model</artifactId>
-  <packaging>pom</packaging>
-  <name>CARDS Data Model elements</name>
+  <artifactId>cards-data-model-migrators</artifactId>
+  <packaging>bundle</packaging>
+  <name>CARDS - Data Model - Data Migrators</name>
 
-  <modules>
-    <module>forms</module>
-    <module>subjects</module>
-    <module>migrators</module>
-  </modules>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>slingfeature-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax.jcr</groupId>
+      <artifactId>jcr</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+  </dependencies>
 </project>

--- a/modules/data-model/migrators/pom.xml
+++ b/modules/data-model/migrators/pom.xml
@@ -56,7 +56,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.framework</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/data-model/migrators/src/main/features/feature.json
+++ b/modules/data-model/migrators/src/main/features/feature.json
@@ -31,7 +31,7 @@
     },
     "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~cards-migrators":{
       "user.mapping":[
-        "io.uhndata.cards.data-model-migrators:dataMigratorManager=[cards-data-migration]"
+        "io.uhndata.cards.data-model-migrators=[cards-data-migration]"
       ]
     }
   }

--- a/modules/data-model/migrators/src/main/features/feature.json
+++ b/modules/data-model/migrators/src/main/features/feature.json
@@ -1,0 +1,38 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+{
+  "bundles":[
+    {
+      "id":"${project.groupId}:${project.artifactId}:${project.version}",
+      "start-order":"30"
+    }
+  ],
+  "configurations":{
+    "org.apache.sling.jcr.repoinit.RepositoryInitializer~migrators":{
+      "service.ranking:Integer":150,
+      "scripts":[
+        "create service user cards-data-migration \n set ACL for cards-data-migration \n   allow jcr:all on / \n end"
+      ]
+    },
+    "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~cards-migrators":{
+      "user.mapping":[
+        "io.uhndata.cards.data-model-migrators:dataMigratorManager=[cards-data-migration]"
+      ]
+    }
+  }
+}

--- a/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/DataMigratorManager.java
+++ b/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/DataMigratorManager.java
@@ -19,7 +19,6 @@ package io.uhndata.cards.migrators.internal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
@@ -67,10 +66,8 @@ public class DataMigratorManager
         this.version = context.getBundleContext().getBundle().getVersion();
 
         // Get the session to run any migrators
-        final Map<String, Object> parameters =
-            Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "dataMigratorManager");
         boolean mustPopResolver = false;
-        try (ResourceResolver resolver = this.resolverFactory.getServiceResourceResolver(parameters);) {
+        try (ResourceResolver resolver = this.resolverFactory.getServiceResourceResolver(null)) {
             final Session session = resolver.adaptTo(Session.class);
             this.rrp.push(resolver);
             mustPopResolver = true;
@@ -109,11 +106,9 @@ public class DataMigratorManager
         }
 
         LOGGER.info("Running newly added migrator {}", migrator.getName());
-        // Get the session to run any migrators
-        final Map<String, Object> parameters =
-            Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "dataMigratorManager");
+        // Get the session to run this migrator
         boolean mustPopResolver = false;
-        try (ResourceResolver resolver = this.resolverFactory.getServiceResourceResolver(parameters);) {
+        try (ResourceResolver resolver = this.resolverFactory.getServiceResourceResolver(null)) {
             final Session session = resolver.adaptTo(Session.class);
             this.rrp.push(resolver);
             mustPopResolver = true;

--- a/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/DataMigratorManager.java
+++ b/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/DataMigratorManager.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
 import org.apache.sling.api.resource.LoginException;
@@ -39,7 +38,7 @@ import org.slf4j.LoggerFactory;
 import io.uhndata.cards.migrators.spi.DataMigrator;
 import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
-@Component
+@Component(immediate = true)
 public class DataMigratorManager
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataMigratorManager.class);
@@ -89,7 +88,7 @@ public class DataMigratorManager
             resolver.commit();
 
             LOGGER.info("Completed Data Migrator");
-        } catch (LoginException | RepositoryException | PersistenceException e) {
+        } catch (LoginException | PersistenceException e) {
             LOGGER.error("Could not migrate data", e);
         } finally {
             if (mustPopResolver) {

--- a/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/DataMigratorManager.java
+++ b/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/DataMigratorManager.java
@@ -31,11 +31,11 @@ import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,16 +46,21 @@ public class DataMigratorManager
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataMigratorManager.class);
 
+    private String previousVersion;
+    private String version;
+    private boolean activated;
+
     @Reference
     private ResourceResolverFactory resolverFactory;
 
-    @Reference(cardinality = ReferenceCardinality.MULTIPLE, fieldOption = FieldOption.UPDATE)
+    @Reference(policyOption = ReferencePolicyOption.GREEDY, bind = "migratorAdded", unbind = "migratorRemoved")
     private volatile List<DataMigrator> migrators = new ArrayList<>();
 
     @Activate
-    protected void activate()
+    protected void activate(ComponentContext context)
     {
         LOGGER.info("Starting Data Migrator");
+        this.version = context.getBundleContext().getBundle().getVersion().toString();
 
         // Get the session to run any migrators
         final Map<String, Object> parameters =
@@ -64,7 +69,9 @@ public class DataMigratorManager
             final Session session = resolver.adaptTo(Session.class);
 
             // Get the previously run CARDS version
-            String previousVersion = DataMigratorUtils.getPreviousVersion(session);
+            this.previousVersion = DataMigratorUtils.getPreviousVersion(session);
+
+            this.activated = true;
 
             // Sort the migrators
             List<DataMigrator> sortedMigrators = new ArrayList<>(this.migrators);
@@ -72,9 +79,7 @@ public class DataMigratorManager
 
             // Run any required migrators
             for (DataMigrator migrator: sortedMigrators) {
-                if (migrator.shouldRun(previousVersion, session)) {
-                    migrator.run(session);
-                }
+                runMigrator(migrator, session);
             }
 
             resolver.commit();
@@ -83,5 +88,41 @@ public class DataMigratorManager
         } catch (LoginException | RepositoryException | PersistenceException e) {
             LOGGER.error("Could not migrate data", e);
         }
+    }
+
+    protected void migratorAdded(final DataMigrator migrator)
+    {
+        if (!this.activated) {
+            // Not yet activated: all current migrators will be run when that happens so no need to run this one now
+            return;
+        }
+
+        LOGGER.info("Running newly added {}", migrator.getName());
+        // Get the session to run any migrators
+        final Map<String, Object> parameters =
+            Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "dataMigratorManager");
+        try (ResourceResolver resolver = this.resolverFactory.getServiceResourceResolver(parameters);) {
+            final Session session = resolver.adaptTo(Session.class);
+
+            runMigrator(migrator, session);
+
+            resolver.commit();
+        } catch (LoginException | PersistenceException e) {
+            LOGGER.error("Could not run newly added migrator", e);
+        }
+
+    }
+
+    protected void runMigrator(final DataMigrator migrator, final Session session)
+    {
+        if (migrator.shouldRun(this.previousVersion, this.version, session)) {
+            LOGGER.info("Running {}", migrator.getName());
+            migrator.run(this.previousVersion, this.version, session);
+        }
+    }
+
+    protected void migratorRemoved(final DataMigrator migrator)
+    {
+        // Do nothing: We are running migrators on creation
     }
 }

--- a/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/DataMigratorManager.java
+++ b/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/DataMigratorManager.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.migrators.internal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.FieldOption;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.uhndata.cards.migrators.spi.DataMigrator;
+
+@Component
+public class DataMigratorManager
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataMigratorManager.class);
+
+    @Reference
+    private ResourceResolverFactory resolverFactory;
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, fieldOption = FieldOption.UPDATE)
+    private volatile List<DataMigrator> migrators = new ArrayList<>();
+
+    @Activate
+    protected void activate()
+    {
+        LOGGER.info("Starting Data Migrator");
+
+        // Get the session to run any migrators
+        final Map<String, Object> parameters =
+            Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, "dataMigratorManager");
+        try (ResourceResolver resolver = this.resolverFactory.getServiceResourceResolver(parameters);) {
+            final Session session = resolver.adaptTo(Session.class);
+
+            // Get the previously run CARDS version
+            String previousVersion = DataMigratorUtils.getPreviousVersion(session);
+
+            // Sort the migrators
+            List<DataMigrator> sortedMigrators = new ArrayList<>(this.migrators);
+            Collections.sort(sortedMigrators);
+
+            // Run any required migrators
+            for (DataMigrator migrator: sortedMigrators) {
+                if (migrator.shouldRun(previousVersion, session)) {
+                    migrator.run(session);
+                }
+            }
+
+            resolver.commit();
+
+            LOGGER.info("Completed Data Migrator");
+        } catch (LoginException | RepositoryException | PersistenceException e) {
+            LOGGER.error("Could not migrate data", e);
+        }
+    }
+}

--- a/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/DataMigratorManager.java
+++ b/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/DataMigratorManager.java
@@ -1,22 +1,19 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.uhndata.cards.migrators.internal;
 
 import java.util.ArrayList;
@@ -85,7 +82,7 @@ public class DataMigratorManager
             Collections.sort(sortedMigrators);
 
             // Run any required migrators
-            for (DataMigrator migrator: sortedMigrators) {
+            for (DataMigrator migrator : sortedMigrators) {
                 runMigrator(migrator, session);
             }
 

--- a/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/DataMigratorManager.java
+++ b/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/DataMigratorManager.java
@@ -28,6 +28,7 @@ import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.osgi.framework.Version;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -44,8 +45,10 @@ public class DataMigratorManager
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataMigratorManager.class);
 
-    private String previousVersion;
-    private String version;
+    private Version previousVersion;
+
+    private Version version;
+
     private boolean activated;
 
     @Reference
@@ -61,7 +64,7 @@ public class DataMigratorManager
     protected void activate(ComponentContext context)
     {
         LOGGER.info("Starting Data Migrator");
-        this.version = context.getBundleContext().getBundle().getVersion().toString();
+        this.version = context.getBundleContext().getBundle().getVersion();
 
         // Get the session to run any migrators
         final Map<String, Object> parameters =

--- a/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/DataMigratorUtils.java
+++ b/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/DataMigratorUtils.java
@@ -1,22 +1,19 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.uhndata.cards.migrators.internal;
 
 import javax.jcr.PathNotFoundException;
@@ -26,8 +23,11 @@ import javax.jcr.Session;
 public final class DataMigratorUtils
 {
     static final String PREV_VERSION_NAME = "PrevVersion";
+
     static final String PREV_VERSION_PATH = "/libs/cards/conf/PrevVersion";
+
     static final String VERSION_PROPERTY = "Version";
+
     static final String VERSION_PATH = "/libs/cards/conf/Version";
 
     /**

--- a/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/DataMigratorUtils.java
+++ b/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/DataMigratorUtils.java
@@ -16,9 +16,10 @@
  */
 package io.uhndata.cards.migrators.internal;
 
-import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+
+import org.osgi.framework.Version;
 
 public final class DataMigratorUtils
 {
@@ -37,22 +38,17 @@ public final class DataMigratorUtils
     {
     }
 
-    public static String getVersion(Session session) throws RepositoryException
+    public static Version getPreviousVersion(Session session) throws RepositoryException
     {
-        return session.getNode(VERSION_PATH).getProperty(VERSION_PROPERTY).getString();
-    }
-
-    public static String getPreviousVersion(Session session) throws RepositoryException
-    {
-        String previousVersion = "";
-        try {
+        String previousVersion = null;
+        if (session.itemExists(PREV_VERSION_PATH + "/" + VERSION_PROPERTY)) {
             previousVersion = session.getNode(DataMigratorUtils.PREV_VERSION_PATH)
                 .getProperty(DataMigratorUtils.VERSION_PROPERTY).getString();
-        } catch (PathNotFoundException e) {
-            // No previous version
-            previousVersion = null;
+        } else if (session.getNode("/Forms").hasNodes()) {
+            // Forms exist, this must be an upgrade from a pre-0.9.18 version
+            previousVersion = "0.1.0";
         }
 
-        return previousVersion;
+        return previousVersion == null ? null : new Version(previousVersion);
     }
 }

--- a/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/DataMigratorUtils.java
+++ b/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/DataMigratorUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.migrators.internal;
+
+import javax.jcr.PathNotFoundException;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+public final class DataMigratorUtils
+{
+    static final String PREV_VERSION_NAME = "PrevVersion";
+    static final String PREV_VERSION_PATH = "/libs/cards/conf/PrevVersion";
+    static final String VERSION_PROPERTY = "Version";
+    static final String VERSION_PATH = "/libs/cards/conf/Version";
+
+    /**
+     * Hide the utility class constructor.
+     */
+    private DataMigratorUtils()
+    {
+    }
+
+    public static String getVersion(Session session) throws RepositoryException
+    {
+        return session.getNode(VERSION_PATH).getProperty(VERSION_PROPERTY).getString();
+    }
+
+    public static String getPreviousVersion(Session session) throws RepositoryException
+    {
+        String previousVersion = "";
+        try {
+            previousVersion = session.getNode(DataMigratorUtils.PREV_VERSION_PATH)
+                .getProperty(DataMigratorUtils.VERSION_PROPERTY).getString();
+        } catch (PathNotFoundException e) {
+            // No previous version
+            previousVersion = null;
+        }
+
+        return previousVersion;
+    }
+}

--- a/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/UpdatePreviousVersionMigrator.java
+++ b/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/UpdatePreviousVersionMigrator.java
@@ -1,22 +1,19 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.uhndata.cards.migrators.internal;
 
 import javax.jcr.Node;

--- a/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/UpdatePreviousVersionMigrator.java
+++ b/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/UpdatePreviousVersionMigrator.java
@@ -20,6 +20,7 @@ import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
+import org.osgi.framework.Version;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,13 +46,13 @@ public class UpdatePreviousVersionMigrator implements DataMigrator
     }
 
     @Override
-    public boolean shouldRun(String previousVersion, String currentVersion, Session session)
+    public boolean shouldRun(Version previousVersion, Version currentVersion, Session session)
     {
         return !currentVersion.equals(previousVersion);
     }
 
     @Override
-    public void run(String previousVersion, String currentVersion, Session session)
+    public void run(Version previousVersion, Version currentVersion, Session session)
     {
         try {
             // Update the previous CARDS version to the current version
@@ -62,7 +63,7 @@ public class UpdatePreviousVersionMigrator implements DataMigrator
                 node = node.addNode(DataMigratorUtils.PREV_VERSION_NAME);
             }
 
-            node.setProperty(DataMigratorUtils.VERSION_PROPERTY, currentVersion);
+            node.setProperty(DataMigratorUtils.VERSION_PROPERTY, currentVersion.toString());
         } catch (RepositoryException e) {
             // Should not happen
             LOGGER.error("Failed to update previous version", e);

--- a/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/UpdatePreviousVersionMigrator.java
+++ b/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/UpdatePreviousVersionMigrator.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.migrators.internal;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.uhndata.cards.migrators.spi.DataMigrator;
+
+@Component
+public class UpdatePreviousVersionMigrator implements DataMigrator
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(UpdatePreviousVersionMigrator.class);
+
+    @Override
+    public int getPriority()
+    {
+        // Always run last
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public boolean shouldRun(String previousVersion, Session session)
+    {
+        return true;
+    }
+
+    @Override
+    public void run(Session session)
+    {
+        LOGGER.info("Running UpdatePreviousVersionMigrator");
+        try {
+            // Get the current CARDS version
+            String currentVersion = DataMigratorUtils.getVersion(session);
+
+            // Update the previous CARDS version to the current version
+            Node node = session.getNode("/libs/cards/conf");
+            if (node.hasNode(DataMigratorUtils.PREV_VERSION_NAME)) {
+                node = node.getNode(DataMigratorUtils.PREV_VERSION_NAME);
+            } else {
+                node = node.addNode(DataMigratorUtils.PREV_VERSION_NAME);
+            }
+
+            node.setProperty(DataMigratorUtils.VERSION_PROPERTY, currentVersion);
+        } catch (RepositoryException e) {
+            // Should not happen
+            LOGGER.error("Failed to update previous version", e);
+        }
+    }
+}

--- a/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/UpdatePreviousVersionMigrator.java
+++ b/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/UpdatePreviousVersionMigrator.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import io.uhndata.cards.migrators.spi.DataMigrator;
 
-@Component
+@Component(immediate = true)
 public class UpdatePreviousVersionMigrator implements DataMigrator
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(UpdatePreviousVersionMigrator.class);

--- a/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/UpdatePreviousVersionMigrator.java
+++ b/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/internal/UpdatePreviousVersionMigrator.java
@@ -35,6 +35,12 @@ public class UpdatePreviousVersionMigrator implements DataMigrator
     private static final Logger LOGGER = LoggerFactory.getLogger(UpdatePreviousVersionMigrator.class);
 
     @Override
+    public String getName()
+    {
+        return "UpdatePreviousVersionMigrator";
+    }
+
+    @Override
     public int getPriority()
     {
         // Always run last
@@ -42,19 +48,15 @@ public class UpdatePreviousVersionMigrator implements DataMigrator
     }
 
     @Override
-    public boolean shouldRun(String previousVersion, Session session)
+    public boolean shouldRun(String previousVersion, String currentVersion, Session session)
     {
-        return true;
+        return !currentVersion.equals(previousVersion);
     }
 
     @Override
-    public void run(Session session)
+    public void run(String previousVersion, String currentVersion, Session session)
     {
-        LOGGER.info("Running UpdatePreviousVersionMigrator");
         try {
-            // Get the current CARDS version
-            String currentVersion = DataMigratorUtils.getVersion(session);
-
             // Update the previous CARDS version to the current version
             Node node = session.getNode("/libs/cards/conf");
             if (node.hasNode(DataMigratorUtils.PREV_VERSION_NAME)) {

--- a/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/spi/DataMigrator.java
+++ b/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/spi/DataMigrator.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.migrators.spi;
+
+import javax.jcr.Session;
+
+public interface DataMigrator extends Comparable<DataMigrator>
+{
+    /**
+     * The priority of this migrator. Migrators with higher numbers are invoked after those with lower numbers.
+     *
+     * @return the priority of this processor, can be any number
+     */
+    int getPriority();
+
+    /**
+     * If this migrator should run based on what version of CARDS was previously run.
+     * @param previousVersion The version of CARDs that was run previously
+     * @param session The session that should be used to pull any other data if required
+     *
+     * @return {@code true} if the migrator should be run
+     */
+    boolean shouldRun(String previousVersion, Session session);
+
+    /**
+     * Change anything that needs to be changed to upgrade to from the previous version of CARDS.
+     * @param session The session that should be used to enact any required changes
+     */
+    void run(Session session);
+
+    @Override
+    default int compareTo(DataMigrator other)
+    {
+        return this.getPriority() - other.getPriority();
+    }
+}

--- a/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/spi/DataMigrator.java
+++ b/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/spi/DataMigrator.java
@@ -38,11 +38,16 @@ public interface DataMigrator extends Comparable<DataMigrator>
     String getName();
 
     /**
-     * The priority of this migrator. Migrators with higher numbers are invoked after those with lower numbers.
+     * The priority of this migrator. Migrators with higher numbers are invoked after those with lower numbers. If a
+     * migrator doesn't really need a specific order, the default of {@code 0} is enough. Migrators of equal priority
+     * are sorted by their name.
      *
      * @return the priority of this migrator, can be any number
      */
-    int getPriority();
+    default int getPriority()
+    {
+        return 0;
+    }
 
     /**
      * If this migrator should run based on what version of CARDS was previously run.
@@ -66,6 +71,7 @@ public interface DataMigrator extends Comparable<DataMigrator>
     @Override
     default int compareTo(DataMigrator other)
     {
-        return this.getPriority() - other.getPriority();
+        return this.getPriority() == other.getPriority() ? this.getName().compareTo(other.getName())
+            : this.getPriority() - other.getPriority();
     }
 }

--- a/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/spi/DataMigrator.java
+++ b/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/spi/DataMigrator.java
@@ -1,22 +1,19 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.uhndata.cards.migrators.spi;
 
 import javax.jcr.Session;
@@ -39,16 +36,17 @@ public interface DataMigrator extends Comparable<DataMigrator>
 
     /**
      * If this migrator should run based on what version of CARDS was previously run.
+     *
      * @param previousVersion The version of CARDs that was run previously
      * @param currentVersion The version of CARDs that is currently running
      * @param session The session that should be used to pull any other data if required
-     *
      * @return {@code true} if the migrator should be run
      */
     boolean shouldRun(String previousVersion, String currentVersion, Session session);
 
     /**
      * Change anything that needs to be changed to upgrade to from the previous version of CARDS.
+     *
      * @param previousVersion The version of CARDs that was run previously
      * @param currentVersion The version of CARDs that is currently running
      * @param session The session that should be used to enact any required changes

--- a/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/spi/DataMigrator.java
+++ b/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/spi/DataMigrator.java
@@ -18,6 +18,8 @@ package io.uhndata.cards.migrators.spi;
 
 import javax.jcr.Session;
 
+import org.osgi.framework.Version;
+
 public interface DataMigrator extends Comparable<DataMigrator>
 {
     /**
@@ -42,7 +44,7 @@ public interface DataMigrator extends Comparable<DataMigrator>
      * @param session The session that should be used to pull any other data if required
      * @return {@code true} if the migrator should be run
      */
-    boolean shouldRun(String previousVersion, String currentVersion, Session session);
+    boolean shouldRun(Version previousVersion, Version currentVersion, Session session);
 
     /**
      * Change anything that needs to be changed to upgrade to from the previous version of CARDS.
@@ -51,7 +53,7 @@ public interface DataMigrator extends Comparable<DataMigrator>
      * @param currentVersion The version of CARDs that is currently running
      * @param session The session that should be used to enact any required changes
      */
-    void run(String previousVersion, String currentVersion, Session session);
+    void run(Version previousVersion, Version currentVersion, Session session);
 
     @Override
     default int compareTo(DataMigrator other)

--- a/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/spi/DataMigrator.java
+++ b/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/spi/DataMigrator.java
@@ -20,6 +20,14 @@ import javax.jcr.Session;
 
 import org.osgi.framework.Version;
 
+/**
+ * Service interface for data migrators. A data migrator runs when the framework is started, and performs any changes
+ * needed to port existing data from the old version to the new version, or to set up any missing details on a new
+ * instance.
+ *
+ * @version $Id$
+ * @since 0.9.18
+ */
 public interface DataMigrator extends Comparable<DataMigrator>
 {
     /**
@@ -39,7 +47,7 @@ public interface DataMigrator extends Comparable<DataMigrator>
     /**
      * If this migrator should run based on what version of CARDS was previously run.
      *
-     * @param previousVersion The version of CARDs that was run previously
+     * @param previousVersion The version of CARDs that was run previously, {@code null} if this is the first run
      * @param currentVersion The version of CARDs that is currently running
      * @param session The session that should be used to pull any other data if required
      * @return {@code true} if the migrator should be run
@@ -47,9 +55,9 @@ public interface DataMigrator extends Comparable<DataMigrator>
     boolean shouldRun(Version previousVersion, Version currentVersion, Session session);
 
     /**
-     * Change anything that needs to be changed to upgrade to from the previous version of CARDS.
+     * Change anything that needs to be changed to upgrade from the previous version of CARDS.
      *
-     * @param previousVersion The version of CARDs that was run previously
+     * @param previousVersion The version of CARDs that was run previously, may be {@code null}
      * @param currentVersion The version of CARDs that is currently running
      * @param session The session that should be used to enact any required changes
      */

--- a/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/spi/DataMigrator.java
+++ b/modules/data-model/migrators/src/main/java/io/uhndata/cards/migrators/spi/DataMigrator.java
@@ -24,26 +24,36 @@ import javax.jcr.Session;
 public interface DataMigrator extends Comparable<DataMigrator>
 {
     /**
+     * The name of this migrator.
+     *
+     * @return the user readable name of this migrator
+     */
+    String getName();
+
+    /**
      * The priority of this migrator. Migrators with higher numbers are invoked after those with lower numbers.
      *
-     * @return the priority of this processor, can be any number
+     * @return the priority of this migrator, can be any number
      */
     int getPriority();
 
     /**
      * If this migrator should run based on what version of CARDS was previously run.
      * @param previousVersion The version of CARDs that was run previously
+     * @param currentVersion The version of CARDs that is currently running
      * @param session The session that should be used to pull any other data if required
      *
      * @return {@code true} if the migrator should be run
      */
-    boolean shouldRun(String previousVersion, Session session);
+    boolean shouldRun(String previousVersion, String currentVersion, Session session);
 
     /**
      * Change anything that needs to be changed to upgrade to from the previous version of CARDS.
+     * @param previousVersion The version of CARDs that was run previously
+     * @param currentVersion The version of CARDs that is currently running
      * @param session The session that should be used to enact any required changes
      */
-    void run(Session session);
+    void run(String previousVersion, String currentVersion, Session session);
 
     @Override
     default int compareTo(DataMigrator other)

--- a/pom.xml
+++ b/pom.xml
@@ -344,6 +344,11 @@
         <artifactId>org.apache.sling.commons.scheduler</artifactId>
         <version>2.7.12</version>
       </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.framework</artifactId>
+        <version>1.9.0</version>
+      </dependency>
       <!-- TEST -->
       <dependency>
         <groupId>junit</groupId>


### PR DESCRIPTION
Add a data migrator that tracks the previous version and checks if any created data migrators need to run.

Also includes CARDS-2336.

To test:
- build and run an older version of cards:
- `git checkout cards-0.9.15`
- `mvn clean install -P docker`
- `cd compose-cluster`
- `python3 generate_compose_yaml.py --dev_docker_image  --composum --cards_project cards4heracles --mongo_singular`
- `docker-compose build && docker-compose up`
- Create a few CPET Interpretation forms, fill in the Protocol question with a few Bike value and a few other values
- Stop docker
- `cd ..`
- `git checkout CARDS-2372`
- `mvn clean install -P docker`
- `cd compose-cluster`
- `python3 generate_compose_yaml.py --dev_docker_image  --composum --cards_project cards4heracles --mongo_singular`
- `docker-compose build && docker-compose up`
- Check that the previous Bike answers are now Bike 50 rpm and the previous other answers are unchanged
- Check that `localhost:8080/libs/cards/conf/PrevVersion.json` now has `0.9.0.SNAPSHOT` stored