### PR TITLE
CARDS-2593: Exporting very big files to S3 may fail

### DIFF
--- a/heracles-resources/feature/src/main/features/feature.json
+++ b/heracles-resources/feature/src/main/features/feature.json
@@ -86,7 +86,11 @@
       ],
       "formatter": "rawFile",
       "fileNameFormat": "{resourcePath}",
-      "storage": "s3"
+      "storage": "s3",
+      "storageParameters": [
+        "blockedApplicationMimeTypeWorkaround=true",
+        "chunkSizeInMB=5"
+      ]
     }
   }
 }

--- a/modules/export/src/main/java/io/uhndata/cards/export/ExportTask.java
+++ b/modules/export/src/main/java/io/uhndata/cards/export/ExportTask.java
@@ -210,7 +210,8 @@ public class ExportTask implements Runnable
     private void output(ResourceRepresentation input, String filename)
     {
         try {
-            this.store.store(input.getRepresentation(), filename, input.getMimeType(), this.config);
+            this.store.store(input.getRepresentation(), input.getRepresentationSize(), filename, input.getMimeType(),
+                this.config);
             input.getDataContents().forEach(form -> {
                 LOGGER.info("Exported {}", form);
                 Metrics.increment(this.resolverFactory, "S3ExportedForms", 1);

--- a/modules/export/src/main/java/io/uhndata/cards/export/internal/formatters/CSVDataFormatter.java
+++ b/modules/export/src/main/java/io/uhndata/cards/export/internal/formatters/CSVDataFormatter.java
@@ -49,10 +49,12 @@ public class CSVDataFormatter implements DataFormatter
         throws RepositoryException
     {
         Resource r = resolver.resolve(what.getExportPath() + ".csv");
+        byte[] bytes = r.adaptTo(CSVString.class).toString().getBytes(StandardCharsets.UTF_8);
 
         return new ResourceRepresentation(what,
             // FIXME Use streaming instead of building the whole CSV in memory
-            new ByteArrayInputStream(r.adaptTo(CSVString.class).toString().getBytes(StandardCharsets.UTF_8)),
+            new ByteArrayInputStream(bytes),
+            bytes.length,
             "text/csv",
             getContentsSummary(what, config, resolver));
     }

--- a/modules/export/src/main/java/io/uhndata/cards/export/internal/formatters/JSONDataFormatter.java
+++ b/modules/export/src/main/java/io/uhndata/cards/export/internal/formatters/JSONDataFormatter.java
@@ -50,9 +50,11 @@ public class JSONDataFormatter implements DataFormatter
     {
         Resource r = resolver.resolve(what.getExportPath() + ".json");
         JsonObject serialization = r.adaptTo(JsonObject.class);
+        byte[] bytes = serialization.toString().getBytes(StandardCharsets.UTF_8);
 
         return new ResourceRepresentation(what,
-            new ByteArrayInputStream(serialization.toString().getBytes(StandardCharsets.UTF_8)),
+            new ByteArrayInputStream(bytes),
+            bytes.length,
             "application/json",
             getContentsSummary(what, config, resolver));
     }

--- a/modules/export/src/main/java/io/uhndata/cards/export/internal/formatters/RawFileDataFormatter.java
+++ b/modules/export/src/main/java/io/uhndata/cards/export/internal/formatters/RawFileDataFormatter.java
@@ -22,6 +22,7 @@ package io.uhndata.cards.export.internal.formatters;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 
+import javax.jcr.Binary;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 
@@ -51,8 +52,10 @@ public class RawFileDataFormatter implements DataFormatter
             n = n.getNode("jcr:content");
         }
         if (n.isNodeType("nt:resource") && n.hasProperty("jcr:data")) {
+            final Binary content = n.getProperty("jcr:data").getBinary();
             return new ResourceRepresentation(what,
-                n.getProperty("jcr:data").getBinary().getStream(),
+                content.getStream(),
+                content.getSize(),
                 n.hasProperty("jcr:mimeType") ? n.getProperty("jcr:mimeType").getString() : "application/octet-stream",
                 Collections.emptyList());
         } else {

--- a/modules/export/src/main/java/io/uhndata/cards/export/internal/formatters/TSVDataFormatter.java
+++ b/modules/export/src/main/java/io/uhndata/cards/export/internal/formatters/TSVDataFormatter.java
@@ -49,10 +49,12 @@ public class TSVDataFormatter implements DataFormatter
         throws RepositoryException
     {
         Resource r = resolver.resolve(what.getExportPath() + ".tsv");
+        byte[] bytes = r.adaptTo(CSVString.class).toString().getBytes(StandardCharsets.UTF_8);
 
         return new ResourceRepresentation(what,
             // FIXME Use streaming instead of building the whole CSV in memory
-            new ByteArrayInputStream(r.adaptTo(CSVString.class).toString().getBytes(StandardCharsets.UTF_8)),
+            new ByteArrayInputStream(bytes),
+            bytes.length,
             "text/tab-separated-values",
             getContentsSummary(what, config, resolver));
     }

--- a/modules/export/src/main/java/io/uhndata/cards/export/internal/stores/FilesystemDataStore.java
+++ b/modules/export/src/main/java/io/uhndata/cards/export/internal/stores/FilesystemDataStore.java
@@ -41,7 +41,7 @@ public class FilesystemDataStore implements DataStore
     }
 
     @Override
-    public void store(final InputStream contents, final String filename, final String mimetype,
+    public void store(final InputStream contents, final long size, final String filename, final String mimetype,
         final ExportConfigDefinition config) throws IOException
     {
         final File targetFile =

--- a/modules/export/src/main/java/io/uhndata/cards/export/spi/DataPipelineStep.java
+++ b/modules/export/src/main/java/io/uhndata/cards/export/spi/DataPipelineStep.java
@@ -93,17 +93,21 @@ public interface DataPipelineStep
 
         private final InputStream data;
 
+        private final long size;
+
         private final List<String> dataContents;
 
         private final String mimeType;
 
         public ResourceRepresentation(final ResourceIdentifier identifier,
             final InputStream data,
+            final long size,
             final String mimeType,
             final List<String> dataContents)
         {
             this.identifier = identifier;
             this.data = data;
+            this.size = size;
             this.mimeType = mimeType;
             this.dataContents = dataContents;
         }
@@ -116,6 +120,11 @@ public interface DataPipelineStep
         public InputStream getRepresentation()
         {
             return this.data;
+        }
+
+        public long getRepresentationSize()
+        {
+            return this.size;
         }
 
         public List<String> getDataContents()

--- a/modules/export/src/main/java/io/uhndata/cards/export/spi/DataStore.java
+++ b/modules/export/src/main/java/io/uhndata/cards/export/spi/DataStore.java
@@ -25,6 +25,6 @@ import io.uhndata.cards.export.ExportConfigDefinition;
 
 public interface DataStore extends DataPipelineStep
 {
-    void store(InputStream contents, String filename, String mimetype, ExportConfigDefinition config)
+    void store(InputStream contents, long size, String filename, String mimetype, ExportConfigDefinition config)
         throws IOException;
 }

--- a/modules/s3-export/pom.xml
+++ b/modules/s3-export/pom.xml
@@ -61,6 +61,14 @@
       <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-osgi</artifactId>
       <version>1.12.158</version>

--- a/modules/s3-export/src/main/java/io/uhndata/cards/s3export/S3DataStore.java
+++ b/modules/s3-export/src/main/java/io/uhndata/cards/s3export/S3DataStore.java
@@ -72,6 +72,7 @@ public class S3DataStore implements DataStore
             new EndpointConfiguration(s3EndpointUrl, s3EndpointRegion);
         final AWSCredentials credentials = new BasicAWSCredentials(awsKey, awsSecret);
         final AmazonS3 s3 = AmazonS3ClientBuilder.standard()
+            .withPayloadSigningEnabled(true)
             .withEndpointConfiguration(endpointConfig)
             .withPathStyleAccessEnabled(true)
             .withCredentials(new AWSStaticCredentialsProvider(credentials))

--- a/modules/s3-export/src/main/java/io/uhndata/cards/s3export/S3DataStore.java
+++ b/modules/s3-export/src/main/java/io/uhndata/cards/s3export/S3DataStore.java
@@ -80,7 +80,10 @@ public class S3DataStore implements DataStore
 
         try {
             final ObjectMetadata meta = new ObjectMetadata();
-            meta.setContentType(mimetype);
+            // Some s3 buckets may forbid uploading "applications", so let's pretend that they're just plain text files
+            meta.setContentType(
+                "true".equals(getNamedParameter(config.storageParameters(), "blockedApplicationMimeTypeWorkaround"))
+                    && mimetype.startsWith("application/") ? "text/plain" : mimetype);
             if (size >= 0) {
                 meta.setContentLength(size);
             }

--- a/modules/s3-export/src/main/java/io/uhndata/cards/s3export/S3DataStore.java
+++ b/modules/s3-export/src/main/java/io/uhndata/cards/s3export/S3DataStore.java
@@ -21,8 +21,13 @@ package io.uhndata.cards.s3export;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
@@ -30,20 +35,21 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PartETag;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.amazonaws.services.s3.model.UploadPartResult;
 import io.uhndata.cards.export.ExportConfigDefinition;
 import io.uhndata.cards.export.spi.DataStore;
 
 @Component(immediate = true, service = DataStore.class)
+@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 public class S3DataStore implements DataStore
 {
-    private String env(final String value)
-    {
-        if (value != null && value.startsWith("%ENV%")) {
-            return System.getenv(value.substring("%ENV%".length()));
-        }
-        return value;
-    }
+    private static final Logger LOGGER = LoggerFactory.getLogger(S3DataStore.class);
 
     @Override
     public String getName()
@@ -52,7 +58,7 @@ public class S3DataStore implements DataStore
     }
 
     @Override
-    public void store(final InputStream contents, final String filename, final String mimetype,
+    public void store(final InputStream contents, final long size, final String filename, final String mimetype,
         final ExportConfigDefinition config) throws IOException
     {
         final String s3EndpointUrl =
@@ -70,12 +76,67 @@ public class S3DataStore implements DataStore
             .withPathStyleAccessEnabled(true)
             .withCredentials(new AWSStaticCredentialsProvider(credentials))
             .build();
+
         try {
             final ObjectMetadata meta = new ObjectMetadata();
             meta.setContentType(mimetype);
-            s3.putObject(s3BucketName, filename, contents, meta);
+            if (size >= 0) {
+                meta.setContentLength(size);
+            }
+
+            final List<PartETag> partETags = new ArrayList<>();
+
+            final InitiateMultipartUploadRequest initRequest =
+                new InitiateMultipartUploadRequest(s3BucketName, filename).withObjectMetadata(meta);
+            final InitiateMultipartUploadResult initResponse = s3.initiateMultipartUpload(initRequest);
+            long position = 0;
+            long partSize = getPartSize(config.storageParameters());
+            for (int partNumber = 1; position < size; ++partNumber) {
+                partSize = Math.min(partSize, (size - position));
+
+                UploadPartRequest uploadRequest = new UploadPartRequest()
+                    .withBucketName(s3BucketName)
+                    .withKey(filename)
+                    .withUploadId(initResponse.getUploadId())
+                    .withInputStream(contents)
+                    .withPartNumber(partNumber)
+                    .withPartSize(partSize);
+
+                UploadPartResult uploadResult = s3.uploadPart(uploadRequest);
+                partETags.add(uploadResult.getPartETag());
+
+                position += partSize;
+            }
+
+            CompleteMultipartUploadRequest compRequest = new CompleteMultipartUploadRequest(s3BucketName, filename,
+                initResponse.getUploadId(), partETags);
+            s3.completeMultipartUpload(compRequest);
         } catch (Exception e) {
             throw new IOException("Failed to store file " + filename + " into S3 store " + getName(), e);
         }
+    }
+
+    private long getPartSize(final String[] parameters)
+    {
+        final String sizeStr = getNamedParameter(parameters, "chunkSizeInMB");
+        if (!StringUtils.isBlank(sizeStr)) {
+            try {
+                final int size = Integer.parseInt(sizeStr);
+                if (size > 0) {
+                    return size * 1024 * 1024;
+                }
+            } catch (NumberFormatException e) {
+                LOGGER.warn("Invalid chink size configured for the S3 storage: {}", sizeStr);
+            }
+        }
+        return 10 * 1024 * 1024;
+    }
+
+    private String env(final String value)
+    {
+        if (value != null && value.startsWith("%ENV%")) {
+            return System.getenv(value.substring("%ENV%".length()));
+        }
+        return value;
     }
 }


### PR DESCRIPTION
To test Heracles:
- build with `mvn clean install -Pdocker`
- generate a compose file with `python3 generate_compose_yaml.py --dev_docker_image  --composum --cards_project cards4heracles --s3_test_container --oak_filesystem`
- start it up with `docker-compose build && docker-compose up`
- create a Holter form, fill it in, upload some files, including a PDF and image to check that they don't get mangled in the upload, and a big one (2G)
- visit `http://localhost:9001/` and create a bucket named `uhn`
- open `http://localhost:8080/Subjects.export?config=Heracles%20-%20Subjects%20with%20Data` and `http://localhost:8080/Subjects.export?config=Heracles%20-%20Big%20Files` to export, wait a bit since transferring many GB of data takes a while
- open `http://localhost:9001/buckets/uhn/browse`
- check that the large Holter files are present, download them and compare against the original to make sure no bytes were lost or mangled
- shut down and cleanup with `docker-compose rm -vf && ./cleanup.sh`
