### PR TITLE
[misc] Minor refactoring in NewSubjectDialog and NewFormDialog

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -157,9 +157,7 @@ function FormView(props) {
         />
       }
       { expanded &&
-        <NewFormDialog presetPath={questionnaire}>
-          New questionnaire
-        </NewFormDialog>
+        <NewFormDialog presetPath={questionnaire} withButton buttonTitle="New questionnaire" />
       }
       </CardContent>
     </Card>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -469,6 +469,7 @@ function NewFormDialog(props) {
         currentSubject={currentSubject}
         onSubmit={createForm}
         open={newSubjectPopperOpen}
+        disableRedirect
         />
       {
         mode === MODE_ACTION &&

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -46,7 +46,7 @@ const PROGRESS_SELECT_SUBJECT = 1;
  * @param {presetPath} string The questionnaire to use automatically, if any.
  */
 function NewFormDialog(props) {
-  const { classes, presetPath, currentSubject, theme, mode, open, onClose, withButton, buttonTitle } = {open: false, ...props };
+  const { classes, presetPath, currentSubject, theme, open, onClose, withButton, buttonTitle } = {open: false, ...props };
   const [ dialogOpen, setDialogOpen ] = useState(false);
   const [ newSubjectPopperOpen, setNewSubjectPopperOpen ] = useState(false);
   const [ initialized, setInitialized ] = useState(false);

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -39,16 +39,14 @@ import FormattedText from "../components/FormattedText.jsx";
 
 const PROGRESS_SELECT_QUESTIONNAIRE = 0;
 const PROGRESS_SELECT_SUBJECT = 1;
-export const MODE_ACTION = 0;
-export const MODE_DIALOG = 1;
 
 /**
- * A component that renders a FAB to open a dialog to create a new form.
+ * A component that renders a dialog to create a new form, and optionally a FAB to activate the dialog.
  *
  * @param {presetPath} string The questionnaire to use automatically, if any.
  */
 function NewFormDialog(props) {
-  const { children, classes, presetPath, currentSubject, theme, mode, open, onClose } = { mode: MODE_ACTION, open: false, ...props };
+  const { classes, presetPath, currentSubject, theme, mode, open, onClose, withButton, buttonTitle } = {open: false, ...props };
   const [ dialogOpen, setDialogOpen ] = useState(false);
   const [ newSubjectPopperOpen, setNewSubjectPopperOpen ] = useState(false);
   const [ initialized, setInitialized ] = useState(false);
@@ -224,7 +222,7 @@ function NewFormDialog(props) {
   const isFetching = numFetchRequests > 0;
   if (wasOpen !== open) {
     setWasOpen(open);
-    if (MODE_DIALOG) {
+    if (!withButton) {
       openDialog();
     }
   }
@@ -347,7 +345,7 @@ function NewFormDialog(props) {
     <React.Fragment>
       <ResponsiveDialog
         title={progress === PROGRESS_SELECT_QUESTIONNAIRE ? "Select a questionnaire" : "Select a subject"}
-        open={mode === MODE_ACTION ? dialogOpen : open}
+        open={withButton ? dialogOpen : open}
         onClose={() => {
           resetDialogState();
           closeAllDialogs();
@@ -472,9 +470,9 @@ function NewFormDialog(props) {
         disableRedirect
         />
       {
-        mode === MODE_ACTION &&
+        withButton &&
           <NewItemButton
-            title={children}
+            title={buttonTitle}
             onClick={openDialog}
             inProgress={!dialogOpen && isFetching}
           />

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
@@ -171,7 +171,6 @@ function SubjectView(props) {
         <NewSubjectDialog
           onClose={() => { setNewSubjectPopperOpen(false);}}
           onSubmit={() => { setNewSubjectPopperOpen(false);}}
-          openNewSubject={true}
           open={newSubjectPopperOpen}
         />
       </>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -169,8 +169,6 @@ function UserDashboard(props) {
             onSubmit={onClose}
             // NewFormDialog specific argument
             mode={MODE_DIALOG}
-            // NewSubjectDialog specific argument
-            openNewSubject={true}
             key={"extensionDialog-" + index}
             />
         })

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -24,7 +24,6 @@ import { loadExtensions } from "../uiextension/extensionManager";
 import NewItemButton from "../components/NewItemButton.jsx";
 import ResponsiveDialog from "../components/ResponsiveDialog"; // commons
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
-import { MODE_DIALOG } from "../dataHomepage/NewFormDialog.jsx";
 
 import {
   Button,
@@ -167,8 +166,6 @@ function UserDashboard(props) {
             open={index === selectedCreation}
             onClose={onClose}
             onSubmit={onClose}
-            // NewFormDialog specific argument
-            mode={MODE_DIALOG}
             key={"extensionDialog-" + index}
             />
         })

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -118,9 +118,7 @@ function Subject(props) {
 
   return (
     <React.Fragment>
-      <NewFormDialog currentSubject={currentSubject}>
-        { "New questionnaire for this " + (currentSubject?.type?.label || "Subject") }
-      </NewFormDialog>
+      <NewFormDialog currentSubject={currentSubject} withButton buttonTitle={ "New questionnaire for this " + (currentSubject?.type?.label || "Subject") } />
       <Grid container spacing={4} direction="column" className={classes.subjectContainer}>
         <SubjectHeader id={currentSubjectId} key={"SubjectHeader"} pageTitle={pageTitle} classes={classes} getSubject={handleSubject} history={history} contentOffset={props.contentOffset}/>
         <Grid item>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -399,11 +399,11 @@ export const parseToArray = (object) => {
  * @param {bool} disabled If true, all controls are disabled
  * @param {func} onClose Callback fired when the user tries to close this dialog
  * @param {func} onSubmit Callback fired when the user clicks the "Create" or "Continue" button
- * @param {bool} openNewSubject whether to redirect to the newly created subject upon successful creation
+ * @param {bool} disableRedirect Whether to disable the default behavior of redirecting to the newly created subject upon successful creation
  * @param {bool} open If true, this dialog is open
  */
 export function NewSubjectDialog (props) {
-  const { allowedTypes, currentSubject, disabled, onClose, onSubmit, open, openNewSubject } = props;
+  const { allowedTypes, currentSubject, disabled, onClose, onSubmit, open, disableRedirect } = props;
   const [ error, setError ] = useState("");
   const [ newSubjectName, setNewSubjectName ] = useState([""]);
   const [ newSubjectType, setNewSubjectType ] = useState([""]);
@@ -432,7 +432,7 @@ export function NewSubjectDialog (props) {
       onClose();
       // redirect to the new just created subject page
       let subjectId = getSubjectIdFromPath(subject);
-      if (openNewSubject && subjectId) {
+      if (!disableRedirect && subjectId) {
         history.push({
           pathname: "/content.html/Subjects/" + subjectId
         });


### PR DESCRIPTION
**NewSubjectDialog:**
* Property `openNewSubject` is replaced by `disableRedirect`, with opposite meaning, so that the default behavior is to redirect to the newly created subject.

**NewFormDialog:**
* Display only the dialog (no fab) by default, so that the behavior matches the component name
* Add an optional property `withButton` to have the dialog initially closed and render a Fab that opens it.

**Testing:**
* There should be no functionality changes.
* Test that new subject creation still works as before everywhere in cards: by itself on the Dashboard &  Subjects page, and as a step of the new Form creation on the Dashboard, Forms page, subject pages.
* Test that the new form creation works on the Dashboard, Forms page, subject pages.