### PR TITLE
CARDS-2474: Clinic dashboards are too slow on large datasets

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -44,7 +44,7 @@ function LiveTable(props) {
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Define the component's state
 
-  const { customUrl, resourceSelectors, columns, defaultLimit, updateData, classes,
+  const { customUrl, resourceSelectors, columns, showTotalRows, defaultLimit, updateData, classes,
     filters, entryType, actions, admin, disableTopPagination, disableBottomPagination,
     onDataReceived, onFiltersChange, filtersJsonString, ...rest } = props;
   const [tableData, setTableData] = useState();
@@ -129,6 +129,7 @@ function LiveTable(props) {
     url.searchParams.set("offset", goToStart ? 0 : newPage.offset ?? paginationData.offset);
     url.searchParams.set("limit", newPage.limit || paginationData.limit);
     url.searchParams.set("req", ++fetchStatus.currentRequestNumber);
+    url.searchParams.set("showTotalRows", showTotalRows);
     resourceSelectors && url.searchParams.set("resourceSelectors", resourceSelectors);
 
     // filters should be nullable, but if left undefined we use the cached filters
@@ -436,7 +437,8 @@ function LiveTable(props) {
 }
 
 LiveTable.defaultProps = {
-  defaultLimit: 20
+  defaultLimit: 20,
+  showTotalRows: false
 }
 
 export default withStyles(LiveTableStyle)(LiveTable);

--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
@@ -463,6 +463,8 @@
                     "name": "jcr:uuid",
                     "propertyIndex": true,
                     "notNullCheckEnabled": true,
+                    "sync": true,
+                    "unique": true,
                     "type": "String"
                 },
                 "primaryType": {

--- a/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/formSubjectQuestionnaire.json
+++ b/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/formSubjectQuestionnaire.json
@@ -1,7 +1,7 @@
 {
   "jcr:primaryType": "oak:QueryIndexDefinition",
   "type": "property",
-  "tags": ["cards", "property"],
+  "tags": ["property"],
   "jcr:name:propertyNames": [
     "subject",
     "questionnaire"

--- a/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/subjectTypes.json
+++ b/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/subjectTypes.json
@@ -29,6 +29,8 @@
                     "name": "jcr:uuid",
                     "propertyIndex": true,
                     "notNullCheckEnabled": true,
+                    "sync": true,
+                    "unique": true,
                     "type": "String"
                 },
                 "primaryType": {

--- a/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/subjects.json
+++ b/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/subjects.json
@@ -49,6 +49,8 @@
                     "name": "jcr:uuid",
                     "propertyIndex": true,
                     "notNullCheckEnabled": true,
+                    "sync": true,
+                    "unique": true,
                     "type": "String"
                 },
                 "primaryType": {


### PR DESCRIPTION
To test:
- build this branch with `mvn clean install -Pdocker`
- in `compose-cluster` generate a docker compose file with `python3 generate_compose_yaml.py --mssql --cards_project cards4proms --oak_filesystem --dev_docker_image --composum --adminer --server_address=localhost:8080`
- in `compose-cluster/mssql` run `python3 ./generate_test_proms_sql.py -n 5000 proms_sample.sql` to generate a big sample file
- start with `docker-compose build && docker-compose up`
- at `http://localhost:1435/?mssql=mssql&username=sa&db=master&ns=path&import=` import the sample sql file from `compose-cluster/mssql`
- access `http://localhost:8080/Subjects.importClarity`  to import the visits
- check that the dashboard loads quickly and shows the correct results
- fill in and submit a couple of visits
- check that the clinic dashboard loads quickly, especially the past tabs
- stop and clean up with `docker-compose rm -vf && ./cleanup.sh`
