### PR TITLE
CARDS-2524: The cards-slack-notifications module should be included in CARDS production container images

### DIFF
--- a/Utilities/Packaging/Docker/cards_feature_list.txt
+++ b/Utilities/Packaging/Docker/cards_feature_list.txt
@@ -37,3 +37,4 @@ mvn:io.uhndata.cards/cards-dataentry/${PROJECT_VERSION}/slingosgifeature/permiss
 mvn:io.uhndata.cards/cards-dataentry/${PROJECT_VERSION}/slingosgifeature/permissions_trusted
 mvn:io.uhndata.cards/cards-dataentry/${PROJECT_VERSION}/slingosgifeature/permissions_ownership
 mvn:io.uhndata.cards/cards-s3-export/${PROJECT_VERSION}/slingosgifeature
+mvn:io.uhndata.cards/cards-slack-notifications/${PROJECT_VERSION}/slingosgifeature


### PR DESCRIPTION
The PR implements CARDS-2524 - see the JIRA task for more details.

Tested by building a _production_ container image with the `build_self_contained.sh` script (`./build_self_contained.sh cards/cards:cards-2524`) and then verified the image by running `docker run --rm --entrypoint /usr/bin/find -it cards/cards:cards-2524 /root/.m2/repository/io/uhndata/cards/cards-slack-notifications`. Files are present as expected.