### PR TITLE
CARDS-2389: /opt/cards/.cards-data in the cardsinitial Docker container is (incorrectly) no longer being bound to the local ./SLING directory

### DIFF
--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -671,7 +671,7 @@ except FileExistsError:
   print("Warning: CARDS_LOGS directory exists")
 
 yaml_obj['services']['cardsinitial']['volumes'] = ["./SLING:/opt/cards/.cards-data"]
-yaml_obj['services']['cardsinitial']['volumes'] = ["./CARDS_LOGS:/opt/cards/logs"]
+yaml_obj['services']['cardsinitial']['volumes'].append("./CARDS_LOGS:/opt/cards/logs")
 yaml_obj['services']['cardsinitial']['volumes'].append("./SSL_CONFIG/cards_certs/:/load_certs:ro")
 if os.path.exists("/etc/localtime"):
   yaml_obj['services']['cardsinitial']['volumes'].append("/etc/localtime:/etc/localtime:ro")


### PR DESCRIPTION
This _Pull Request_ fixes a bug that was introduced in CARDS-2301 where instead of appending the `CARDS_LOGS` mount to the list of _volume mounts_ for the `cardsinitial` container, said list of _volume mounts_ would be completely overwritten to only contain the `CARDS_LOGS` volume mount.

To test this PR, start a Docker Compose environment with:

```bash
cd compose-cluster
python3 generate_compose_yaml.py --dev_docker_image --oak_filesystem --composum --cards_project cards4heracles
docker-compose build
docker-compose up -d
```

Visit http://localhost:8080, login as `admin`:`admin` and create some test data.

```bash
docker-compose down && docker-compose rm && docker volume prune -f
docker-compose up -d
```
Visit http://localhost:8080, login as `admin`:`admin` and verify that the previously created data still exists.

Clean up with

```bash
docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh
```