### PR TITLE
HERACLES-31: Auto create visit numbers for heracles forms

### DIFF
--- a/heracles-resources/backend/pom.xml
+++ b/heracles-resources/backend/pom.xml
@@ -58,6 +58,10 @@
       <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.metatype.annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.jcr</groupId>
       <artifactId>jcr</artifactId>
     </dependency>

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/VisitNumberConfiguration.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/VisitNumberConfiguration.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.heracles.internal;
+
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+import io.uhndata.cards.forms.api.FormUtils;
+
+/**
+ * The configuration details for a form that needs automatic visit numbers.
+ * Includes details about:
+ * - The questions that have required information for determining the visit
+ * - The lists of valid visit numbers for both streams
+ * - The questions to save the visit number into depending on the stream
+ * - Functions to retrieve questions and answers associated from forms for this questionnaire
+ *
+ * @version $Id$
+ */
+@Component(
+    configurationPolicy = ConfigurationPolicy.REQUIRE,
+    immediate = true,
+    service = VisitNumberConfiguration.class)
+@Designate(
+    ocd = VisitNumberConfiguration.Config.class,
+    factory = true)
+public class VisitNumberConfiguration
+{
+    private static final String STREAM_LOW = "Low Touch";
+    private static final String STREAM_HIGH = "High Touch";
+
+    // Configured parameters
+    private String questionnaire;
+    private long[] visitsLow;
+    private long[] visitsHigh;
+    private String visitPathLow;
+    private String visitPathHigh;
+    private String studyStreamPath;
+
+    @ObjectClassDefinition(name = "Visit Number Configuration",
+        description = "Configuration for the Visit Number Editor that auto fills the "
+            + "visit number for applicable Heracles forms.")
+    public @interface Config
+    {
+        @AttributeDefinition(name = "Questionnaire",
+            description = "The path to a questionnaire that needs a visit nunmber")
+        String questionnairePath();
+
+        @AttributeDefinition(name = "Visit Numbers - Low",
+            description = "The valid visit numbers for low stream visits")
+        long[] visitsLow();
+
+        @AttributeDefinition(name = "Visit Numbers - High",
+            description = "The valid visit numbers for high stream visits")
+        long[] visitsHigh();
+
+        @AttributeDefinition(name = "Visit Path - Low",
+            description = "The path to the visit number question that should be filled out for low stream visits")
+        String visitPathLow();
+
+        @AttributeDefinition(name = "Visit Path - High",
+            description = "The path to the visit number question that should be filled out for high stream visits")
+        String visitPathHigh();
+
+        @AttributeDefinition(name = "Study Stream Path",
+            description = "The path the the question that contains the study stream."
+            + " This should be a reference question that references the study stream questionnaire")
+        String studyStreamPath();
+    }
+
+
+    @Activate
+    public VisitNumberConfiguration(final Config config)
+    {
+        this.questionnaire = config.questionnairePath();
+        this.visitsLow = config.visitsLow();
+        this.visitsHigh = config.visitsHigh();
+        this.visitPathLow = config.visitPathLow();
+        this.visitPathHigh = config.visitPathHigh();
+        this.studyStreamPath = config.studyStreamPath();
+    }
+
+    /**
+     * Retrieve the questionnaire path that this configuration applies to.
+     * @return the questionnaire path
+     */
+    public String getQuestionnairePath()
+    {
+        return this.questionnaire;
+    }
+
+    /**
+     * Get a list of the valid visit numbers for this questionnaire for the provided stream.
+     * @param studyStream The stream for this subject. Expects {@code "Low Touch"} or {@code "High Touch"}.
+     *                    Defaults to High Touch if an unexpected stream is provided
+     * @return The valid visit numbers for this stream
+     */
+    public long[] getScheduledVisits(String studyStream)
+    {
+        return VisitNumberConfiguration.STREAM_LOW.equals(studyStream) ? this.visitsLow : this.visitsHigh;
+    }
+
+    /**
+     * Get the path to the visit number question for the provided stream.
+     * @param studyStream The stream for this subject. Expects {@code "Low Touch"} or {@code "High Touch"}.
+     *                    Defaults to High Touch if an unexpected stream is provided
+     * @return a relative path to the visit number question from the {@code Questionnaire} node
+     */
+    public String getVisitPath(String studyStream)
+    {
+        return VisitNumberConfiguration.STREAM_LOW.equals(studyStream) ? this.visitPathLow : this.visitPathHigh;
+    }
+
+    /**
+     * Get a visit number question for the provided stream.
+     * @param session the session to be used to retrieve the question node
+     * @param studyStream The stream for this subject. Expects {@code "Low Touch"} or {@code "High Touch"}.
+     *                    Defaults to High Touch if an unexpected stream is provided
+     * @return the {@code Question} node for the visit number. May be {@code null}
+     */
+    public Node getVisitQuestion(Session session, String studyStream)
+    {
+        return getQuestion(session,
+            VisitNumberConfiguration.STREAM_LOW.equals(studyStream) ? this.visitPathLow : this.visitPathHigh);
+    }
+
+    /**
+     * Get the question which contains the study stream for the current questionnaire.
+     * @param session the session to be used to retrieve the question node
+     * @return the {@code Question} node for the study stream question. May be {@code null}
+     */
+    public Node getStudyStreamQuestion(Session session)
+    {
+        return getQuestion(session, this.studyStreamPath);
+    }
+
+    /**
+     * Retrieve the visit number answer for a given form.
+     * Will return either high or low stream visit numbers depending on which is available
+     * @param session the session to be used to retrieve the visit number
+     * @param formUtils An {@code FormUtils} instance to be used to help retrieve the visit number
+     * @param form the form to retrieve the visit number for
+     * @return A visit number included in the form's answers or {@code null} if no answer could be found
+     */
+    public Long getVisitNumber(Session session, FormUtils formUtils, Node form)
+    {
+        Long visitLow = getVisitNumber(session, formUtils, form, VisitNumberConfiguration.STREAM_LOW);
+
+        // Only one (or neither) visit should have an answer.
+        // If no low answer, return the high answer or the default of null if it isn't present either
+        if (visitLow == null) {
+            return getVisitNumber(session, formUtils, form, VisitNumberConfiguration.STREAM_HIGH);
+        } else {
+            return visitLow;
+        }
+    }
+
+    /**
+     * Check if this configuration is for a provided questionnaire.
+     * @param questionnaire the questionnaire node to compare against
+     * @return {@code true} if this configuration is for the provided questionnaire node
+     */
+    public boolean matches(Node questionnaire)
+    {
+        try {
+            return this.questionnaire.equals(questionnaire.getPath());
+        } catch (RepositoryException e) {
+            return false;
+        }
+    }
+
+    // Get the visit number for a given form and study string.
+    // Returns null if no value could be found
+    private Long getVisitNumber(Session session, FormUtils formUtils, Node form, String studyStream)
+    {
+        try {
+            Property answerProperty = getAnswerProperty(formUtils, form, this.getVisitQuestion(session, studyStream));
+            return answerProperty == null ? null : answerProperty.getLong();
+        } catch (RepositoryException e) {
+            return null;
+        }
+    }
+
+    // Retrieve the question node that exists at a given subpath from the current questionnaire.
+    // Returns null if it could not be found
+    private Node getQuestion(Session session, String subPath)
+    {
+        try {
+            return session.getNode(this.questionnaire + "/" + subPath);
+        } catch (RepositoryException e) {
+            return null;
+        }
+    }
+
+    // Retrieve the property containing an answer for a given form and question.
+    // Returns null if the property could not be found
+    private Property getAnswerProperty(FormUtils formUtils, Node form, Node question)
+        throws RepositoryException
+    {
+        Node answerNode = formUtils.getAnswer(form, question);
+        if (answerNode != null && answerNode.hasProperty(FormUtils.VALUE_PROPERTY)) {
+            return answerNode.getProperty(FormUtils.VALUE_PROPERTY);
+        } else {
+            return null;
+        }
+    }
+}

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/VisitNumberEditor.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/VisitNumberEditor.java
@@ -1,0 +1,358 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.heracles.internal;
+
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.spi.commit.DefaultEditor;
+import org.apache.jackrabbit.oak.spi.commit.Editor;
+import org.apache.jackrabbit.oak.spi.state.ChildNodeEntry;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.uhndata.cards.forms.api.FormUtils;
+import io.uhndata.cards.forms.api.QuestionnaireUtils;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
+
+/**
+ * Visit Editor looking for new Heracles forms that should have a visit number auto-created.
+ * When a new form matching one of the configured questionnaires is detected, it will check for
+ * a study stream answer using the study stream reference question's path to determine which
+ * visit numbers are valid. It will then check for other instances of the same questionnaire on
+ * the subject and set the visit number to the lowest unused valid number for the study stream.
+ *
+ * @version $Id$
+ */
+public class VisitNumberEditor extends DefaultEditor
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(VisitNumberEditor.class);
+
+    private final ResourceResolverFactory rrf;
+
+    private final ThreadResourceResolverProvider rrp;
+
+    private final FormUtils formUtils;
+
+    private final QuestionnaireUtils questionnaireUtils;
+
+    private boolean isForm;
+
+    private boolean isNew;
+
+    private List<VisitNumberConfiguration> questionnaireDetails;
+
+    private NodeBuilder currentNodeBuilder;
+
+    public VisitNumberEditor(final NodeBuilder nodeBuilder, final ResourceResolverFactory rrf,
+        final ThreadResourceResolverProvider rrp, final FormUtils formUtils,
+        final QuestionnaireUtils questionnaireUtils, final boolean isNew,
+        final List<VisitNumberConfiguration> questionnaireDetails)
+    {
+        this.currentNodeBuilder = nodeBuilder;
+        this.rrf = rrf;
+        this.rrp = rrp;
+        this.formUtils = formUtils;
+        this.questionnaireUtils = questionnaireUtils;
+        this.isNew = isNew;
+        this.questionnaireDetails = questionnaireDetails;
+
+        boolean mustPopResolver = false;
+        try (ResourceResolver resolver = this.rrf
+            .getServiceResourceResolver(Map.of(ResourceResolverFactory.SUBSERVICE, "VisitNumberEditor")))
+        {
+            this.rrp.push(resolver);
+            mustPopResolver = true;
+
+            this.isForm = formUtils.isForm(nodeBuilder);
+        } catch (LoginException e) {
+            LOGGER.warn("Failed to get service session to check form state {}", e.getMessage(), e);
+        } finally {
+            if (mustPopResolver) {
+                this.rrp.pop();
+            }
+        }
+    }
+
+    @Override
+    public Editor childNodeAdded(final String name, final NodeState after)
+    {
+        return processChildNode(name, null, after);
+    }
+
+    @Override
+    public Editor childNodeChanged(final String name, final NodeState before, final NodeState after)
+    {
+        return processChildNode(name, before, after);
+    }
+
+    private Editor processChildNode(final String name, final NodeState before, final NodeState after)
+    {
+        if (this.isForm) {
+            // Found a form: no need to traverse further
+            return null;
+        } else {
+            return new VisitNumberEditor(this.currentNodeBuilder.getChildNode(name), this.rrf, this.rrp,
+                this.formUtils, this.questionnaireUtils, before == null, this.questionnaireDetails);
+        }
+    }
+
+    @Override
+    public void leave(final NodeState before, final NodeState after)
+    {
+        // When the form node is found, save its NodeBuilder
+        if (this.isForm && this.isNew) {
+            handleNewForm(after);
+        }
+    }
+
+    // Check if the new form needs to have a visit number assigned and do so if required
+    private void handleNewForm(NodeState after)
+    {
+        boolean mustPopResolver = false;
+        try (ResourceResolver resolver = this.rrf
+            .getServiceResourceResolver(Map.of(ResourceResolverFactory.SUBSERVICE, "VisitNumberEditor"))) {
+            this.rrp.push(resolver);
+            mustPopResolver = true;
+
+            Node questionnaireNode = this.formUtils.getQuestionnaire(after);
+
+            // Get the configuration details for the current questionnaire.
+            // If no configuration details are available, this form does not need to be modified
+            VisitNumberConfiguration details = getQuestionnaireDetails(questionnaireNode);
+            if (details != null) {
+                String subjectUUID = this.formUtils.getSubjectIdentifier(after);
+                String studyStream = getStudyStream(resolver, details, subjectUUID);
+                // Retrieve the set of visit numbers that already exist for the current subject and questionnaire
+                Set<Long> existingVisits = findExistingVisits(resolver, details, subjectUUID, questionnaireNode);
+
+                // If there is an unused valid visit number for the current questionnaire and stream, save that
+                for (Long visit : details.getScheduledVisits(studyStream)) {
+                    if (!existingVisits.contains(visit)) {
+                        setVisitNumber(visit, details, studyStream, questionnaireNode);
+                        return;
+                    }
+                }
+            }
+        } catch (LoginException e) {
+            LOGGER.warn("Failed to get service session to update form {}", e.getMessage(), e);
+        } catch (ItemNotFoundException e) {
+            LOGGER.info("Unable to locate required information for setting visit number");
+        } catch (RepositoryException e) {
+            LOGGER.warn("Enexpected error processing visit number {}", e.getMessage(), e);
+        } finally {
+            if (mustPopResolver) {
+                this.rrp.pop();
+            }
+        }
+    }
+
+    // Retrieve the configured details for the specified questionnaire.
+    // Returns null if nothing found
+    private VisitNumberConfiguration getQuestionnaireDetails(Node questionnaireNode)
+    {
+        // Get the information needed from the triggering form
+        return this.questionnaireDetails.stream()
+            .filter(details -> details.matches(questionnaireNode)).findAny().orElse(null);
+    }
+
+    // Retrieve the study stream for the specified subject.
+    // Cannot retrieve this data directly from the reference question on the current form as Editors cannot
+    // see the modifications made by other Editors during the current commit (namely the ReferenceAnswerEditor)
+    // so instead pull the study stream from the Study Stream form using the study stream reference question's path.
+    // Throws itemNotFoundException if a study stream could not be found.
+    private String getStudyStream(final ResourceResolver resolver, final VisitNumberConfiguration details,
+        final String subjectUUID)
+        throws RepositoryException
+    {
+        // Study stream question from the current form's questionnaire
+        Node studyStreamReferenceQuestion = details.getStudyStreamQuestion(resolver.adaptTo(Session.class));
+        // Study stream question from the study stream questionnaire
+        Node studyStreamSourceQuestion = studyStreamReferenceQuestion.getProperty("question").getNode();
+        // UUID of the study stream questionnaire's study stream question
+        String sourceQuestionnaireUUID = this.questionnaireUtils.getOwnerQuestionnaire(studyStreamSourceQuestion)
+            .getIdentifier();
+
+        // Get the study stream form for the current subject, if present
+        Iterator<Resource> sourceForms = this.getSubjectForms(resolver, sourceQuestionnaireUUID, subjectUUID);
+        if (sourceForms.hasNext()) {
+            Node foundForm = sourceForms.next().adaptTo(Node.class);
+            Node studyStreamAnswer = this.formUtils.getAnswer(foundForm, studyStreamSourceQuestion);
+            Property answerProperty = studyStreamAnswer.getProperty("value");
+
+            // Throw an exception if a study stream could not be found to halt processing early
+            if (answerProperty == null) {
+                throw new ItemNotFoundException();
+            }
+            return answerProperty.getString();
+        } else {
+            // Throw an exception if a study stream could not be found to halt processing early
+            throw new ItemNotFoundException();
+        }
+    }
+
+    // Get the set of visit numbers that exist for the current subject and questionnaire.
+    // This is study stream agnostic as we don't want to duplicate visits even if the subject has changed streams
+    private Set<Long> findExistingVisits(final ResourceResolver resolver, final VisitNumberConfiguration details,
+        final String subjectUUID, final Node questionnaireNode)
+        throws RepositoryException
+    {
+        Iterator<Resource> foundForms = getSubjectForms(resolver, questionnaireNode.getIdentifier(), subjectUUID);
+
+        Set<Long> recordedVisits = new HashSet<>();
+        while (foundForms.hasNext()) {
+            Node foundForm = foundForms.next().adaptTo(Node.class);
+            recordedVisits.add(details.getVisitNumber(resolver.adaptTo(Session.class), this.formUtils, foundForm));
+        }
+
+        return recordedVisits;
+    }
+
+    // Get all the forms for a given subject and questionnaire
+    private Iterator<Resource> getSubjectForms(final ResourceResolver resolver, final String questionnaireUUID,
+        final String subjectUUID)
+    {
+        String sqlQuery = "SELECT * FROM [cards:Form] as f WHERE f.'relatedSubjects'='" + subjectUUID + "'"
+            + " AND f.'questionnaire'='" + questionnaireUUID + "'"
+            + " OPTION (index tag cards)";
+
+        return resolver.findResources(sqlQuery, "JCR-SQL2");
+    }
+
+    // Save the specified visit number into the current form based on the current study stream.
+    // Will create any required sections.
+    private void setVisitNumber(final Long visitNumber, final VisitNumberConfiguration details,
+        final String studyStream, final Node questionnaireNode)
+    {
+        String[] visitPath = details.getVisitPath(studyStream).split("/");
+
+        Node node = questionnaireNode;
+        NodeBuilder nodeBuilder = this.currentNodeBuilder;
+
+        try {
+            // Traverse through the questionnaire to the visit question,
+            // generating any missing answer sections or answers as required
+            for (String nodeName : visitPath) {
+                node = node.getNode(nodeName);
+                nodeBuilder = getChildNodeBuilder(nodeBuilder, node);
+            }
+
+            if (nodeBuilder != null) {
+                // Found the required answer, save the value
+                nodeBuilder.setProperty("value", visitNumber);
+            } else {
+                LOGGER.warn("Unable to traverse form to locate visit answer");
+            }
+        } catch (RepositoryException e) {
+            LOGGER.warn("Unable save the calculated visit number {}", e.getMessage(), e);
+        }
+    }
+
+    // Retrieve the answer or answer section child for a given question or section
+    NodeBuilder getChildNodeBuilder(final NodeBuilder parent, Node questionnaireNode)
+        throws RepositoryException
+    {
+        // Missing required node: exit early
+        if (parent == null || questionnaireNode == null) {
+            return null;
+        }
+
+        boolean isQuestion = this.questionnaireUtils.isQuestion(questionnaireNode);
+        // Easier to traverse children of NodeStates than NodeBuilders
+        NodeState parentState = parent.getNodeState();
+        // Get the ID of the desired question or section
+        String questionnaireNodeUUID = questionnaireNode.getIdentifier();
+
+        NodeBuilder result = null;
+        // Traverse through children looking for an answer or answer section matching the desired questionnaire node
+        for (ChildNodeEntry childEntry : parentState.getChildNodeEntries()) {
+            NodeState child = childEntry.getNodeState();
+            boolean isAnswer = this.formUtils.isAnswer(child);
+
+            // Type of child does not match desired type, this cannot be the right child
+            if (isAnswer != isQuestion) {
+                continue;
+            }
+
+            String childQuestionnaireID = this.formUtils.isAnswer(child)
+                ? this.formUtils.getQuestionIdentifier(child)
+                : this.formUtils.getSectionIdentifier(child);
+
+            if (questionnaireNodeUUID.equals(childQuestionnaireID)) {
+                // Found the right child: done
+                result = parent.child(childEntry.getName());
+                break;
+            }
+        }
+
+        if (result == null) {
+            // No matching child was found: Create it
+            result = isQuestion ? generateAnswer(parent, questionnaireNodeUUID)
+                : generateSection(parent, questionnaireNodeUUID);
+        }
+
+        return result;
+    }
+
+    private NodeBuilder generateAnswer(NodeBuilder parent, String questionUUID)
+    {
+        return generateChild(parent, FormUtils.QUESTION_PROPERTY, questionUUID, "LongAnswer", "Answer");
+    }
+
+    private NodeBuilder generateSection(NodeBuilder parent, String sectionUUID)
+    {
+        return generateChild(parent, FormUtils.SECTION_PROPERTY, sectionUUID, "AnswerSection", "Resource");
+    }
+
+    private NodeBuilder generateChild(NodeBuilder parent, String questionnaireNodeProperty, String questionnaireNodeID,
+        String type, String superType)
+    {
+        final String uuid = UUID.randomUUID().toString();
+        NodeBuilder node = parent.setChildNode(uuid);
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+        node.setProperty("jcr:created", dateFormat.format(new Date()), Type.DATE);
+        node.setProperty("jcr:createdBy", this.rrp.getThreadResourceResolver().getUserID(), Type.NAME);
+        node.setProperty(questionnaireNodeProperty, questionnaireNodeID, Type.REFERENCE);
+        node.setProperty("jcr:primaryType", "cards:" + type, Type.NAME);
+        node.setProperty("sling:resourceSuperType", "cards/" + superType, Type.STRING);
+        node.setProperty("sling:resourceType", "cards/" + type, Type.STRING);
+        node.setProperty("statusFlags", Collections.emptyList(), Type.STRINGS);
+
+        return node;
+
+    }
+}

--- a/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/VisitNumberEditorProvider.java
+++ b/heracles-resources/backend/src/main/java/io/uhndata/cards/heracles/internal/VisitNumberEditorProvider.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.heracles.internal;
+
+import java.util.List;
+
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
+import org.apache.jackrabbit.oak.spi.commit.Editor;
+import org.apache.jackrabbit.oak.spi.commit.EditorProvider;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.FieldOption;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import io.uhndata.cards.forms.api.FormUtils;
+import io.uhndata.cards.forms.api.QuestionnaireUtils;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
+
+/**
+ * A {@link EditorProvider} returning {@link VisitNumberEditor}.
+ *
+ * @version $Id$
+ */
+@Component(property = "service.ranking:Integer=10")
+public class VisitNumberEditorProvider implements EditorProvider
+{
+    @Reference(fieldOption = FieldOption.REPLACE, cardinality = ReferenceCardinality.OPTIONAL,
+        policyOption = ReferencePolicyOption.GREEDY)
+    private ResourceResolverFactory rrf;
+
+    @Reference
+    private ThreadResourceResolverProvider rrp;
+
+    @Reference
+    private FormUtils formUtils;
+
+    @Reference
+    private QuestionnaireUtils questionnaireUtils;
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE,
+        fieldOption = FieldOption.REPLACE,
+        policy = ReferencePolicy.DYNAMIC)
+    private volatile List<VisitNumberConfiguration> configurations;
+
+    @Override
+    public Editor getRootEditor(NodeState before, NodeState after, NodeBuilder builder, CommitInfo info)
+        throws CommitFailedException
+    {
+        if (this.rrf != null) {
+            // Each VisitNumberEditor maintains a state, so a new instance must be returned each time
+            return new VisitNumberEditor(builder, this.rrf, this.rrp, this.formUtils, this.questionnaireUtils, false,
+                this.configurations);
+        }
+        return null;
+    }
+}

--- a/heracles-resources/feature/src/main/features/feature.json
+++ b/heracles-resources/feature/src/main/features/feature.json
@@ -54,14 +54,16 @@
         "set properties on /Metrics/S3ExportedSubjects/prevTotal \n   default value{Long} to 0 \n end",
         "set properties on /Metrics/S3ExportFailures/name \n   default value{String} to \"{003} Number Of Failed S3 export jobs\" \n end",
         "set properties on /Metrics/S3ExportFailures/prevTotal \n   default value{Long} to 0 \n end",
-        "create service user cards-exporter with path system/cards \n set ACL for cards-exporter \n   allow jcr:read on / \n end"
+        "create service user cards-exporter with path system/cards \n set ACL for cards-exporter \n   allow jcr:read on / \n end",
+        "create service user visit-number-editor \n set ACL for visit-number-editor \n allow jcr:read on /Questionnaires,/Subjects \n allow jcr:read,rep:write on /Forms \n end"
       ]
     },
     "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~heracles":{
       "user.mapping":[
         "io.uhndata.cards.heracles-backend:S3Export=[cards-exporter]",
         "io.uhndata.cards.heracles-backend:PauseResumeEditor=[sling-readall]",
-        "io.uhndata.cards.heracles-backend:MetricLogger=[cards-metrics]"
+        "io.uhndata.cards.heracles-backend:MetricLogger=[cards-metrics]",
+        "io.uhndata.cards.heracles-backend:VisitNumberEditor=[visit-number-editor]"
       ]
     },
     "io.uhndata.cards.s3export.ExportConfig~heracles":{
@@ -69,6 +71,38 @@
       "exportSchedule": "0 0 0 * * ? *",
       "fileNameFormat": "{subject}_formData_{yesterday(yyyyMMdd)}",
       "selectors": ".bare.-labels.-identify.relativeDates.nolinks.answerFilter.answerFilter:exclude=/Questionnaires/PhoneCallFollow-Up/section_medical_care/section_provider_emergencyclinic.answerFilter:exclude=/Questionnaires/Phone Call Follow-Up/section_medical_care/section_provider_hospitalvisit.answerFilter:exclude=/Questionnaires/Phone Call Follow-Up/section_medical_care/section_provider_walkin.answerFilter:exclude=/Questionnaires/Phone Call Follow-Up/section_medical_care/section_provider_familydoctor.answerFilter:exclude=/Questionnaires/Phone Call Follow-Up/section_medical_care/section_provider_specialist.answerFilter:exclude=/Questionnaires/Phone Call Follow-Up/section_medication_changes/pc_conditions_summary.answerFilter:exclude=/Questionnaires/Phone Call Follow-Up/section_admin/pc_call_initiated.answerFilter:exclude=/Questionnaires/Phone Call Follow-Up/section_medication_changes/pc_22_1section/pc_22_1"
+    },
+    "io.uhndata.cards.heracles.internal.VisitNumberConfiguration~CPET-external": {
+      "questionnairePath": "/Questionnaires/CPET - External File",
+      "visitsLow": [0, 2],
+      "visitsHigh": [0, 2, 4, 6, 8, 10],
+      "visitPathLow": "externalfile_visit_lowSection/externalfile_visit_low",
+      "visitPathHigh": "externalfile_visit_highSection/externalfile_visit_high",
+      "studyStreamPath": "study_stream"
+    },
+    "io.uhndata.cards.heracles.internal.VisitNumberConfiguration~CPET-interpretation": {
+      "questionnairePath": "/Questionnaires/CPET Interpretation",
+      "visitsLow": [0, 2],
+      "visitsHigh": [0, 2, 4, 6, 8, 10],
+      "visitPathLow": "CardiacStressTestType/cpet_visit_lowSection/cpet_visit_low",
+      "visitPathHigh": "CardiacStressTestType/cpet_visit_highSection/cpet_visit_high",
+      "studyStreamPath": "CardiacStressTestType/study_stream"
+    },
+    "io.uhndata.cards.heracles.internal.VisitNumberConfiguration~6MWT": {
+      "questionnairePath": "/Questionnaires/6MWT",
+      "visitsLow": [1, 3],
+      "visitsHigh": [1, 3, 5, 7, 9, 11],
+      "visitPathLow": "6MWTType/6mwt-visit_lowSection/6mwt-visit_low",
+      "visitPathHigh": "6MWTType/6mwt-visit_highSection/6mwt-visit_high",
+      "studyStreamPath": "6MWTType/study_stream"
+    },
+    "io.uhndata.cards.heracles.internal.VisitNumberConfiguration~laboratoryResults": {
+      "questionnairePath": "/Questionnaires/Laboratory Results",
+      "visitsLow": [1, 3],
+      "visitsHigh": [1, 3, 5, 7, 9, 11],
+      "visitPathLow": "lab_results_lowSection/lab_results_low",
+      "visitPathHigh": "lab_results_highSection/lab_results_high",
+      "studyStreamPath": "study_stream"
     }
   }
 }


### PR DESCRIPTION
- Adds VisitNumberConfiguration and VisitNumberEditor
- Editor runs on all new forms that have a matching configuration
- Pulls the study stream from a study stream form based on a reference
  question in the form being process
- Saves the lowest valid and unused visit number into the visit number answer
  for the correct study stream form
  - If the visit nunber is inside a conditional section the answer will last until the
    form is saved by the front end. This means the user can satisfy the condition and
    see the generated visit number on the first edit but it will be discard if they do
    not satisfy the condition and then close the edit page
    eg. by picking Triggered Assessment instead of Visit or by closing the form without
    picking either