### PR TITLE
CARDS-2513: Status flags for subjects

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -564,7 +564,7 @@ function Form (props) {
             <Chip
               label={item[0].toUpperCase() + item.slice(1).toLowerCase()}
               variant="outlined"
-              className={`${classes[item + "Chip"] || classes.DefaultChip}`}
+              className={`${classes[item + "Flag"] || classes.DefaultFlag}`}
               size="small"
             />
           ))}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -246,9 +246,6 @@ const questionnaireStyle = theme => ({
         marginRight: theme.spacing(1.5),
         zoom: .75,
     },
-    subjectChartLink: {
-      marginRight: theme.spacing(1)
-    },
     childSubjectHeader: {
         marginLeft: theme.spacing(-5),
         "& > *" : {
@@ -563,21 +560,24 @@ const questionnaireStyle = theme => ({
         padding: theme.spacing(1),
         fontFamily: "'Roboto', 'Helvetica', 'Arial', sans-serif",
     },
-    subjectChip: {
+    childFormFlag: {
         marginBottom: theme.spacing(1),
         marginRight: theme.spacing(1),
     },
-    subjectChartChip: {
+    childSubjectFlag: {
       marginLeft: theme.spacing(1),
       textTransform: "none"
     },
-    INCOMPLETEChip: {
+    childSubjectActions: {
+      marginRight: theme.spacing(1),
     },
-    INVALIDChip: {
+    INCOMPLETEFlag: {
+    },
+    INVALIDFlag: {
         borderColor: theme.palette.error.main,
         color: theme.palette.error.main,
     },
-    DefaultChip: {
+    DefaultFlag: {
     },
     formPreview: {
         padding: theme.spacing(1),

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -246,6 +246,9 @@ const questionnaireStyle = theme => ({
         marginRight: theme.spacing(1.5),
         zoom: .75,
     },
+    subjectChartLink : {
+      marginRight: theme.spacing(1)
+    },
     childSubjectHeader: {
         marginLeft: theme.spacing(-5),
         "& > *" : {
@@ -563,6 +566,10 @@ const questionnaireStyle = theme => ({
     subjectChip: {
         marginBottom: theme.spacing(1),
         marginRight: theme.spacing(1),
+    },
+    subjectChartChip: {
+      marginLeft: theme.spacing(1),
+      textTransform: "none"
     },
     INCOMPLETEChip: {
     },

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -234,19 +234,19 @@ const questionnaireStyle = theme => ({
           padding: theme.spacing(0, GRID_SPACE_UNIT),
         }
     },
-    subjectAvatar : {
+    subjectAvatar: {
         backgroundColor: theme.palette.secondary.main,
         marginLeft: theme.spacing(-1),
         marginRight: theme.spacing(1.5),
         zoom: .75,
     },
-    subjectFormAvatar : {
+    subjectFormAvatar: {
         backgroundColor: theme.palette.primary.main,
         marginTop: theme.spacing(-.5),
         marginRight: theme.spacing(1.5),
         zoom: .75,
     },
-    subjectChartLink : {
+    subjectChartLink: {
       marginRight: theme.spacing(1)
     },
     childSubjectHeader: {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -326,7 +326,7 @@ function SubjectHeader(props) {
           <Chip
             label={item[0].toUpperCase() + item.slice(1).toLowerCase()}
             variant="outlined"
-            className={`${classes[item + "Chip"] || classes.DefaultChip}`}
+            className={`${classes[item + "Flag"] || classes.DefaultFlag}`}
             size="small"
           />
         ))}
@@ -449,7 +449,7 @@ function SubjectMemberInternal (props) {
       <Chip
         label={item[0].toUpperCase() + item.slice(1).toLowerCase()}
         variant="outlined"
-        className={`${[classes[item + "Chip"] || classes.DefaultChip, classes.childSubjectFlag].join(" ")}`}
+        className={`${[classes[item + "Flag"] || classes.DefaultFlag, classes.childSubjectFlag].join(" ")}`}
         size="small"
       />
     ))

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -234,6 +234,7 @@ function SubjectHeader(props) {
   let [ subject, setSubject ] = useState(null);
   // Error message set when fetching the data from the server fails
   let [ error, setError ] = useState();
+  let [ statusFlags, setStatusFlags ] = useState([]);
 
   let globalLoginDisplay = useContext(GlobalLoginContext);
 
@@ -252,6 +253,7 @@ function SubjectHeader(props) {
   let handleSubjectResponse = (json) => {
     getSubject(json);
     setSubject({data: json});
+    setStatusFlags(json.statusFlags);
   };
 
   // Callback method for the `fetchData` method, invoked when the request failed.
@@ -320,6 +322,14 @@ function SubjectHeader(props) {
         breadcrumbs={parentDetails}
         action={subjectMenu}
         contentOffset={props.contentOffset}
+        tags={ statusFlags?.map( item => (
+          <Chip
+            label={item[0].toUpperCase() + item.slice(1).toLowerCase()}
+            variant="outlined"
+            className={`${classes[item + "Chip"] || classes.DefaultChip}`}
+            size="small"
+          />
+        ))}
         >
       {
         subject?.data?.['jcr:created'] ?
@@ -405,6 +415,7 @@ function SubjectMemberInternal (props) {
 
   let identifier = data && data.identifier ? data.identifier : id;
   let label = data?.type?.label;
+  let statusFlags = data?.statusFlags;
   let title = `${label || "Subject"} ${identifier}`;
   let path = data ? data["@path"] : "/Subjects/" + id;
   let avatar = <Avatar className={classes.subjectAvatar}><SubjectIcon/></Avatar>;
@@ -434,6 +445,15 @@ function SubjectMemberInternal (props) {
                  />
                </>
 
+  let tags = statusFlags?.map( item => (
+      <Chip
+        label={item[0].toUpperCase() + item.slice(1).toLowerCase()}
+        variant="outlined"
+        className={`${[classes[item + "Chip"] || classes.DefaultChip, classes.subjectChartChip].join(" ")}`}
+        size="small"
+      />
+    ))
+
   return ( data &&
     <>
     {
@@ -444,7 +464,8 @@ function SubjectMemberInternal (props) {
             <Grid item xs={false}>{avatar}</Grid>
             <Grid item>
               <Typography variant="overline">
-                 {label} <Link to={"/content.html" + path} underline="hover">{identifier}</Link>
+                 {label} <Link to={"/content.html" + path} underline="hover" className={classes.subjectChartLink}>{identifier}</Link>
+                 {tags}
                  {action}
               </Typography>
             </Grid>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -449,7 +449,7 @@ function SubjectMemberInternal (props) {
       <Chip
         label={item[0].toUpperCase() + item.slice(1).toLowerCase()}
         variant="outlined"
-        className={`${[classes[item + "Chip"] || classes.DefaultChip, classes.subjectChartChip].join(" ")}`}
+        className={`${[classes[item + "Chip"] || classes.DefaultChip, classes.childSubjectFlag].join(" ")}`}
         size="small"
       />
     ))
@@ -462,13 +462,13 @@ function SubjectMemberInternal (props) {
           <Grid container direction="row" spacing={1} justifyContent="flex-start">
             <Grid item xs={false}>{expandAction}</Grid>
             <Grid item xs={false}>{avatar}</Grid>
-            <Grid item>
+            <Grid item xs={true}>
               <Typography variant="overline">
-                 {label} <Link to={"/content.html" + path} underline="hover" className={classes.subjectChartLink}>{identifier}</Link>
-                 {tags}
-                 {action}
+                 {label} <Link to={"/content.html" + path} underline="hover">{identifier}</Link>
               </Typography>
             </Grid>
+            <Grid item xs="3.5">{tags}</Grid>
+            <Grid item className={classes.childSubjectActions}>{action}</Grid>
           </Grid>
         </Grid>
       }
@@ -583,7 +583,7 @@ function SubjectMemberInternal (props) {
                                              key={status}
                                              label={wordToTitleCase(status)}
                                              variant="outlined"
-                                             className={`${classes.subjectChip} ${classes[status + "Chip"] || classes.DefaultChip}`}
+                                             className={`${classes.childFormFlag} ${classes[status + "Flag"] || classes.DefaultFlag}`}
                                              size="small"
                                            />
                                          })}

--- a/modules/data-model/subjects/api/src/main/resources/SLING-INF/nodetypes/subjects.cnd
+++ b/modules/data-model/subjects/api/src/main/resources/SLING-INF/nodetypes/subjects.cnd
@@ -57,6 +57,9 @@
   // Full hierarchy of Subject identifiers
   - fullIdentifier (String) = ''
 
+  // A potentially empty list of status flags for the subject
+  - statusFlags (STRING) autocreated multiple IGNORE
+
 //-----------------------------------------------------------------------------
 // The homepage for the Subjects space.
 [cards:SubjectsHomepage] > sling:Folder


### PR DESCRIPTION
Add status flags to subjects which are displayed in the subject chart and subject header

![image](https://github.com/data-team-uhn/cards/assets/20056751/1a655994-a596-4491-8422-c74f35705d1e)

