### PR TITLE
CARDS-2495: Speed up queries involving forms for a specific subject

### DIFF
--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/content/oak%3Aindex/forms.json
@@ -482,6 +482,7 @@
                 "subject": {
                     "analyzed": false,
                     "boost": 1,
+                    "weight": 1000000,
                     "nodeScopeIndex": false,
                     "useInExcerpt": true,
                     "ordered": true,
@@ -491,6 +492,7 @@
                 "relatedSubjects": {
                     "analyzed": false,
                     "boost": 1,
+                    "weight": 100000,
                     "nodeScopeIndex": false,
                     "useInExcerpt": true,
                     "ordered": false,

--- a/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/subjects.json
+++ b/modules/data-model/subjects/api/src/main/resources/SLING-INF/content/oak%3Aindex/subjects.json
@@ -15,6 +15,7 @@
                 "identifier": {
                     "analyzed": false,
                     "boost": 100,
+                    "weight": 100000,
                     "nodeScopeIndex": true,
                     "useInExcerpt": true,
                     "ordered": true,
@@ -22,6 +23,7 @@
                 },
                 "loweridentifier": {
                     "function": "lower([identifier])",
+                    "weight": 100000,
                     "ordered": true,
                     "propertyIndex": true
                 },
@@ -43,6 +45,7 @@
                 "parents": {
                     "propertyIndex": true,
                     "notNullCheckEnabled": true,
+                    "weight": 100000,
                     "type": "String"
                 },
                 "uuid": {


### PR DESCRIPTION
Tested live on YE.

To test:
- build, start in prems mode
- create two visit information forms
- generate a token for one of the subjects
- on the dashboard check that filtering the subjects by visit time, and filtering the forms by subject and visit time works