### PR TITLE
[Misc] Fix SPARC questionnaire csv import

### DIFF
--- a/Utilities/FormImport/import.py
+++ b/Utilities/FormImport/import.py
@@ -421,7 +421,10 @@ def option_handler(self, questionnaire, row):
 
 def number_handler(self, questionnaire, row):
     value = self.get_value(row)
-    questionnaire.question[self.name] = float(value) if '.' in value else int(value)
+    try:
+        questionnaire.question[self.name] = float(value) if '.' in value else int(value)
+    except ValueError:
+        log(Logging.WARNING, "Could not parse \"{}\" to number".format(value))
 
 def min_value_handler(self, questionnaire, row):
     range_value_handler(self, questionnaire, row, "lowerLimit")

--- a/Utilities/FormImport/import.py
+++ b/Utilities/FormImport/import.py
@@ -498,7 +498,7 @@ def split_ignore_strings(input, splitters, limit = -1):
         elif len(ignore_list) == 0:
             for splitter in splitters:
                 if i + len(splitter) <= len(input):
-                    if input[i:i+len(splitter)] == splitter:
+                    if input[i:i+len(splitter)].lower() == splitter.lower():
                         results.append(input[last_split:i].strip())
                         i += len(splitter)
                         last_split = i
@@ -636,12 +636,12 @@ def process_conditional(self, questionnaire, row):
     needs_section = get_row_type_map(row).row_type not in (SECTION_TYPES + MATRIX_TYPES)
     if needs_section:
         questionnaire.push_section(create_new_section(questionnaire.question['name'] + "section", False), False)
+        questionnaire.flag_must_complete_section()
 
     conditional_string = self.get_value(row)
     log(Logging.INFO, "Processing conditional " + conditional_string)
     condition_handle_brackets(questionnaire, questionnaire.parent, conditional_string)
 
-    questionnaire.flag_must_complete_section()
 
 def condition_handle_brackets(questionnaire, condition_parent, conditional_string, index=0):
     log(Logging.INFO, "Handling brackets      " + conditional_string)

--- a/Utilities/FormImport/import.py
+++ b/Utilities/FormImport/import.py
@@ -50,6 +50,9 @@ class RowTypes(enum.Enum):
     MATRIX_END = 14
     VOCABULARY = 15
     SECTION_REPEATED = 16
+    ADDRESS = 17
+    PHONE = 18
+    SELECTABLE_AREAS = 19
 
 # Basic logging support
 class Logging:
@@ -230,7 +233,10 @@ RowTypesMappings = [
     RowTypeMap(RowTypes.SECTION_END, "section end", True, "", section_end_handler),
     RowTypeMap(RowTypes.SECTION_RECURRENT, "recurrent section", True, "", recurrent_section_handler),
     RowTypeMap(RowTypes.MATRIX_END, "matrix end", True, "", matrix_end_handler),
-    RowTypeMap(RowTypes.SECTION_REPEATED, "repeated section", True, "", repeated_section_handler)
+    RowTypeMap(RowTypes.SECTION_REPEATED, "repeated section", True, "", repeated_section_handler),
+    RowTypeMap(RowTypes.ADDRESS, "address"),
+    RowTypeMap(RowTypes.PHONE, "phone"),
+    RowTypeMap(RowTypes.SELECTABLE_AREAS, "selectablearea", True, "selectableArea")
 ]
 DefaultRowTypeMap = RowTypeMap(RowTypes.DEFAULT, "", True, "text")
 
@@ -480,7 +486,14 @@ DefaultHeaders["SLIDER_MARK"] = HeaderColumn("Slider Mark Step", "sliderMarkStep
 DefaultHeaders["SLIDER_ORIENTATION"] = HeaderColumn("Slider Orientation", "sliderOrientation")
 DefaultHeaders["ENTRY_MODE"] = HeaderColumn("Entry Mode", "entryMode")
 DefaultHeaders["ENTRY_MODE_QUESTION"] = HeaderColumn("Reference Question", "question")
-
+DefaultHeaders["ENABLE_NOTES"] = HeaderColumn("enableNotes", "enableNotes")
+DefaultHeaders["VALIDATION_REGEXP"] = HeaderColumn("Validation regexp", "validationRegexp")
+DefaultHeaders["VARIANT"] = HeaderColumn("variant", "variant")
+DefaultHeaders["COUNTRIES"] = HeaderColumn("countries", "countries")
+DefaultHeaders["DEFAULT_COUNTRY"] = HeaderColumn("defaultCountry", "defaultCountry")
+DefaultHeaders["ONLY_COUNTRIES"] = HeaderColumn("onlyCountries", "onlyCountries")
+DefaultHeaders["REGIONS"] = HeaderColumn("regions", "regions")
+DefaultHeaders["SEARCH_PLACES_AROUND"] = HeaderColumn("searchPlacesAround", "searchPlacesAround")
 
 
 #==================

--- a/Utilities/FormImport/import.py
+++ b/Utilities/FormImport/import.py
@@ -96,7 +96,7 @@ class RowTypeMap:
         self.handler = handler
 
 def section_start_handler(self, questionnaire, row):
-    if (not Headers["SECTION"].has_value(row)):
+    if (not Headers["SECTION"].has_value(row) and not Headers["QUESTION"].has_value(row)):
         # Section will not have been created yet: Create a section with a unique name
         questionnaire.section_index += 1
         label = "Section {}".format(questionnaire.section_index)
@@ -396,7 +396,7 @@ def question_handler(self, questionnaire, row):
         if Headers["SECTION"].has_value(row):
             questionnaire.parent["title"] = title
         else:
-            questionnaire.push_section(create_new_section(""))
+            questionnaire.push_section(create_new_section(title, False))
     else:
         create_question(questionnaire, self.get_value(row).strip().lower())
 

--- a/Utilities/FormImport/import.py
+++ b/Utilities/FormImport/import.py
@@ -105,14 +105,14 @@ def section_start_handler(self, questionnaire, row):
 def recurrent_section_handler(self, questionnaire, row):
     section_start_handler(self, questionnaire, row)
     questionnaire.parent['recurrent'] = True
-    
+
 def repeated_section_handler(self, questionnaire, row):
     section_start_handler(self, questionnaire, row)
     questionnaire.parent['repeated'] = True
     parent_label = questionnaire.parent['title' if 'title' in questionnaire.parent else 'label']
     referenced_question_key = Headers['ENTRY_MODE_QUESTION'].get_value(row)
     referenced_question = questionnaire.parents[-2][referenced_question_key]
-    
+
     for key in referenced_question.keys():
         entry = referenced_question[key]
         if type(entry) == dict and 'jcr:primaryType' in entry and entry['jcr:primaryType'] == 'cards:AnswerOption':
@@ -123,13 +123,13 @@ def repeated_section_handler(self, questionnaire, row):
             questionnaire.push_section(new_section)
             condition_handle_brackets(questionnaire, new_section, referenced_question_key + "=\"" + entry['value'] + "\"")
             questionnaire.complete_section()
-            
+
 def end_repeated_section(self, questionnaire, row):
     parent_label = questionnaire.parent['title' if 'title' in questionnaire.parent else 'label']
-    
+
     repeated_conditionals = []
     non_repeated_children = []
-    
+
     for key in questionnaire.parent.keys():
         entry = questionnaire.parent[key]
         if type(entry) == dict:
@@ -138,19 +138,19 @@ def end_repeated_section(self, questionnaire, row):
                 repeated_conditionals.append(key)
             else:
                 non_repeated_children.append(key)
-                
+
     for non_repeated_key in non_repeated_children:
         non_repeated_child = questionnaire.parent.pop(non_repeated_key)
         for repeated_key in repeated_conditionals:
             questionnaire.parent[repeated_key][repeated_key + "_" + non_repeated_key] = non_repeated_child
-                
+
     questionnaire.parent.pop('repeated')
 
 def section_end_handler(self, questionnaire, row):
     if is_section(questionnaire.parent):
         if 'repeated' in questionnaire.parent:
             end_repeated_section(self, questionnaire, row)
-    
+
     if is_matrix(questionnaire.parent):
         # End any matrix sections first as matrixes cannot span section borders
         questionnaire.complete_section()
@@ -678,7 +678,7 @@ def condition_handle_single(questionnaire, condition_parent, conditional_string,
         "=",
         "<=",
         ">=",
-        "<>"
+        "<>",
         "<",
         ">",
     ]
@@ -760,22 +760,6 @@ def csv_to_json(title):
             json.dump(q, jsonFile, indent='\t')
         os.system("python3 ../JSON-to-XML/json_to_xml.py '" + name + ".json' > '" + name + ".xml'")
 
-# Specify the titles of each csv file and which set of column titles and options should be used
-# TODO: Add parameterized titles
-titles = [
-    "BPI",
-    "CSI",
-    "GAD-7",
-    "IEQ",
-    "P-3",
-    "PHQ-9",
-    "PQ",
-    "ROM",
-    "RPS IQ",
-    "S-LPS",
-    "WPI"
-]
-
 CLI = argparse.ArgumentParser()
 CLI.add_argument("--forms", nargs="*", type=str, required=True)
 CLI.add_argument("--paginate", nargs=1, type=bool, default=False)
@@ -788,5 +772,5 @@ args = CLI.parse_args()
 for title in args.forms:
     Headers = DefaultHeaders
     Options = args
-    Options.logging = Logging.INFO
+    Options.logging = Logging.WARNING
     csv_to_json(title)

--- a/Utilities/FormImport/import.py
+++ b/Utilities/FormImport/import.py
@@ -494,7 +494,8 @@ DefaultHeaders["DEFAULT_COUNTRY"] = HeaderColumn("defaultCountry", "defaultCount
 DefaultHeaders["ONLY_COUNTRIES"] = HeaderColumn("onlyCountries", "onlyCountries")
 DefaultHeaders["REGIONS"] = HeaderColumn("regions", "regions")
 DefaultHeaders["SEARCH_PLACES_AROUND"] = HeaderColumn("searchPlacesAround", "searchPlacesAround")
-
+DefaultHeaders["TYPE_PROPERTY"] = HeaderColumn("type", "type")
+DefaultHeaders["VALIDATION_ERROR_TEXT"] = HeaderColumn("validationErrorText", "validationErrorText")
 
 #==================
 # Utility functions

--- a/Utilities/FormImport/import.py
+++ b/Utilities/FormImport/import.py
@@ -125,6 +125,7 @@ def repeated_section_handler(self, questionnaire, row):
                 new_section = create_new_section(conditional_label)
                 new_section['label'] = entry['label']
                 new_section['repeated_parent'] = parent_label
+                new_section['title'] = parent_label + "_" + clean_name(entry['label'].lower())
                 questionnaire.push_section(new_section)
                 condition_handle_brackets(questionnaire, new_section, referenced_question_key + "=\"" + entry['value'] + "\"")
                 questionnaire.complete_section()
@@ -148,13 +149,17 @@ def end_repeated_section(self, questionnaire, row):
         non_repeated_child = questionnaire.parent.pop(non_repeated_key)
         for repeated_key in repeated_conditionals:
             questionnaire.parent[repeated_key][repeated_key + "_" + non_repeated_key] = non_repeated_child
+            questionnaire.parents[-2][repeated_key] = questionnaire.parent[repeated_key]
 
-    questionnaire.parent.pop('repeated')
+    questionnaire.parents.pop()
+    questionnaire.parent = questionnaire.parents[-1]
+    questionnaire.question = questionnaire.parent
 
 def section_end_handler(self, questionnaire, row):
     if is_section(questionnaire.parent):
         if 'repeated' in questionnaire.parent:
             end_repeated_section(self, questionnaire, row)
+            return
 
     if is_matrix(questionnaire.parent):
         # End any matrix sections first as matrixes cannot span section borders

--- a/Utilities/JSON-to-XML/json_to_xml.py
+++ b/Utilities/JSON-to-XML/json_to_xml.py
@@ -46,7 +46,7 @@ def get_jcr_type(d):
         return "String"
 
 def convert_xml_safe(itm):
-    if str(itm) in ["<>", "<", ">"] or (isinstance(itm, str) and ("<" in itm or ">" in itm)):
+    if str(itm) in ["<>", "<", ">"] or (isinstance(itm, str) and ("<" in itm or ">" in itm or "&" in itm)):
         return "<![CDATA[" + str(itm) + "]]>"
     return str(itm)
 


### PR DESCRIPTION
- Disabled pagination by default
- Fixed bug with conditional handling that caused operators `<>` and `<` to not be parsed
- Added arguments to questionnaire import script:
  - `--forms`: A list of the CSV files to import. Eg. `--forms "Your Voice Matters" PQ`
  - `--paginate`: If the questionnaire should be paginated. True or False, Default `False`
  - `--subject-types`: The subject types this questionnaire should be able to be created for. Default `/SubjectTypes/Patient/Visit`
  - `--logging`: The log level that should be run with. One of `run`, `error`, `warn` or `info`. Defaults to `info` if not provided or not recognized.
  - `--max-answers`: The default Max Answers for a question if not specified for that specific question. Default `1`
  - `--max-per-subject`: The maximum number of times these forms can be created for an individual subject. Default `1`
- Add `repeated section` meta section:
  - Requires the following columns:
    - `Question Type` = `repeated section`
    - `Section Name` = a section ID
    - `Reference Question` = the ID of a list question. This question must have the same parent as the repeated section
    - (optional) `Variable Name` = the displayed title of the generated sections
  - For each option in the referenced question a `conditional section` will be created
    - This `conditional section` will only show if the referenced question has that specific value
    - Each generated `conditional section` will contain a copy of every child of the `repeated section`