### PR TITLE
CARDS-2536: In emails sent to patient, do not mention the patient names

### DIFF
--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/CPES/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/CPES/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       You are receiving this email because you have recently been discharged from a University Health Network (UHN) hospital.
     </p>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/CPES/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/CPES/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 You are receiving this email because you have recently been discharged from a
 University Health Network (UHN) hospital.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/CPES/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/CPES/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       You are receiving this email because you have recently been discharged from a University Health Network (UHN) hospital
       and our records indicate that we sent you a survey asking about your experience. However we have not heard back from you.
@@ -15,7 +15,7 @@
       team and answering will not impact future care you receive at UHN.
     </p>
     <p>
-     This questionnaire will take about 15 to 20 minutes to complete. Based on your responses you may be asked up to 49 questions. 
+     This questionnaire will take about 15 to 20 minutes to complete. Based on your responses you may be asked up to 49 questions.
     </p>
     <p>
       <strong>The survey will be available until ${expirationDate}. Please do not delay.</strong>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/CPES/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/CPES/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 You are receiving this email because you have recently been discharged from a
 University Health Network (UHN) hospital and our records indicate that we sent

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC-IP/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC-IP/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
       Our records show that you had a recent visit to ${unit} followed by an inpatient stay at Princess Margaret.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC-IP/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC-IP/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
 Our records show that you had a recent visit to ${unit} followed by an inpatient stay at Princess Margaret.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC-IP/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC-IP/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
       We would like to learn more about your most recent visit to ${unit} and inpatient stay at Princess Margaret.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC-IP/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC-IP/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
 We would like to learn more about your most recent visit to ${unit} and inpatient stay at Princess

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
       Our records show that you had a recent visit at ${unit}.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
 Our records show that you had a recent visit at ${unit}.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
       We would like to learn more about your most recent visit at ${unit}.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
 We would like to learn more about your most recent visit at ${unit}.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
       Our records show that you had a recent outpatient clinic visit with your nurse and/or doctor.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
 Our records show that you had a recent outpatient clinic visit with your nurse and/or doctor.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
       We would like to learn more about your most recent outpatient clinic visit with nurse and/or doctor.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
 We would like to learn more about your most recent outpatient clinic visit with nurse and/or

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-ED/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-ED/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       You are receiving this email because you have recently been discharged from a University Health Network (UHN) hospital.
     </p>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-ED/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-ED/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 You are receiving this email because you have recently been discharged from a
 University Health Network (UHN) hospital.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-ED/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-ED/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       You are receiving this email because you have recently been discharged from a University Health Network (UHN) hospital
       and our records indicate that we sent you a survey asking about your experience. However we have not heard back from you.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-ED/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-ED/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 You are receiving this email because you have recently been discharged from a
 University Health Network (UHN) hospital and our records indicate that we sent

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-EDIP/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-EDIP/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       You are receiving this email because you have recently been discharged from a University Health Network (UHN) hospital.
     </p>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-EDIP/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-EDIP/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 You are receiving this email because you have recently been discharged from a
 University Health Network (UHN) hospital.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-EDIP/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-EDIP/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       You are receiving this email because you have recently been discharged from a University Health Network (UHN) hospital
       and our records indicate that we sent you a survey asking about your experience. However we have not heard back from you.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-EDIP/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-EDIP/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 You are receiving this email because you have recently been discharged from a
 University Health Network (UHN) hospital and our records indicate that we sent

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       You are receiving this email because of your recent visit at a University Health Network (UHN) hospital within the last 30 days.
       We’d like to hear about your experience while you were a patient in UHN’s Emergency Department.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 You are receiving this email because of your recent visit at a University
 Health Network (UHN) hospital within the last 30 days. We’d like to

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       You are receiving this email because you have recently visited a University Health Network (UHN) hospital within the last 30 days
       and our records indicate that we sent you a survey asking about your experience. However we have not heard back from you.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 You are receiving this email because you have recently visited a
 University Health Network (UHN) hospital within the last 30 days

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       You are receiving this email because of your recent visit at a University Health Network (UHN) hospital within the last 30 days.
       We’d like to hear about your experience while you were a patient at UHN.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 You are receiving this email because of your recent visit at a University
 Health Network (UHN) hospital within the last 30 days. We’d like to

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       You are receiving this email because you have recently visited a University Health Network (UHN) hospital within the last 30 days
       and our records indicate that we sent you a survey asking about your experience. However we have not heard back from you.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 You are receiving this email because you have recently visited a University
 Health Network (UHN) hospital within the last 30 days and our records indicate

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       You are receiving this email because of your recent visit at a University Health Network (UHN) hospital within the last 30 days.
       We’d like to hear about your experience while you were an inpatient at UHN.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 You are receiving this email because of your recent visit at a University
 Health Network (UHN) hospital within the last 30 days. We’d like to

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       You are receiving this email because you have recently visited a University Health Network (UHN) hospital within the last 30 days
       and our records indicate that we sent you a survey asking about your experience. However we have not heard back from you.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 You are receiving this email because you have recently visited a University
 Health Network (UHN) hospital within your last 30 days and our records

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       You are receiving this email because of your recent visit at a University Health Network (UHN) hospital within the last 30 days.
       We would like you to reflect on your experience with the Integrated Care Program in the last month when you were discharged from

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 You are receiving this email because of your recent visit at a University
 Health Network (UHN) hospital within the last 30 days. We would like you

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       You are receiving this email because you have recently visited a University Health Network (UHN) hospital within the last 30 days
       and our records indicate that we sent you a survey asking about your experience with the Integrated Care Program.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 You are receiving this email because you have recently visited a
 University Health Network (UHN) hospital within the last 30 days

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IP/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IP/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       You are receiving this email because you have recently been discharged from a University Health Network (UHN) hospital.
     </p>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IP/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IP/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 You are receiving this email because you have recently been discharged from a
 University Health Network (UHN) hospital.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IP/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IP/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       You are receiving this email because you have recently been discharged from a University Health Network (UHN) hospital
       and our records indicate that we sent you a survey asking about your experience. However we have not heard back from you.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IP/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IP/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 You are receiving this email because you have recently been discharged from a
 University Health Network (UHN) hospital and our records indicate that we sent

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-Rehab/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-Rehab/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       You are receiving this email because you have recently been discharged from a University Health Network (UHN) hospital.
     </p>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-Rehab/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-Rehab/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 You are receiving this email because you have recently been discharged from a
 University Health Network (UHN) hospital.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-Rehab/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-Rehab/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -1,4 +1,4 @@
-    <p>Dear ${first_name} ${last_name},</p>
+    <p>Good morning,</p>
     <p>
       You are receiving this email because you have recently been discharged from a University Health Network (UHN) hospital
       and our records indicate that we sent you a survey asking about your experience. However we have not heard back from you.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-Rehab/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-Rehab/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -1,4 +1,4 @@
-Dear ${first_name} ${last_name},
+Good morning,
 
 You are receiving this email because you have recently been discharged from a
 University Health Network (UHN) hospital and our records indicate that we sent


### PR DESCRIPTION
Replace "Dear <name>," with "Good morning" in all PREMs email templates

To test:
- Build with `-P docker`
- In `compose-cluster`, run `python3 generate_compose_yaml.py --dev_docker_image --oak_filesystem --cards_project cards4prems --smtps --smtps_test_container --smtps_test_mail_path ~/cardsmail --composum`
- Edit the generated `docker-compose.yml` file, and at the end of the environment section of the `cardsinitial` service, add:
    ```
    - NIGHTLY_NOTIFICATIONS_SCHEDULE=0 * * * * ? *
    ```
- Start with `docker-compose up`
- Create a new `Patient Information` form and a `Visit information` form 7 days ago.
-Wait one minute, then check the contents of the `~/cardsmail` folder
