### PR TITLE
[misc] Use a custom groupId for our patched version of the saml2 plugin

### DIFF
--- a/modules/saml-support/src/main/features/base.json
+++ b/modules/saml-support/src/main/features/base.json
@@ -24,7 +24,7 @@
       "start-order":"15"
     },
     {
-      "id":"org.apache.sling:org.apache.sling.auth.saml2:${sling.saml.version}",
+      "id":"io.uhndata.cards:org.apache.sling.auth.saml2:${sling.saml.version}",
       "start-order":"15"
     },
     {

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
     <slf4j.version>1.7.36</slf4j.version>
     <jackrabbit.version>2.21.20</jackrabbit.version>
     <oak.version>1.44.0</oak.version>
-    <sling.saml.version>0.2.6.cards.1</sling.saml.version>
+    <sling.saml.version>0.2.6.cards.2</sling.saml.version>
 
     <!-- Versions to be replaced in the feature files -->
     <asm.version>9.3</asm.version>


### PR DESCRIPTION
Test like in #1156

This is needed in order to stop using the custom repository and instead only use the Maven Central repository. This version of the saml2 plugin is already published there.