### PR TITLE
[misc] Upgrade Apache Felix Health Check Webconsole Plugin

### DIFF
--- a/distribution/src/main/features/webconsole.json
+++ b/distribution/src/main/features/webconsole.json
@@ -33,7 +33,11 @@
             "start-order":"5"
         },
         {
-            "id":"org.apache.felix:org.apache.felix.healthcheck.webconsoleplugin:2.0.2",
+            "id":"org.apache.felix:org.apache.felix.healthcheck.webconsoleplugin:2.1.0",
+            "start-order":"5"
+        },
+        {
+            "id":"org.owasp.encoder:encoder:1.2.3",
             "start-order":"5"
         },
         {


### PR DESCRIPTION
This _Pull Request_ upgrades the _Apache Felix Health Check Webconsole Plugin_ from `2.0.2` to `2.1.0` to patch CVE-2023-38435.

To test, build this branch and ensure that http://localhost:8080/system/console/healthcheck is still available.