### PR TITLE
[misc] Prems emails: make the text in the yellow box easier to read

### DIFF
--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/mailTemplates/bodyTemplate.header.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/mailTemplates/bodyTemplate.header.html
@@ -30,7 +30,6 @@
         max-width: 45% !important;
       }
       .note {
-        color: #c6934b;
         font-size: small;
         border: 1px solid #c6934b;
         background: rgba(198, 147, 75, .065);


### PR DESCRIPTION
|Before: |Expected after: 
|---|---
| ![image](https://github.com/data-team-uhn/cards/assets/651980/15bfbce6-3b3a-4009-b03c-d613ae00e69f) | ![image](https://github.com/data-team-uhn/cards/assets/651980/216d56ac-e44e-40e6-8efe-431620a7eb16)
