### PR TITLE
CARDS-2467: The s3-export Sling service user should have jcr:read and jcr:write permissions for /Metrics

### DIFF
--- a/modules/s3-export/src/main/features/feature.json
+++ b/modules/s3-export/src/main/features/feature.json
@@ -75,7 +75,7 @@
       "service.ranking:Integer":300,
       "scripts": [
         // In certain environments, this script gets executed before the main forms repoinit does, so we must make sure the paths we reference are created.
-        "create path (cards:QuestionnairesHomepage) /Questionnaires \n create path (cards:FormsHomepage) /Forms \n create path (cards:SubjectsHomepage) /Subjects \n create path (cards:SubjectTypesHomepage) /SubjectTypes",
+        "create path (cards:QuestionnairesHomepage) /Questionnaires \n create path (cards:FormsHomepage) /Forms \n create path (cards:SubjectsHomepage) /Subjects \n create path (cards:SubjectTypesHomepage) /SubjectTypes \n create path (sling:Folder) /Metrics",
         // Exporting data requires being able to read it
         "create service user s3-export \n set ACL on /Questionnaires,/Forms,/Subjects,/SubjectTypes \n   allow jcr:read for s3-export \n end",
         // We also want to keep track of S3 export performance metrics


### PR DESCRIPTION
Continuation of https://github.com/data-team-uhn/cards/pull/1674 but ensures that the JCR path `/Metrics` exists before attempting to set ACL rules on it.