### PR TITLE
CARDS-2467: The s3-export Sling service user should have jcr:read and jcr:write permissions for /Metrics

### DIFF
--- a/modules/s3-export/src/main/features/feature.json
+++ b/modules/s3-export/src/main/features/feature.json
@@ -77,7 +77,9 @@
         // In certain environments, this script gets executed before the main forms repoinit does, so we must make sure the paths we reference are created.
         "create path (cards:QuestionnairesHomepage) /Questionnaires \n create path (cards:FormsHomepage) /Forms \n create path (cards:SubjectsHomepage) /Subjects \n create path (cards:SubjectTypesHomepage) /SubjectTypes",
         // Exporting data requires being able to read it
-        "create service user s3-export \n set ACL on /Questionnaires,/Forms,/Subjects,/SubjectTypes \n   allow jcr:read for s3-export \n end"
+        "create service user s3-export \n set ACL on /Questionnaires,/Forms,/Subjects,/SubjectTypes \n   allow jcr:read for s3-export \n end",
+        // We also want to keep track of S3 export performance metrics
+        "set ACL on /Metrics \n   allow jcr:read,jcr:write for s3-export \n end"
       ]
     },
     "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~scheduledS3export":{


### PR DESCRIPTION
This _Pull Request_ fixes the bug described by https://phenotips.atlassian.net/browse/CARDS-2467.

To test, follow the instructions in https://github.com/data-team-uhn/cards/pull/1653 and use Composum (`/bin/browser.html`) to ensure that the _values_ of the `/Metrics/S3ExportedForms/total` and `/Metrics/S3ExportedSubjects/total` nodes are incrementing as expected.