### PR TITLE
CARDS-2054: Auto-created nodes are out of order

### DIFF
--- a/modules/data-entry/src/main/features/feature.json
+++ b/modules/data-entry/src/main/features/feature.json
@@ -82,6 +82,7 @@
         "io.uhndata.cards.data-model-forms-impl:createMissingAnswers=[cards-answer-editor]",
         "io.uhndata.cards.data-model-forms-impl:computedAnswers=[cards-answer-editor]",
         "io.uhndata.cards.data-model-forms-impl:referenceAnswers=[cards-answer-editor]",
+        "io.uhndata.cards.data-model-forms-impl:sortChildren=[cards-answer-editor]",
         "io.uhndata.cards.data-model-forms-impl:maxFormsOfTypePerSubjectValidator=[sling-readall]",
         "io.uhndata.cards.data-model-forms-impl:requiredSubjectTypesValidator=[sling-readall]",
         "io.uhndata.cards.data-model-forms-impl:referenceAnswersChangedListener=[cards-reference-answer-editor]"

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/SortChildrenEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/SortChildrenEditor.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.forms.internal;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.spi.commit.DefaultEditor;
+import org.apache.jackrabbit.oak.spi.commit.Editor;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.uhndata.cards.forms.api.FormUtils;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
+
+/**
+ * An {@link Editor} that sorts answers and answer sections in a form, following the questionnaire as a template.
+ *
+ * @version $Id$
+ */
+public class SortChildrenEditor extends DefaultEditor
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(SortChildrenEditor.class);
+
+    // This holds the builder for the current node. The methods called for editing specific properties don't receive the
+    // actual parent node of those properties, so we must manually keep track of the current node.
+    private final NodeBuilder currentNodeBuilder;
+
+    private final ResourceResolverFactory rrf;
+
+    private final ThreadResourceResolverProvider rrp;
+
+    private final FormUtils formUtils;
+
+    private final boolean isFormNode;
+
+    /**
+     * Simple constructor.
+     *
+     * @param nodeBuilder the builder for the current node
+     * @param rrf the resource resolver factory which can provide access to JCR sessions
+     * @param rrp for sharing the resource resolver with other components
+     * @param formUtils for working with form data
+     */
+    public SortChildrenEditor(final NodeBuilder nodeBuilder, final ResourceResolverFactory rrf,
+        final ThreadResourceResolverProvider rrp, final FormUtils formUtils)
+    {
+        this.currentNodeBuilder = nodeBuilder;
+        this.formUtils = formUtils;
+        this.rrf = rrf;
+        this.rrp = rrp;
+        this.isFormNode = this.formUtils.isForm(nodeBuilder);
+    }
+
+    @Override
+    public Editor childNodeAdded(final String name, final NodeState after)
+    {
+        if (this.isFormNode) {
+            // No need to descend further down, we already know that this is a form that has changes
+            return null;
+        } else {
+            return new SortChildrenEditor(this.currentNodeBuilder.getChildNode(name), this.rrf, this.rrp,
+                this.formUtils);
+        }
+    }
+
+    @Override
+    public Editor childNodeChanged(final String name, final NodeState before, final NodeState after)
+    {
+        return childNodeAdded(name, after);
+    }
+
+    @Override
+    public void leave(final NodeState before, final NodeState after)
+    {
+        if (!this.isFormNode) {
+            return;
+        }
+
+        boolean mustPopResolver = false;
+        try (ResourceResolver serviceResolver =
+            this.rrf.getServiceResourceResolver(Map.of(ResourceResolverFactory.SUBSERVICE, "sortChildren"))) {
+            this.rrp.push(serviceResolver);
+            mustPopResolver = true;
+            sortNodes();
+        } catch (final LoginException e) {
+            // Should not happen
+        } finally {
+            if (mustPopResolver) {
+                this.rrp.pop();
+            }
+        }
+    }
+
+    private void sortNodes()
+    {
+        final Node questionnaireNode = this.formUtils.getQuestionnaire(this.currentNodeBuilder);
+        if (questionnaireNode == null) {
+            return;
+        }
+        sortNodes(this.currentNodeBuilder, questionnaireNode);
+    }
+
+    private void sortNodes(final NodeBuilder node, final Node definition)
+    {
+        final List<Pair<String, NodeBuilder>> sortedNodes = new ArrayList<>();
+        for (String childName : node.getChildNodeNames()) {
+            NodeBuilder child = node.getChildNode(childName);
+            sortedNodes.add(Pair.of(childName, child));
+            if (this.formUtils.isAnswerSection(child)) {
+                sortNodes(child, this.formUtils.getSection(child));
+            }
+        }
+        sortedNodes.sort(new DefinitionComparator(definition));
+        node.setProperty(":childOrder", sortedNodes.stream().map(Pair::getKey).collect(Collectors.toList()),
+            Type.NAMES);
+    }
+
+    class DefinitionComparator implements Comparator<Pair<String, NodeBuilder>>
+    {
+        private final List<String> definitionUuids = new ArrayList<>();
+
+        DefinitionComparator(final Node definition)
+        {
+            NodeIterator children;
+            try {
+                children = definition.getNodes();
+                while (children.hasNext()) {
+                    Node child = children.nextNode();
+                    if (child.hasProperty("jcr:uuid")) {
+                        this.definitionUuids.add(child.getIdentifier());
+                    }
+                }
+            } catch (RepositoryException e) {
+                LOGGER.warn("Unexpected exception while sorting children: {}", e.getMessage(), e);
+            }
+        }
+
+        @Override
+        public int compare(Pair<String, NodeBuilder> child1, Pair<String, NodeBuilder> child2)
+        {
+            final String uuid1 = this.getDefinitionUuid(child1.getValue());
+            final String uuid2 = this.getDefinitionUuid(child2.getValue());
+
+            if (this.definitionUuids.contains(uuid1) && this.definitionUuids.contains(uuid2)) {
+                return this.definitionUuids.indexOf(uuid1) - this.definitionUuids.indexOf(uuid2);
+            } else {
+                return 0;
+            }
+        }
+
+        private String getDefinitionUuid(final NodeBuilder node)
+        {
+            if (SortChildrenEditor.this.formUtils.isAnswer(node)) {
+                return SortChildrenEditor.this.formUtils.getQuestionIdentifier(node);
+            } else if (SortChildrenEditor.this.formUtils.isAnswerSection(node)) {
+                return SortChildrenEditor.this.formUtils.getSectionIdentifier(node);
+            }
+            return "";
+        }
+    }
+}

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/SortChildrenEditorProvider.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/SortChildrenEditorProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.forms.internal;
+
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
+import org.apache.jackrabbit.oak.spi.commit.Editor;
+import org.apache.jackrabbit.oak.spi.commit.EditorProvider;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.FieldOption;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import io.uhndata.cards.forms.api.FormUtils;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
+
+/**
+ * A {@link EditorProvider} returning {@link SortChildrenEditor}.
+ *
+ * @version $Id$
+ */
+@Component(property = "service.ranking:Integer=100")
+public class SortChildrenEditorProvider implements EditorProvider
+{
+    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
+        policyOption = ReferencePolicyOption.GREEDY)
+    private ResourceResolverFactory rrf;
+
+    @Reference
+    private ThreadResourceResolverProvider rrp;
+
+    @Reference
+    private FormUtils formUtils;
+
+    @Override
+    public Editor getRootEditor(final NodeState before, final NodeState after, final NodeBuilder builder,
+        final CommitInfo info)
+        throws CommitFailedException
+    {
+        final ResourceResolver resolver = this.rrp.getThreadResourceResolver();
+        if (resolver != null) {
+            // Each editor maintains a state, so a new instance must be returned each time
+            return new SortChildrenEditor(builder, this.rrf, this.rrp, this.formUtils);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
To test:

- start in prems mode
- create a new Visit Information for one of the clinics, YVM for example
- open the JSON of the YVM form, check if the JSON order of the answer and answer section nodes matches the questionnaire order, including inside sections
- start in heracles mode
- create a new Phone Call Follow-Up form, with repeatable sections
- play with the repeatable section, add, save, remove, save, add, save...
- check that in the JSON the repeatable sections are all grouped together in the correct place, and check that the original order of the sections is preserved, i.e. if you add 3 family doctors, A B and C, they are still in the ABC order