### PR TITLE
CARDS-2485: Remove queries on subject.ancestors

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -976,7 +976,7 @@ function SubjectSelectorList(props) {
       }
       if (currentSubject) {
         let subjectID = currentSubject["jcr:uuid"];
-        conditions.push(`(n.'ancestors'='${subjectID}' OR isdescendantnode(n,'${currentSubject["@path"]}') OR n.'jcr:uuid'='${subjectID}')`);
+        conditions.push(`(isdescendantnode(n,'${currentSubject["@path"]}') OR n.'jcr:uuid'='${subjectID}')`);
       }
       let condition = (conditions.length === 0) ? "" : ` WHERE ${conditions.join(" AND ")}`
 


### PR DESCRIPTION
Details on Jira: [CARDS-2485](https://phenotips.atlassian.net/browse/CARDS-2485)

To test:
- start in prems mode
- create a patient with a CPESIC and an ED visit
- on the subject page, create a new Patient Information form -> check that the patient itself shows up
- fill in the form, go back to the Patient page
- try to create another Patient Information -> check that the patient shows up but is not available; cancel the operation
- create a new CPESIC form, check that the two visits show up, and one is greyed out one is available
- create a new questionnaire that doesn't put any restrictions on the subject type
- go to the Patient page, create a new form for the questionnaire above, check that both the patient and its two visits show up

[CARDS-2485]: https://phenotips.atlassian.net/browse/CARDS-2485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ