### PR TITLE
[misc] Update computed question expressions in Phone Call Follow-Up that fail on the backend because of unsupported js syntax

### DIFF
--- a/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Phone Call Follow-Up.xml
+++ b/heracles-resources/clinical-data/src/main/resources/SLING-INF/content/Questionnaires/Phone Call Follow-Up.xml
@@ -2890,7 +2890,7 @@
 				</property>
 				<property>
 					<name>expression</name>
-					<value><![CDATA[return (@{[other_event_subtype?]}.some(e => ["cancer", "neuropathy"].includes(e)) ? 1 : 0)]]></value>
+					<value><![CDATA[return (@{[other_event_subtype?]}.some(function(e) {return ["cancer", "neuropathy"].includes(e)}) ? 1 : 0)]]></value>
 					<type>String</type>
 				</property>
 				<property>
@@ -6214,7 +6214,7 @@
 				<property>
 					<name>expression</name>
 					<value><![CDATA[let values = ["hospital", "emergency", "walkin", "familydoctor", "specialist"];
-return (@{[medical_care_type]}.some(e => values.includes(e)) ? 1 : 0)]]></value>
+return (@{[medical_care_type]}.some(function(e) {return values.includes(e)}) ? 1 : 0)]]></value>
 					<type>String</type>
 				</property>
 				<property>


### PR DESCRIPTION
The expressions of the following computed answers were updated: `cancer_neuropathy`, `medical_care_type_ispredefined`.

Test that they are still correctly computed.