### PR TITLE
CARDS-2436: QuestionMatrix: the row of option labels should be sticky to the top

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -159,7 +159,7 @@ let displayInformation = (infoDefinition, key, classes, pageActive, isEdit) => {
  * @param {Object} classes style classes
  * @returns a React component that renders the matrix section
  */
-let displayMatrix = (sectionDefinition, path, existingAnswer, key, classes, pageActive, isEdit) => {
+let displayMatrix = (sectionDefinition, path, existingAnswer, key, classes, pageActive, isEdit, contentOffset) => {
   // Find the existing AnswerSection for this section, if available
   const existingSectionAnswer = existingAnswer && Object.entries(existingAnswer)
     .find(([key, value]) => value["sling:resourceType"] == "cards/AnswerSection"
@@ -192,6 +192,7 @@ let displayMatrix = (sectionDefinition, path, existingAnswer, key, classes, page
         path={path}
         isEdit={isEdit}
         pageActive={pageActive}
+        contentOffset={contentOffset}
       />
     </Grid>
   );
@@ -218,7 +219,7 @@ let displayMatrix = (sectionDefinition, path, existingAnswer, key, classes, page
   } else if (SECTION_TYPES.includes(entryDefinition["jcr:primaryType"])) {
     if (visibleCallback) visibleCallback(true);
     if ("matrix" === entryDefinition["displayMode"]) {
-      return displayMatrix(entryDefinition, path, existingAnswers, keyProp, classes, pageActive, isEdit);
+      return displayMatrix(entryDefinition, path, existingAnswers, keyProp, classes, pageActive, isEdit, contentOffset);
     } else {
       return displaySection(entryDefinition, path, depth, existingAnswers, keyProp, onChange, visibleCallback, pageActive, isEdit, isSummary, instanceId, contentOffset);
     }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionMatrix.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionMatrix.jsx
@@ -62,7 +62,7 @@ const DATA_TO_NODE_TYPE = {
 // existingAnswer array of sub-question answers
 
 let QuestionMatrix = (props) => {
-  const { sectionDefinition, existingSectionAnswer, existingAnswers, path, isEdit, classes, pageActive, ...rest} = props;
+  const { sectionDefinition, existingSectionAnswer, existingAnswers, path, isEdit, classes, pageActive, contentOffset, ...rest} = props;
   const { maxAnswers, minAnswers } = {...sectionDefinition, ...props};
 
   // Use existing existingAnswer, Otherwise, create a new UUID
@@ -192,7 +192,7 @@ let QuestionMatrix = (props) => {
 
   let renderTableHead = () => {
     return ((!isEdit || enableVerticalLayout) ? null :
-      <TableHead>
+      <TableHead sx={{top: contentOffset}}>
         <TableRow>
         { [["",""]].concat(defaults).map( (option, index) => (
           <TableCell key={index} align="center" component="th">

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -642,7 +642,7 @@ const questionnaireStyle = theme => ({
     questionMatrixControls: {
       "& .MuiTableHead-root th": {
         fontWeight: "bold",
-        paddingTop: 0,
+        padding: theme.spacing(.5, 1, 1, .5),
         verticalAlign: "top",
       },
       "& .MuiTableBody-root th": {
@@ -653,6 +653,15 @@ const questionnaireStyle = theme => ({
       },
     },
     questionMatrixHorizontal: {
+      position: "relative",
+      "& .MuiTableHead-root" : {
+        position: "sticky",
+        boxShadow: "0 1px 0 " + theme.palette.divider,
+        zIndex: 1,
+        "& th" : {
+          backgroundColor: theme.palette.background.paper,
+        },
+      },
       "& .MuiFormControlLabel-root" : {
         margin: "0 !important",
       },


### PR DESCRIPTION
Testing:
* Create a questionnaire with a QuestionMatrix containing 20-25 questions (or as many as it takes so the whole list wouldn't fit on the screen)
* Preview the questionnaire, scroll, check that the table head is always visible