### PR TITLE
CARDS-2406: Add questions for tracking the IC notification emails in the Survey Events forms

### DIFF
--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Survey events.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Survey events.xml
@@ -377,11 +377,6 @@
 		<name>ic_invitation_sent</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
-			<name>minAnswers</name>
-			<value>1</value>
-			<type>Long</type>
-		</property>
-		<property>
 			<name>maxAnswers</name>
 			<value>1</value>
 			<type>Long</type>


### PR DESCRIPTION
None of these questions are mandatory.