### PR TITLE
CARDS-2510: Fix computed questions always recalculating on checkin

### DIFF
--- a/modules/data-model/forms/api/src/main/java/io/uhndata/cards/forms/api/ExpressionUtils.java
+++ b/modules/data-model/forms/api/src/main/java/io/uhndata/cards/forms/api/ExpressionUtils.java
@@ -68,11 +68,12 @@ public interface ExpressionUtils
      *
      * @param question the question node
      * @param values the other values in the form
+     * @param changedQuestions a list of question identifiers that have changed leading up to this evaluation
      * @return a string representation of the result, may be {@code null} if the expression has unmet dependencies
      */
-    default String evaluate(Node question, Map<String, Object> values)
+    default String evaluate(Node question, Map<String, Object> values, Set<String> changedQuestions)
     {
-        return String.valueOf(evaluate(question, values, Type.STRING));
+        return String.valueOf(evaluate(question, values, Type.STRING, changedQuestions).getResult());
     }
 
     /**
@@ -81,8 +82,48 @@ public interface ExpressionUtils
      * @param question the question node
      * @param values the other values in the form
      * @param type the expected type of the result
+     * @param changedQuestions a list of question identifiers that have changed leading up to this evaluation
      * @return a representation of the evaluation result, forced into the desired data type; may be {@code null} if the
      *         expression has unmet dependencies or the actual evaluation result cannot be converted to the desired type
      */
-    Object evaluate(Node question, Map<String, Object> values, Type<?> type);
+    ExpressionResult evaluate(Node question, Map<String, Object> values, Type<?> type, Set<String> changedQuestions);
+
+    /**
+     *
+     */
+    final class ExpressionResult
+    {
+        private final boolean missingValue;
+        private final boolean usedChangedValue;
+        private final Object result;
+        private final int arguments;
+
+        public ExpressionResult(boolean missingValue, boolean usedChangedValue, Object result, int arguments)
+        {
+            this.missingValue = missingValue;
+            this.usedChangedValue = usedChangedValue;
+            this.result = result;
+            this.arguments = arguments;
+        }
+
+        public boolean hasMissingValue()
+        {
+            return this.missingValue;
+        }
+
+        public boolean expressionUsedChangedValue()
+        {
+            return this.usedChangedValue;
+        }
+
+        public Object getResult()
+        {
+            return this.result;
+        }
+
+        public int numberOfArguments()
+        {
+            return this.arguments;
+        }
+    }
 }

--- a/modules/data-model/forms/api/src/main/java/io/uhndata/cards/forms/api/FormUtils.java
+++ b/modules/data-model/forms/api/src/main/java/io/uhndata/cards/forms/api/FormUtils.java
@@ -321,6 +321,15 @@ public interface FormUtils
     Node getAnswer(Node form, Node question);
 
     /**
+     * Get the first answer for a specific question, if any.
+     *
+     * @param form a Form node
+     * @param question a question node, part of the questionnaire that the form is answering
+     * @return an Answer node, may be {@code null}
+     */
+    NodeState getAnswer(NodeState form, Node question);
+
+    /**
      * Get all the answers for a specific question, if any.
      *
      * @param form a Form node

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ComputedAnswersEditor.java
@@ -126,9 +126,9 @@ public class ComputedAnswersEditor extends AnswersEditor
             return;
         }
         final QuestionTree computedQuestionsTree =
-            getUnansweredMatchingQuestions(questionnaireNode);
+            getUnmodifiedMatchingQuestions(questionnaireNode);
 
-        // There are missing computed questions, let's create them!
+        // There are computed questions that were not modified in the most recent save, calculate them!
         if (computedQuestionsTree != null) {
             Map<Node, NodeBuilder> questionAndAnswers =
                 computedQuestionsTree.getQuestionAndAnswers(this.currentNodeBuilder);
@@ -145,6 +145,18 @@ public class ComputedAnswersEditor extends AnswersEditor
                 }).collect(Collectors.toConcurrentMap(Pair::getKey, Pair::getValue));
             final List<String> orderedAnswersToCompute = sortDependencies(computedAnswerDependencies);
 
+            final Set<String> changedQuestions = new HashSet<>();
+            for (String modifiedAnswer : this.answerChangeTracker.getAllModifiedAnswers()) {
+                try {
+                    Node questionNode = this.currentSession.getNodeByIdentifier(modifiedAnswer);
+                    String name = questionNode.getName();
+                    changedQuestions.add(name);
+                } catch (Exception e) {
+                    // Could not find the answer: not an answer the user has permissions to edit so can't be modified
+                    // by the user
+                }
+            }
+
             // We have the right order, compute all the missing answers
             orderedAnswersToCompute.stream()
                 // Get the right answer node
@@ -154,35 +166,57 @@ public class ComputedAnswersEditor extends AnswersEditor
                     .findFirst().get())
                 // Evaluate it
                 .forEachOrdered(entry -> {
-                    computeAnswer(entry, answersByQuestionName);
+                    computeAnswer(entry, form, answersByQuestionName, changedQuestions);
                 });
         }
     }
 
-    private void computeAnswer(final Map.Entry<Node, NodeBuilder> entry,
-        final Map<String, Object> answersByQuestionName)
+    // Calculate and save the answer for the provided computed question if it should be evaluated
+    private void computeAnswer(final Map.Entry<Node, NodeBuilder> entry, NodeState form,
+        final Map<String, Object> answersByQuestionName, final Set<String> changedQuestions)
     {
-        final Node question = entry.getKey();
-        final NodeBuilder answer = entry.getValue();
-        Type<?> resultType = getAnswerType(question);
-        Object result = this.expressionUtils.evaluate(question, answersByQuestionName, resultType);
+        try {
+            final Node question = entry.getKey();
+            final NodeBuilder answer = entry.getValue();
+            Type<?> resultType = getAnswerType(question);
 
-        if (result == null || (result instanceof String && "null".equals(result))) {
-            answer.removeProperty(FormUtils.VALUE_PROPERTY);
-        } else {
-            // Type erasure makes the actual type irrelevant, there's only one real implementation method
-            // The implementation can extract the right type from the type object
-            @SuppressWarnings("unchecked")
-            Type<Object> untypedResultType = (Type<Object>) resultType;
-            answer.setProperty(FormUtils.VALUE_PROPERTY, result, untypedResultType);
-        }
-        // Update the computed value in the map of existing answers
-        String questionName = this.questionnaireUtils.getQuestionName(question);
-        if (answersByQuestionName.containsKey(questionName)) {
-            // Question has multiple answers. Ignore this answer, just keep previous.
-            // TODO: Implement better recurrent section handling
-        } else {
-            answersByQuestionName.put(questionName, result);
+            ExpressionUtils.ExpressionResult expressionResult = this.expressionUtils.evaluate(question,
+                answersByQuestionName, resultType, changedQuestions);
+            // Do not compute the question if all the following are true
+            // - The expression depends on other questions
+            // - One of the other questions has changed
+            // - The computed question already has an answer
+            if (
+                expressionResult.numberOfArguments() > 0
+                    && !expressionResult.expressionUsedChangedValue()
+                    && this.formUtils.getAnswer(form, question) != null
+            ) {
+                return;
+            }
+
+            Object result = expressionResult.getResult();
+
+            if (result == null || (result instanceof String && "null".equals(result))) {
+                answer.removeProperty(FormUtils.VALUE_PROPERTY);
+            } else {
+                // Type erasure makes the actual type irrelevant, there's only one real implementation method
+                // The implementation can extract the right type from the type object
+                @SuppressWarnings("unchecked")
+                Type<Object> untypedResultType = (Type<Object>) resultType;
+                answer.setProperty(FormUtils.VALUE_PROPERTY, result, untypedResultType);
+                changedQuestions.add(question.getName());
+            }
+            // Update the computed value in the map of existing answers
+            String questionName = this.questionnaireUtils.getQuestionName(question);
+            if (answersByQuestionName.containsKey(questionName)) {
+                // Question has multiple answers. Ignore this answer, just keep previous.
+                // TODO: Implement better recurrent section handling
+            } else {
+                answersByQuestionName.put(questionName, result);
+            }
+        } catch (RepositoryException e) {
+            // Should not happen
+            LOGGER.warn("Error calculating computing answer", e);
         }
     }
 

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/ReferenceAnswersEditor.java
@@ -118,7 +118,7 @@ public class ReferenceAnswersEditor extends AnswersEditor
             return;
         }
         final QuestionTree unansweredQuestionsTree =
-            getUnansweredMatchingQuestions(questionnaireNode);
+            getUnmodifiedMatchingQuestions(questionnaireNode);
 
         // There are missing reference questions, let's create them!
         if (unansweredQuestionsTree != null) {

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/BackendComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/BackendComputedTest.xml
@@ -284,6 +284,45 @@ which can then be verified for accuracy by opening the form in read mode with th
             </property>
         </node>
         <node>
+            <name>question3bcomputed</name>
+            <primaryNodeType>cards:Question</primaryNodeType>
+            <property>
+                <name>text</name>
+                <value>Sequential Computed Question. Should equal the previous computed question</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>dataType</name>
+                <value>long</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>displayMode</name>
+                <value>input</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>maxAnswers</name>
+                <value>1</value>
+                <type>Long</type>
+            </property>
+            <property>
+                <name>compact</name>
+                <value>True</value>
+                <type>Boolean</type>
+            </property>
+            <property>
+                <name>entryMode</name>
+                <value>computed</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>expression</name>
+                <value>return @{question3computed}</value>
+                <type>String</type>
+            </property>
+        </node>
+        <node>
             <name>question4a_computed</name>
             <primaryNodeType>cards:Question</primaryNodeType>
             <property>
@@ -363,6 +402,27 @@ return values.length == 0 ? "No values at Question 4" : values.join(", ");
                 <name>expression</name>
                 <value><![CDATA[
 return "The first value from Question 4 is " + @{question4_multi?};
+                ]]></value>
+                <type>String</type>
+            </property>
+        </node>
+        <node>
+            <name>question5_computed</name>
+            <primaryNodeType>cards:Question</primaryNodeType>
+            <property>
+                <name>text</name>
+                <value>Question 5 Computed. Should have a value of "1"</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>entryMode</name>
+                <value>computed</value>
+                <type>String</type>
+            </property>
+            <property>
+                <name>expression</name>
+                <value><![CDATA[
+return 1;
                 ]]></value>
                 <type>String</type>
             </property>


### PR DESCRIPTION
- Fix computed questions being recalculated by the backend whenever the front end submits the a form with no relevant changed answers

To ensure that computed questions are working as expected:
- Launch in runmode test with --dev enables
- Sign in to user: `computedtestuser` password: `testpassword`
- Create a Backend Computed Question form but do not input any answers or save it
- Check the created form using composum. It should have 2 sections, one with 4 answers and one with 8 answers.
  - Check the section with 8 answers: Two should have strings describing the (lack of) values in Question 4
![image](https://github.com/data-team-uhn/cards/assets/20056751/9c94b6a1-d8f6-4ce1-8d19-844dd4b30171)

- Save the form with no edited answers
- Create a new Backend Computed Question form, fill out all answers and save it.
- Sign out of `computedtestuser` and sign into `admin`
- View the created forms in view mode only and verify that the answers are as expected
  
  
To ensure that the computed questions are only being recalculated when desired:
- Launch cards in runmode test with --dev and a debugger attached
- Put breakpoints on `ComputedAnswersEditor.computeAnswers` on lines 194 and 199 as shown below:
![image](https://github.com/data-team-uhn/cards/assets/20056751/59067944-6fe0-4dcc-80c9-1d9ff1f87348)
- Verify that the line 194 breakpoint is being hit whenever the computation shouldn't be saved
- Verify that the line 199 breakpoint is being hit whenever the computation should be saved:
  - When a form is created all computed questions should be calculated
  - When the question does not take any other question inputs (seen by 1 question always computing with `result=1`)
  - When the form is modified by a user that does not have access to the computed questions and modifies an input answer