### PR TITLE
[MISC] Fix unescaped query in ReferenceAnswersChangedListener

### DIFF
--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersChangedListener.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersChangedListener.java
@@ -145,7 +145,8 @@ public class ReferenceAnswersChangedListener implements ResourceChangeListener
                 final NodeIterator resourceIteratorReferencingAnswers = session
                     .getWorkspace().getQueryManager().createQuery(
                         // Answers that were explicitly copied from this answer
-                        "SELECT a.* FROM [" + answerNodeType + "] AS a WHERE a.copiedFrom = '" + node.getPath() + "'"
+                        "SELECT a.* FROM [" + answerNodeType + "] AS a WHERE a.copiedFrom = '"
+                            + escape(node.getPath()) + "'"
                             + " UNION "
                             // Answers that don't have a value yet
                             + "SELECT a.* FROM [" + answerNodeType + "] AS a"
@@ -155,7 +156,8 @@ public class ReferenceAnswersChangedListener implements ResourceChangeListener
                             // The answer doesn't have a value
                             + "    a.value is null"
                             // The answer's question references this question
-                            + "    AND q.question = '" + node.getProperty("question").getNode().getPath() + "'"
+                            + "    AND q.question = '"
+                            + escape(node.getProperty("question").getNode().getPath()) + "'"
                             // The answer belongs to the same subject or one of its descendants
                             + "    AND f.relatedSubjects = '" + subject + "'"
                             // Use the fast index for the query
@@ -214,5 +216,10 @@ public class ReferenceAnswersChangedListener implements ResourceChangeListener
             referenceValues.add(referenceAnswerValue.getValue().getString());
         }
         return !sourceValues.equals(referenceValues);
+    }
+
+    private String escape(final String value)
+    {
+        return value.replace("'", "''");
     }
 }


### PR DESCRIPTION
This error was discovered when testing the Clinician Assessment form for SPARC

Testing:
- Copy the [SPARC Clinician Assessment](https://github.com/data-team-uhn/sparc/blob/7de27e9667d6a89c904e7c8fb6c73dd0ac2c74d3/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/ClinicianAssessment.xml) form into the test questionnaires folder
- Edit the Clinician Assessment form, changing the `SelectableArea` dataType found on line 78 to `text`
- Build and launch in the test runmode
- Create a Clinician Assessment form
- Verify there are no `InvalidQueryException`s in error.log

Here is an example of the errors that were occuring before this fix:
```
12.03.2024 14:11:10.238 *ERROR* [oak-executor-9] io.uhndata.cards.forms.internal.ReferenceAnswersChangedListener java.text.ParseException: Query: SELECT a.* FROM [cards:TextAnswer] AS a WHERE a.copiedFrom = '/Forms/d12365ad-a245-4dc2-8b64-f2ed7d5cafcf/ea9845d0-85ee-4f15-8c09-e60ee7e7c914/35b2f058-9289-4cc9-be30-5c7b4c0b0f23/cbd81321-fd47-4279-b42b-6335375de6f9/4f65f5ae-07df-4bd7-a4a8-873ef58024c9' UNION SELECT a.* FROM [cards:TextAnswer] AS a  INNER JOIN [cards:Form] AS f ON a.form = f.[jcr:uuid]  INNER JOIN [cards:Question] AS q ON a.question = q.[jcr:uuid]  WHERE    a.value is null    AND q.question = '/Questionnaires/ClinicianAssessment/section_tpm/section_tpm_rhomboid_rigth/section_tpm_rhomboid_rigth_section_tpm_matrix/section_tpm_rhomboid_rigth_reproductionofthepatient'ssymptoms'    AND f.relatedSubjects = 'cf604476-01af-44a3-9e25-edfd177427d3(*)' OPTION (index tag cards)
javax.jcr.query.InvalidQueryException: java.text.ParseException: Query: SELECT a.* FROM [cards:TextAnswer] AS a WHERE a.copiedFrom = '/Forms/d12365ad-a245-4dc2-8b64-f2ed7d5cafcf/ea9845d0-85ee-4f15-8c09-e60ee7e7c914/35b2f058-9289-4cc9-be30-5c7b4c0b0f23/cbd81321-fd47-4279-b42b-6335375de6f9/4f65f5ae-07df-4bd7-a4a8-873ef58024c9' UNION SELECT a.* FROM [cards:TextAnswer] AS a  INNER JOIN [cards:Form] AS f ON a.form = f.[jcr:uuid]  INNER JOIN [cards:Question] AS q ON a.question = q.[jcr:uuid]  WHERE    a.value is null    AND q.question = '/Questionnaires/ClinicianAssessment/section_tpm/section_tpm_rhomboid_rigth/section_tpm_rhomboid_rigth_section_tpm_matrix/section_tpm_rhomboid_rigth_reproductionofthepatient'ssymptoms'    AND f.relatedSubjects = 'cf604476-01af-44a3-9e25-edfd177427d3(*)' OPTION (index tag cards)
```