### PR TITLE
[misc] Do not require completion on Holter forms

### DIFF
--- a/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Holter.xml
+++ b/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Holter.xml
@@ -39,7 +39,7 @@
 	</property>
 	<property>
 		<name>requireCompletion</name>
-		<value>True</value>
+		<value>False</value>
 		<type>Boolean</type>
 	</property>
 	<property>


### PR DESCRIPTION
This change is to avoid bug https://phenotips.atlassian.net/browse/CARDS-2587 (_Malfunction in forms with mandatory file questions and requireCompletion = true_). It also adds consistency to questionnaire settings across Heracles, as for the majority of the questionnaires completion is not required.