### PR TITLE
[MISC] Fix questions in repeated sections having the section name prefixed

### DIFF
--- a/Utilities/FormImport/import.py
+++ b/Utilities/FormImport/import.py
@@ -152,7 +152,7 @@ def repeated_section_handler(self, questionnaire, row):
                         and entry['jcr:primaryType'] == 'cards:AnswerOption'
                         and ('noneOfTheAbove' not in entry.keys() or not entry['noneOfTheAbove'])
                         and ('notApplicable' not in entry.keys() or not entry['notApplicable'])):
-                    section_title = parent_label + "_" + clean_name(entry['value'])
+                    section_title = clean_name(entry['value'])
                     new_section = create_new_section(section_title)
                     new_section['label'] = clean_title(entry['label'])
                     new_section['repeated_parent'] = parent_label
@@ -186,7 +186,7 @@ def process_repeated_child_section(section, repeated_key):
     return section
 
 
-def process_repeated(self, questionnaire, child, repeated_conditionals, non_repeated_key):
+def process_repeated(self, questionnaire, child, repeated_conditionals, non_repeated_key, parent_name):
     for repeated_key in repeated_conditionals:
         repeated_child_name = repeated_key + "_" + non_repeated_key
         new_child = copy.deepcopy(child)
@@ -197,7 +197,7 @@ def process_repeated(self, questionnaire, child, repeated_conditionals, non_repe
         # TODO: clean up mess of nested []: changing the order of operations and using new_child instead may make this more readable
         questionnaire.parent[repeated_key][repeated_child_name] = new_child
         modify_repeated_conditionals(self, questionnaire.parent[repeated_key][repeated_child_name], repeated_key)
-        questionnaire.parents[-2][repeated_key] = questionnaire.parent[repeated_key]
+        questionnaire.parents[-2][parent_name + "_" + repeated_key] = questionnaire.parent[repeated_key]
 
 
 def end_repeated_section(self, questionnaire, row):
@@ -217,7 +217,7 @@ def end_repeated_section(self, questionnaire, row):
 
     for non_repeated_key in non_repeated_children:
         non_repeated_child = questionnaire.parent.pop(non_repeated_key)
-        process_repeated(self, questionnaire, non_repeated_child, repeated_conditionals, non_repeated_key)
+        process_repeated(self, questionnaire, non_repeated_child, repeated_conditionals, non_repeated_key, parent_label)
 
     questionnaire.parents.pop()
     questionnaire.parent = questionnaire.parents[-1]

--- a/Utilities/FormImport/import.py
+++ b/Utilities/FormImport/import.py
@@ -152,7 +152,11 @@ def repeated_section_handler(self, questionnaire, row):
                         and entry['jcr:primaryType'] == 'cards:AnswerOption'
                         and ('noneOfTheAbove' not in entry.keys() or not entry['noneOfTheAbove'])
                         and ('notApplicable' not in entry.keys() or not entry['notApplicable'])):
-                    section_title = clean_name(entry['value'])
+
+                    section_title = parent_label
+                    if (section_title.startswith("section_")):
+                        section_title = section_title[len("section_"):]
+                    section_title = section_title + "_" + clean_name(entry['value'])
                     new_section = create_new_section(section_title)
                     new_section['label'] = clean_title(entry['label'])
                     new_section['repeated_parent'] = parent_label
@@ -180,15 +184,24 @@ def process_repeated_child_section(section, repeated_key):
         child = section[key]
         if type(child) == dict:
             if is_section(child):
-                section[repeated_key + "_" + key] = process_repeated_child_section(section.pop(key), repeated_key)
+                new_key = key
+                if (new_key.startswith("section_")):
+                    new_key = "section_" + repeated_key + new_key[len("section"):]
+                else:
+                    new_key = repeated_key + "_" + new_key
+                section[new_key] = process_repeated_child_section(section.pop(key), repeated_key)
             elif is_question(child):
                 section[repeated_key + "_" + key] = section.pop(key)
     return section
 
 
-def process_repeated(self, questionnaire, child, repeated_conditionals, non_repeated_key, parent_name):
+def process_repeated(self, questionnaire, child, repeated_conditionals, non_repeated_key):
     for repeated_key in repeated_conditionals:
-        repeated_child_name = repeated_key + "_" + non_repeated_key
+        repeated_child_name = non_repeated_key
+        if (repeated_child_name.startswith("section_")):
+            repeated_child_name = "section_" + repeated_key + repeated_child_name[len("section"):]
+        else:
+            repeated_child_name = repeated_key + "_" + repeated_child_name
         new_child = copy.deepcopy(child)
 
         if type(new_child) == dict and is_section(new_child):
@@ -197,7 +210,7 @@ def process_repeated(self, questionnaire, child, repeated_conditionals, non_repe
         # TODO: clean up mess of nested []: changing the order of operations and using new_child instead may make this more readable
         questionnaire.parent[repeated_key][repeated_child_name] = new_child
         modify_repeated_conditionals(self, questionnaire.parent[repeated_key][repeated_child_name], repeated_key)
-        questionnaire.parents[-2][parent_name + "_" + repeated_key] = questionnaire.parent[repeated_key]
+        questionnaire.parents[-2][repeated_key] = questionnaire.parent[repeated_key]
 
 
 def end_repeated_section(self, questionnaire, row):
@@ -217,7 +230,7 @@ def end_repeated_section(self, questionnaire, row):
 
     for non_repeated_key in non_repeated_children:
         non_repeated_child = questionnaire.parent.pop(non_repeated_key)
-        process_repeated(self, questionnaire, non_repeated_child, repeated_conditionals, non_repeated_key, parent_label)
+        process_repeated(self, questionnaire, non_repeated_child, repeated_conditionals, non_repeated_key)
 
     questionnaire.parents.pop()
     questionnaire.parent = questionnaire.parents[-1]


### PR DESCRIPTION
CSV used for replicating issue:
[RepeatedNamingTest.csv](https://github.com/data-team-uhn/cards/files/15082125/RepeatedNamingTest.csv)

Issue:
GIven the following form setup:
```
base_question: option_x, option_y
repeated_section:
  q_1
```
q_1 would have the name `repeated_section_<option_x or option_y>_q_1`
when it should be called `<option_x or option_y>_q_1`