### PR TITLE
CARDS-2605: Remove patient names from email to: fields

### DIFF
--- a/modules/email-notifications/src/main/java/io/uhndata/cards/emailnotifications/EmailUtils.java
+++ b/modules/email-notifications/src/main/java/io/uhndata/cards/emailnotifications/EmailUtils.java
@@ -60,10 +60,14 @@ public final class EmailUtils
     {
         final MessageBuilder message = mailService.getMessageBuilder()
             .from(email.getSenderAddress(), email.getSenderName())
-            .to(email.getRecipientAddress(), email.getRecipientName())
             .replyTo(email.getReplyToAddress(), email.getReplyToName())
             .subject(email.getSubject())
             .text(email.getTextBody());
+        if (email.getRecipientName() == null) {
+            message.to(email.getRecipientAddress());
+        } else {
+            message.to(email.getRecipientAddress(), email.getRecipientName());
+        }
         for (Map.Entry<String, String> header : email.getExtraHeaders().entrySet()) {
             message.header(header.getKey(), header.getValue());
         }

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
@@ -74,10 +74,14 @@ abstract class AbstractEmailNotification
 
     private final PatientAccessConfiguration patientAccessConfiguration;
 
+    private final boolean includePatientName;
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
     AbstractEmailNotification(final ResourceResolverFactory resolverFactory,
         final ThreadResourceResolverProvider resolverProvider,
         final TokenManager tokenManager, final MailService mailService, final FormUtils formUtils,
-        final PatientAccessConfiguration patientAccessConfiguration, final EventAdmin eventAdmin)
+        final PatientAccessConfiguration patientAccessConfiguration, final EventAdmin eventAdmin,
+        final boolean includePatientName)
     {
         this.resolverFactory = resolverFactory;
         this.resolverProvider = resolverProvider;
@@ -86,6 +90,7 @@ abstract class AbstractEmailNotification
         this.formUtils = formUtils;
         this.patientAccessConfiguration = patientAccessConfiguration;
         this.eventAdmin = eventAdmin;
+        this.includePatientName = includePatientName;
     }
 
     /*
@@ -164,7 +169,10 @@ abstract class AbstractEmailNotification
             return null;
         }
 
-        String patientFullName = AppointmentUtils.getPatientFullName(this.formUtils, patientSubject);
+        String patientFullName = this.includePatientName
+            ? AppointmentUtils.getPatientFullName(this.formUtils, patientSubject)
+            : null;
+
         Calendar visitDate = (Calendar) this.formUtils.getValue(appointmentDate);
         Calendar tokenExpiryDate = (Calendar) visitDate.clone();
         final int tokenLifetime =

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentEmailNotificationsFactory.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentEmailNotificationsFactory.java
@@ -109,6 +109,11 @@ public final class AppointmentEmailNotificationsFactory
                 + "If empty, the environment variable NIGHTLY_NOTIFICATIONS_SCHEDULE is used. "
                 + "If that one isn't set either, a default schedule of 6 AM daily is used.")
         String schedule();
+
+        @AttributeDefinition(name = "Patient name in header",
+            description = "If true, the patients' name will be included in the email headers 'To:' field"
+        )
+        boolean includePatientName() default false;
     }
 
     @Activate
@@ -129,7 +134,7 @@ public final class AppointmentEmailNotificationsFactory
         final Runnable notificationsJob = new GeneralNotificationsTask(this.resolverFactory, this.resolverProvider,
             this.eventAdmin, this.tokenManager, this.mailService, this.formUtils, this.patientAccessConfiguration,
             config.name(), config.notificationType(), config.clinicId(), config.emailConfiguration(),
-            config.daysToVisit());
+            config.daysToVisit(), config.includePatientName());
 
         try {
             this.scheduler.schedule(notificationsJob, notificationsOptions);

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/GeneralNotificationsTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/GeneralNotificationsTask.java
@@ -76,10 +76,11 @@ public class GeneralNotificationsTask extends AbstractEmailNotification implemen
         final ThreadResourceResolverProvider resolverProvider, final EventAdmin eventAdmin,
         final TokenManager tokenManager, final MailService mailService,
         final FormUtils formUtils, final PatientAccessConfiguration patientAccessConfiguration, final String taskName,
-        final String notificationType, final String clinicId, final String emailTemplatePath, final int daysToVisit)
+        final String notificationType, final String clinicId, final String emailTemplatePath, final int daysToVisit,
+        final boolean includePatientName)
     {
         super(resolverFactory, resolverProvider, tokenManager, mailService, formUtils, patientAccessConfiguration,
-            eventAdmin);
+            eventAdmin, includePatientName);
         this.taskName = taskName;
         this.notificationType = notificationType;
         this.clinicId = clinicId;

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/CPES/mailTemplates/InitialInvitation/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/CPES/mailTemplates/InitialInvitation/ROOT.json
@@ -2,7 +2,5 @@
   "jcr:primaryType": "cards:EmailTemplate",
   "senderAddress": "yourexperience@uhn.ca",
   "senderName": "Your Experience",
-  "subject": "UHN Patient Experience Survey",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "subject": "UHN Patient Experience Survey"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/CPES/mailTemplates/ReminderNotification/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/CPES/mailTemplates/ReminderNotification/ROOT.json
@@ -2,7 +2,5 @@
   "jcr:primaryType": "cards:EmailTemplate",
   "senderAddress": "yourexperience@uhn.ca",
   "senderName": "Your Experience",
-  "subject": "UHN Patient Experience Survey",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "subject": "UHN Patient Experience Survey"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC-IP/mailTemplates/InitialInvitation/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC-IP/mailTemplates/InitialInvitation/ROOT.json
@@ -3,7 +3,5 @@
   "senderAddress": "PMExperience@uhn.ca",
   "senderName": "The Patient Experience Team",
   "subject": "Princess Margaret Patient Experience Survey",
-  "unit": "/Questionnaires/Visit information/provider",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "unit": "/Questionnaires/Visit information/provider"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC-IP/mailTemplates/ReminderNotification/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC-IP/mailTemplates/ReminderNotification/ROOT.json
@@ -3,7 +3,5 @@
   "senderAddress": "PMExperience@uhn.ca",
   "senderName": "The Patient Experience Team",
   "subject": "Princess Margaret Patient Experience Survey",
-  "unit": "/Questionnaires/Visit information/provider",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "unit": "/Questionnaires/Visit information/provider"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC/mailTemplates/InitialInvitation/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC/mailTemplates/InitialInvitation/ROOT.json
@@ -4,7 +4,5 @@
   "senderName": "The Patient Experience Team",
   "subject": "Princess Margaret Patient Experience Survey",
   "skipAttachment_PE-Logo.png": true,
-  "unit": "/Questionnaires/Visit information/provider",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "unit": "/Questionnaires/Visit information/provider"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC/mailTemplates/ReminderNotification/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-AC/mailTemplates/ReminderNotification/ROOT.json
@@ -4,7 +4,5 @@
   "senderName": "The Patient Experience Team",
   "subject": "Princess Margaret Patient Experience Survey",
   "skipAttachment_PE-Logo.png": true,
-  "unit": "/Questionnaires/Visit information/provider",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "unit": "/Questionnaires/Visit information/provider"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/ROOT.json
@@ -3,7 +3,5 @@
   "senderAddress": "PMExperience@uhn.ca",
   "senderName": "The Patient Experience Team",
   "subject": "About Your Recent Experience at Princess Margaret Cancer Centre",
-  "skipAttachment_PE-Logo.png": true,
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "skipAttachment_PE-Logo.png": true
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/ROOT.json
@@ -3,7 +3,5 @@
   "senderAddress": "PMExperience@uhn.ca",
   "senderName": "The Patient Experience Team",
   "subject": "About Your Recent Experience at Princess Margaret Cancer Centre",
-  "skipAttachment_PE-Logo.png": true,
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "skipAttachment_PE-Logo.png": true
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-ED/mailTemplates/InitialInvitation/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-ED/mailTemplates/InitialInvitation/ROOT.json
@@ -2,7 +2,5 @@
   "jcr:primaryType": "cards:EmailTemplate",
   "senderAddress": "yourexperience@uhn.ca",
   "senderName": "Your Experience",
-  "subject": "UHN Patient Experience Survey",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "subject": "UHN Patient Experience Survey"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-ED/mailTemplates/ReminderNotification/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-ED/mailTemplates/ReminderNotification/ROOT.json
@@ -2,7 +2,5 @@
   "jcr:primaryType": "cards:EmailTemplate",
   "senderAddress": "yourexperience@uhn.ca",
   "senderName": "Your Experience",
-  "subject": "UHN Patient Experience Survey",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "subject": "UHN Patient Experience Survey"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-EDIP/mailTemplates/InitialInvitation/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-EDIP/mailTemplates/InitialInvitation/ROOT.json
@@ -2,7 +2,5 @@
   "jcr:primaryType": "cards:EmailTemplate",
   "senderAddress": "yourexperience@uhn.ca",
   "senderName": "Your Experience",
-  "subject": "UHN Patient Experience Survey",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "subject": "UHN Patient Experience Survey"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-EDIP/mailTemplates/ReminderNotification/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-EDIP/mailTemplates/ReminderNotification/ROOT.json
@@ -2,7 +2,5 @@
   "jcr:primaryType": "cards:EmailTemplate",
   "senderAddress": "yourexperience@uhn.ca",
   "senderName": "Your Experience",
-  "subject": "UHN Patient Experience Survey",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "subject": "UHN Patient Experience Survey"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/InitialInvitation/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/InitialInvitation/ROOT.json
@@ -4,7 +4,5 @@
   "senderName": "UHN Integrated Care",
   "replyToAddress": "IC_Patientexperience@uhn.ca",
   "replyToName": "UHN Integrated Care",
-  "subject": "UHN Patient Experience Survey",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "subject": "UHN Patient Experience Survey"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/ReminderNotification/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-ED/mailTemplates/ReminderNotification/ROOT.json
@@ -4,7 +4,5 @@
   "senderName": "UHN Integrated Care",
   "replyToAddress": "IC_Patientexperience@uhn.ca",
   "replyToName": "UHN Integrated Care",
-  "subject": "UHN Patient Experience Survey",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "subject": "UHN Patient Experience Survey"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/InitialInvitation/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/InitialInvitation/ROOT.json
@@ -4,7 +4,5 @@
   "senderName": "UHN Integrated Care",
   "replyToAddress": "IC_Patientexperience@uhn.ca",
   "replyToName": "UHN Integrated Care",
-  "subject": "UHN Patient Experience Survey",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "subject": "UHN Patient Experience Survey"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/ReminderNotification/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-EDIP/mailTemplates/ReminderNotification/ROOT.json
@@ -4,7 +4,5 @@
   "senderName": "UHN Integrated Care",
   "replyToAddress": "IC_Patientexperience@uhn.ca",
   "replyToName": "UHN Integrated Care",
-  "subject": "UHN Patient Experience Survey",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "subject": "UHN Patient Experience Survey"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/InitialInvitation/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/InitialInvitation/ROOT.json
@@ -4,7 +4,5 @@
   "senderName": "UHN Integrated Care",
   "replyToAddress": "IC_Patientexperience@uhn.ca",
   "replyToName": "UHN Integrated Care",
-  "subject": "UHN Patient Experience Survey",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "subject": "UHN Patient Experience Survey"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/ReminderNotification/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC-IP/mailTemplates/ReminderNotification/ROOT.json
@@ -4,7 +4,5 @@
   "senderName": "UHN Integrated Care",
   "replyToAddress": "IC_Patientexperience@uhn.ca",
   "replyToName": "UHN Integrated Care",
-  "subject": "UHN Patient Experience Survey",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "subject": "UHN Patient Experience Survey"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/InitialInvitation/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/InitialInvitation/ROOT.json
@@ -4,7 +4,5 @@
   "senderName": "UHN Integrated Care",
   "replyToAddress": "IC_Patientexperience@uhn.ca",
   "replyToName": "UHN Integrated Care",
-  "subject": "UHN Patient Experience Survey",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "subject": "UHN Patient Experience Survey"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/ReminderNotification/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IC/mailTemplates/ReminderNotification/ROOT.json
@@ -4,7 +4,5 @@
   "senderName": "UHN Integrated Care",
   "replyToAddress": "IC_Patientexperience@uhn.ca",
   "replyToName": "UHN Integrated Care",
-  "subject": "UHN Patient Experience Survey",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "subject": "UHN Patient Experience Survey"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IP/mailTemplates/InitialInvitation/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IP/mailTemplates/InitialInvitation/ROOT.json
@@ -2,7 +2,5 @@
   "jcr:primaryType": "cards:EmailTemplate",
   "senderAddress": "yourexperience@uhn.ca",
   "senderName": "Your Experience",
-  "subject": "UHN Patient Experience Survey",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "subject": "UHN Patient Experience Survey"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IP/mailTemplates/ReminderNotification/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-IP/mailTemplates/ReminderNotification/ROOT.json
@@ -2,7 +2,5 @@
   "jcr:primaryType": "cards:EmailTemplate",
   "senderAddress": "yourexperience@uhn.ca",
   "senderName": "Your Experience",
-  "subject": "UHN Patient Experience Survey",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "subject": "UHN Patient Experience Survey"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-Rehab/mailTemplates/InitialInvitation/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-Rehab/mailTemplates/InitialInvitation/ROOT.json
@@ -2,7 +2,5 @@
   "jcr:primaryType": "cards:EmailTemplate",
   "senderAddress": "yourexperience@uhn.ca",
   "senderName": "Your Experience",
-  "subject": "UHN Patient Experience Survey",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "subject": "UHN Patient Experience Survey"
 }

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-Rehab/mailTemplates/ReminderNotification/ROOT.json
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/UHN-Rehab/mailTemplates/ReminderNotification/ROOT.json
@@ -2,7 +2,5 @@
   "jcr:primaryType": "cards:EmailTemplate",
   "senderAddress": "yourexperience@uhn.ca",
   "senderName": "Your Experience",
-  "subject": "UHN Patient Experience Survey",
-  "first_name": "/Questionnaires/Patient information/first_name",
-  "last_name": "/Questionnaires/Patient information/last_name"
+  "subject": "UHN Patient Experience Survey"
 }


### PR DESCRIPTION
- Adds a configuration option to include the patient's name in the emails' To: field.
  - This configuration is False by default.
- Remove unused first and last name properties from prems email configurations

To test:
- Build with `-P docker`
- In `compose-cluster`, run `python3 generate_compose_yaml.py --dev_docker_image --oak_filesystem --cards_project cards4prems --smtps --smtps_test_container --smtps_test_mail_path ~/cardsmail --composum`
- Edit the generated `docker-compose.yml` file, and at the end of the environment section of the `cardsinitial` service, add:
```
- NIGHTLY_NOTIFICATIONS_SCHEDULE=0 * * * * ? *
```
- Start with `docker-compose up`
Create a new `Patient Information` form with no names and a `Visit information` form 7 days ago. Remember which clinic is selected.
- Wait one minute, then check the contents of the `~/cardsmail` folder. Make sure there is no name in the emails `To:` field (eg. `To: a@b.ca`)
- Edit the Patient Information form to add a first and last name
- Use the web console to edit the configuration for the used clinic
  - http://localhost:8080/system/console/configMgr
  - The desired configuration will be named similar to `io.uhndata.cards.patients.emailnotifications.AppointmentEmailNotificationsFactory~PM-AC-InitialInvitationTask`
  - Select `Patient name in header` and save the configuration
- Wait one minute and check the `~/cardsmail` folder. Make sure that the patient name is now in the most recent `To:` field (eg. `To: John Doe <a@b.ca>`)