### PR TITLE
[misc] Better wording for displaying the last successful save time in the "Failed to save" error dialog

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -681,7 +681,7 @@ function Form (props) {
         <Typography variant="h6">Your changes were not saved.</Typography>
         <Typography variant="body1" paragraph>Server responded with error code {errorCode}: {errorMessage}</Typography>
         {lastSaveTimestamp &&
-          <Typography variant="body1" paragraph>Time of the last successful save: {getTimestampString(lastSaveTimestamp.toISOString())}</Typography>
+          <Typography variant="body1" paragraph>The last successful save was {getTimestampString(lastSaveTimestamp.toISOString())}.</Typography>
         }
       </ErrorDialog>
       { isEdit &&


### PR DESCRIPTION
To test:
* create a form, enter some data, click save (stay on the form editing page)
* in the browser dev tools, network tab, go offline
* click save again -> the "failed to save" dialog should be displayed showing the timestamp of the last successful save
  * before this change, it should say `Time of the last successful save: at <time>` or `Time of the last successful save: yesterday`
  * after this change, it should say just  `The last successful save was at <time>.` or `The last successful save was at yesterday.`