### PR TITLE
[misc] Add python script to reorder importable json files

### DIFF
--- a/Utilities/JSON-to-XML/importable_json_processor.py
+++ b/Utilities/JSON-to-XML/importable_json_processor.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+"""
+
+import sys
+import json
+import os
+from collections import OrderedDict
+
+RAW_JSON = sys.argv[1]
+with open(RAW_JSON, 'r') as f_json:
+    questionnaire = json.loads(f_json.read(), object_pairs_hook=OrderedDict)
+
+def process_node(node):
+    ordered_properties = [
+        "jcr:primaryType",
+        "title",
+        "text",
+        "description",
+        "maxAnswers",
+        "minAnswers",
+        "dataType",
+        "entryMode",
+        "displayMode"
+    ]
+    ordered_properties.reverse()
+    for prop in ordered_properties:
+        if prop in node.keys():
+            node.move_to_end(prop, last=False)
+    for key in node.keys():
+        val = node[key]
+        if type(val) == OrderedDict:
+            process_node(val)
+
+process_node(questionnaire)
+with open(RAW_JSON, 'w') as output:
+    json.dump(questionnaire, output, indent='\t')
+    output.close()
+    os.system("python3 ../JSON-to-XML/json_to_xml.py '" + RAW_JSON + "' > '" + RAW_JSON[:-5] + ".xml'")

--- a/Utilities/JSON-to-XML/importable_json_processor.py
+++ b/Utilities/JSON-to-XML/importable_json_processor.py
@@ -54,4 +54,5 @@ process_node(questionnaire)
 with open(RAW_JSON, 'w') as output:
     json.dump(questionnaire, output, indent='\t')
     output.close()
-    os.system("python3 ../JSON-to-XML/json_to_xml.py '" + RAW_JSON + "' > '" + RAW_JSON[:-5] + ".xml'")
+    file_path = os.path.dirname(os.path.abspath(__file__))
+    os.system("python3 " + file_path + "/json_to_xml.py '" + RAW_JSON + "' > '" + RAW_JSON[:-5] + ".xml'")

--- a/Utilities/JSON-to-XML/json_to_xml.py
+++ b/Utilities/JSON-to-XML/json_to_xml.py
@@ -95,6 +95,9 @@ def save_as_xml(d, node_name="XmlQuestionnaire", indentation_level=0):
 xml_name = JSON_QUESTIONNAIRE
 if (xml_name.endswith('.json')):
     xml_name = xml_name[:-1*len('.json')]
+if ("/" in xml_name):
+    # Only use the base filename, not the path to the file
+    xml_name = xml_name[xml_name.rfind("/") + 1:]
 
 print("""<!--
   Licensed to the Apache Software Foundation (ASF) under one


### PR DESCRIPTION
- Add a new python script that will:
  1. Take in a json file that was outputted by the json importable export
  2. Reorder some node properties to be in a more readable order
  3. Send the output to JSON_to_XML script

Example usage:
Run the following in cards/Utilities/JSON-to-XML:
```
python3 importable_json_processor.py Example.json
```
Example importable forms can be generated by following the testing steps in #1838
This will:
- Read cards/Utilities/JSON-to-XML/Example.json
- Write the reordered json back into Example.json
- Output the resulting xml to cards/Utilities/JSON-to-XML/Example.xml