### PR TITLE
CARDS-2529: Conditional sections show up when they shouldn't upon deselecting and reselecting their preconditions (again)

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
@@ -75,7 +75,7 @@ let getValue = function(operand, context) {
     // Otherwise use the value as is
     : operand?.value
   // Filter out blanks, default to empty array
-  )?.filter(v => typeof(v) != 'undefined') || [];
+  )?.filter(v => v !== "" && typeof(v) != 'undefined') || [];
   return value;
 }
 


### PR DESCRIPTION
* Previously fixed in #1764
* Broken again shortly after by #1766
* This PR amends the fix form #1766 to filter out empty strings