### PR TITLE
CARDS-2444: Boolean labels not shown in view mode

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -52,7 +52,7 @@ const GHOST_SENTINEL = "custom-input";
   * @param {bool} error indicates if the current selection is in a state of error
   */
 function MultipleChoice(props) {
-  let { classes, customInput, customInputProps, existingAnswer, input, textbox, onUpdate, onChange, additionalInputProps, muiInputProps, naValue, noneOfTheAboveValue, error, questionName, answerNodeType, ...rest } = props;
+  let { classes, customInput, customInputProps, existingAnswer, input, textbox, onUpdate, onChange, additionalInputProps, muiInputProps, naValue, noneOfTheAboveValue, error, questionName, ...rest } = props;
   let { maxAnswers, minAnswers, displayMode, enableSeparatorDetection } = {...props.questionDefinition, ...props};
   let { validate, validationErrorText, liveValidation } = {...props.questionDefinition, ...props};
   // pageActive should be passed to the Answer component, so we make sure to include it in the `rest` variable above
@@ -491,7 +491,6 @@ function MultipleChoice(props) {
           existingAnswer={existingAnswer}
           questionName={questionName}
           onAddSuggestion={acceptOptionFromWidget}
-          answerNodeType={answerNodeType}
           {...rest}
           />
       </React.Fragment>


### PR DESCRIPTION
In addition to testing that boolean labels now work, all questions using the MultipleChoice components with dataType other than text need to be retested: number, resource, vocabulary, etc.