### PR TITLE
CARDS-2442: Include LICENSE and NOTICE files in the generated jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -349,6 +349,32 @@
         </executions>
       </plugin>
 
+      <!-- Package LICENSE and NOTICE files in the built artifacts -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-remote-resources-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>io.uhndata.cards</groupId>
+            <artifactId>cards-license-resources</artifactId>
+            <version>1.0-SNAPSHOT</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>generate-license-resources</id>
+            <goals>
+              <goal>process</goal>
+            </goals>
+            <configuration>
+              <resourceBundles>
+                <resourceBundle>io.uhndata.cards:cards-license-resources:1.0-SNAPSHOT</resourceBundle>
+              </resourceBundles>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- Fail the build if the test coverage is below a given value. -->
       <plugin>
         <groupId>org.jacoco</groupId>


### PR DESCRIPTION
To test:
- first build [this PR](https://github.com/data-team-uhn/cards-license-resources/pull/2)
- build this branch
- open a few of the generated jar files, e.g. `modules/data-entry/target/cards-dataentry-0.9.23-SNAPSHOT.jar`, and check that in the `META-INF` directory there is a LICENSE file with the Apache2 license, and a NOTICE describing the module and listing all dependencies, like:

```
CARDS - Data entry module

Copyright 2019-2024 DATA Team at UHN.

This software is made available under the Apache License, Version 2.0. See the LICENSE file for more details.

This product includes/uses software developed by 'an unknown organization'
  - FindBugs-jsr305 (http://findbugs.sourceforge.net/)
      License: The Apache Software License, Version 2.0
  - Guava InternalFutureFailureAccess and InternalFutures (https://github.com/google/guava/failureaccess)
      License: The Apache Software License, Version 2.0
...
```