### PR TITLE
CARDS-2449: Update the RecentVisitDiscardFilter to discard visits depending on the clinic/survey

### DIFF
--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -373,10 +373,11 @@
       "emailConsentColumn": "EMAIL_CONSENT_YN"
     },
     // Only send surveys to patients once every 6 months
-    "io.uhndata.cards.clarity.importer.internal.RecentVisitDiscardFilter": {
+    "io.uhndata.cards.clarity.importer.internal.RecentVisitDiscardFilter~ye": {
       "enable": true,
       "supportedTypes": ["prems"],
-      "minimum.visit.frequency": 183
+      "minimum.visit.frequency": 183,
+      "clinics": ["/Survey/ClinicMapping/2075099", "/Survey/ClinicMapping/-1792626663", "/Survey/ClinicMapping/-1792626799", "/Survey/ClinicMapping/-432465800", "/Survey/ClinicMapping/78840662", "/Survey/ClinicMapping/-1792626676", "/Survey/ClinicMapping/-432465813", "/Survey/ClinicMapping/-432335117", "/Survey/ClinicMapping/1012196242"]
     },
     // Don't import visits for patients who have opted out of emails
     "io.uhndata.cards.clarity.importer.internal.UnsubscribedFilter": {


### PR DESCRIPTION
To test:
- build the **`CARDS-2449-test`** branch with `mvn clean install -Pdocker`
- in `compose-cluster` generate a docker compose file with `python3 generate_compose_yaml.py --mssql --cards_project cards4prems --oak_filesystem --dev_docker_image --composum --adminer --server_address=localhost:8080`
- start with `docker-compose build && docker-compose up`
- at `http://localhost:1435/?mssql=mssql&username=sa&db=master&ns=path&import=` import the two sample sql files from `compose-cluster/mssql`
- access `http://localhost:8080/Subjects.importClarity?config=Your%20Experience%20-%20Discharge%20events`  to import the YourExperience visits
- check that patient `4423979` has only one visit, 1000000 on 2024-01-12, and not 1000001 on 2024-01-22
- check that visit 1000004 was not imported
- access `http://localhost:8080/Subjects.importClarity?config=Your%20Voice%20Matters%20-%20Discharge%20events` to import the YVM visits
- check that patient `4423979` has two visits, 1000000 (inpatient) and 2000000 (yvm), but not 2000001
- check that visits 2000001 to 2000005 were not imported
- check that visit 2000006 was imported (yvm)
- stop and clean up with `docker-compose rm -vf && ./cleanup.sh`
- repeat the steps, but this time first import yvm then ye and make sure the same visits were imported