### PR TITLE
CARDS-2540: Add ability to submit questionnaire responses starting with a certain day relative to the appointment, regardless of completion status

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
@@ -35,7 +35,6 @@ export const DEFAULT_PATIENT_ACCESS_CONFIG = {
     tokenlessAuthEnabled: false,
     PIIAuthRequired: false,
     daysRelativeToEventWhileSurveyIsValid: "0",
-    daysPriorToEventWhenIncompleteSurveysCanBeSubmitted: "-1",
     draftLifetime: "-1"
 };
 
@@ -67,10 +66,9 @@ function PatientAccessConfiguration() {
       "Relatively to the associated event, patients can fill out surveys within:",
       "Use a negative number when patient responses are due a number of days before the event, 0 for the day of the event, and a positive number when their responses are expected after the event."
     ],
-    daysPriorToEventWhenIncompleteSurveysCanBeSubmitted: [
-      "Starting at how many days before the event are patients permitted to submit incomplete surveys?",
-      "-1 means incomplete submission is never allowed, 0 means incomplete submission is allowed on the day of the event, a number greater or equal to 1 means incomplete submission is allowed starting at that many days before the event.",
-      "Please use a value of at least 0, or -1 to disable incomplete survey submissions."
+    daysRelativeToEventWhenIncompleteSurveysCanBeSubmitted: [
+      "Relatively to the associated event, patients can start submitting incomplete surveys within:",
+      "An absent value means patients are never allowed to submit incomplete surveys. Use a negative number when incomplete surveys are permitted a number of days before the event and onward, 0 for the day of the event and onward, and a positive number if incomplete submission is permitted a number of days after the event and onward.",
     ],
     draftLifetime: [
       "Patients can edit unsubmitted responses for:",
@@ -80,7 +78,6 @@ function PatientAccessConfiguration() {
   };
 
   const LIMITS = {
-    daysPriorToEventWhenIncompleteSurveysCanBeSubmitted: {min: -1},
     draftLifetime: {min: -1}
   }
 
@@ -123,7 +120,7 @@ function PatientAccessConfiguration() {
             onChange={event => onInputValueChanged(key, event.target.value)}
             onBlur={event => onInputValueChanged(key, event.target.value)}
             placeholder={DEFAULT_PATIENT_ACCESS_CONFIG[key] || ""}
-            value={patientAccessConfig?.[key]}
+            value={patientAccessConfig?.[key] || ""}
             error={error[key]}
             helperText={error[key] ? LABELS[key][2] : LABELS[key][1]}
             InputProps={{
@@ -149,7 +146,7 @@ function PatientAccessConfiguration() {
             { renderConfigCheckbox("tokenlessAuthEnabled") }
             { renderConfigCheckbox("PIIAuthRequired", patientAccessConfig?.tokenlessAuthEnabled) }
             { renderConfigInput("daysRelativeToEventWhileSurveyIsValid", "days") }
-            { renderConfigInput("daysPriorToEventWhenIncompleteSurveysCanBeSubmitted", "days") }
+            { renderConfigInput("daysRelativeToEventWhenIncompleteSurveysCanBeSubmitted", "days") }
             { renderConfigInput("draftLifetime", "days") }
           </List>
       </AdminConfigScreen>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
@@ -35,6 +35,7 @@ export const DEFAULT_PATIENT_ACCESS_CONFIG = {
     tokenlessAuthEnabled: false,
     PIIAuthRequired: false,
     daysRelativeToEventWhileSurveyIsValid: "0",
+    daysPriorToEventWhenIncompleteSurveysCanBeSubmitted: "-1",
     draftLifetime: "-1"
 };
 
@@ -66,6 +67,11 @@ function PatientAccessConfiguration() {
       "Relatively to the associated event, patients can fill out surveys within:",
       "Use a negative number when patient responses are due a number of days before the event, 0 for the day of the event, and a positive number when their responses are expected after the event."
     ],
+    daysPriorToEventWhenIncompleteSurveysCanBeSubmitted: [
+      "Starting at how many days before the event are patients permitted to submit incomplete surveys?",
+      "-1 means incomplete submission is never allowed, 0 means incomplete submission is allowed on the day of the event, a number greater or equal to 1 means incomplete submission is allowed starting at that many days before the event.",
+      "Please use a value of at least 0, or -1 to disable incomplete survey submissions."
+    ],
     draftLifetime: [
       "Patients can edit unsubmitted responses for:",
       "-1 means that drafts are kept until the patient is no longer able to access their surveys, 0 means drafts are deleted daily at midnight, 1 means they are kept until the next day at midmight, etc.",
@@ -74,6 +80,7 @@ function PatientAccessConfiguration() {
   };
 
   const LIMITS = {
+    daysPriorToEventWhenIncompleteSurveysCanBeSubmitted: {min: -1},
     draftLifetime: {min: -1}
   }
 
@@ -142,6 +149,7 @@ function PatientAccessConfiguration() {
             { renderConfigCheckbox("tokenlessAuthEnabled") }
             { renderConfigCheckbox("PIIAuthRequired", patientAccessConfig?.tokenlessAuthEnabled) }
             { renderConfigInput("daysRelativeToEventWhileSurveyIsValid", "days") }
+            { renderConfigInput("daysPriorToEventWhenIncompleteSurveysCanBeSubmitted", "days") }
             { renderConfigInput("draftLifetime", "days") }
           </List>
       </AdminConfigScreen>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -211,17 +211,17 @@ function QuestionnaireSet(props) {
 
   // Initialize the `canSubmitIncomplete` setting based on the config and the visit date
   useEffect(() => {
-    if (config?.daysPriorToEventWhenIncompleteSurveysCanBeSubmitted >= 0 && visitInformation) {
+    if (!Number.isNaN(+(config?.daysRelativeToEventWhenIncompleteSurveysCanBeSubmitted)) && visitInformation) {
       let visitDate = getVisitDate();
-      let dateIncompleteSubmissionEnabled = visitDate.minus({
-        days: config.daysPriorToEventWhenIncompleteSurveysCanBeSubmitted
+      let dateIncompleteSubmissionEnabled = visitDate.plus({
+        days: config.daysRelativeToEventWhenIncompleteSurveysCanBeSubmitted
       }).endOf('day');
       const diff = dateIncompleteSubmissionEnabled.diffNow(["days"]);
       if (Math.floor(diff["days"]) <= 0) {
         setCanSubmitIncomplete(true);
       }
     }
-  }, [config?.daysPriorToEventWhenIncompleteSurveysCanBeSubmitted, visitInformation]);
+  }, [config?.daysRelativeToEventWhenIncompleteSurveysCanBeSubmitted, visitInformation]);
 
   // Determine the screen type (and style) based on the step number
   useEffect(() => {

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -794,16 +794,20 @@ function QuestionnaireSet(props) {
         ))}
         </List>,
         <Typography color="error" key="incomplete-message">Your answers are incomplete. Please update your answers by responding to all mandatory questions.</Typography>,
-        <Grid container spacing={2} direction="row">
-          <Grid item>
-            <Fab variant="extended" color="primary" onClick={() => {setCrtStep(-1)}} key="incomplete-button">Update my answers</Fab>
+        <>
+        { canSubmitIncomplete ?
+          <Grid container spacing={2} direction="row">
+            <Grid item>
+              <Button variant="contained" color="primary" onClick={() => {setCrtStep(-1)}} key="incomplete-button">Update my answers</Button>
+            </Grid>
+            <Grid item>
+              <Button variant="outlined" color="primary" onClick={() => setSubmittingIncomplete(true)}>Proceed anyway</Button>
+            </Grid>
           </Grid>
-        { canSubmitIncomplete &&
-          <Grid item>
-            <Fab variant="extended" color="secondary" onClick={() => setSubmittingIncomplete(true)}>Proceed anyway</Fab>
-          </Grid>
+          :
+          <Fab variant="extended" color="primary" onClick={() => {setCrtStep(-1)}} key="incomplete-button">Update my answers</Fab>
         }
-        </Grid>
+        </>
   ];
 
   let exitScreen = (


### PR DESCRIPTION
Specs: https://phenotips.atlassian.net/browse/CARDS-2540

The implementation differs slightly from the specs: instead of enabling incomplete submission 24h before, it can be enabled the day of the visit, or the day before the visit, or any number of days before or after the visit. Incomplete submission becomes enabled at midnight.

To test:
* start in `prems` or `proms`
* Administration / Patient Access -> change the incomplete submission setting according to helper text
* Create visits with surveys
   * test that visits occurring earlier than `<setting>` days before visit are (still) required to be complete in order to be submitted
   * test that visits occurring later than `<setting>` days before visit are NOT required to be complete in order to be submitted