### PR TITLE
CARDS-2518: Conditional sections show up when they shouldn't upon deselecting and reselecting their preconditions

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -68,9 +68,7 @@ function Answer (props) {
 
   // When the answers change, we inform the FormContext
   useEffect(() => {
-    if (answers && answers.length > 0) {
-      changeFormContext((oldContext) => ({...oldContext, [questionName]: answers}));
-    }
+    changeFormContext((oldContext) => ({...oldContext, [questionName]: answers}));
   }, [answers]);
 
   return (


### PR DESCRIPTION
This could affect conditionals and computed questions and needs to be tested thoroughly. To test:
- in heracles mode, the scenario in the issue description - use branch `CARDS_2518_with_new_heracles_forms` which contains this fix as well as the new ECC and PFU forms
- test with **recurrent** sections what happens when filling in and adding new section instances
- conditional sections in general
- computed questions