### PR TITLE
SPARC-12: SPARC Form Graphics: Fix black background on Formatted Text Images

### DIFF
--- a/modules/commons/src/main/frontend/src/components/FormattedText.jsx
+++ b/modules/commons/src/main/frontend/src/components/FormattedText.jsx
@@ -33,6 +33,9 @@ const useStyles = makeStyles(theme => ({
       "& .anchor" : {
         display: "none",
       },
+      "& img": {
+        background: "transparent"
+      }
     },
   }
 }));


### PR DESCRIPTION
- Update Formatted Text to default to a transparent background instead of a black background for child images