### PR TITLE
CARDS-2557: User Dashboard: if there are no action extensions, do not display the (+) button

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -89,6 +89,7 @@ function UserDashboard(props) {
 
   return (
     <React.Fragment>
+    { dashboardExtensions.length > 0 &&
       <Grid container spacing={4} className={classes.dashboardContainer}>
         {
           dashboardExtensions.map((extension, index) => {
@@ -99,6 +100,8 @@ function UserDashboard(props) {
           })
         }
       </Grid>
+    }
+    { creationExtensions.length > 0 && <>
       <ResponsiveDialog title="New" width="xs" open={open} onClose={onClose}>
         <DialogContent dividers className={classes.dialogContentWithTable}>
           <MaterialReactTable
@@ -175,6 +178,7 @@ function UserDashboard(props) {
             />
         })
       }
+    </>}
     </React.Fragment>
   );
 }


### PR DESCRIPTION
* Launch cards with `--dev`
* **Regression testing:** when launching cards built from this branch, the User Dashboard (+) button should be present
* From /bin/browser, disable the 2 extensions listed under `Extensions/DashboardMenuItems/`: 
  * http://localhost:8080/bin/browser.html/Extensions/DashboardMenuItems/NewFormDialog - set `cards:defaultDisabled` to true
  * http://localhost:8080/bin/browser.html/Extensions/DashboardMenuItems/NewSubjectDialog - set `cards:defaultDisabled` to true
* Refresh the User Dashboard - the (+) button should no longer be present