### PR TITLE
CARDS-2413: Prevent overriding forms with stale data

### DIFF
--- a/modules/utils/src/main/java/io/uhndata/cards/utils/internal/PreventVersionOverrideServletFilter.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/utils/internal/PreventVersionOverrideServletFilter.java
@@ -71,7 +71,7 @@ public class PreventVersionOverrideServletFilter implements Filter
             if (node != null && !requestBaseVersion.equals(node.getProperty("jcr:baseVersion").getNode().getPath())) {
                 slingRequest.setAttribute("javax.servlet.error.status_code", HttpServletResponse.SC_CONFLICT);
                 throw new ServletException(
-                    "This document was changed in a different tab, please refresh to see the latest data.");
+                    "The answers to this form were modified while you were editing. Please refresh to see the latest data.");
             }
         } catch (RepositoryException e) {
             LOGGER.warn("Failed to determine current resource version: {}", e.getMessage(), e);

--- a/modules/utils/src/main/java/io/uhndata/cards/utils/internal/PreventVersionOverrideServletFilter.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/utils/internal/PreventVersionOverrideServletFilter.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.utils.internal;
+
+import java.io.IOException;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Check if a base version was passed in the request, and if it doesn't match the base version of the resource being
+ * modified, abort the request.
+ *
+ * @version $Id$
+ */
+@Component(service = Filter.class,
+    property = {
+        "service.ranking:Integer=0",
+        "sling.filter.scope=REQUEST",
+        "sling.filter.methods=POST",
+        "sling.filter.methods=PUT"
+    })
+public class PreventVersionOverrideServletFilter implements Filter
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(PreventVersionOverrideServletFilter.class);
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException
+    {
+        // Nothing to do
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws IOException, ServletException
+    {
+        String requestBaseVersion = request.getParameter(":baseVersion");
+        if (!(request instanceof SlingHttpServletRequest) || requestBaseVersion == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+        SlingHttpServletRequest slingRequest = (SlingHttpServletRequest) request;
+        try {
+            Node node = slingRequest.getResource().adaptTo(Node.class);
+            if (node != null && !requestBaseVersion.equals(node.getProperty("jcr:baseVersion").getNode().getPath())) {
+                slingRequest.setAttribute("javax.servlet.error.status_code", HttpServletResponse.SC_CONFLICT);
+                throw new ServletException(
+                    "This document was changed in a different tab, please refresh to see the latest data.");
+            }
+        } catch (RepositoryException e) {
+            LOGGER.warn("Failed to determine current resource version: {}", e.getMessage(), e);
+        }
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    public void destroy()
+    {
+        // Nothing to do
+    }
+}


### PR DESCRIPTION
To test:
- start in prems mode
- start editing a new Visit Information form, put some data in, **don't save**
- open it in another tab, enter different data, save & close
- in the first tab try to save -> there should be an error message displayed
- refresh, check that the data from the tab that actually saved is still there, and not the stale data
- generate a token for the visit, open the patient UI in **two different browsers**, advance to the form filling in stage
- in one of the browsers fill in and submit
- in the other browser try to save -> there should be an error message displayed

To discuss: This works as long as the form in one of the tabs is closed (checked in). This won't prevent overriding the data while the form is still being edited, for example in the patient UI all forms are checked in at the end when they are submitted, so it is possible to override data between the browsers while the submit button wasn't clicked yet and both tabs are opened. This could be changed if instead of keeping the forms checked out throughout, we create a new version every time we save, either save & continue or go to the next page. The advantage is that it won't allow overriding any save at all, the disadvantage is that we'll create a lot more versions.

Or, instead of relying on the version ID, we could rely on the `jcr:lastModified` date as the detection mechanism.

So, how much prevention do we want to have?