### PR TITLE
CARDS-2590: A section that contains only an information entry will never be shown in view mode

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -122,6 +122,11 @@ let displaySection = (sectionDefinition, path, depth, existingAnswer, key, onCha
     .filter(([key, value]) => value["sling:resourceType"] == "cards/AnswerSection"
       && value["section"]["jcr:uuid"] === sectionDefinition["jcr:uuid"]);
 
+  // If there is no existing answer / answerSection, and we're not in edit mode, don't display this
+  if (!isEdit && existingQuestionAnswer.length == 0) {
+    return null;
+  }
+
   return (
     <Section
       key={key}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Question.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Question.jsx
@@ -25,7 +25,6 @@ import { Card, CardHeader, CardContent, List, ListItem, Typography } from "@mui/
 
 import withStyles from '@mui/styles/withStyles';
 
-import { useFormWriterContext } from "./FormContext";
 import QuestionnaireStyle from "./QuestionnaireStyle";
 import AnswerInstructions from "./AnswerInstructions";
 import FormattedText from "../components/FormattedText.jsx";
@@ -40,16 +39,6 @@ function Question (props) {
   const [ anchor, setAnchor ] = useState();
 
   const location = useLocation();
-
-  const changeFormContext = useFormWriterContext();
-
-  // In view mode, load the existing answers into the form context to enable the computation of conditions
-  useEffect(() => {
-    let answer = existingAnswer?.[1] ?? {};
-    !isEdit && changeFormContext(oldContext => ({...(oldContext ?? {}),
-      [questionDefinition["@name"]]: Array.of(answer.value ?? []).flat().map(v => [v, v])
-    }));
-  }, [isEdit, existingAnswer]);
 
   // if autofocus is needed and specified in the url
   useEffect(() => {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Question.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Question.jsx
@@ -25,6 +25,7 @@ import { Card, CardHeader, CardContent, List, ListItem, Typography } from "@mui/
 
 import withStyles from '@mui/styles/withStyles';
 
+import { useFormWriterContext } from "./FormContext";
 import QuestionnaireStyle from "./QuestionnaireStyle";
 import AnswerInstructions from "./AnswerInstructions";
 import FormattedText from "../components/FormattedText.jsx";
@@ -39,6 +40,16 @@ function Question (props) {
   const [ anchor, setAnchor ] = useState();
 
   const location = useLocation();
+
+  const changeFormContext = useFormWriterContext();
+
+  // In view mode, load the existing answers into the form context to enable the computation of conditions
+  useEffect(() => {
+    let answer = existingAnswer?.[1] ?? {};
+    !isEdit && changeFormContext(oldContext => ({...(oldContext ?? {}),
+      [questionDefinition["@name"]]: Array.of(answer.value ?? []).flat().map(v => [v, v])
+    }));
+  }, [isEdit, existingAnswer]);
 
   // if autofocus is needed and specified in the url
   useEffect(() => {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -142,13 +142,12 @@ function Section(props) {
       .some(childEntry => ["view", "any"].includes(childEntry.formMode) || determineContent(childEntry))
   )
 
-  let hasContent = !isEdit && determineContent(sectionDefinition);
+  let hasContent = isEdit || determineContent(sectionDefinition);
 
   // Display the section in view mode if it has answers or is marked as incomplete.
   // Do not display summary questions outside of summary mode, or regular questions in summary mode.
-  const isDisplayed = (conditionIsMet && (isEdit || isFlagged || hasAnswers || hasContent))
+  const isDisplayed = (isEdit && conditionIsMet || !isEdit && (isFlagged || hasAnswers || hasContent))
     && (isSummary && "summary" === displayMode || !isSummary && displayMode !== "summary");
-
 
   if (visibleCallback) visibleCallback(conditionIsMet);
 
@@ -161,7 +160,7 @@ function Section(props) {
   }
   // Hide the section if it is conditioned to be hidden in edit mode
   // Or if we're in view mode and do not have any answers or other content, and the section is not marked as incomplete
-  if (!(conditionIsMet && (isEdit || isFlagged || hasAnswers || hasContent))) {
+  if (!isDisplayed) {
     collapseClasses.push(classes.collapsedSection);
   }
   if (hasHeader) {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -136,13 +136,13 @@ function Section(props) {
   let hasAnswers = isEdit || detectAnswers(existingAnswer[0]?.[1]);
 
   // Determine if the section has any other content that should be displayed
-  let determineContent = (entryDefinition) => (
+  let detectOtherContent = (entryDefinition) => (
     Object.values(entryDefinition)
       .filter(childEntry => ENTRY_TYPES.includes(childEntry['jcr:primaryType']))
-      .some(childEntry => ["view", "any"].includes(childEntry.formMode) || determineContent(childEntry))
+      .some(childEntry => ["view", "any"].includes(childEntry.formMode) || detectOtherContent(childEntry))
   )
 
-  let hasContent = isEdit || determineContent(sectionDefinition);
+  let hasContent = isEdit || detectOtherContent(sectionDefinition);
 
   // Display the section in view mode if it has answers or is marked as incomplete.
   // Do not display summary questions outside of summary mode, or regular questions in summary mode.

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -135,10 +135,20 @@ function Section(props) {
 
   let hasAnswers = isEdit || detectAnswers(existingAnswer[0]?.[1]);
 
+  // Determine if the section has any other content that should be displayed
+  let determineContent = (entryDefinition) => (
+    Object.values(entryDefinition)
+      .filter(childEntry => ENTRY_TYPES.includes(childEntry['jcr:primaryType']))
+      .some(childEntry => ["view", "any"].includes(childEntry.formMode) || determineContent(childEntry))
+  )
+
+  let hasContent = !isEdit && determineContent(sectionDefinition);
+
   // Display the section in view mode if it has answers or is marked as incomplete.
   // Do not display summary questions outside of summary mode, or regular questions in summary mode.
-  const isDisplayed = (isEdit && conditionIsMet || !isEdit && (hasAnswers || isFlagged))
+  const isDisplayed = (conditionIsMet && (isEdit || isFlagged || hasAnswers || hasContent))
     && (isSummary && "summary" === displayMode || !isSummary && displayMode !== "summary");
+
 
   if (visibleCallback) visibleCallback(conditionIsMet);
 
@@ -150,8 +160,8 @@ function Section(props) {
     collapseClasses.push("cards-edit-section");
   }
   // Hide the section if it is conditioned to be hidden in edit mode
-  // Or if we're in view mode and do not have any answers and the section is not marked as incomplete
-  if (isEdit && !conditionIsMet || !isEdit && !hasAnswers && !isFlagged) {
+  // Or if we're in view mode and do not have any answers or other content, and the section is not marked as incomplete
+  if (!(conditionIsMet && (isEdit || isFlagged || hasAnswers || hasContent))) {
     collapseClasses.push(classes.collapsedSection);
   }
   if (hasHeader) {

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/SectionsWithInfoNodesTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/SectionsWithInfoNodesTest.xml
@@ -1,0 +1,344 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>SectionsWithInfoNodesTest</name>
+	<primaryNodeType>cards:Questionnaire</primaryNodeType>
+	<property>
+		<name>title</name>
+		<value>Sections with only Information nodes Test</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>description</name>
+		<value>CARDS-2590: Sections with only Information nodes displayed in view mode</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>paginate</name>
+		<value>False</value>
+		<type>Boolean</type>
+	</property>
+	<node>
+		<name>always-displayed</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>compact</name>
+			<value>False</value>
+			<type>Boolean</type>
+		</property>
+		<property>
+			<name>description</name>
+			<value>This should have an Info displayed both in edit and view mode</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>default</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>label</name>
+			<value>S1: Always Displayed</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>recurrent</name>
+			<value>False</value>
+			<type>Boolean</type>
+		</property>
+		<node>
+			<name>alaways</name>
+			<primaryNodeType>cards:Information</primaryNodeType>
+			<property>
+				<name>formMode</name>
+				<value>any</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>This info box should be visible.</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>type</name>
+				<value>success</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
+		<name>view-only</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>compact</name>
+			<value>False</value>
+			<type>Boolean</type>
+		</property>
+		<property>
+			<name>description</name>
+			<value>This section should not have anything in edit mode, but it should have an info box in view mode.</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>default</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>label</name>
+			<value>S3: View mode only</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>recurrent</name>
+			<value>False</value>
+			<type>Boolean</type>
+		</property>
+		<node>
+			<name>view-only</name>
+			<primaryNodeType>cards:Information</primaryNodeType>
+			<property>
+				<name>formMode</name>
+				<value>view</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>This info box must only be displayed in view mode.</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>type</name>
+				<value>warning</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
+		<name>edit-only</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>compact</name>
+			<value>False</value>
+			<type>Boolean</type>
+		</property>
+		<property>
+			<name>description</name>
+			<value>This should contain an info box in edit mode, and be hidden in view mode</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>default</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>label</name>
+			<value>S2: Edit mode only</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>recurrent</name>
+			<value>False</value>
+			<type>Boolean</type>
+		</property>
+		<node>
+			<name>edit</name>
+			<primaryNodeType>cards:Information</primaryNodeType>
+			<property>
+				<name>formMode</name>
+				<value>edit</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>This should not be seen in View mode.</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>type</name>
+				<value>error</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
+		<name>q</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>compact</name>
+			<value>False</value>
+			<type>Boolean</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>boolean</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>input</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>enableNotes</name>
+			<value>False</value>
+			<type>Boolean</type>
+		</property>
+		<property>
+			<name>enableUnknown</name>
+			<value>False</value>
+			<type>Boolean</type>
+		</property>
+		<property>
+			<name>entryMode</name>
+			<value>user</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>minAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>text</name>
+			<value>Display the last info box?</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
+		<name>conditioned</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>compact</name>
+			<value>False</value>
+			<type>Boolean</type>
+		</property>
+		<property>
+			<name>description</name>
+			<value>This section should only appear if the previous question is true. The info box should show up both in view and edit modes.</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>default</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>label</name>
+			<value>S4: Conditional</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>recurrent</name>
+			<value>False</value>
+			<type>Boolean</type>
+		</property>
+		<node>
+			<name>condition</name>
+			<primaryNodeType>cards:Conditional</primaryNodeType>
+			<property>
+				<name>comparator</name>
+				<value>=</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>dataType</name>
+				<value>long</value>
+				<type>String</type>
+			</property>
+			<node>
+				<name>operandA</name>
+				<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+				<property>
+					<name>isReference</name>
+					<value>True</value>
+					<type>Boolean</type>
+				</property>
+				<property>
+					<name>value</name>
+					<values>
+						<value>q</value>
+					</values>
+					<type>String</type>
+				</property>
+			</node>
+			<node>
+				<name>operandB</name>
+				<primaryNodeType>cards:ConditionalValue</primaryNodeType>
+				<property>
+					<name>isReference</name>
+					<value>False</value>
+					<type>Boolean</type>
+				</property>
+				<property>
+					<name>value</name>
+					<values>
+						<value>1</value>
+					</values>
+					<type>String</type>
+				</property>
+			</node>
+		</node>
+		<node>
+			<name>conditional</name>
+			<primaryNodeType>cards:Information</primaryNodeType>
+			<property>
+				<name>formMode</name>
+				<value>any</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>This info box should only appear if the answer is true.</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>type</name>
+				<value>success</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
+		<name>toplevel</name>
+		<primaryNodeType>cards:Information</primaryNodeType>
+		<property>
+			<name>formMode</name>
+			<value>any</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>text</name>
+			<value>This info box should always appear.</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>type</name>
+			<value>success</value>
+			<type>String</type>
+		</property>
+	</node>
+</node>


### PR DESCRIPTION
This is preventing information boxes with formMode = "view" or "any" from being displayed in view mode.

Issue details: https://phenotips.atlassian.net/browse/CARDS-2590

**Regression testing:** all types of section display (conditional or otherwise) may be impacted by these changes.