### PR TITLE
CARDS-2281: Only count the total number of subjects for a type in the administration

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -44,7 +44,7 @@ function LiveTable(props) {
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Define the component's state
 
-  const { customUrl, columns, defaultLimit, updateData, classes,
+  const { customUrl, resourceSelectors, columns, defaultLimit, updateData, classes,
     filters, entryType, actions, admin, disableTopPagination, disableBottomPagination,
     onDataReceived, onFiltersChange, filtersJsonString, ...rest } = props;
   const [tableData, setTableData] = useState();
@@ -129,6 +129,7 @@ function LiveTable(props) {
     url.searchParams.set("offset", goToStart ? 0 : newPage.offset ?? paginationData.offset);
     url.searchParams.set("limit", newPage.limit || paginationData.limit);
     url.searchParams.set("req", ++fetchStatus.currentRequestNumber);
+    resourceSelectors && url.searchParams.set("resourceSelectors", resourceSelectors);
 
     // filters should be nullable, but if left undefined we use the cached filters
     let filters = (newPage.filters === null ? null : (newPage.filters || cachedFilters));

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
@@ -74,7 +74,7 @@ function SubjectTypes(props) {
       "label": "Default Order",
       "format": "string",
     },
-        {
+    {
       "key": "jcr:createdBy",
       "label": "Created by",
       "format": "string",
@@ -119,6 +119,7 @@ function SubjectTypes(props) {
         title: "New subject type",
         onClick: () => setDialogOpen(true)
       }}
+      resourceSelectors=".instanceCount"
       columns={columns}
       entryType={"Subject Type"}
       admin={true}

--- a/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
@@ -978,6 +978,9 @@ public class PaginationServlet extends SlingSafeMethodsServlet
         // - After outputting "limit" items, keep counting how many new unique items are there until there are no more
         // results, or encounter 10 more pages of unique items, rounded up to a whole 10*page batch
 
+        final String selectors =
+            (request.getParameter("resourceSelectors") == null ? "" : "." + request.getParameter("resourceSelectors"))
+                .replaceAll("\\.\\.", ".");
         // The returned number of items
         long returnedResults = 0;
         // If there are more results that haven't been counted
@@ -1020,7 +1023,8 @@ public class PaginationServlet extends SlingSafeMethodsServlet
                     // If we've passed the "offset" mark, and we didn't output "limit" items yet, include the
                     // resource in the output
                     if (seenResources.size() > resultOffset && limitCounter > 0) {
-                        jsonGen.write(request.getResourceResolver().getResource(path).adaptTo(JsonObject.class));
+                        jsonGen.write(
+                            request.getResourceResolver().resolve(path + selectors).adaptTo(JsonObject.class));
                         --limitCounter;
                         ++returnedResults;
                     }

--- a/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/serialize/SubjectTypeInstanceCountProcessor.java
+++ b/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/serialize/SubjectTypeInstanceCountProcessor.java
@@ -95,9 +95,9 @@ public class SubjectTypeInstanceCountProcessor implements ResourceJsonProcessor
                 // Getting the count directly fails for some index types, so we have to manually count the number of
                 // items returned.
                 AtomicLong atomicCount = new AtomicLong();
-                Consumer<Object> consumer = i -> atomicCount.incrementAndGet();
-                while (queryResult.hasNext()) {
-                    consumer.accept(queryResult.next());
+                Predicate<Object> consumer = i -> atomicCount.incrementAndGet() < 10000;
+                while (queryResult.hasNext() && consumer.test(queryResult.next())) {
+                    // Nothing to do, all the code is in the conditions above
                 }
                 count = atomicCount.get();
             }

--- a/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/serialize/SubjectTypeInstanceCountProcessor.java
+++ b/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/serialize/SubjectTypeInstanceCountProcessor.java
@@ -45,6 +45,8 @@ public class SubjectTypeInstanceCountProcessor implements ResourceJsonProcessor
 {
     private static final String NAME = "instanceCount";
 
+    private static final long MAX_RESULTS = 10_000;
+
     /** An original resource path. */
     private ThreadLocal<String> originalPath = new ThreadLocal<>();
 
@@ -95,7 +97,7 @@ public class SubjectTypeInstanceCountProcessor implements ResourceJsonProcessor
                 // Getting the count directly fails for some index types, so we have to manually count the number of
                 // items returned.
                 AtomicLong atomicCount = new AtomicLong();
-                Predicate<Object> consumer = i -> atomicCount.incrementAndGet() < 10000;
+                Predicate<Object> consumer = i -> atomicCount.incrementAndGet() < MAX_RESULTS;
                 while (queryResult.hasNext() && consumer.test(queryResult.next())) {
                     // Nothing to do, all the code is in the conditions above
                 }

--- a/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/serialize/SubjectTypeInstanceCountProcessor.java
+++ b/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/serialize/SubjectTypeInstanceCountProcessor.java
@@ -19,8 +19,8 @@
 package io.uhndata.cards.subjects.internal.serialize;
 
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
@@ -69,7 +69,7 @@ public class SubjectTypeInstanceCountProcessor implements ResourceJsonProcessor
     @Override
     public boolean isEnabledByDefault(Resource resource)
     {
-        return true;
+        return false;
     }
 
     @Override
@@ -110,9 +110,8 @@ public class SubjectTypeInstanceCountProcessor implements ResourceJsonProcessor
     private String generateDataQuery(final Node node)
         throws RepositoryException
     {
-        String query = String.format(
-            "select n from [cards:Subject] as n where n.type = '%s' OPTION (index tag property)",
+        return String.format(
+            "select [jcr:path] from [cards:Subject] as n where n.type = '%s' OPTION (index tag property)",
             node.getProperty("jcr:uuid").getString());
-        return query;
     }
 }


### PR DESCRIPTION
Includes [CARDS-2478](https://phenotips.atlassian.net/jira/software/c/projects/CARDS/issues/CARDS-2478), [CARDS-2281](https://phenotips.atlassian.net/jira/software/c/projects/CARDS/issues/CARDS-2281) and [CARDS-2479](https://phenotips.atlassian.net/jira/software/c/projects/CARDS/issues/CARDS-2479).

To test:
- build this branch with `mvn clean install -Pdocker`
- in `compose-cluster` generate a docker compose file with `python3 generate_compose_yaml.py --mssql --cards_project cards4prems --oak_filesystem --dev_docker_image --composum --adminer --server_address=localhost:8080`
- in `compose-cluster/mssql` run `python3 ./generate_test_YE_sql.py -n 1000 prems_sample.sql` to generate a big sample file
- start with `docker-compose build && docker-compose up`
- at `http://localhost:1435/?mssql=mssql&username=sa&db=master&ns=path&import=` import the sample sql file from `compose-cluster/mssql`
- access `http://localhost:8080/Subjects.importClarity?config=Your%20Experience%20-%20Discharge%20events`  to import the visits
- check that the dashboard loads quickly and shows the correct results
- check that the Questionnaires and Patients tables load fine (the sidebar entries)
- check that the Subject Types and Questionnaires administration pages load fine, and the correct number of subjects is displayed in the Subject Types table
- stop and clean up with `docker-compose rm -vf && ./cleanup.sh`


[CARDS-2478]: https://phenotips.atlassian.net/browse/CARDS-2478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CARDS-2281]: https://phenotips.atlassian.net/browse/CARDS-2281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CARDS-2479]: https://phenotips.atlassian.net/browse/CARDS-2479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ