### PR TITLE
CARDS-2476 / CARDS-2477: The CARDS build process should fail if conflicting NPM/Yarn dependencies are specified

### DIFF
--- a/aggregated-frontend/src/main/frontend/webpack_script.py
+++ b/aggregated-frontend/src/main/frontend/webpack_script.py
@@ -27,6 +27,16 @@ from os import path
 
 package_name = 'cards-aggregated-frontend'
 
+def update_dependency_version_map(dependencies, new_dependencies):
+    for key in new_dependencies:
+        if key not in dependencies:
+            dependencies[key] = new_dependencies[key]
+        else:
+            if dependencies[key] == new_dependencies[key]:
+                continue
+            else:
+                raise Exception("Conflicting versions of package {}".format(key))
+
 def merge_package_json_files(root, dir_name, project_to_name_map, package_merged):
     fl = os.path.join(root, dir_name, 'src', 'main', 'frontend', 'package.json')
     if path.exists(fl):
@@ -46,8 +56,9 @@ def merge_package_json_files(root, dir_name, project_to_name_map, package_merged
             for i in package["babel"]["plugins"]:
                 if i not in package_merged["babel"]["plugins"]:
                     package_merged["babel"]["plugins"].append(i)
-            package_merged["devDependencies"].update(package["devDependencies"])
-            package_merged["dependencies"].update(package["dependencies"])
+            update_dependency_version_map(package_merged["devDependencies"], package["devDependencies"])
+            update_dependency_version_map(package_merged["dependencies"], package["dependencies"])
+
             if "resolutions" in package:
                 package_merged["resolutions"].update(package["resolutions"])
 

--- a/modules/patient-portal/src/main/frontend/package.json
+++ b/modules/patient-portal/src/main/frontend/package.json
@@ -45,7 +45,7 @@
     "history": "4.10.1",
     "luxon": "3.2.1",
     "semantic-ui-css": "2.5.0",
-    "semantic-ui-react": "2.0.1"
+    "semantic-ui-react": "2.1.4"
   },
   "resolutions": {
     "@babel/runtime": "^7.21.0"

--- a/modules/permissions-trusted/src/main/frontend/package.json
+++ b/modules/permissions-trusted/src/main/frontend/package.json
@@ -40,7 +40,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "semantic-ui-css": "2.5.0",
-    "semantic-ui-react": "2.0.1"
+    "semantic-ui-react": "2.1.4"
   },
   "resolutions": {
     "@babel/runtime": "^7.21.0"

--- a/modules/statistics/src/main/frontend/package.json
+++ b/modules/statistics/src/main/frontend/package.json
@@ -46,7 +46,7 @@
     "react-router-dom": "5.2.0",
     "recharts": "2.2.0",
     "semantic-ui-css": "2.5.0",
-    "semantic-ui-react": "0.83.0",
+    "semantic-ui-react": "2.1.4",
     "set-blocking": "2.0.0"
   }
 }


### PR DESCRIPTION
This _Pull Request_ implements CARDS-2476 by changing the behavior of the `aggregated-frontend/src/main/frontend/webpack_script.py` script so that it will raise an exception and exit with a non-zero exit status if multiple versions of the same package are specified.

To test that this functionality from CARDS-2476 works, `git checkout CARDS-2476` and run `mvn clean install`. The build process should fail with the message `Failed to execute goal org.codehaus.mojo:exec-maven-plugin:3.0.0:exec (python-build) on project cards-aggregated-frontend: Command execution failed.: Process exited with an error (Exit value: 1)`. Further up on the page it will display why `python-build` failed - `Exception: Conflicting versions of package semantic-ui-react`.

The next part of this _Pull Request_ implements CARDS-2477 and fixes the build process by setting all versions of the `semantic-ui-react` package to `2.1.4`. To test, `git checkout CARDS-2477` and run `mvn clean install`. The build process should complete without error.