### PR TITLE
CARDS-2530: Question Option Descriptions not displayed

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -609,7 +609,7 @@ function generateDefaultOptions(defaults, selection, disabled, isRadio, onClick,
         isDefaultOption={childData[IS_DEFAULT_OPTION_POS]}
         isRadio={isRadio}
         isInvalid={isInvalid}
-        description={childData[DESC_POS] || isInvalid ? validationErrorText : ""}
+        description={childData[DESC_POS] || (isInvalid ? validationErrorText : "")}
       ></StyledResponseChild>
     );
   });


### PR DESCRIPTION
Fix question option descriptions being replaced by default error text when present

Reproduction: On dev, edit any multiple choice question to add a description to one or more of the options. Observe that the description you submitted is not shown and instead `Invalid input` is shown.

Matrix questions are not impacted by this issue

To verify the fix, check that the description is now shown. The description is not being properly formatted but that will be looked at in another PR.