### PR TITLE
[misc] Update the Form's error display to match the current backend response format

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -296,10 +296,10 @@ function Form (props) {
           setLastSaveStatus(true);
           setLastSaveTimestamp(new Date());
         }
-      } else if (response.status === 500) {
+      } else if (response.status >= 400 || response.status < 100) {
         response.json().then((json) => {
-            setErrorCode(json["status.code"]);
-            setErrorMessage(json.error.message);
+            setErrorCode(response.status);
+            setErrorMessage(json["status.message"]);
             openErrorDialog();
         })
         setLastSaveStatus(undefined);


### PR DESCRIPTION
The response format was changed in PR #1500 for CARDS-2235 but the frontend code wasn't updated to match it.