### PR TITLE
CARDS-2462: The docker_entry.sh script should support references to environment variables specified in the ADDITIONAL_SLING_FEATURES environment variable

### DIFF
--- a/distribution/Dockerfile
+++ b/distribution/Dockerfile
@@ -49,6 +49,7 @@ RUN apk update
 RUN apk add --upgrade apk-tools
 RUN apk upgrade --available
 RUN apk add \
+  gettext \
   openjdk11-jre \
   tzdata
 

--- a/distribution/docker_entry.sh
+++ b/distribution/docker_entry.sh
@@ -42,6 +42,9 @@ fi
 PROJECT_ARTIFACTID=$1
 PROJECT_VERSION=$2
 
+# Resolve any environment variable references in ADDITIONAL_SLING_FEATURES
+export ADDITIONAL_SLING_FEATURES=$(echo "$ADDITIONAL_SLING_FEATURES" | envsubst)
+
 VALID_CARDS_PROJECTS="||cards4kids|cards4lfs|cards4proms|cards4prems|cards4heracles|"
 echo "${VALID_CARDS_PROJECTS}" | grep -q "|${CARDS_PROJECT}|" || { echo "Invalid project specified - defaulting to generic CARDS."; unset CARDS_PROJECT; }
 


### PR DESCRIPTION
This _Pull Request_ implements CARDS-2462 by allowing environment variable references to be placed inside the `ADDITIONAL_SLING_FEATURES` environment variable.

To test:

1. Build this (`CARDS-2462`) branch including a _development_ Docker image with `mvn clean install -Pdocker`.
2. `cd compose-cluster`
3. `python3 generate_compose_yaml.py --dev_docker_image --oak_filesystem`
4. Edit the generated `docker-compose.yml` file and under the `services.cardsinitial.environment` section, add the following lines:
  - `CARDS_VERSION=0.9.22-SNAPSHOT`
  - `ADDITIONAL_SLING_FEATURES=mvn:io.uhndata.cards/cards-slack-notifications/$${CARDS_VERSION}/slingosgifeature`
5. `docker-compose build`
6. `docker-compose up -d`
7. `docker-compose logs -f cardsinitial`
8. Ensure that the line `ADDITIONAL_SLING_FEATURES = mvn:io.uhndata.cards/cards-slack-notifications/0.9.22-SNAPSHOT/slingosgifeature` is present.
9. CTRL+C
10. Clean up with `docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh`