### PR TITLE
[misc] We don't really use logback-classic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,11 +220,6 @@
         <artifactId>log4j-over-slf4j</artifactId>
         <version>${slf4j.version}</version>
       </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>1.2.11</version>
-      </dependency>
       <!-- OSGI -->
       <dependency>
         <groupId>org.osgi</groupId>


### PR DESCRIPTION
To test: 
- just build and run with the `start.sh` script, make sure `.cards-data/logs/*` still fill up as you cards
- build with `-Pdocker`, start with `python3 generate_compose_yaml.py --cards_project cards4prems --oak_filesystem --dev_docker_image && docker-compose build && docker-compose up`, navigate a bit, make sure `compose-cluster/CARDS_LOGS/*` still fill up