### PR TITLE
[misc] Prems YVM: update the survey time estimate in the email to match the landing page estimate

### DIFF
--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -2,7 +2,7 @@
     <p>
       We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
       Our records show that you had a recent outpatient clinic visit with your nurse and/or doctor.
-      We would like to learn more about your experience in an optional survey. It should take approximately 5-10 minutes to complete.
+      We would like to learn more about your experience in an optional survey. It should take approximately 5 minutes to complete.
     </p>
     <p class="surveylink">
       <a href="${surveysLink}">Complete the survey</a>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -3,7 +3,7 @@ Dear ${first_name} ${last_name},
 We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
 Our records show that you had a recent outpatient clinic visit with your nurse and/or doctor.
 We would like to learn more about your experience in an optional survey. It should take
-approximately 5-10 minutes to complete.
+approximately 5 minutes to complete.
 
 To begin the survey, click the following link:
 ${surveysLink}

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -4,7 +4,7 @@
       We would like to learn more about your most recent outpatient clinic visit with nurse and/or doctor.
       Our records indicate that we sent you an optional survey asking about your experience.
       However, we have not heard back from you. This is the last reminder.
-      The survey should take approximately 5-10 minutes to complete.
+      The survey should take approximately 5 minutes to complete.
     </p>
     <p class="surveylink">
       <a href="${surveysLink}">Complete the survey</a>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -4,7 +4,7 @@ We are always striving to improve the experience of care at Princess Margaret Ca
 We would like to learn more about your most recent outpatient clinic visit with nurse and/or
 doctor. Our records indicate that we sent you an optional survey asking about your experience.
 However, we have not heard back from you. This is the last reminder. The survey should take
-approximately 5-10 minutes to complete.
+approximately 5 minutes to complete.
 
 To begin the survey, click the following link:
 ${surveysLink}


### PR DESCRIPTION
Emails said "approximately 5-10 minutes", landing page said "5 minutes". Keeping "5" in both.