### PR TITLE
CARDS-2497: Filtering forms by date equality doesn't work reliably

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/ExportButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/ExportButton.jsx
@@ -193,16 +193,16 @@ function ExportButton(props) {
       path += ".dataFilter:modifiedBy=" + modifiedBy.replace('.', '%5C.');
     }
     if (createdAfter) {
-      path += ".dataFilter:createdAfter=" + createdAfter.toISO().replace('.', '%5C.');
+      path += ".dataFilter:createdAfter=" + createdAfter.startOf('minute').toISO().replace('.', '%5C.');
     }
     if (createdBefore) {
-      path += ".dataFilter:createdBefore=" + createdBefore.toISO().replace('.', '%5C.');
+      path += ".dataFilter:createdBefore=" + createdBefore.startOf('minute').toISO().replace('.', '%5C.');
     }
     if (modifiedAfter) {
-      path += ".dataFilter:modifiedAfter=" + modifiedAfter.toISO().replace('.', '%5C.');
+      path += ".dataFilter:modifiedAfter=" + modifiedAfter.startOf('minute').toISO().replace('.', '%5C.');
     }
     if (modifiedBefore) {
-      path += ".dataFilter:modifiedBefore=" + modifiedBefore.toISO().replace('.', '%5C.');
+      path += ".dataFilter:modifiedBefore=" + modifiedBefore.startOf('minute').toISO().replace('.', '%5C.');
     }
     if (status) {
       let pref = `.dataFilter:${statusSelectionMode}=`;

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/DateFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/DateFilter.jsx
@@ -64,7 +64,7 @@ const DateFilter = forwardRef((props, ref) => {
         value={displayedDate}
         onChange={(value) => {
           setDisplayedDate(value);
-          onChangeInput(value ? value.toISO() : null, value ? value.toFormat(dateFormat) : null);
+          onChangeInput(value ? DateQuestionUtilities.toPrecision(value, dateFormat).toISO() : null, value ? value.toFormat(dateFormat) : null);
         }}
         componentsProps={{ textField: {
                              variant: 'standard',


### PR DESCRIPTION
To test:
- build and start in prems mode
- create a visit information with a set time
- go to the dashboard, add a filter on Time=that time
- check that the form shows up
- change the filter to >= and <= and check that the form still shows up
- change the filter to > and < and check that the form does not show up