### PR TITLE
CARDS-2575: Submitted IP/ED forms will be deleted if the clinic switches to Integrated Care

### DIFF
--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupScheduler.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupScheduler.java
@@ -67,7 +67,7 @@ public class UnsubmittedFormsCleanupScheduler
     {
         try {
             // Every night at midnight
-            final ScheduleOptions options = this.scheduler.EXPR("0 0 0 * * ? *");
+            final ScheduleOptions options = this.scheduler.EXPR("0 0 1 * * ? *");
             options.name(SCHEDULER_JOB_NAME);
             options.canRunConcurrently(false);
 

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
@@ -116,10 +116,10 @@ public class UnsubmittedFormsCleanupTask implements Runnable
                         // link to the correct Visit Information questionnaire
                         + "  visitInformation.questionnaire = '%1$s'"
                         // link to the exact clinic in Visit Information form
-                        + "  and clinic.value = '%5$s'"
+                        + "  and clinic.value = '%4$s'"
                         // the visit date is in the past
                         + "  and visitDate.question = '%2$s'"
-                        + "  and visitDate.value < '%4$s'"
+                        + "  and visitDate.value < '%3$s'"
                         // the form is not submitted
                         + "  and not dataForm.statusFlags = 'SUBMITTED'"
                         // exclude the Visit Information form itself

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/UnsubmittedFormsCleanupTask.java
@@ -86,8 +86,6 @@ public class UnsubmittedFormsCleanupTask implements Runnable
                 (String) resolver.getResource("/Questionnaires/Visit information").getValueMap().get("jcr:uuid");
             final String time =
                 (String) resolver.getResource("/Questionnaires/Visit information/time").getValueMap().get("jcr:uuid");
-            final String submitted = (String) resolver
-                .getResource("/Questionnaires/Visit information/surveys_submitted").getValueMap().get("jcr:uuid");
             final int patientTokenLifetime = this.patientAccessConfiguration.getDaysRelativeToEventWhileSurveyIsValid();
 
             // Find all clinics to iterate over
@@ -114,8 +112,6 @@ public class UnsubmittedFormsCleanupTask implements Runnable
                         + "       on clinic.form = visitInformation.[jcr:uuid]"
                         + "    inner join [cards:DateAnswer] as visitDate"
                         + "       on visitDate.form=visitInformation.[jcr:uuid]"
-                        + "    inner join [cards:BooleanAnswer] as submitted"
-                        + "      on submitted.form = visitInformation.[jcr:uuid]"
                         + " where"
                         // link to the correct Visit Information questionnaire
                         + "  visitInformation.questionnaire = '%1$s'"
@@ -124,13 +120,12 @@ public class UnsubmittedFormsCleanupTask implements Runnable
                         // the visit date is in the past
                         + "  and visitDate.question = '%2$s'"
                         + "  and visitDate.value < '%4$s'"
-                        // the visit is not submitted
-                        + "  and submitted.question = '%3$s'"
-                        + "  and (submitted.value <> 1 OR submitted.value IS NULL)"
+                        // the form is not submitted
+                        + "  and not dataForm.statusFlags = 'SUBMITTED'"
                         // exclude the Visit Information form itself
                         + "  and dataForm.questionnaire <> '%1$s'"
                         + " option (index tag cards)",
-                    visitInformationQuestionnaire, time, submitted,
+                    visitInformationQuestionnaire, time,
                     ZonedDateTime.now().minusDays(delay)
                         .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSxxx")), clinicPath),
                     Query.JCR_SQL2);


### PR DESCRIPTION
To test:
- build the **`CARDS-2575-test`** branch
- create a new visit PE1/E1 for ED set a week ago, generate a token, fill in and submit as the patient
- create a new visit PE2/E2 for ED set a week ago, generate a token, fill in as the patient but DO NOT submit
- create a new visit PE3/E3 for ED set a week ago, leave empty
- create a new visit PI1/I1 for ED set a week ago, generate a token, fill in and submit as the patient
- change the clinic of I1 to IC
- create a new visit PI2/I2 for ED set a week ago, generate a token, fill in and submit as the patient
- change the clinic of I2 to IC
- create a new visit PI3/I3 for ED set a week ago, generate a token, fill in and submit as the patient
- change the clinic of I3 to IC
- create a new visit PEI1/EI1 for ED+IC set a week ago, leave empty
- create a new visit PEI2/EI2 for ED set a week ago, generate a token, fill in as the patient but DO NOT submit
- change the clinic of EI2 to ED+IC
- create a new visit PEI3/EI3 for ED+IC set a week ago, leave empty
- change all visits' dates to 5 week ago
- wait a couple of minutes
- check that E2/ED and E3/ED data forms were deleted, but not any of the others
- generate tokens, fill in and submit visits I1, EI1
- generate tokens, fill in but do not submit visits I2, EI2 (check that for EI2 the ED form was still completed, the previous answers were presented in the survey summary)
- change all visits' dates to 10 week ago
- wait a couple of minutes
- check that I2/IC, I3/IC, EI2/all, EI3/all data forms were deleted, but not any of the others

Intended results:
ED-only:
- E1 submitted, keeps ED
- E2 completed, deletes ED
- E3 empty, deletes ED

ED then IC:
- I1 submitted, keeps ED and IC
- I2 completed, keeps ED deletes IC
- I3 empty, keeps ED deletes IC

ED+IC:
- EI1 submitted, keeps ED and IC
- EI2 completed, deletes all
- EI3 empty, deletes all

After the initial steps of generating visits, these data forms should be present: E1/ED, E2/ED, E3/ED, I1/ED, I1/IC, I2/ED, I2/IC, I3/ED, I3/IC, EI1/ED, EI1/IC, EI2/ED, EI2/IC, EI3/ED, EI3/IC.

After changing visit dates to 5 weeks ago and waiting a couple of minutes, these data forms should be present: E1/ED, I1/ED, I1/IC, I2/ED, I2/IC, I3/ED, I3/IC, EI1/ED, EI1/IC, EI2/ED, EI2/IC, EI3/ED, EI3/IC. These should be missing: E2/ED, E3/ED.

After changing visit dates to 10 weeks ago and waiting a couple of minutes, these data forms should be present: E1/ED, I1/ED, I1/IC, I2/ED, I3/ED, EI1/ED, EI1/IC. These should be missing: E2/ED, E3/ED, I2/IC, I3/IC, EI2/ED, EI2/IC, EI3/ED, EI3/IC.

Wrong behavior in dev: I2/ED and I3/ED would also be deleted when they shouldn't.