### PR TITLE
CARDS-2494: Non-matrix sections should not have dataType and min/maxAnswers properties

### DIFF
--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/nodetypes/forms.cnd
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/nodetypes/forms.cnd
@@ -313,18 +313,19 @@
   // For sections with the default display mode, whether to use horizontal layout (compact = true) to minimize negative space, or use vertical layout (default)
   - compact (boolean)
 
+  // These make sense for question matrix sections, since such a section behaves like a question
   // Same as for cards:Question.
-  - minAnswers (long) = '0' autocreated
+  - minAnswers (long) = '0'
 
   // Same as for cards:Question.
-  - maxAnswers (long) = '0' autocreated
+  - maxAnswers (long) = '0'
 
   // Which type of data is being recorded?
   // The possible values are limited to:
   // - text: simple text, either from a list of predefined options, or free text entered by the user
   // - long, double, decimal: a number
   // - vocabulary: a term from a vocabulary
-  - dataType (string) = 'text' mandatory autocreated
+  - dataType (string) = 'text'
 
   // Children
 


### PR DESCRIPTION
To test:
- start in proms mode, check that the SF-12 form still works
- check that creating a new questionnaire with matrix and non-matrix sections still works
