### PR TITLE
CARDS-2441: Computed questions only have access to the first value of multivalued variables

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -70,7 +70,7 @@ let ComputedQuestion = (props) => {
   const endTagSingleVal = "}";
   const startTagArrayVal = "@{[";
   const endTagArrayVal = "]}";
-  const acceptMissingTag = "?";
+  const optionalTag = "?";
   const defaultTag = ":-";
   const booleanDefaultLabels = {"0": "No", "1": "Yes", "-1": "Unknown"}
 
@@ -198,10 +198,10 @@ let ComputedQuestion = (props) => {
       }
 
       // Check if missing values are acceptable
-      let acceptMissingValue = false;
-      if (questionName.endsWith(acceptMissingTag)) {
-        acceptMissingValue = true;
-        questionName = questionName.replace(acceptMissingTag, "");
+      let isValueOptional = false;
+      if (questionName.endsWith(optionalTag)) {
+        isValueOptional = true;
+        questionName = questionName.substring(0, questionName.lastIndexOf(optionalTag));
       }
 
       // Insert this question into the list of arguments
@@ -211,7 +211,7 @@ let ComputedQuestion = (props) => {
             "value": getQuestionValue(questionName, form, defaultValue, asArray)});
       }
 
-      missingValue &&= !acceptMissingValue;
+      missingValue &&= !isValueOptional;
       if (missingValue) {
         // Exit early as the expression cannot be evaluated without all inputs
         return null;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -70,6 +70,7 @@ let ComputedQuestion = (props) => {
   const endTagSingleVal = "}";
   const startTagArrayVal = "@{[";
   const endTagArrayVal = "]}";
+  const ignoreMissingTag = "!";
   const defaultTag = ":-";
   const booleanDefaultLabels = {"0": "No", "1": "Yes", "-1": "Unknown"}
 
@@ -196,6 +197,13 @@ let ComputedQuestion = (props) => {
         questionName = expr.substring(start + startTag.length, end);
       }
 
+      // Check if missing values are acceptable
+      let acceptMissingValue = false;
+      if (questionName.startsWith(ignoreMissingTag)) {
+        acceptMissingValue = true;
+        questionName = questionName.substring(ignoreMissingTag.length);
+      }
+
       // Insert this question into the list of arguments
       if (!questions.has(questionName)) {
         questions.set(questionName,
@@ -203,6 +211,7 @@ let ComputedQuestion = (props) => {
             "value": getQuestionValue(questionName, form, defaultValue, asArray)});
       }
 
+      missingValue &&= !acceptMissingValue;
       if (missingValue) {
         // Exit early as the expression cannot be evaluated without all inputs
         return null;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -147,6 +147,7 @@ let ComputedQuestion = (props) => {
     let values = (
         form[name] || (defaultValue !== null ? [[defaultValue, defaultValue]] : [])
       ).map(e => e[VALUE_POS])
+       .map(v => (typeof(v) === "undefined" || v === "") && defaultValue != null ? defaultValue : v)
        .map(v => v && !isNaN(Number(v)) ? Number(v) : v);
 
     // Record whether a value is absent

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -168,14 +168,16 @@ let ComputedQuestion = (props) => {
     // To prevent question names from breaking the evaluating funtion, replace them with a default
     // argument name in the evaluated expression.
     while (expr) {
-      start = expr.indexOf(startTagArrayVal);
-      if (start >= 0) {
+      let arrayStart = expr.indexOf(startTagArrayVal);
+      let singleStart = expr.indexOf(startTagSingleVal);
+      if (arrayStart >= 0 && (singleStart < 0  || arrayStart <= singleStart)) {
+        start = arrayStart;
         end = expr.indexOf(endTagArrayVal, start);
         asArray = true;
         startTag = startTagArrayVal;
         endTag = endTagArrayVal;
       } else {
-        start = expr.indexOf(startTagSingleVal)
+        start = singleStart;
         end = expr.indexOf(endTagSingleVal, start);
         asArray = false;
         startTag = startTagSingleVal;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -148,6 +148,7 @@ let ComputedQuestion = (props) => {
         form[name] || (defaultValue !== null ? [[defaultValue, defaultValue]] : [])
       ).map(e => e[VALUE_POS])
        .map(v => (typeof(v) === "undefined" || v === "") && defaultValue != null ? defaultValue : v)
+       .filter(v => !(typeof(v) === "undefined" || v === ""))
        .map(v => v && !isNaN(Number(v)) ? Number(v) : v);
 
     // Record whether a value is absent

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -23,7 +23,7 @@ import { InputAdornment, TextField, Typography } from "@mui/material";
 
 import withStyles from '@mui/styles/withStyles';
 
-import Answer from "./Answer";
+import Answer, {VALUE_POS} from "./Answer";
 import AnswerComponentManager from "./AnswerComponentManager";
 import DateQuestionUtilities from "./DateQuestionUtilities";
 import Question from "./Question";
@@ -137,8 +137,12 @@ let ComputedQuestion = (props) => {
   let missingValue = false;
   let getQuestionValue = (name, form, defaultValue) => {
     let value;
-    if (form[name] && form[name][0]) {
-      value = form[name][0][1];
+    if (form[name]?.length > 0) {
+      if (form[name].length == 1) {
+        value = form[name][0][VALUE_POS];
+      } else {
+        value = form[name].map(e => e[VALUE_POS]);
+      }
     }
     if (typeof(value) === "undefined" || value === "") {
       if (defaultValue != null) {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -70,7 +70,7 @@ let ComputedQuestion = (props) => {
   const endTagSingleVal = "}";
   const startTagArrayVal = "@{[";
   const endTagArrayVal = "]}";
-  const ignoreMissingTag = "!";
+  const acceptMissingTag = "?";
   const defaultTag = ":-";
   const booleanDefaultLabels = {"0": "No", "1": "Yes", "-1": "Unknown"}
 
@@ -199,9 +199,9 @@ let ComputedQuestion = (props) => {
 
       // Check if missing values are acceptable
       let acceptMissingValue = false;
-      if (questionName.startsWith(ignoreMissingTag)) {
+      if (questionName.endsWith(acceptMissingTag)) {
         acceptMissingValue = true;
-        questionName = questionName.substring(ignoreMissingTag.length);
+        questionName = questionName.replace(acceptMissingTag, "");
       }
 
       // Insert this question into the list of arguments

--- a/modules/data-model/forms/api/src/main/java/io/uhndata/cards/forms/api/ExpressionUtils.java
+++ b/modules/data-model/forms/api/src/main/java/io/uhndata/cards/forms/api/ExpressionUtils.java
@@ -31,14 +31,21 @@ import org.apache.jackrabbit.oak.api.Type;
  */
 public interface ExpressionUtils
 {
-    /** Marker for the start of a variable. */
-    String START_MARKER = "@{";
+    /** Marker for the start of a single valued variable. */
+    String START_MARKER_SINGLE = "@{";
+    /** Marker for the end of a single valued variable. */
+    String END_MARKER_SINGLE = "}";
 
-    /** Marker for the end of a variable. */
-    String END_MARKER = "}";
+    /** Marker for the start of a multi valued variable. */
+    String START_MARKER_ARRAY = "@{[";
+    /** Marker for the end of a multi valued variable. */
+    String END_MARKER_ARRAY = "]}";
 
     /** Marker for the default value to use for a variable when it doesn't have a value. */
     String DEFAULT_MARKER = ":-";
+
+    /** Marker for an optional variable. */
+    String OPTIONAL_MARKER = "?";
 
     /**
      * List the variable names used in the expression of a computed question.

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ExpressionUtilsImpl.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ExpressionUtilsImpl.java
@@ -218,8 +218,12 @@ public final class ExpressionUtilsImpl implements ExpressionUtils
         }
 
         if (value != null) {
-            if (value.getClass().isArray() && !shouldBeArray && ((Object[]) value).length > 0) {
-                value = ((Object[]) value)[0];
+            if (value.getClass().isArray() && !shouldBeArray) {
+                if (((Object[]) value).length > 0) {
+                    value = ((Object[]) value)[0];
+                } else {
+                    value = null;
+                }
             } else if (!value.getClass().isArray() && shouldBeArray) {
                 value = new Object[]{value};
             }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ExpressionUtilsImpl.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ExpressionUtilsImpl.java
@@ -126,7 +126,7 @@ public final class ExpressionUtilsImpl implements ExpressionUtils
             this.startMarker = this.isArrayArgument ? START_MARKER_ARRAY : START_MARKER_SINGLE;
             this.endMarker = this.isArrayArgument ? END_MARKER_ARRAY : END_MARKER_SINGLE;
             this.start = this.expression.indexOf(this.startMarker);
-            this.end = this.expression.indexOf(this.endMarker);
+            this.end = this.expression.indexOf(this.endMarker, this.start);
         }
 
         public ParsedExpression parse()
@@ -183,7 +183,7 @@ public final class ExpressionUtilsImpl implements ExpressionUtils
                 if (questionValue == null) {
                     if (!isOptional) {
                         this.missingValue = true;
-                    } else if (isOptional && this.isArrayArgument) {
+                    } else if (this.isArrayArgument) {
                         questionValue = new Object[]{};
                     }
                 }
@@ -218,7 +218,7 @@ public final class ExpressionUtilsImpl implements ExpressionUtils
         }
 
         if (value != null) {
-            if (value.getClass().isArray() && !shouldBeArray) {
+            if (value.getClass().isArray() && !shouldBeArray && ((Object[]) value).length > 0) {
                 value = ((Object[]) value)[0];
             } else if (!value.getClass().isArray() && shouldBeArray) {
                 value = new Object[]{value};

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/BackendComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/BackendComputedTest.xml
@@ -284,11 +284,11 @@ which can then be verified for accuracy by opening the form in read mode with th
             </property>
         </node>
         <node>
-            <name>question4computed</name>
+            <name>question4a_computed</name>
             <primaryNodeType>cards:Question</primaryNodeType>
             <property>
                 <name>text</name>
-                <value>Question 4 Computed. Should display the values from Question 4, formatted</value>
+                <value>Question 4a Computed. If any values are entered at Question 4, they should appear as a bullet list, preceded by an intro text</value>
                 <type>String</type>
             </property>
             <property>
@@ -305,11 +305,64 @@ which can then be verified for accuracy by opening the form in read mode with th
                 <name>expression</name>
                 <value><![CDATA[
 var values = @{[question4_multi]};
-var result = "";
+var result = "The values entered at question 4 are:";
 for (var i = 0; values && i < values.length; i++) {
   result += "\n* " + (i+1) + ": " + values[i];
 }
 return result;
+                ]]></value>
+                <type>String</type>
+            </property>
+        </node>
+        <node>
+            <name>question4b_computed</name>
+            <primaryNodeType>cards:Question</primaryNodeType>
+            <property>
+                <name>text</name>
+                <value>Question 4b Computed. If no values are entered at Question 4, display "No values at Question 4", otherwise display them comma-separated</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>displayMode</name>
+                <value>formatted</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>entryMode</name>
+                <value>computed</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>expression</name>
+                <value><![CDATA[
+var values = @{[question4_multi?]};
+return values.length == 0 ? "No values at Question 4" : values.join(", ");
+                ]]></value>
+                <type>String</type>
+            </property>
+        </node>
+        <node>
+            <name>question4c_computed</name>
+            <primaryNodeType>cards:Question</primaryNodeType>
+            <property>
+                <name>text</name>
+                <value>Question 4c Computed. Displays "The first value from Question 4 is " and the first value, if any</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>displayMode</name>
+                <value>formatted</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>entryMode</name>
+                <value>computed</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>expression</name>
+                <value><![CDATA[
+return "The first value from Question 4 is " + @{question4_multi?};
                 ]]></value>
                 <type>String</type>
             </property>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/BackendComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/BackendComputedTest.xml
@@ -27,7 +27,7 @@
     </property>
     <property>
         <name>description</name>
-        <value>CARDS-1800</value>
+        <value>CARDS-1800, CARDS-2441</value>
         <type>String</type>
     </property>
     <node>
@@ -304,10 +304,10 @@ which can then be verified for accuracy by opening the form in read mode with th
             <property>
                 <name>expression</name>
                 <value><![CDATA[
-var values = typeof(@{question4_multi}) != 'object' ? [@{question4_multi}] : @{question4_multi};
+var values = @{[question4_multi]};
 var result = "";
 for (var i = 0; values && i < values.length; i++) {
-  result += "\n* " + i + ": " + values[i];
+  result += "\n* " + (i+1) + ": " + values[i];
 }
 return result;
                 ]]></value>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/BackendComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/BackendComputedTest.xml
@@ -143,6 +143,20 @@ which can then be verified for accuracy by opening the form in read mode with th
                 <type>Boolean</type>
             </property>
         </node>
+        <node>
+            <name>question4_multi</name>
+            <primaryNodeType>cards:Question</primaryNodeType>
+            <property>
+                <name>text</name>
+                <value>Question 4: Multi-valued answer</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>maxAnswers</name>
+                <value>0</value>
+                <type>Long</type>
+            </property>
+        </node>
     </node>
     <node>
        <name>computedquestions</name>
@@ -266,6 +280,37 @@ which can then be verified for accuracy by opening the form in read mode with th
             <property>
                 <name>expression</name>
                 <value>return @{question 3}</value>
+                <type>String</type>
+            </property>
+        </node>
+        <node>
+            <name>question4computed</name>
+            <primaryNodeType>cards:Question</primaryNodeType>
+            <property>
+                <name>text</name>
+                <value>Question 4 Computed. Should display the values from Question 4, formatted</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>displayMode</name>
+                <value>formatted</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>entryMode</name>
+                <value>computed</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>expression</name>
+                <value><![CDATA[
+var values = typeof(@{question4_multi}) != 'object' ? [@{question4_multi}] : @{question4_multi};
+var result = "";
+for (var i = 0; values && i < values.length; i++) {
+  result += "\n* " + i + ": " + values[i];
+}
+return result;
+                ]]></value>
                 <type>String</type>
             </property>
         </node>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ComputedTest.xml
@@ -27,7 +27,7 @@
 	</property>
 	<property>
 		<name>description</name>
-		<value>CARDS-317, CARDS-699, CARDS-1302, CARDS-1463</value>
+		<value>CARDS-317, CARDS-699, CARDS-1302, CARDS-1463, CARDS-2441</value>
 		<type>String</type>
 	</property>
 	<property>
@@ -389,6 +389,67 @@ or
 			<property>
 				<name>expression</name>
 				<value>return (@{textAnswerInput:-} ? ("* You wrote *" + @{textAnswerInput} + "*...\n* ...and **nothing else**") : "You wrote nothing")</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>textAnswerInputMultivalue</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Enter several lines of text</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>0</value>
+				<type>Long</type>
+			</property>
+		</node>
+		<node>
+			<name>textAnswerFormattedMultivalue</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Computed text using multiple values, formatted</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value><![CDATA[
+Expected output:
+
+> * Entry 1: line one from previous question
+> * Entry 2: line two from previous question
+> * ....
+				]]></value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>text</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>displayMode</name>
+				<value>formatted</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value><![CDATA[
+var values = @{[textAnswerInputMultivalue]};
+var result = "";
+for (var i = 0; values && i < values.length; i++) {
+  result += "\n* Entry " + (i+1) + ": " + values[i];
+}
+return result;
+				]]></value>
 				<type>String</type>
 			</property>
 		</node>
@@ -1109,6 +1170,61 @@ or
 			<property>
 				<name>expression</name>
 				<value>return @{longAnswerInput}</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>longAnswerInputMultivalue</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Enter several numbers</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>long</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>maxAnswers</name>
+				<value>0</value>
+				<type>Long</type>
+			</property>
+		</node>
+		<node>
+			<name>longAnswerComputedMultivalue</name>
+			<primaryNodeType>cards:Question</primaryNodeType>
+			<property>
+				<name>text</name>
+				<value>Sum of all the numbers entered at the previous question</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>description</name>
+				<value>Expected output: the sum of the numbers entered above</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>text</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>entryMode</name>
+				<value>computed</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>expression</name>
+				<value><![CDATA[
+var values = @{[longAnswerInputMultivalue:-0]};
+var result = 0;
+for (var i = 0; i < values.length; i++) {
+  result += values[i];
+}
+return result;
+				]]></value>
 				<type>String</type>
 			</property>
 		</node>


### PR DESCRIPTION
**Summary of changes:**
* introduced new syntax for returning the values of a variable as an array via `[]`: `@{[questionId:-defaultvalue]}` and for accepting missing values via `?`:  `@{[questionId?]}`
  * updated the `ComputedQuestion` **frontend code** to put the values in an array when the `[]` are used (even if the variable is single valued) and to accept missing values when `?` is used; when the already existing syntax is used ( `@{questionId:-defaultvalue}`, no square brackets, no questiob mark), the behavior remains the same, and only the first value is return from multivalued answers with the expression not being evaluated when any value is missing
* updated the `BackendComputedTest` questionnaire to showcase computed answers with multivalued variables, including with the `?` syntax
* updated the `ComputedTest` questionnaire to showcase one computed question using a `text` multivalued variable and one computed question using a `long` multivalued variable 

**Testing:**
* start with `--test`
* test the entire `ComputedTest` questionnaire (this will cover new syntax as well as backward compatibility)
* test the questionnaire `BackendComputedTest` following the instructions listed in the infobox as both `admin` and `computedtestuser`
  * **Question 4** and **Question 4a|b|c Computed** help test the newly introduced syntax, but test everything for backwards compatibility 
* testing as a developer: create your own computed question using multivalued variables
  * more interesting additions to the `ComputedTest` questionnaires are welcome