### PR TITLE
[misc] Update json importability processor with requiredSubjectTypes support

### DIFF
--- a/modules/utils/src/main/java/io/uhndata/cards/serialize/ResourceToJsonAdapterFactory.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/serialize/ResourceToJsonAdapterFactory.java
@@ -171,12 +171,14 @@ public class ResourceToJsonAdapterFactory
         while (properties.hasNext()) {
             Property thisProp = properties.nextProperty();
             JsonValue value = null;
+            String name = thisProp.getName();
             for (ResourceJsonProcessor p : enabledProcessors) {
                 value =
                     p.processProperty(node, thisProp, value, n -> serializeNode(n, enabledProcessors, processedNodes));
+                name = p.processPropertyName(node, thisProp, name);
             }
-            if (value != null) {
-                json.add(thisProp.getName(), value);
+            if (value != null && name != null) {
+                json.add(name, value);
             }
         }
     }

--- a/modules/utils/src/main/java/io/uhndata/cards/serialize/internal/ImportableProcessor.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/serialize/internal/ImportableProcessor.java
@@ -23,6 +23,9 @@ import java.util.function.Function;
 import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+import javax.json.Json;
+import javax.json.JsonArrayBuilder;
 import javax.json.JsonValue;
 
 import org.osgi.service.component.annotations.Component;
@@ -41,6 +44,8 @@ import io.uhndata.cards.serialize.spi.ResourceJsonProcessor;
 @Component(immediate = true)
 public class ImportableProcessor implements ResourceJsonProcessor
 {
+    private static final String SUBJECT_TYPES_PROPERTY = "requiredSubjectTypes";
+
     @Override
     public String getName()
     {
@@ -69,8 +74,14 @@ public class ImportableProcessor implements ResourceJsonProcessor
             } else if (propertyName.startsWith("sling:")) {
                 // Remove all sling properties
                 result = null;
+            } else if (SUBJECT_TYPES_PROPERTY.equals(propertyName)) {
+                final JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
+                for (Value value : property.getValues()) {
+                    Node subjectTypeNode = property.getSession().getNodeByIdentifier(value.getString());
+                    arrayBuilder.add(subjectTypeNode.getPath());
+                }
+                result = arrayBuilder.build();
             }
-            // TODO: Add in better handling for requiredSubjectTypes
 
             return result;
         } catch (RepositoryException e) {
@@ -88,6 +99,19 @@ public class ImportableProcessor implements ResourceJsonProcessor
             // TODO: If inter-processor dependencies are added, add a dependency to .nolinks instead
             if (child.isNodeType("cards:Links")) {
                 return null;
+            }
+        } catch (RepositoryException e) {
+            // Really shouldn't happen
+        }
+        return input;
+    }
+
+    @Override
+    public String processPropertyName(final Node node, final Property property, final String input)
+    {
+        try {
+            if (SUBJECT_TYPES_PROPERTY.equals(property.getName())) {
+                return "jcr:reference:" + SUBJECT_TYPES_PROPERTY;
             }
         } catch (RepositoryException e) {
             // Really shouldn't happen

--- a/modules/utils/src/main/java/io/uhndata/cards/serialize/internal/ImportableProcessor.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/serialize/internal/ImportableProcessor.java
@@ -83,8 +83,7 @@ public class ImportableProcessor implements ResourceJsonProcessor
                     }
                     result = arrayBuilder.build();
                 } else {
-                    Node referencedNode = property.getSession().getNodeByIdentifier(property.getValue().getString());
-                    result = Json.createValue(referencedNode.getPath());
+                    result = Json.createValue(property.getNode().getPath());
                 }
             }
 

--- a/modules/utils/src/main/java/io/uhndata/cards/serialize/internal/ImportableProcessor.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/serialize/internal/ImportableProcessor.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 
 import javax.jcr.Node;
 import javax.jcr.Property;
+import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 import javax.json.Json;
@@ -44,8 +45,6 @@ import io.uhndata.cards.serialize.spi.ResourceJsonProcessor;
 @Component(immediate = true)
 public class ImportableProcessor implements ResourceJsonProcessor
 {
-    private static final String SUBJECT_TYPES_PROPERTY = "requiredSubjectTypes";
-
     @Override
     public String getName()
     {
@@ -74,13 +73,19 @@ public class ImportableProcessor implements ResourceJsonProcessor
             } else if (propertyName.startsWith("sling:")) {
                 // Remove all sling properties
                 result = null;
-            } else if (SUBJECT_TYPES_PROPERTY.equals(propertyName)) {
-                final JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
-                for (Value value : property.getValues()) {
-                    Node subjectTypeNode = property.getSession().getNodeByIdentifier(value.getString());
-                    arrayBuilder.add(subjectTypeNode.getPath());
+            } else if (isReference(property)) {
+                // Convert all reference properties to the path being referenced
+                if (property.isMultiple()) {
+                    final JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
+                    for (Value value : property.getValues()) {
+                        Node referencedNode = property.getSession().getNodeByIdentifier(value.getString());
+                        arrayBuilder.add(referencedNode.getPath());
+                    }
+                    result = arrayBuilder.build();
+                } else {
+                    Node referencedNode = property.getSession().getNodeByIdentifier(property.getValue().getString());
+                    result = Json.createValue(referencedNode.getPath());
                 }
-                result = arrayBuilder.build();
             }
 
             return result;
@@ -110,12 +115,20 @@ public class ImportableProcessor implements ResourceJsonProcessor
     public String processPropertyName(final Node node, final Property property, final String input)
     {
         try {
-            if (SUBJECT_TYPES_PROPERTY.equals(property.getName())) {
-                return "jcr:reference:" + SUBJECT_TYPES_PROPERTY;
+            if (isReference(property)) {
+                // Prefix all reference property names so the json to xml script recognizes they should
+                // be references and not strings
+                return "jcr:reference:" + property.getName();
             }
         } catch (RepositoryException e) {
             // Really shouldn't happen
         }
         return input;
+    }
+
+    private boolean isReference(Property property)
+        throws RepositoryException
+    {
+        return PropertyType.REFERENCE == property.getType() || PropertyType.WEAKREFERENCE == property.getType();
     }
 }

--- a/modules/utils/src/main/java/io/uhndata/cards/serialize/spi/ResourceJsonProcessor.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/serialize/spi/ResourceJsonProcessor.java
@@ -155,6 +155,24 @@ public interface ResourceJsonProcessor
     }
 
     /**
+     * Called for each property of a serialized node, allows adjusting the name of the JSON serialized property. The
+     * first processer invoked will recieve the properties original name as the input string, and each subsequent
+     * processor being invoked recieves the output of the previous one. If at the end of the process the outcome is
+     * {@code null}, then the property is skipped from the parent node's serialization. Only the outcome of the last
+     * processor is taken into consideration when serializing the parent node. The default implementation simply
+     * returns the input unmodified
+     * @param node the node who's properties name is being deternmined
+     * @param property the property which is being named
+     * @param input the name determined by the previous processors, may be {@code null}
+     * @return the desired name for the property to be saved under in the JSON serialization, may be {@code} null if
+     *         the property should be skipped
+     */
+    default String processPropertyName(final Node node, final Property property, final String input)
+    {
+        return input;
+    }
+
+    /**
      * Called for each child node of a serialized node, allows processing the JSON serialization of a child node. The
      * first processor invoked will receive {@code null} as the JSON input, and each subsequent processor being invoked
      * receives the output of the previous one. If at the end of the process the outcome is {@code null}, then the child

--- a/modules/utils/src/main/java/io/uhndata/cards/serialize/spi/ResourceJsonProcessor.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/serialize/spi/ResourceJsonProcessor.java
@@ -156,12 +156,12 @@ public interface ResourceJsonProcessor
 
     /**
      * Called for each property of a serialized node, allows adjusting the name of the JSON serialized property. The
-     * first processer invoked will recieve the properties original name as the input string, and each subsequent
-     * processor being invoked recieves the output of the previous one. If at the end of the process the outcome is
+     * first processor invoked will receive the properties original name as the input string, and each subsequent
+     * processor being invoked receives the output of the previous one. If at the end of the process the outcome is
      * {@code null}, then the property is skipped from the parent node's serialization. Only the outcome of the last
      * processor is taken into consideration when serializing the parent node. The default implementation simply
      * returns the input unmodified
-     * @param node the node whose properties name is being determined
+     * @param node the node whose property name is being determined
      * @param property the property which is being named
      * @param input the name determined by the previous processors, may be {@code null}
      * @return the desired name for the property to be saved under in the JSON serialization, may be {@code} null if

--- a/modules/utils/src/main/java/io/uhndata/cards/serialize/spi/ResourceJsonProcessor.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/serialize/spi/ResourceJsonProcessor.java
@@ -161,7 +161,7 @@ public interface ResourceJsonProcessor
      * {@code null}, then the property is skipped from the parent node's serialization. Only the outcome of the last
      * processor is taken into consideration when serializing the parent node. The default implementation simply
      * returns the input unmodified
-     * @param node the node who's properties name is being deternmined
+     * @param node the node whose properties name is being determined
      * @param property the property which is being named
      * @param input the name determined by the previous processors, may be {@code null}
      * @return the desired name for the property to be saved under in the JSON serialization, may be {@code} null if


### PR DESCRIPTION
Add the ability for JsonProcessors to rename a property
Add custom handling to Importability for requiredSubjectTypes properties:
- Replace the subject type reference with the subject type path
- Add a prefix to the property name so the json to xml script knows it is a reference