### PR TITLE
CARDS-2526: New form pagination variant: navigable

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -55,7 +55,7 @@ import FormPagination from "./FormPagination";
 import { usePageNameWriterContext } from "../themePage/Page.jsx";
 import FormattedText from "../components/FormattedText.jsx";
 import ResourceHeader from "./ResourceHeader.jsx";
-import { getFirstIncompleteQuestionEl } from "./FormUtilities.jsx";
+import { getFirstIncompleteQuestionEl, hasWarningFlags } from "./FormUtilities.jsx";
 import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
 import SessionExpiryWarningModal from "./SessionExpiryWarningModal.jsx";
 
@@ -654,6 +654,12 @@ function Form (props) {
               navMode = {paginationProps?.navMode || data?.questionnaire?.paginationMode}
               questionnaireData={data.questionnaire}
               setPagesCallback={setPages}
+              isPageCompleted={keys => (
+               Object.values(data)
+                 .filter(e => Object.values(e).find(val => ENTRY_TYPES.includes(val["jcr:primaryType"])))
+                 .filter(e => keys.includes((e.section || e.question)?.["@name"] || ""))
+                 .every(p => !hasWarningFlags(p))
+              )}
               onDone={() => { setEndReached(true); }}
               onPageChange={() => { setDisableProgress(requireCompletion); setIncompleteQuestionEl(null); }}
               doneLabel={doneLabel}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPageNavigation.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPageNavigation.jsx
@@ -111,6 +111,7 @@ function FormPageNavigation (props) {
         anchorEl={pageSelectorAnchorEl}
         open={!!pageSelectorAnchorEl}
         onClose={() => setPageSelectorAnchorEl(null)}
+        disableScrollLock={true}
       >
         { pages.map((p, index) => (
           <MenuItem

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPageNavigation.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPageNavigation.jsx
@@ -1,0 +1,158 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React, { useState, useEffect } from "react";
+
+import {
+  Fab,
+  Grid,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Tooltip,
+} from "@mui/material";
+
+import CheckIcon from '@mui/icons-material/Check';
+import WarningIcon from '@mui/icons-material/Warning';
+
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+
+import PropTypes from "prop-types";
+
+import FormattedText from "../components/FormattedText";
+import QuestionnaireStyle from "./QuestionnaireStyle";
+
+/**
+ * Component that enables the navigation between different pages of a Form. Used in FormPagination when the paginationVariant is "navigable".
+ */
+function FormPageNavigation (props) {
+  const { pages, activePage, saveButton, backButton, isPageCompleted, navigateTo } = props;
+
+  const [pageSelectorAnchorEl, setPageSelectorAnchorEl] = useState();
+
+  const theme = useTheme();
+  const condensedPageList = useMediaQuery(theme.breakpoints.down('lg'));
+
+  // -------------------------------------------------------------------------------
+  // Rendering helpers
+  //
+
+  // Page icon
+  // Previous pages that are enabled are marked with a checkmark if completed, and with a warning sign if incomplete
+  let pageIcon = (page, index) => (
+    index < activePage && page.canBeVisible && isPageCompleted
+    ? (isPageCompleted(page.keys) ? <CheckIcon sx={{fontSize: "medium"}} /> : <WarningIcon sx={{fontSize: "medium"}} />)
+    : (index + 1)
+  )
+
+  // Format the title
+  let pageTitle = (page) => (page ? <FormattedText variant="caption">{page.title}</FormattedText> : page)
+
+  // Individual page buttons
+  let pageButton = (page, index) => (
+    <Fab
+      size="small"
+      type="submit"
+      sx={{ width: 30, height: 30, minHeight: 30, boxShadow: "none", fontWeight: "normal" }}
+      color={index == activePage ? "primary" : ''}
+      onClick={() => navigateTo(index)}
+      disabled={!page.canBeVisible}
+    >
+      { pageIcon(page, index) }
+    </Fab>
+  )
+
+  // List of page buttons
+  let pageList = () => (
+    <Grid container spacing={2} justifyContent="space-evenly">
+    { pages.map((p, index) => (
+      <Grid item key={index}>
+      { p.canBeVisible ?
+          <Tooltip title={pageTitle(p)}>
+          { pageButton(p, index) }
+          </Tooltip>
+        :
+          pageButton(p, index)
+      }
+      </Grid>
+    ))}
+    </Grid>
+  );
+
+  // Condensed view: one button that unravels a page "menu"
+  let pageSelector = () => (
+    <div>
+      <Fab
+        sx={{ boxShadow: "none", fontWeight: "normal" }}
+        onClick={event => setPageSelectorAnchorEl(event.currentTarget)}
+      >
+        { (activePage + 1) + "/" + pages.length }
+      </Fab>
+      <Menu
+        disablePortal
+        anchorEl={pageSelectorAnchorEl}
+        open={!!pageSelectorAnchorEl}
+        onClose={() => setPageSelectorAnchorEl(null)}
+      >
+        { pages.map((p, index) => (
+          <MenuItem
+            component="button"
+            type="submit"
+            key={index}
+            sx={{width: "100%", textAlign: "inherit"}}
+            disabled={!p.canBeVisible}
+            selected={index == activePage}
+            onClick={() => {setPageSelectorAnchorEl(null); navigateTo(index) }}
+          >
+            <ListItemIcon>{pageIcon(p, index)}</ListItemIcon>
+            <ListItemText>{pageTitle(p)}</ListItemText>
+          </MenuItem>
+        ))}
+      </Menu>
+    </div>
+  )
+
+  // Render the expanded or condensed view depending on screen width
+  return (
+    <Grid container direction="row" spacing={4} justifyContent="space-between" alignItems="center" flexWrap="nowrap">
+      {backButton && <Grid item>{backButton}</Grid>}
+      <Grid item>
+        { condensedPageList ? pageSelector() : pageList() }
+      </Grid>
+      <Grid item>{saveButton}</Grid>
+    </Grid>
+  );
+};
+
+FormPageNavigation.propTypes = {
+  pages: PropTypes.array.isRequired,
+  activePage: PropTypes.number.isRequired,
+  saveButton: PropTypes.object.isRequired,
+  backButton: PropTypes.object,
+  isPageCompleted: PropTypes.func,
+  navigateTo: PropTypes.func.isRequired,
+};
+
+FormPageNavigation.defaultProps = {
+  activePage: 0,
+};
+
+export default FormPageNavigation;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPageNavigation.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPageNavigation.jsx
@@ -68,7 +68,7 @@ function FormPageNavigation (props) {
   )
 
   // Format the title
-  let pageTitle = (page) => (page ? <FormattedText variant="caption">{page.title}</FormattedText> : page)
+  let pageTitle = (page, index) => (<FormattedText variant="caption">{page?.title ? page.title : "Page " + (index + 1)}</FormattedText>)
 
   // Individual page buttons
   let pageButton = (page, index) => (
@@ -90,7 +90,7 @@ function FormPageNavigation (props) {
     { pages.map((p, index) => (
       <Grid item key={index}>
       { p.canBeVisible ?
-          <Tooltip title={pageTitle(p)}>
+          <Tooltip title={pageTitle(p, index)}>
           { pageButton(p, index) }
           </Tooltip>
         :
@@ -128,7 +128,7 @@ function FormPageNavigation (props) {
             onClick={() => {setPageSelectorAnchorEl(null); navigateTo(index) }}
           >
             <ListItemIcon>{pageIcon(p, index)}</ListItemIcon>
-            <ListItemText>{pageTitle(p)}</ListItemText>
+            <ListItemText>{pageTitle(p, index)}</ListItemText>
           </MenuItem>
         ))}
       </Menu>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPageNavigation.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPageNavigation.jsx
@@ -51,6 +51,10 @@ function FormPageNavigation (props) {
   const theme = useTheme();
   const condensedPageList = useMediaQuery(theme.breakpoints.down('lg'));
 
+  useEffect(() => {
+    !condensedPageList && setPageSelectorAnchorEl(null);
+  }, [condensedPageList]);
+
   // -------------------------------------------------------------------------------
   // Rendering helpers
   //

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -133,7 +133,6 @@ function FormPagination (props) {
       setDirection(undefined);
     } else {
       // If saving is not enabled, we can call handlePageChange directly
-      // And call the onDone() if we're on the last page
       pages[pageIndex]?.canBeVisible && activatePage(pageIndex);
     }
   }
@@ -148,7 +147,12 @@ function FormPagination (props) {
       setNextActivePage(undefined);
     } else {
       // If saving is not enabled, we can call handlePageChange directly
+      // And call the onDone() if we're on the last page
       handlePageChange(changeDirection);
+      if (activePage === lastValidPage() && changeDirection === DIRECTION_NEXT) {
+        setSavedLastPage(true);
+        onDone && onDone();
+      }
     }
   }
 
@@ -169,11 +173,6 @@ function FormPagination (props) {
       window.scrollTo(0, 0);
       setActivePage(nextPage);
       onPageChange?.();
-      // Call the onDone() if we're on the last page
-      if (nextPage === lastValidPage()) {
-        setSavedLastPage(true);
-        onDone?.();
-      }
     }
   }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -88,7 +88,7 @@ function FormPagination (props) {
       } else {
         page = new Page(
           !enabled || activePage == pagesArray.length,
-          entryDefinition.label || entryDefinition.text || entryDefinition["@name"],
+          entryDefinition.label || entryDefinition.text || "",
           entryDefinition["@name"]
         );
         pagesArray.push(page);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -28,12 +28,16 @@ import withStyles from '@mui/styles/withStyles';
 
 import PropTypes from "prop-types";
 import { SECTION_TYPES, ENTRY_TYPES } from "./FormEntry";
+import FormPageNavigation from "./FormPageNavigation";
+
 import QuestionnaireStyle from "./QuestionnaireStyle";
 
 class Page {
-  constructor(visible) {
+  constructor(visible, title, key) {
     this.visible = visible;
     this.canBeVisible = true;
+    this.title = title;
+    this.keys = [ key ];
   }
   conditionalVisible = [];
 
@@ -47,13 +51,14 @@ class Page {
  * Component that displays a page of a Form.
  */
 function FormPagination (props) {
-  let { classes, enabled, variant, navMode, saveInProgress, lastSaveStatus, setPagesCallback, enableSave, onDone, doneLabel, doneIcon, questionnaireData, disableProgress, onPageChange } = props;
+  let { classes, enabled, variant, navMode, saveInProgress, lastSaveStatus, setPagesCallback, isPageCompleted, enableSave, onDone, doneLabel, doneIcon, questionnaireData, disableProgress, onPageChange } = props;
 
   let [ savedLastPage, setSavedLastPage ] = useState(false);
   let [ pendingSubmission, setPendingSubmission ] = useState(false);
   let [ pages, setPages ] = useState([]);
   let [ activePage, setActivePage ] = useState(0);
   let [ direction, setDirection ] = useState(1);
+  let [ nextActivePage, setNextActivePage ] = useState();
   const DIRECTION_NEXT = 1, DIRECTION_PREV = -1;
 
   let previousEntryType;
@@ -78,9 +83,14 @@ function FormPagination (props) {
       let page;
       if (!SECTION_TYPES.includes(entryDefinition["jcr:primaryType"]) && previousEntryType && !SECTION_TYPES.includes(previousEntryType)) {
         page = pagesArray[pagesArray.length - 1];
+        page.keys?.push(entryDefinition["@name"]);
         questionIndex++;
       } else {
-        page = new Page(!enabled || activePage == pagesArray.length);
+        page = new Page(
+          !enabled || activePage == pagesArray.length,
+          entryDefinition.label || entryDefinition.text || entryDefinition["@name"],
+          entryDefinition["@name"]
+        );
         pagesArray.push(page);
         questionIndex = 0;
       }
@@ -113,6 +123,21 @@ function FormPagination (props) {
   let handleBack = () => {
     initChangePage(DIRECTION_PREV);
   }
+
+  let handleNavigateTo = (pageIndex) => {
+    if (enableSave) {
+      // If we must save the page before going, we make sure to not move to the new page
+      // until the submission process is complete.
+      setPendingSubmission(true);
+      setNextActivePage(pageIndex);
+      setDirection(undefined);
+    } else {
+      // If saving is not enabled, we can call handlePageChange directly
+      // And call the onDone() if we're on the last page
+      pages[pageIndex]?.canBeVisible && activatePage(pageIndex);
+    }
+  }
+
   // Change the page in the given direction
   let initChangePage = (changeDirection) => {
     if (enableSave) {
@@ -120,14 +145,10 @@ function FormPagination (props) {
       // until the submission process is complete.
       setPendingSubmission(true);
       setDirection(changeDirection);
+      setNextActivePage(undefined);
     } else {
       // If saving is not enabled, we can call handlePageChange directly
-      // And call the onDone() if we're on the last page
       handlePageChange(changeDirection);
-      if (activePage === lastValidPage() && changeDirection === DIRECTION_NEXT) {
-        setSavedLastPage(true);
-        onDone && onDone();
-      }
     }
   }
 
@@ -138,25 +159,36 @@ function FormPagination (props) {
       nextPage += change;
       if (pages[nextPage].canBeVisible) break;
     }
+    activatePage(nextPage);
+  }
+
+  let activatePage = (page) => {
+    let nextPage = page ?? nextActivePage;
+    // If the next page is not the one we're on already
     if (nextPage !== activePage) {
       window.scrollTo(0, 0);
+      setActivePage(nextPage);
+      onPageChange?.();
+      // Call the onDone() if we're on the last page
+      if (nextPage === lastValidPage()) {
+        setSavedLastPage(true);
+        onDone?.();
+      }
     }
-    setActivePage(nextPage);
-    onPageChange && onPageChange();
   }
 
   useEffect(() => {
-    if (!saveInProgress && pendingSubmission && !(disableProgress && direction === DIRECTION_NEXT)) {
+    if (!saveInProgress && pendingSubmission && !(disableProgress && (nextActivePage > activePage || direction === DIRECTION_NEXT))) {
       setPendingSubmission(false);
       if (activePage === lastValidPage() && direction === DIRECTION_NEXT) {
         setSavedLastPage(true);
         onDone && onDone();
       } else {
         setSavedLastPage(false);
-        handlePageChange();
+        typeof(nextActivePage) != 'undefined' ? activatePage() : handlePageChange();
       }
     }
-  }, [saveInProgress, pendingSubmission, disableProgress]);
+  }, [saveInProgress, pendingSubmission, disableProgress, nextActivePage, direction, activePage]);
 
   let saveButton =
     <Button
@@ -202,6 +234,16 @@ function FormPagination (props) {
   return (
     enabled
     ?
+      variant == "navigable" && pages?.length > 0 ?
+        <FormPageNavigation
+          pages={pages}
+          activePage={activePage}
+          saveButton={saveButton}
+          backButton={backButton}
+          isPageCompleted={isPageCompleted}
+          navigateTo={handleNavigateTo}
+        />
+      :
       lastValidPage() > 0
       ?
         <MobileStepper
@@ -233,10 +275,11 @@ function FormPagination (props) {
 FormPagination.propTypes = {
   enableSave: PropTypes.bool,
   enabled: PropTypes.bool,
-  variant: PropTypes.oneOf(['progress', 'dots', 'text']),
+  variant: PropTypes.oneOf(['progress', 'dots', 'text', "navigable"]),
   navMode: PropTypes.oneOf(['back_next', 'only_next']),
   questionnaireData: PropTypes.object.isRequired,
   setPagesCallback: PropTypes.func.isRequired,
+  isPageCompleted: PropTypes.func.isRequired,
   lastSaveStatus: PropTypes.bool,
   saveInProgress: PropTypes.bool
 };

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Questionnaire.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Questionnaire.json
@@ -20,8 +20,9 @@
       "true" : {
         "paginationVariant" : {
           "progress" : {},
-          "dots": {},
-          "text" : {}
+          "dots" : {},
+          "text" : {},
+          "navigable" : {}
         },
         "paginationMode" : {
            "back_next" : {},


### PR DESCRIPTION
DRAFT because:
* it was only tested on one paginated form as admin; no testing was done as a patient user
* the QuestionnairePreview might also need to be updated (not tested)

**Specs:** : https://phenotips.atlassian.net/browse/CARDS-2526

**Known issues:**
* sometimes `requireCompletion` doesn't work (also happens in `dev` - not introduced in this PR)
* Phone Call Follow-Up - sometimes advancing past the first page requires two attempts (also happens in `dev` - not introduced in this PR)

**To test:**
* Choose a paginated questionnaire or create a new one. Examples of existing paginated questionnaires:
  * `test` : Pagination Test
  * `heracles`: Phone Call Follow-Up
  * `prems`: CPESIC, Rehab
  * `proms`: Smoking cessation
  * `sparc`: Clinician Assessment (the sparc project + navigable pagination are available in branch `sparc-demo-2`
* Set the questionnaire's pagination variant to `navigable`
![image](https://github.com/data-team-uhn/cards/assets/651980/3271c8a0-452d-43d0-976a-9dba54851739)
* Test  the questionnaire preview
* Create a form for the questionnaire
* Test the form with different screen widths
* Test forms with title-less section pages, and with pages made of questions not wrapped in a section