### PR TITLE
CARDS-2466: Order of matrix items is not preserved in view mode

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionMatrix.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionMatrix.jsx
@@ -238,12 +238,14 @@ let QuestionMatrix = (props) => {
 
   let renderViewMode = () => {
     return (<>
-      { existingAnswers.map((answer, idx) => (answer[1].displayedValue || hasWarningFlags(answer)) && (
-        <TableRow key={answer[0] + idx} className={enableVerticalLayout ? classes.questionMatrixStackedAnswer : ''}>
-          { renderQuestion(answer[1].question, hasWarningFlags(answer)) }
-          { !enableVerticalLayout && <TableCell>—</TableCell> }
-          { renderAnswer(answer[1], (enableVerticalLayout ? '-' : '')) }
-        </TableRow>
+      { subquestions.map( question => existingAnswers.find(answer  => answer[1]?.question?.["@path"] == question[1]?.["@path"]) )
+          .filter (answer => answer && (answer[1].displayedValue || hasWarningFlags(answer)))
+          .map( (answer, idx) => (
+            <TableRow key={answer[0] + idx} className={enableVerticalLayout ? classes.questionMatrixStackedAnswer : ''}>
+              { renderQuestion(answer[1].question, hasWarningFlags(answer)) }
+              { !enableVerticalLayout && <TableCell>—</TableCell> }
+              { renderAnswer(answer[1], (enableVerticalLayout ? '-' : '')) }
+            </TableRow>
       ))}
     </>);
   };


### PR DESCRIPTION
Testing:
* Start with `--test`
* Optional: in Administration > Questionnaires, edit the `Question Matrix Test` to add an order number before the text of each question in the matrix, to facilitate observing the order (e.g. "Feeling nervous, anxious, or on edge" -> "1 Feeling nervous, anxious, or on edge", "Not being able to stop or control worrying" -> "2 Not being able to stop or control worrying", etc)
* Create a `Question Matrix Test` form and answer it
* Save and view - check that the answers are listed in the same order as in edit mode