### PR TITLE
[misc] Add json processor for exporting questionnaires to importable XMLs

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
@@ -22,6 +22,7 @@ import { Link, useHistory } from 'react-router-dom';
 import PropTypes from "prop-types";
 
 import {
+  Button,
   CircularProgress,
   Grid,
   IconButton,
@@ -132,6 +133,18 @@ let Questionnaire = (props) => {
               variant="text"
               onClose={() => { setActionsMenu(null); }}
           />
+        </ListItem>
+        <ListItem className={classes.actionsMenuItem}>
+            <Button
+                size="medium"
+                component="a"
+                download={`${id}.json`}
+                href={`/Questionnaires/${id}.deep.simple.-identify.nolinks.jsontoxml.json`}
+                onClick={() => {
+                    setActionsMenu(null);
+                }}>
+                    Export as JSON
+            </Button>
         </ListItem>
         <ListItem className={classes.actionsMenuItem}>
           <DeleteButton

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
@@ -139,7 +139,7 @@ let Questionnaire = (props) => {
                 size="medium"
                 component="a"
                 download={`${id}.json`}
-                href={`/Questionnaires/${id}.deep.simple.-identify.nolinks.jsontoxml.json`}
+                href={`/Questionnaires/${id}.deep.-identify.importable.json`}
                 onClick={() => {
                     setActionsMenu(null);
                 }}>

--- a/modules/utils/src/main/java/io/uhndata/cards/serialize/internal/JsonToXmlProcessor.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/serialize/internal/JsonToXmlProcessor.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.uhndata.cards.serialize.internal;
+
+import java.util.function.Function;
+
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.json.JsonValue;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import io.uhndata.cards.forms.api.FormUtils;
+import io.uhndata.cards.serialize.spi.ResourceJsonProcessor;
+
+/**
+ * Remove any properties from the output that woulkd not be present in an importable questionnaire XML.
+ * This processor is intended to be run alongside the following other processors:
+ * * .deep
+ * * .simple
+ * * .-identify
+ * * .nolinks
+ * The name of this processor is {@code jsontoxml}.
+ *
+ * @version $Id$
+ */
+@Component(immediate = true)
+public class JsonToXmlProcessor implements ResourceJsonProcessor
+{
+    @Reference
+    private FormUtils formUtils;
+
+    @Override
+    public String getName()
+    {
+        return "jsontoxml";
+    }
+
+    @Override
+    public int getPriority()
+    {
+        return 100;
+    }
+
+    @Override
+    public JsonValue processProperty(final Node node, final Property property, final JsonValue input,
+        final Function<Node, JsonValue> serializeNode)
+    {
+        try {
+            switch (property.getName()) {
+                case "jcr:created":
+                case "jcr:createdBy":
+                case "jcr:lastModified":
+                case "jcr:lastModifiedBy":
+                case "jcr:uuid":
+                    // Skip most jcr nodes. Can't skip all as jcr:primaryType is still needed
+                    return null;
+                default:
+                    return input;
+            }
+        } catch (RepositoryException e) {
+            // Really shouldn't happen
+        }
+        return input;
+    }
+}


### PR DESCRIPTION
JSON to XML export process:

1. Grab the form's URL from the admin dashboard:
`http://localhost:8080/content.html/admin/Questionnaires/CompactSectionsTest`


2. Remove `/content.html/admin`, add all the needed export tags to the end (`.deep.-identify.importable.json`):
`http://localhost:8080/Questionnaires/CompactSectionsTest.deep.-identify.importable.json`
4.  Save the json (right click -> "Save As" or "Save Page As" depending on what browser you are using)
     - For simplicity, save the file to `cards/Utilities/JSON-to-XML/` with a name of your choice (`CompactSectionsTest.json` in this case)

OR **Replace steps 2&3 with clicking the `Export as JSON` entry in the questionnaire dropdown menu** 


5. In terminal, navigate to `cards/Utilities/JSON-to-XML/` and run the converter (editing the file names as appropriate):
`python3 json_to_xml.py CompactSectionsTest.json > CompactSectionsTest.xml`
     - The resulting XML will be in `cards/Utilities/JSON-to-XML/`

To quickly test the generated XML, you can deploy it to a running instance with:

```
curl 'http://localhost:8080/Questionnaires/' -u admin:admin -F ':operation=import' -F ':contentType=xml' -F ":content=@FileName.xml" -F ':name=QuestionnaireId' -F ':replace=true'
```
(Update port, FileName and QuestionnaireId as needed)

This process will not lead to identical XMLs from the original source XMLs:
- Any default properties will be included in the newly exported file (eg. `paginate` will be on all questionnaire nodes as it defaults to `False` when originally imported)
- Ordering may not be the same