### PR TITLE
CARDS-2390: Rework the clarity import functionality to support multiple sources

### DIFF
--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportConfig.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportConfig.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.uhndata.cards.clarity.importer;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.metatype.annotations.Designate;
+
+@Component(immediate = true, service = ClarityImportConfig.class)
+@Designate(ocd = ClarityImportConfigDefinition.class, factory = true)
+public class ClarityImportConfig
+{
+    private ClarityImportConfigDefinition config;
+
+    @Activate
+    protected void activate(final ClarityImportConfigDefinition config)
+    {
+        this.config = config;
+    }
+
+    public ClarityImportConfigDefinition getConfig()
+    {
+        return this.config;
+    }
+}

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportConfigDefinition.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportConfigDefinition.java
@@ -32,6 +32,10 @@ public @interface ClarityImportConfigDefinition
     @AttributeDefinition(name = "Name", description = "Configuration name")
     String name();
 
+    @AttributeDefinition(name = "Type",
+        description = "A tag that can be used to filter the used import processors applied during the import")
+    String type();
+
     @AttributeDefinition(name = "Import schedule", description = "Quartz-readable import schedule")
     String importSchedule() default NIGHTLY;
 

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportConfigDefinition.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportConfigDefinition.java
@@ -26,15 +26,43 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
     description = "Configuration for the Clarity importer")
 public @interface ClarityImportConfigDefinition
 {
-    /** Cron-readable import schedule. */
-    String NIGHTLY_IMPORT_SCHEDULE = "0 0 0 * * ? *";
+    /** Cron-readable schedule. */
+    String NIGHTLY = "0 0 0 * * ? *";
 
-    @AttributeDefinition(name = "Import schedule", description = "Cron-readable import schedule")
-    String nightly_import_schedule() default NIGHTLY_IMPORT_SCHEDULE;
+    @AttributeDefinition(name = "Name", description = "Configuration name")
+    String name();
+
+    @AttributeDefinition(name = "Import schedule", description = "Quartz-readable import schedule")
+    String importSchedule() default NIGHTLY;
 
     @AttributeDefinition(name = "Day to import",
         description = "Difference from today. 0 means today, 1 means tomorrow, -1 means yesterday. "
             + "As a special value, 2147483647 (Integer.MAX_VALUE) means no date filtering, "
             + "all data found in the table will be imported. ")
     int dayToImport() default Integer.MAX_VALUE;
+
+    @AttributeDefinition(name = "Server")
+    String server() default "%ENV%CLARITY_SQL_SERVER";
+
+    @AttributeDefinition(name = "Username")
+    String username() default "%ENV%CLARITY_SQL_USERNAME";
+
+    @AttributeDefinition(name = "Password")
+    String password() default "%ENV%CLARITY_SQL_PASSWORD";
+
+    @AttributeDefinition(name = "Encrypted connection", description = "Use either true or false")
+    String encrypt() default "%ENV%CLARITY_SQL_ENCRYPT";
+
+    @AttributeDefinition(name = "Schema")
+    String schemaName() default "%ENV%CLARITY_SQL_SCHEMA";
+
+    @AttributeDefinition(name = "Table")
+    String tableName() default "%ENV%CLARITY_SQL_TABLE";
+
+    @AttributeDefinition(name = "Date column", description = "An (optional) Clarity column to use for date filtering",
+        required = false)
+    String dateColumn() default "%ENV%CLARITY_EVENT_TIME_COLUMN";
+
+    @AttributeDefinition(name = "Column mapping", description = "Full path to the clarity mapping node")
+    String mapping() default "/apps/cards/clarityImport";
 }

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
@@ -28,7 +28,6 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -37,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
@@ -267,9 +267,9 @@ public class ClarityImportTask implements Runnable
             PreparedStatement statement = connection.prepareStatement(generateClarityQuery());
             ResultSet results = statement.executeQuery();
 
-            // Sort the data processors
-            List<ClarityDataProcessor> sortedProcessors = new ArrayList<>(this.processors);
-            Collections.sort(sortedProcessors);
+            // Sort and filter the data processors
+            List<ClarityDataProcessor> sortedProcessors = new ArrayList<>(this.processors).stream()
+                .filter(p -> p.supportsImportType(this.config.type())).sorted().collect(Collectors.toList());
 
             while (results.next()) {
                 // Create the Subjects and Forms as is needed

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/NightlyClarityImport.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/NightlyClarityImport.java
@@ -22,32 +22,30 @@ package io.uhndata.cards.clarity.importer;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.commons.scheduler.ScheduleOptions;
 import org.apache.sling.commons.scheduler.Scheduler;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
 import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
-@Component(configurationPolicy = ConfigurationPolicy.REQUIRE, immediate = true)
-@Designate(ocd = ClarityImportConfigDefinition.class)
+@Component(immediate = true)
 public class NightlyClarityImport
 {
     /** Default log. */
     private static final Logger LOGGER = LoggerFactory.getLogger(NightlyClarityImport.class);
 
-    private static final String SCHEDULER_JOB_NAME = "NightlyClarityImport";
+    private static final String SCHEDULER_JOB_PREFIX = "ScheduledClarityImport-";
 
     /** Provides access to resources. */
     @Reference
@@ -61,43 +59,53 @@ public class NightlyClarityImport
         policy = ReferencePolicy.DYNAMIC)
     private volatile List<ClarityDataProcessor> processors = new ArrayList<>();
 
+    @Reference(policyOption = ReferencePolicyOption.GREEDY, bind = "configAdded", unbind = "configRemoved")
+    private volatile List<ClarityImportConfig> configs;
+
     /** The scheduler for rescheduling jobs. */
     @Reference
     private Scheduler scheduler;
 
-    @Activate
-    protected void activate(final ClarityImportConfigDefinition config)
+    public void configAdded(final ClarityImportConfig newConfig)
     {
         if (this.scheduler == null) {
+            // This method can be called both before the component is activated, while the scheduler dependency may
+            // still be unsatisfied, and while the component is active and the configuration is changed.
+            // If the scheduler is not bound, it's OK to do nothing now, the method will be called during activation.
+            return;
+        }
+        final ClarityImportConfigDefinition config = newConfig.getConfig();
+        LOGGER.debug("Added clarity import configuration {}", config.name());
+
+        final String schedule = config.importSchedule();
+        if (StringUtils.isBlank(schedule)) {
+            LOGGER.info("ClarityImport {} skipped because a cron schedule was not specified.", config.name());
             return;
         }
 
-        LOGGER.info("Activating Clarity Importer configuration");
-
-        final String nightlyClarityImportSchedule = config.nightly_import_schedule();
-        if ("".equals(nightlyClarityImportSchedule)) {
-            LOGGER.error("Failed to schedule NightlyClarityImport because a cron schedule was not given.");
-            return;
-        }
-
-        final ScheduleOptions options = this.scheduler.EXPR(nightlyClarityImportSchedule);
-        options.name(SCHEDULER_JOB_NAME);
+        final ScheduleOptions options = this.scheduler.EXPR(schedule);
+        options.name(SCHEDULER_JOB_PREFIX + config.name());
         options.canRunConcurrently(true);
 
-        final Runnable importJob =
-            new ClarityImportTask(config.dayToImport(), this.resolverFactory, this.rrp, this.processors);
+        final Runnable job =
+            new ClarityImportTask(config, config.dayToImport(), this.resolverFactory, this.rrp, this.processors);
         try {
-            this.scheduler.schedule(importJob, options);
-            LOGGER.info("Activated Clarity Importer configuration");
+            this.scheduler.schedule(job, options);
+            LOGGER.debug("Activated scheduled clarity import configuration {}", config.name());
         } catch (final Exception e) {
-            LOGGER.error("NightlyClarityImport Failed to schedule: {}", e.getMessage(), e);
+            LOGGER.error("Scheduled clarity import {} failed to schedule: {}", config.name(), e.getMessage(), e);
         }
     }
 
-    @Deactivate
-    private void deactivate()
+    public void configRemoved(final ClarityImportConfig removedConfig)
     {
-        LOGGER.info("Deactivated Clarity Importer");
-        this.scheduler.unschedule(SCHEDULER_JOB_NAME);
+        LOGGER.debug("Removed clarity import configuration {}", removedConfig.getConfig().name());
+        this.scheduler.unschedule(SCHEDULER_JOB_PREFIX + removedConfig.getConfig().name());
+    }
+
+    @Activate
+    protected void activate()
+    {
+        this.configs.forEach(this::configAdded);
     }
 }

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ScheduledClarityImport.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ScheduledClarityImport.java
@@ -40,10 +40,10 @@ import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
 import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
 @Component(immediate = true)
-public class NightlyClarityImport
+public class ScheduledClarityImport
 {
     /** Default log. */
-    private static final Logger LOGGER = LoggerFactory.getLogger(NightlyClarityImport.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScheduledClarityImport.class);
 
     private static final String SCHEDULER_JOB_PREFIX = "ScheduledClarityImport-";
 

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/internal/AbstractConditionalClarityDataProcessor.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/internal/AbstractConditionalClarityDataProcessor.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.osgi.service.cm.ConfigurationException;
 
+import io.uhndata.cards.clarity.importer.spi.AbstractClarityDataProcessor;
 import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
 
 /**
@@ -36,15 +37,15 @@ import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
  *
  * @version $Id$
  */
-public abstract class AbstractConditionalClarityDataProcessor implements ClarityDataProcessor
+public abstract class AbstractConditionalClarityDataProcessor extends AbstractClarityDataProcessor
+    implements ClarityDataProcessor
 {
-    protected final int priority;
-
     protected final List<ConditionDefinition> conditions;
 
-    AbstractConditionalClarityDataProcessor(int priority, String[] conditionStrings) throws ConfigurationException
+    protected AbstractConditionalClarityDataProcessor(String[] types, int priority, String[] conditionStrings)
+        throws ConfigurationException
     {
-        this.priority = priority;
+        super(true, types, priority);
         this.conditions = new ArrayList<>(conditionStrings.length);
         for (String conditionString : conditionStrings) {
             ConditionDefinition def = new ConditionDefinition(conditionString);
@@ -70,12 +71,6 @@ public abstract class AbstractConditionalClarityDataProcessor implements Clarity
         }
         // All filters match if data got here
         return this.handleAllConditionsMatched(input);
-    }
-
-    @Override
-    public int getPriority()
-    {
-        return this.priority;
     }
 
     private enum Operator

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/internal/ConfiguredCohortMapper.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/internal/ConfiguredCohortMapper.java
@@ -48,6 +48,9 @@ public class ConfiguredCohortMapper extends AbstractConditionalClarityDataProces
             + " cohort")
     public @interface Config
     {
+        @AttributeDefinition(name = "Supported import types", description = "Leave empty to support all imports")
+        String[] supportedTypes();
+
         @AttributeDefinition(name = "Priority", description = "Clarity Data Processor priority."
             + " Processors are run in ascending priority order")
         int priority();
@@ -79,7 +82,7 @@ public class ConfiguredCohortMapper extends AbstractConditionalClarityDataProces
     @Activate
     public ConfiguredCohortMapper(Config configuration) throws ConfigurationException
     {
-        super(configuration.priority(), configuration.conditions());
+        super(configuration.supportedTypes(), configuration.priority(), configuration.conditions());
         this.cohort = configuration.clinic();
         String pid = configuration.service_pid();
         this.id = pid.substring(pid.lastIndexOf("~") + 1);

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/internal/ConfiguredDiscardFilter.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/internal/ConfiguredDiscardFilter.java
@@ -48,6 +48,9 @@ public class ConfiguredDiscardFilter extends AbstractConditionalClarityDataProce
             + " conditions")
     public @interface Config
     {
+        @AttributeDefinition(name = "Supported import types", description = "Leave empty to support all imports")
+        String[] supportedTypes();
+
         @AttributeDefinition(name = "Priority", description = "Clarity Data Processor priority."
             + " Processors are run in ascending priority order")
         int priority();
@@ -72,7 +75,7 @@ public class ConfiguredDiscardFilter extends AbstractConditionalClarityDataProce
     @Activate
     public ConfiguredDiscardFilter(Config configuration) throws ConfigurationException
     {
-        super(configuration.priority(), configuration.conditions());
+        super(configuration.supportedTypes(), configuration.priority(), configuration.conditions());
         String pid = configuration.service_pid();
         this.id = pid.substring(pid.lastIndexOf("~") + 1);
     }

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/internal/ConfiguredGenericMapper.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/internal/ConfiguredGenericMapper.java
@@ -47,6 +47,9 @@ public class ConfiguredGenericMapper extends AbstractConditionalClarityDataProce
         description = "Configuration for the Clarity importer to assign a specific value to a column")
     public @interface Config
     {
+        @AttributeDefinition(name = "Supported import types", description = "Leave empty to support all imports")
+        String[] supportedTypes();
+
         @AttributeDefinition(name = "Priority", description = "Clarity Data Processor priority."
             + " Processors are run in ascending priority order")
         int priority();
@@ -82,7 +85,7 @@ public class ConfiguredGenericMapper extends AbstractConditionalClarityDataProce
     @Activate
     public ConfiguredGenericMapper(Config configuration) throws ConfigurationException
     {
-        super(configuration.priority(), configuration.conditions());
+        super(configuration.supportedTypes(), configuration.priority(), configuration.conditions());
         this.column = configuration.column();
         this.value = configuration.value();
         String pid = configuration.service_pid();

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/spi/AbstractClarityDataProcessor.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/spi/AbstractClarityDataProcessor.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.clarity.importer.spi;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Base class for implementing Clarity import processors. Handles the {@link #getPriority()} and
+ * {@link #supportsImportType(String)} methods.
+ *
+ * @version $Id$
+ */
+public abstract class AbstractClarityDataProcessor implements ClarityDataProcessor
+{
+    private final boolean enabled;
+
+    private final int priority;
+
+    private final List<String> supportedTypes;
+
+    /**
+     * Base constructor.
+     *
+     * @param enabled whether this processor is enabled or not; if this is {@code false}, then
+     *            {@link #supportsImportType} will return {@code false} as well, regardless of the passed import type
+     * @param types the list of supported import types; if this is empty or {@code null}, then the processor is
+     *            considered to support all import types
+     * @param priority the priority of this processor, used as the return value of {@link #getPriority()}
+     */
+    protected AbstractClarityDataProcessor(final boolean enabled, final String[] types, final int priority)
+    {
+        this.enabled = enabled;
+        this.supportedTypes = types == null ? Collections.emptyList() : Arrays.asList(types);
+        this.priority = priority;
+    }
+
+    @Override
+    public int getPriority()
+    {
+        return this.priority;
+    }
+
+    @Override
+    public boolean supportsImportType(String type)
+    {
+        return this.enabled && (this.supportedTypes.contains(type) || this.supportedTypes.isEmpty());
+    }
+}

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/spi/ClarityDataProcessor.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/spi/ClarityDataProcessor.java
@@ -68,6 +68,19 @@ public interface ClarityDataProcessor extends Comparable<ClarityDataProcessor>
      */
     int getPriority();
 
+    /**
+     * A processor can either be active for all imports, or just a subset of them. Each import has a specific type, and
+     * each processor can support specific types. This method check if an import type is supported. By default,
+     * processors are active for all imports, override this method to restrict it.
+     *
+     * @param type a short label identifying the import process
+     * @return {@code true} if this processor should be used for the specified import type, {@code false} otherwise
+     */
+    default boolean supportsImportType(String type)
+    {
+        return true;
+    }
+
     @Override
     default int compareTo(ClarityDataProcessor other)
     {

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/DischargedFiller.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/DischargedFiller.java
@@ -21,8 +21,10 @@ package io.uhndata.cards.prems.internal.importer;
 
 import java.util.Map;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 
+import io.uhndata.cards.clarity.importer.spi.AbstractClarityDataProcessor;
 import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
 
 /**
@@ -31,19 +33,19 @@ import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
  * @version $Id$
  */
 @Component
-public class DischargedFiller implements ClarityDataProcessor
+public class DischargedFiller extends AbstractClarityDataProcessor implements ClarityDataProcessor
 {
+    @Activate
+    public DischargedFiller()
+    {
+        super(true, new String[] { "prems" }, 30);
+    }
+
     @Override
     public Map<String, String> processEntry(Map<String, String> input)
     {
         // All visits we receive are discharged, add this to the output so it can get inserted into the visit
         input.put("STATUS", "discharged");
         return input;
-    }
-
-    @Override
-    public int getPriority()
-    {
-        return 30;
     }
 }

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/LengthOfStayMapper.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/LengthOfStayMapper.java
@@ -34,6 +34,7 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.uhndata.cards.clarity.importer.spi.AbstractClarityDataProcessor;
 import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
 
 /**
@@ -44,7 +45,7 @@ import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
  */
 @Component
 @Designate(ocd = LengthOfStayMapper.LengthOfStayMapperConfigDefinition.class)
-public class LengthOfStayMapper implements ClarityDataProcessor
+public class LengthOfStayMapper extends AbstractClarityDataProcessor implements ClarityDataProcessor
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(LengthOfStayMapper.class);
 
@@ -62,11 +63,13 @@ public class LengthOfStayMapper implements ClarityDataProcessor
     }
 
     private final boolean overwrite;
+
     private final boolean useCalendarDays;
 
     @Activate
     public LengthOfStayMapper(LengthOfStayMapperConfigDefinition configuration)
     {
+        super(true, new String[] { "prems" }, 10);
         this.overwrite = configuration.overwrite();
         this.useCalendarDays = configuration.useCalendarDays();
     }
@@ -107,11 +110,5 @@ public class LengthOfStayMapper implements ClarityDataProcessor
             }
         }
         return input;
-    }
-
-    @Override
-    public int getPriority()
-    {
-        return 10;
     }
 }

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/MychartEmailConsentMapper.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/MychartEmailConsentMapper.java
@@ -21,10 +21,12 @@ package io.uhndata.cards.prems.internal.importer;
 
 import java.util.Map;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.uhndata.cards.clarity.importer.spi.AbstractClarityDataProcessor;
 import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
 
 /**
@@ -33,9 +35,15 @@ import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
  * @version $Id$
  */
 @Component
-public class MychartEmailConsentMapper implements ClarityDataProcessor
+public class MychartEmailConsentMapper extends AbstractClarityDataProcessor implements ClarityDataProcessor
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(MychartEmailConsentMapper.class);
+
+    @Activate
+    public MychartEmailConsentMapper()
+    {
+        super(true, new String[] { "prems" }, 0);
+    }
 
     @Override
     public Map<String, String> processEntry(Map<String, String> input)
@@ -46,11 +54,5 @@ public class MychartEmailConsentMapper implements ClarityDataProcessor
                 input.getOrDefault("/SubjectTypes/Patient/Visit", "Unknown"));
         }
         return input;
-    }
-
-    @Override
-    public int getPriority()
-    {
-        return 0;
     }
 }

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/SendCPESForDepartmentFrequency.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/SendCPESForDepartmentFrequency.java
@@ -30,6 +30,7 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.uhndata.cards.clarity.importer.spi.AbstractClarityDataProcessor;
 import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
 
 /**
@@ -40,7 +41,7 @@ import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
  */
 @Component
 @Designate(ocd = SendCPESForDepartmentFrequency.SendCPESForDepartmentFrequencyConfigDefinition.class)
-public class SendCPESForDepartmentFrequency implements ClarityDataProcessor
+public class SendCPESForDepartmentFrequency extends AbstractClarityDataProcessor implements ClarityDataProcessor
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(SendCPESForDepartmentFrequency.class);
 
@@ -63,6 +64,7 @@ public class SendCPESForDepartmentFrequency implements ClarityDataProcessor
     @Activate
     public SendCPESForDepartmentFrequency(SendCPESForDepartmentFrequencyConfigDefinition configuration)
     {
+        super(true, new String[] { "prems" }, 120);
         this.defaultFrequency = configuration.default_frequency();
         this.perDepartmentFrequency = new HashMap<>(configuration.frequency_per_department().length);
         for (String clinic : configuration.frequency_per_department()) {
@@ -86,11 +88,5 @@ public class SendCPESForDepartmentFrequency implements ClarityDataProcessor
                 input.getOrDefault("/SubjectTypes/Patient/Visit", "Unknown"));
         }
         return input;
-    }
-
-    @Override
-    public int getPriority()
-    {
-        return 120;
     }
 }

--- a/prems-resources/clinical-data/pom.xml
+++ b/prems-resources/clinical-data/pom.xml
@@ -72,7 +72,7 @@
               SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates;path:=/apps/cards/clinics/UHN-IC-IP/mailTemplates;overwrite:=true,
               SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates;path:=/apps/cards/clinics/UHN-IC-EDIP/mailTemplates;overwrite:=true,
               SLING-INF/content/apps/cards/clinics/UHN-Rehab/mailTemplates;path:=/apps/cards/clinics/UHN-Rehab/mailTemplates;overwrite:=true,
-              SLING-INF/content/apps/cards/clarityMapping.xml;path:=/apps/cards/clarityImport;overwrite:=true,
+              SLING-INF/content/apps/cards/clarityImport/YourExperience.xml;path:=/apps/cards/clarityImport/YourExperience;overwrite:=true,
               SLING-INF/content/Statistics/;path:=/Statistics/;overwriteProperties:=true;uninstall:=true,
             </Sling-Initial-Content>
           </instructions>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clarityImport/YourExperience.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clarityImport/YourExperience.xml
@@ -18,14 +18,14 @@
 -->
 
 <node>
-  <name>clarityImport</name>
+  <name>YourExperience</name>
   <primaryNodeType>sling:Folder</primaryNodeType>
   <node>
     <name>Patient</name>
     <primaryNodeType>cards:ClaritySubjectMapping</primaryNodeType>
     <property>
       <name>subjectIDColumn</name>
-      <value>PATIENT_ID</value>
+      <value>PAT_MRN</value>
       <type>String</type>
     </property>
     <property>
@@ -49,7 +49,7 @@
           <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
           <property>
             <name>column</name>
-            <value>MRN</value>
+            <value>PAT_MRN</value>
             <type>String</type>
           </property>
           <property>
@@ -63,21 +63,7 @@
           <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
           <property>
             <name>column</name>
-            <value>OHIP_NBR</value>
-            <type>String</type>
-          </property>
-          <property>
-            <name>question</name>
-            <value>/Questionnaires/Patient information/health_card</value>
-            <type>String</type>
-          </property>
-        </node>
-        <node>
-          <name>00000003</name>
-          <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
-          <property>
-            <name>column</name>
-            <value>FIRST_NAME</value>
+            <value>PAT_FIRST_NAME</value>
             <type>String</type>
           </property>
           <property>
@@ -87,11 +73,11 @@
           </property>
         </node>
         <node>
-          <name>00000004</name>
+          <name>00000003</name>
           <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
           <property>
             <name>column</name>
-            <value>LAST_NAME</value>
+            <value>PAT_LAST_NAME</value>
             <type>String</type>
           </property>
           <property>
@@ -101,39 +87,11 @@
           </property>
         </node>
         <node>
-          <name>00000005</name>
+          <name>00000004</name>
           <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
           <property>
             <name>column</name>
-            <value>DATE_OF_BIRTH</value>
-            <type>String</type>
-          </property>
-          <property>
-            <name>question</name>
-            <value>/Questionnaires/Patient information/date_of_birth</value>
-            <type>String</type>
-          </property>
-        </node>
-        <node>
-          <name>00000006</name>
-          <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
-          <property>
-            <name>column</name>
-            <value>SEX</value>
-            <type>String</type>
-          </property>
-          <property>
-            <name>question</name>
-            <value>/Questionnaires/Patient information/sex</value>
-            <type>String</type>
-          </property>
-        </node>
-        <node>
-          <name>00000007</name>
-          <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
-          <property>
-            <name>column</name>
-            <value>EMAIL</value>
+            <value>EMAIL_ADDRESS</value>
             <type>String</type>
           </property>
           <property>
@@ -143,11 +101,11 @@
           </property>
         </node>
         <node>
-          <name>00000008</name>
+          <name>00000005</name>
           <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
           <property>
             <name>column</name>
-            <value>EMAIL_CONSENT</value>
+            <value>EMAIL_CONSENT_YN</value>
             <type>String</type>
           </property>
           <property>
@@ -157,7 +115,7 @@
           </property>
         </node>
         <node>
-          <name>00000009</name>
+          <name>00000006</name>
           <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
           <property>
             <name>column</name>
@@ -171,11 +129,11 @@
           </property>
         </node>
         <node>
-          <name>00000010</name>
+          <name>00000007</name>
           <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
           <property>
             <name>column</name>
-            <value>PATIENT_ID</value>
+            <value>DEATH_DATE</value>
             <type>String</type>
           </property>
           <property>
@@ -199,7 +157,7 @@
         </property>
         <property>
           <name>subjectIDColumn</name>
-          <value>ENCOUNTER_ID</value>
+          <value>PAT_ENC_CSN_ID</value>
           <type>String</type>
         </property>
         <property>
@@ -223,7 +181,7 @@
               <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
               <property>
                 <name>column</name>
-                <value>ATTENDING_PROV_NAME</value>
+                <value>DISCH_DEPT_NAME</value>
                 <type>String</type>
               </property>
               <property>
@@ -237,7 +195,7 @@
               <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
               <property>
                 <name>column</name>
-                <value>ENCOUNTER_DATE</value>
+                <value>HOSP_DISCHARGE_DTTM</value>
                 <type>String</type>
               </property>
               <property>
@@ -251,12 +209,26 @@
               <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
               <property>
                 <name>column</name>
-                <value>LOCATION</value>
+                <value>DISCH_LOC_NAME</value>
                 <type>String</type>
               </property>
               <property>
                 <name>question</name>
                 <value>/Questionnaires/Visit information/location</value>
+                <type>String</type>
+              </property>
+            </node>
+            <node>
+              <name>00000004</name>
+              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+              <property>
+                <name>column</name>
+                <value>CLINIC</value>
+                <type>String</type>
+              </property>
+              <property>
+                <name>question</name>
+                <value>/Questionnaires/Visit information/clinic</value>
                 <type>String</type>
               </property>
               <property>
@@ -266,25 +238,11 @@
               </property>
             </node>
             <node>
-              <name>00000004</name>
-              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
-              <property>
-                <name>column</name>
-                <value>ENCOUNTER_CLINIC</value>
-                <type>String</type>
-              </property>
-              <property>
-                <name>question</name>
-                <value>/Questionnaires/Visit information/clinic</value>
-                <type>String</type>
-              </property>
-            </node>
-            <node>
               <name>00000005</name>
               <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
               <property>
                 <name>column</name>
-                <value>ENCOUNTER_STATUS</value>
+                <value>STATUS</value>
                 <type>String</type>
               </property>
               <property>
@@ -292,13 +250,144 @@
                 <value>/Questionnaires/Visit information/status</value>
                 <type>String</type>
               </property>
+              <property>
+                <name>computed</name>
+                <value>True</value>
+                <type>Boolean</type>
+              </property>
             </node>
             <node>
-              <name>00000006</name>
+              <name>00000007</name>
               <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
               <property>
                 <name>column</name>
-                <value>ENCOUNTER_ID</value>
+                <value>DISCH_DISPOSITION</value>
+                <type>String</type>
+              </property>
+              <property>
+                <name>question</name>
+                <value></value>
+                <type>String</type>
+              </property>
+            </node>
+            <node>
+              <name>00000008</name>
+              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+              <property>
+                <name>column</name>
+                <value>LEVEL_OF_CARE</value>
+                <type>String</type>
+              </property>
+              <property>
+                <name>question</name>
+                <value></value>
+                <type>String</type>
+              </property>
+            </node>
+            <node>
+              <name>00000009</name>
+              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+              <property>
+                <name>column</name>
+                <value>ED_IP_TRANSFER_YN</value>
+                <type>String</type>
+              </property>
+              <property>
+                <name>question</name>
+                <value></value>
+                <type>String</type>
+              </property>
+            </node>
+            <node>
+              <name>00000010</name>
+              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+              <property>
+                <name>column</name>
+                <value>LENGTH_OF_STAY_DAYS</value>
+                <type>String</type>
+              </property>
+              <property>
+                <name>question</name>
+                <value></value>
+                <type>String</type>
+              </property>
+            </node>
+            <node>
+              <name>00000012</name>
+              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+              <property>
+                <name>column</name>
+                <value>HOSP_ADMISSION_DTTM</value>
+                <type>String</type>
+              </property>
+              <property>
+                <name>question</name>
+                <value></value>
+                <type>String</type>
+              </property>
+            </node>
+            <node>
+              <name>00000013</name>
+              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+              <property>
+                <name>column</name>
+                <value>PRIMARY_DX_NAME</value>
+                <type>String</type>
+              </property>
+              <property>
+                <name>question</name>
+                <value></value>
+                <type>String</type>
+              </property>
+            </node>
+            <node>
+              <name>00000014</name>
+              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+              <property>
+                <name>column</name>
+                <value>PAT_ENC_CSN_ID</value>
+                <type>String</type>
+              </property>
+              <property>
+                <name>question</name>
+                <value></value>
+                <type>String</type>
+              </property>
+            </node>
+            <node>
+              <name>00000015</name>
+              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+              <property>
+                <name>column</name>
+                <value>PATIENT_CLASS</value>
+                <type>String</type>
+              </property>
+              <property>
+                <name>question</name>
+                <value></value>
+                <type>String</type>
+              </property>
+            </node>
+            <node>
+              <name>00000016</name>
+              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+              <property>
+                <name>column</name>
+                <value>UHN_ICC_STATUS</value>
+                <type>String</type>
+              </property>
+              <property>
+                <name>question</name>
+                <value></value>
+                <type>String</type>
+              </property>
+            </node>
+            <node>
+              <name>00000017</name>
+              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+              <property>
+                <name>column</name>
+                <value>UHN_ICC_PATIENT_ELIGIBILITY</value>
                 <type>String</type>
               </property>
               <property>

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -358,6 +358,7 @@
     "io.uhndata.cards.clarity.importer.ClarityImportConfig~prems-discharge-events": {
       "name": "Your Experience - Discharge events",
       "importSchedule": "0 0 3 * * ? *",
+      "mapping": "/apps/cards/clarityImport/YourExperience",
       "dayToImport": -7
     },
 

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -354,9 +354,10 @@
       "export.format": "csv"
     },
 
-    // Clarity import
-    "io.uhndata.cards.clarity.importer.NightlyClarityImport": {
-      "nightly.import.schedule": "0 0 3 * * ? *",
+    // Clarity import scheduling
+    "io.uhndata.cards.clarity.importer.ClarityImportConfig~prems-discharge-events": {
+      "name": "Your Experience - Discharge events",
+      "importSchedule": "0 0 3 * * ? *",
       "dayToImport": -7
     },
 

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -357,6 +357,7 @@
     // Clarity import scheduling
     "io.uhndata.cards.clarity.importer.ClarityImportConfig~prems-discharge-events": {
       "name": "Your Experience - Discharge events",
+      "type": "prems",
       "importSchedule": "0 0 3 * * ? *",
       "mapping": "/apps/cards/clarityImport/YourExperience",
       "dayToImport": -7
@@ -367,20 +368,24 @@
     // Discard patients with invalid or non-consented emails
     "io.uhndata.cards.clarity.importer.internal.EmailConsentFilter": {
       "enable": true,
+      "supportedTypes": ["prems"],
       "emailColumn": "EMAIL_ADDRESS",
       "emailConsentColumn": "EMAIL_CONSENT_YN"
     },
     // Only send surveys to patients once every 6 months
     "io.uhndata.cards.clarity.importer.internal.RecentVisitDiscardFilter": {
       "enable": true,
+      "supportedTypes": ["prems"],
       "minimum.visit.frequency": 183
     },
     // Don't import visits for patients who have opted out of emails
     "io.uhndata.cards.clarity.importer.internal.UnsubscribedFilter": {
-      "enable": true
+      "enable": true,
+      "supportedTypes": ["prems"]
     },
     // Only look at events from the participating hospitals, discard everything else
     "io.uhndata.cards.clarity.importer.internal.ConfiguredDiscardFilter~Discard-NonParticipatingHospitals":{
+      "supportedTypes": ["prems"],
       "priority": 10,
       "conditions": [
         "DISCH_LOC_NAME <> Toronto General Hospital",
@@ -395,6 +400,7 @@
     },
     // Only look at actual Emergency or Inpatient events
     "io.uhndata.cards.clarity.importer.internal.ConfiguredDiscardFilter~Discard-OtherVisitTypes":{
+      "supportedTypes": ["prems"],
       "priority": 10,
       "conditions": [
         "PATIENT_CLASS not in Emergency; Inpatient; Inpatient Rehab"
@@ -402,34 +408,41 @@
     },
     // Discard deceased patients
     "io.uhndata.cards.clarity.importer.internal.ConfiguredDiscardFilter~Discard-DeathDate":{
+      "supportedTypes": ["prems"],
       "priority": 20,
       "conditions": ["DEATH_DATE is not empty"]
     },
     "io.uhndata.cards.clarity.importer.internal.ConfiguredDiscardFilter~Discard-Deceased":{
+      "supportedTypes": ["prems"],
       "priority": 20,
       "conditions": ["DISCH_DISPOSITION in Cad Donor; Deceased; Died on Leav; Died; Donor; Stillbirth; Suicide Out; Death After; MAID; Death on Arr; IP Medically; IP In-Facili; IP Died Whil; IP Out of Fa; DOA; OP Medically; OP In-Facili; Suicide fac; Still Born; Pt. suicide; Expired LOA; Expired; Med assist d; Suicide fac; DOA"]
     },
     // Discard patients discharged to another institution or not arrived at all
     "io.uhndata.cards.clarity.importer.internal.ConfiguredDiscardFilter~Discard-DischargeToLocation":{
+      "supportedTypes": ["prems"],
       "priority": 20,
       "conditions": ["DISCH_DISPOSITION in Not Arrived; Left Triage; Jail; Diverted; Shelter; Jail or half; Res Care; Inpatient Ac; Inpt Ac Diff; Inpt Ac Same; Inpatient Ps; IP Trnsfr; OP Discharge; OP Transfer; RehabPsych"]
     },
     // Discard patients with special care
     "io.uhndata.cards.clarity.importer.internal.ConfiguredDiscardFilter~Discard-AlternativeLevelOfCare":{
+      "supportedTypes": ["prems"],
       "priority": 20,
       "conditions": ["LEVEL_OF_CARE matches ALC.*"]
     },
     "io.uhndata.cards.clarity.importer.internal.ConfiguredDiscardFilter~Discard-Psychiatric":{
+      "supportedTypes": ["prems"],
       "priority": 20,
       "conditions": ["DISCH_DEPT_NAME = TG-8ES PSYCHIATRY"]
     },
     "io.uhndata.cards.clarity.importer.internal.ConfiguredDiscardFilter~Discard-Palliative":{
+      "supportedTypes": ["prems"],
       "priority": 20,
       "conditions": ["DISCH_DEPT_NAME in PM-PALLIATIVE CARE ONCOLOGY CLINIC; TW-PALLIATIVE CARE CLINIC; TG-PALLIATIVE CARE; PM-16P PALLIATIVE CARE"]
     },
     // Patients eligible for Integrated Care surveys should have a different status
     // The default status is set at priority 30 by DischargedFiller
     "io.uhndata.cards.clarity.importer.internal.ConfiguredGenericMapper~IntegratedCareStatusInProgress":{
+      "supportedTypes": ["prems"],
       "priority": 35,
       "column": "STATUS",
       "value": "in-progress",
@@ -440,51 +453,61 @@
     },
     // Assign patients from Toronto Rehab to the Rehab cohort
     "io.uhndata.cards.clarity.importer.internal.ConfiguredCohortMapper~CohortMapper-Rehab":{
+      "supportedTypes": ["prems"],
       "priority": 40,
       "clinic": "/Survey/ClinicMapping/78840662",
       "conditions": ["DISCH_LOC_NAME matches Toronto Rehab .*"]
     },
     // From the Rehab, exclude patients from the Special Dementia Unit
     "io.uhndata.cards.clarity.importer.internal.ConfiguredDiscardFilter~Discard-Rehab-Dementia":{
+      "supportedTypes": ["prems"],
       "priority": 60,
       "conditions": ["CLINIC = /Survey/ClinicMapping/78840662", "DISCH_DEPT_NAME = UC-5 SOUTH IP"]
     },
     // From the Rehab, exclude Complex Continuing Care patients
     "io.uhndata.cards.clarity.importer.internal.ConfiguredDiscardFilter~Discard-Rehab-ComplexContinuingCare":{
+      "supportedTypes": ["prems"],
       "priority": 60,
       "conditions": ["CLINIC = /Survey/ClinicMapping/78840662", "DISCH_DEPT_NAME in BC-3 NORTH TCU IP; BC-5A NORTH IP; BC-5B NORTH IP; BC-3 SOUTH IP; BC-5 SOUTH IP"]
     },
     "io.uhndata.cards.clarity.importer.internal.ConfiguredDiscardFilter~Discard-Rehab-ComplexContinuingMatch":{
+      "supportedTypes": ["prems"],
       "priority": 60,
       "conditions": ["CLINIC = /Survey/ClinicMapping/78840662", "DISCH_DEPT_NAME matches .*CCC.*"]
     },
     // From the Rehab, exclude patients that are not rehab patients
     "io.uhndata.cards.prems.internal.importer.ConfiguredDiscardFilter~Discard-Rehab-NotRehabDepartments":{
+      "supportedTypes": ["prems"],
       "priority": 60,
       "conditions": ["CLINIC = /Survey/ClinicMapping/78840662", "DISCH_DEPT_NAME in BC-AAC CLINIC; BC-DENTISTRY; LC-ASSISTIVE TECHNOLOGY; LC-CHIROPODY CLINIC; LC-ITB CLINIC; LC-NEUROPHYSIOLOGY CLINIC; LC-NURSING CLINIC; LC-PHYSIATRY; LC-PSYCHIATRY CLINIC; LC-ROBSON CLINIC; LC-SEATING CLINIC; LC-SKIN AND WOUND; LC-SPINAL CORD REHAB-OP-ALLIED HEALTH; RN-CHRONIC PAIN LEAP SERVICE; UC-DENTISTRY; UC-EMG CLINIC; UC-GERIATRIC REHAB SERVICE; UC-PHYSIOTHERAPY-LOGIN; UC-SLEEP LAB"]
     },
     "io.uhndata.cards.prems.internal.importer.ConfiguredDiscardFilter~Discard-Rehab-NotRehabPatients":{
+      "supportedTypes": ["prems"],
       "priority": 60,
       "conditions": ["CLINIC = /Survey/ClinicMapping/78840662", "PATIENT_CLASS <> Inpatient Rehab"]
     },
     // Only non-rehab patients from now on.
     // Discard patients not from Rehab, and with psychiatric or substance abuse as primary diagnosis
     "io.uhndata.cards.clarity.importer.internal.ConfiguredDiscardFilter~Discard-NotRehab-PsychiatricOrSubstanceAbusePrimaryDiagnosis":{
+      "supportedTypes": ["prems"],
       "priority": 60,
       "conditions": ["CLINIC is empty", "PRIMARY_DX_NAME in Acute alcoholic intoxication; Acute delirium; Adjustment disorder; Adjustment disorder with mixed anxiety and depressed mood; Adjustment disorders, unspecified; Agitation; Alcohol dependence in remission; Alcohol intoxication; Alcohol use; Alcohol use disorder; Alcohol withdrawal; Alcoholism in recovery; Alzheimer disease; Anoxic brain injury; Anxiety; Anxiety about health; Anxiety and depression; Bipolar 1 disorder; Bipolar affective disorder, current episode manic; Bipolar disorder; Cocaine use; Cocaine use disorder, severe, dependence; Cognitive impairment; Confusion; Delirium; Delirium superimposed on dementia; Dementia; Depression; Depression, prolonged; Developmental delay; Drug-induced psychotic disorder; Essential tremor; Generalized anxiety disorder; Impaired cognition; Major depressive disorder; Memory impairment; MDD (major depressive disorder); Mood disorder; Overdose; Overdose of drug/medicinal substance; Overdose of tricyclic antidepressants; Polysubstance dependence; Schizoaffective disorder; Schizoaffective disorder, bipolar type; Schizophrenia; Seizure; Seizure disorder; Seizures; Severe anxiety with panic; Stress; Stress and adjustment reaction; Substance abuse; Substance use; Substance use disorder; Suicidal ideation; Tremor; Unspecified intellectual developmental disorder (intellectual disability); Unspecified schizophrenia spectrum and other psychotic disorder; Unspecified trauma- and stressor-related disorder; Vapes nicotine containing substance; Withdrawal symptoms, alcohol"]
     },
     // Discard patients not from Rehab, and discharged to long term care
     "io.uhndata.cards.clarity.importer.internal.ConfiguredDiscardFilter~Discard-NotRehab-LongTermCare":{
+      "supportedTypes": ["prems"],
       "priority": 60,
       "conditions": ["CLINIC is empty", "DISCH_DISPOSITION in Residential; Discharge; IP Transfer; LTC; Res Care; Board & Care"]
     },
     // Assign patients that were only at the emergency department to the ED cohort
     "io.uhndata.cards.clarity.importer.internal.ConfiguredCohortMapper~CohortMapper-ED-NoTransferTG":{
+      "supportedTypes": ["prems"],
       "priority": 80,
       "clinic": "/Survey/ClinicMapping/-1792626799",
       "conditions": ["CLINIC is empty", "ED_IP_TRANSFER_YN = no", "DISCH_DEPT_NAME = TG-EMERGENCY"]
     },
     "io.uhndata.cards.clarity.importer.internal.ConfiguredCohortMapper~CohortMapper-ED-NoTransferTW":{
+      "supportedTypes": ["prems"],
       "priority": 80,
       "clinic": "/Survey/ClinicMapping/-1792626799",
       "conditions": ["CLINIC is empty", "ED_IP_TRANSFER_YN = no", "DISCH_DEPT_NAME = TW-EMERGENCY"]
@@ -492,12 +515,14 @@
     // Discard patients that were discharged from the emergency department to in-patient for now;
     // a follow up event will be generated later when they are discharged from in-patient
     "io.uhndata.cards.clarity.importer.internal.ConfiguredDiscardFilter~Discard-ED-Transfer":{
+      "supportedTypes": ["prems"],
       "priority": 100,
       "conditions": ["CLINIC is empty", "DISCH_DEPT_NAME matches .*EMERGENCY.*"]
     },
     // Only in-patients from now on.
     // Discard patients that were only in-patient for a short time
     "io.uhndata.cards.clarity.importer.internal.ConfiguredDiscardFilter~Discard-IP-ShortStay":{
+      "supportedTypes": ["prems"],
       "priority": 100,
       "conditions": ["CLINIC <> /Survey/ClinicMapping/-1792626799", "LENGTH_OF_STAY_DAYS < 1"]
     },
@@ -512,12 +537,14 @@
     // Only non-CPESIC patients from now on.
     // Assign patients that were both in the emergency and in-patient to the EDIP cohort
     "io.uhndata.cards.clarity.importer.internal.ConfiguredCohortMapper~CohortMapper-EDIP-Transfer":{
+      "supportedTypes": ["prems"],
       "priority": 140,
       "clinic": "/Survey/ClinicMapping/-432465800",
       "conditions": ["CLINIC is empty", "ED_IP_TRANSFER_YN = yes"]
     },
     // Assign patients that were only in-patient to the IP cohort
     "io.uhndata.cards.clarity.importer.internal.ConfiguredCohortMapper~CohortMapper-IP":{
+      "supportedTypes": ["prems"],
       "priority": 160,
       "clinic": "/Survey/ClinicMapping/-1792626663",
       "conditions": ["CLINIC is empty"]
@@ -525,6 +552,7 @@
     // Discard duplicates if there's more than one event per patient
     "io.uhndata.cards.clarity.importer.internal.DiscardDuplicatesFilter":{
       "enable": true,
+      "supportedTypes": ["prems"],
       "subjectType": "/SubjectTypes/Patient"
     },
     // Submission event listener

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ClinicMapper.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ClinicMapper.java
@@ -23,11 +23,13 @@ import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.uhndata.cards.clarity.importer.spi.AbstractClarityDataProcessor;
 import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
 import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
@@ -38,12 +40,18 @@ import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
  * @version $Id$
  */
 @Component
-public class ClinicMapper implements ClarityDataProcessor
+public class ClinicMapper extends AbstractClarityDataProcessor implements ClarityDataProcessor
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClinicMapper.class);
 
     @Reference
     private ThreadResourceResolverProvider trrp;
+
+    @Activate
+    public ClinicMapper()
+    {
+        super(true, new String[] { "proms" }, 50);
+    }
 
     @Override
     public Map<String, String> processEntry(Map<String, String> input)
@@ -69,11 +77,5 @@ public class ClinicMapper implements ClarityDataProcessor
         LOGGER.warn("Updated visit {} ENCOUNTER_CLINIC to {}",
             input.getOrDefault("/SubjectTypes/Patient/Visit", "Unknown"), clinicPath);
         return input;
-    }
-
-    @Override
-    public int getPriority()
-    {
-        return 50;
     }
 }

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ClinicToLocationFiller.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/ClinicToLocationFiller.java
@@ -22,11 +22,13 @@ package io.uhndata.cards.proms.internal.importer;
 import java.util.Map;
 
 import org.apache.sling.api.resource.Resource;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.uhndata.cards.clarity.importer.spi.AbstractClarityDataProcessor;
 import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
 import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
@@ -36,12 +38,18 @@ import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
  * @version $Id$
  */
 @Component
-public class ClinicToLocationFiller implements ClarityDataProcessor
+public class ClinicToLocationFiller extends AbstractClarityDataProcessor implements ClarityDataProcessor
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClinicToLocationFiller.class);
 
     @Reference
     private ThreadResourceResolverProvider trrp;
+
+    @Activate
+    public ClinicToLocationFiller()
+    {
+        super(true, new String[] { "proms" }, 300);
+    }
 
     @Override
     public Map<String, String> processEntry(Map<String, String> input)
@@ -59,11 +67,5 @@ public class ClinicToLocationFiller implements ClarityDataProcessor
                 clinicLabel);
         }
         return input;
-    }
-
-    @Override
-    public int getPriority()
-    {
-        return 300;
     }
 }

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/DiscardCanceledEvents.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/DiscardCanceledEvents.java
@@ -22,11 +22,13 @@ package io.uhndata.cards.proms.internal.importer;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.uhndata.cards.clarity.importer.spi.AbstractClarityDataProcessor;
 import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
 import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 
@@ -36,12 +38,18 @@ import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
  * @version $Id$
  */
 @Component
-public class DiscardCanceledEvents implements ClarityDataProcessor
+public class DiscardCanceledEvents extends AbstractClarityDataProcessor implements ClarityDataProcessor
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(DiscardCanceledEvents.class);
 
     @Reference
     private ThreadResourceResolverProvider trrp;
+
+    @Activate
+    public DiscardCanceledEvents()
+    {
+        super(true, new String[] { "proms" }, 10);
+    }
 
     @Override
     public Map<String, String> processEntry(Map<String, String> input)
@@ -54,11 +62,5 @@ public class DiscardCanceledEvents implements ClarityDataProcessor
             return null;
         }
         return input;
-    }
-
-    @Override
-    public int getPriority()
-    {
-        return 10;
     }
 }

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/EmailConsentBooleanMapper.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/EmailConsentBooleanMapper.java
@@ -21,8 +21,10 @@ package io.uhndata.cards.proms.internal.importer;
 
 import java.util.Map;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 
+import io.uhndata.cards.clarity.importer.spi.AbstractClarityDataProcessor;
 import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
 
 /**
@@ -31,9 +33,15 @@ import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
  * @version $Id$
  */
 @Component
-public class EmailConsentBooleanMapper implements ClarityDataProcessor
+public class EmailConsentBooleanMapper extends AbstractClarityDataProcessor implements ClarityDataProcessor
 {
     private static final String COLUMN = "EMAIL_CONSENT";
+
+    @Activate
+    public EmailConsentBooleanMapper()
+    {
+        super(true, new String[] { "proms" }, 0);
+    }
 
     @Override
     public Map<String, String> processEntry(Map<String, String> input)
@@ -44,11 +52,5 @@ public class EmailConsentBooleanMapper implements ClarityDataProcessor
             input.put(COLUMN, "Yes");
         }
         return input;
-    }
-
-    @Override
-    public int getPriority()
-    {
-        return 0;
     }
 }

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/EncounterStatusFhirMapper.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/EncounterStatusFhirMapper.java
@@ -22,8 +22,10 @@ package io.uhndata.cards.proms.internal.importer;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 
+import io.uhndata.cards.clarity.importer.spi.AbstractClarityDataProcessor;
 import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
 
 /**
@@ -32,9 +34,15 @@ import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
  * @version $Id$
  */
 @Component
-public class EncounterStatusFhirMapper implements ClarityDataProcessor
+public class EncounterStatusFhirMapper extends AbstractClarityDataProcessor implements ClarityDataProcessor
 {
     private static final String COLUMN = "ENCOUNTER_STATUS";
+
+    @Activate
+    public EncounterStatusFhirMapper()
+    {
+        super(true, new String[] { "proms" }, 0);
+    }
 
     @Override
     public Map<String, String> processEntry(Map<String, String> input)
@@ -46,11 +54,5 @@ public class EncounterStatusFhirMapper implements ClarityDataProcessor
             input.put(COLUMN, "planned");
         }
         return input;
-    }
-
-    @Override
-    public int getPriority()
-    {
-        return 0;
     }
 }

--- a/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/MychartEmailConsentMapper.java
+++ b/proms-resources/backend/src/main/java/io/uhndata/cards/proms/internal/importer/MychartEmailConsentMapper.java
@@ -21,10 +21,12 @@ package io.uhndata.cards.proms.internal.importer;
 
 import java.util.Map;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.uhndata.cards.clarity.importer.spi.AbstractClarityDataProcessor;
 import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
 
 /**
@@ -33,9 +35,15 @@ import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
  * @version $Id$
  */
 @Component
-public class MychartEmailConsentMapper implements ClarityDataProcessor
+public class MychartEmailConsentMapper extends AbstractClarityDataProcessor implements ClarityDataProcessor
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(MychartEmailConsentMapper.class);
+
+    @Activate
+    public MychartEmailConsentMapper()
+    {
+        super(true, new String[] { "proms" }, 0);
+    }
 
     @Override
     public Map<String, String> processEntry(Map<String, String> input)
@@ -46,11 +54,5 @@ public class MychartEmailConsentMapper implements ClarityDataProcessor
                 input.getOrDefault("/SubjectTypes/Patient/Visit", "Unknown"));
         }
         return input;
-    }
-
-    @Override
-    public int getPriority()
-    {
-        return 0;
     }
 }

--- a/proms-resources/clinical-data/pom.xml
+++ b/proms-resources/clinical-data/pom.xml
@@ -52,7 +52,7 @@
               SLING-INF/content/libs/cards/conf/Media.json;path:=/libs/cards/conf/Media;overwriteProperties:=true,
               SLING-INF/content/libs/cards/conf/AppName.json;path:=/libs/cards/conf/AppName;overwrite:=true,
               SLING-INF/content/libs/cards/conf/ThemeColor.json;path:=/libs/cards/conf/ThemeColor;overwrite:=true,
-              SLING-INF/content/apps/cards/clarityMapping.xml;path:=/apps/cards/clarityImport;overwrite:=true,
+              SLING-INF/content/apps/cards/clarityImport/DataPro.xml;path:=/apps/cards/clarityImport/DataPro;overwrite:=true,
               SLING-INF/content/apps/cards/config/CopyAnswers;path:=/apps/cards/config/CopyAnswers;overwriteProperties:=true;uninstall:=true,
               SLING-INF/content/Statistics/;path:=/Statistics/;overwrite:=false;overwriteProperties:=true;uninstall:=true,
             </Sling-Initial-Content>

--- a/proms-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clarityImport/DataPro.xml
+++ b/proms-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clarityImport/DataPro.xml
@@ -18,14 +18,14 @@
 -->
 
 <node>
-  <name>clarityImport</name>
+  <name>DataPro</name>
   <primaryNodeType>sling:Folder</primaryNodeType>
   <node>
     <name>Patient</name>
     <primaryNodeType>cards:ClaritySubjectMapping</primaryNodeType>
     <property>
       <name>subjectIDColumn</name>
-      <value>PAT_MRN</value>
+      <value>PATIENT_ID</value>
       <type>String</type>
     </property>
     <property>
@@ -49,7 +49,7 @@
           <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
           <property>
             <name>column</name>
-            <value>PAT_MRN</value>
+            <value>MRN</value>
             <type>String</type>
           </property>
           <property>
@@ -63,7 +63,21 @@
           <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
           <property>
             <name>column</name>
-            <value>PAT_FIRST_NAME</value>
+            <value>OHIP_NBR</value>
+            <type>String</type>
+          </property>
+          <property>
+            <name>question</name>
+            <value>/Questionnaires/Patient information/health_card</value>
+            <type>String</type>
+          </property>
+        </node>
+        <node>
+          <name>00000003</name>
+          <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+          <property>
+            <name>column</name>
+            <value>FIRST_NAME</value>
             <type>String</type>
           </property>
           <property>
@@ -73,11 +87,11 @@
           </property>
         </node>
         <node>
-          <name>00000003</name>
+          <name>00000004</name>
           <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
           <property>
             <name>column</name>
-            <value>PAT_LAST_NAME</value>
+            <value>LAST_NAME</value>
             <type>String</type>
           </property>
           <property>
@@ -87,11 +101,39 @@
           </property>
         </node>
         <node>
-          <name>00000004</name>
+          <name>00000005</name>
           <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
           <property>
             <name>column</name>
-            <value>EMAIL_ADDRESS</value>
+            <value>DATE_OF_BIRTH</value>
+            <type>String</type>
+          </property>
+          <property>
+            <name>question</name>
+            <value>/Questionnaires/Patient information/date_of_birth</value>
+            <type>String</type>
+          </property>
+        </node>
+        <node>
+          <name>00000006</name>
+          <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+          <property>
+            <name>column</name>
+            <value>SEX</value>
+            <type>String</type>
+          </property>
+          <property>
+            <name>question</name>
+            <value>/Questionnaires/Patient information/sex</value>
+            <type>String</type>
+          </property>
+        </node>
+        <node>
+          <name>00000007</name>
+          <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+          <property>
+            <name>column</name>
+            <value>EMAIL</value>
             <type>String</type>
           </property>
           <property>
@@ -101,11 +143,11 @@
           </property>
         </node>
         <node>
-          <name>00000005</name>
+          <name>00000008</name>
           <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
           <property>
             <name>column</name>
-            <value>EMAIL_CONSENT_YN</value>
+            <value>EMAIL_CONSENT</value>
             <type>String</type>
           </property>
           <property>
@@ -115,7 +157,7 @@
           </property>
         </node>
         <node>
-          <name>00000006</name>
+          <name>00000009</name>
           <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
           <property>
             <name>column</name>
@@ -129,11 +171,11 @@
           </property>
         </node>
         <node>
-          <name>00000007</name>
+          <name>00000010</name>
           <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
           <property>
             <name>column</name>
-            <value>DEATH_DATE</value>
+            <value>PATIENT_ID</value>
             <type>String</type>
           </property>
           <property>
@@ -157,7 +199,7 @@
         </property>
         <property>
           <name>subjectIDColumn</name>
-          <value>PAT_ENC_CSN_ID</value>
+          <value>ENCOUNTER_ID</value>
           <type>String</type>
         </property>
         <property>
@@ -181,7 +223,7 @@
               <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
               <property>
                 <name>column</name>
-                <value>DISCH_DEPT_NAME</value>
+                <value>ATTENDING_PROV_NAME</value>
                 <type>String</type>
               </property>
               <property>
@@ -195,7 +237,7 @@
               <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
               <property>
                 <name>column</name>
-                <value>HOSP_DISCHARGE_DTTM</value>
+                <value>ENCOUNTER_DATE</value>
                 <type>String</type>
               </property>
               <property>
@@ -209,7 +251,7 @@
               <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
               <property>
                 <name>column</name>
-                <value>DISCH_LOC_NAME</value>
+                <value>LOCATION</value>
                 <type>String</type>
               </property>
               <property>
@@ -217,13 +259,18 @@
                 <value>/Questionnaires/Visit information/location</value>
                 <type>String</type>
               </property>
+              <property>
+                <name>computed</name>
+                <value>True</value>
+                <type>Boolean</type>
+              </property>
             </node>
             <node>
               <name>00000004</name>
               <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
               <property>
                 <name>column</name>
-                <value>CLINIC</value>
+                <value>ENCOUNTER_CLINIC</value>
                 <type>String</type>
               </property>
               <property>
@@ -231,18 +278,13 @@
                 <value>/Questionnaires/Visit information/clinic</value>
                 <type>String</type>
               </property>
-              <property>
-                <name>computed</name>
-                <value>True</value>
-                <type>Boolean</type>
-              </property>
             </node>
             <node>
               <name>00000005</name>
               <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
               <property>
                 <name>column</name>
-                <value>STATUS</value>
+                <value>ENCOUNTER_STATUS</value>
                 <type>String</type>
               </property>
               <property>
@@ -250,144 +292,13 @@
                 <value>/Questionnaires/Visit information/status</value>
                 <type>String</type>
               </property>
-              <property>
-                <name>computed</name>
-                <value>True</value>
-                <type>Boolean</type>
-              </property>
             </node>
             <node>
-              <name>00000007</name>
+              <name>00000006</name>
               <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
               <property>
                 <name>column</name>
-                <value>DISCH_DISPOSITION</value>
-                <type>String</type>
-              </property>
-              <property>
-                <name>question</name>
-                <value></value>
-                <type>String</type>
-              </property>
-            </node>
-            <node>
-              <name>00000008</name>
-              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
-              <property>
-                <name>column</name>
-                <value>LEVEL_OF_CARE</value>
-                <type>String</type>
-              </property>
-              <property>
-                <name>question</name>
-                <value></value>
-                <type>String</type>
-              </property>
-            </node>
-            <node>
-              <name>00000009</name>
-              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
-              <property>
-                <name>column</name>
-                <value>ED_IP_TRANSFER_YN</value>
-                <type>String</type>
-              </property>
-              <property>
-                <name>question</name>
-                <value></value>
-                <type>String</type>
-              </property>
-            </node>
-            <node>
-              <name>00000010</name>
-              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
-              <property>
-                <name>column</name>
-                <value>LENGTH_OF_STAY_DAYS</value>
-                <type>String</type>
-              </property>
-              <property>
-                <name>question</name>
-                <value></value>
-                <type>String</type>
-              </property>
-            </node>
-            <node>
-              <name>00000012</name>
-              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
-              <property>
-                <name>column</name>
-                <value>HOSP_ADMISSION_DTTM</value>
-                <type>String</type>
-              </property>
-              <property>
-                <name>question</name>
-                <value></value>
-                <type>String</type>
-              </property>
-            </node>
-            <node>
-              <name>00000013</name>
-              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
-              <property>
-                <name>column</name>
-                <value>PRIMARY_DX_NAME</value>
-                <type>String</type>
-              </property>
-              <property>
-                <name>question</name>
-                <value></value>
-                <type>String</type>
-              </property>
-            </node>
-            <node>
-              <name>00000014</name>
-              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
-              <property>
-                <name>column</name>
-                <value>PAT_ENC_CSN_ID</value>
-                <type>String</type>
-              </property>
-              <property>
-                <name>question</name>
-                <value></value>
-                <type>String</type>
-              </property>
-            </node>
-            <node>
-              <name>00000015</name>
-              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
-              <property>
-                <name>column</name>
-                <value>PATIENT_CLASS</value>
-                <type>String</type>
-              </property>
-              <property>
-                <name>question</name>
-                <value></value>
-                <type>String</type>
-              </property>
-            </node>
-            <node>
-              <name>00000016</name>
-              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
-              <property>
-                <name>column</name>
-                <value>UHN_ICC_STATUS</value>
-                <type>String</type>
-              </property>
-              <property>
-                <name>question</name>
-                <value></value>
-                <type>String</type>
-              </property>
-            </node>
-            <node>
-              <name>00000017</name>
-              <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
-              <property>
-                <name>column</name>
-                <value>UHN_ICC_PATIENT_ELIGIBILITY</value>
+                <value>ENCOUNTER_ID</value>
                 <type>String</type>
               </property>
               <property>

--- a/proms-resources/feature/src/main/features/feature.json
+++ b/proms-resources/feature/src/main/features/feature.json
@@ -96,6 +96,7 @@
     "io.uhndata.cards.clarity.importer.ClarityImportConfig~proms-today-visits": {
       "name": "DATAPRO - Today's visits",
       "importSchedule": "0 15 7 * * ? *",
+      "mapping": "/apps/cards/clarityImport/DataPro",
       "dayToImport": 0
     },
 

--- a/proms-resources/feature/src/main/features/feature.json
+++ b/proms-resources/feature/src/main/features/feature.json
@@ -95,6 +95,7 @@
     // Clarity import scheduling
     "io.uhndata.cards.clarity.importer.ClarityImportConfig~proms-today-visits": {
       "name": "DATAPRO - Today's visits",
+      "type": "proms",
       "importSchedule": "0 15 7 * * ? *",
       "mapping": "/apps/cards/clarityImport/DataPro",
       "dayToImport": 0
@@ -105,12 +106,14 @@
     // Discard patients with invalid emails
     "io.uhndata.cards.clarity.importer.internal.EmailConsentFilter": {
       "enable": false,
+      "supportedTypes": ["proms"],
       "emailColumn": "EMAIL",
       "emailConsentColumn": ""
     },
 
     // Discard patients without DoB, since they won't be able to authenticate
     "io.uhndata.cards.clarity.importer.internal.ConfiguredDiscardFilter~Discard-NoDateOfBirth":{
+      "supportedTypes": ["proms"],
       "priority": 10,
       "conditions": [
         "DATE_OF_BIRTH is empty"
@@ -119,6 +122,7 @@
 
     // Discard patients without MRN and OHIP, since they won't be able to authenticate
     "io.uhndata.cards.clarity.importer.internal.ConfiguredDiscardFilter~Discard-NoMrnAndOhip":{
+      "supportedTypes": ["proms"],
       "priority": 10,
       "conditions": [
         "MRN is empty",
@@ -128,6 +132,7 @@
 
     // Merge TG-PMCC CARDIAC CLINICS DIAGNOSTIC into TG-PMCC CARDIAC CLINICS
     "io.uhndata.cards.clarity.importer.internal.ConfiguredGenericMapper~MergeDiagnosticIntoCardiacClinic":{
+      "supportedTypes": ["proms"],
       "priority": 5,
       "column": "ENCOUNTER_CLINIC",
       "value": "TG-PMCC CARDIAC CLINICS",
@@ -138,6 +143,7 @@
 
     // Only look at events from the participating clinics, discard everything else
     "io.uhndata.cards.clarity.importer.internal.ConfiguredDiscardFilter~Discard-NonParticipatingClinics":{
+      "supportedTypes": ["proms"],
       "priority": 10,
       "conditions": [
         "ENCOUNTER_CLINIC <> TG-PMCC CARDIAC CLINICS"
@@ -148,6 +154,7 @@
     // Discard duplicates if there's more than one event per visit
     "io.uhndata.cards.clarity.importer.internal.DiscardDuplicatesFilter":{
       "enable": true,
+      "supportedTypes": ["proms"],
       "subjectType": "/SubjectTypes/Patient/Visit"
     },
     // Submission event listener

--- a/proms-resources/feature/src/main/features/feature.json
+++ b/proms-resources/feature/src/main/features/feature.json
@@ -92,9 +92,10 @@
       "trackEmails": true
     },
 
-    // Clarity import
-    "io.uhndata.cards.clarity.importer.NightlyClarityImport": {
-      "nightly.import.schedule": "0 15 7 * * ? *",
+    // Clarity import scheduling
+    "io.uhndata.cards.clarity.importer.ClarityImportConfig~proms-today-visits": {
+      "name": "DATAPRO - Today's visits",
+      "importSchedule": "0 15 7 * * ? *",
       "dayToImport": 0
     },
 


### PR DESCRIPTION
To test:

- prems
    - build with `mvn clean install -Pdocker`
    - in `compose-cluster` run `python3 generate_compose_yaml.py --mssql --cards_project cards4prems --oak_filesystem --dev_docker_image --composum --adminer --server_address=localhost:8080`
    - in `compose-cluster/mssql` run `python generate_test_YE_sql.py -n 100 --time_spread_seconds 3456000 prems_sample.sql`
    - in `compose-cluster` start with `docker-compose build && docker-compose up`
    - at `http://localhost:1435/?mssql=mssql&username=sa&db=master&ns=path&import=` import the generated `prems_sample.sql`
    - Trigger the import at `http://localhost:8080/Subjects.importClarity`
    - Wait a bit, make sure that visits were imported
    - Stop docker and cleanup with `docker-compose rm -vf && ./cleanup.sh`
- proms
    - build with `mvn clean install -Pdocker`
    - in `compose-cluster` run `python3 generate_compose_yaml.py --mssql --cards_project cards4proms --oak_filesystem --dev_docker_image --composum --adminer --server_address=localhost:8080`
    - in `compose-cluster/mssql` run `python3 generate_test_proms_sql.py -n 20 proms_sample.sql`
    - in `compose-cluster` start with `docker-compose build && docker-compose up`
    - at `http://localhost:1435/?mssql=mssql&username=sa&db=master&ns=path&import=` import the generated `proms_sample.sql`
    - Trigger the import at `http://localhost:8080/Subjects.importClarity`
    - Wait a bit, make sure that visits were imported
    - Stop docker and cleanup with `docker-compose rm -vf && ./cleanup.sh`