### PR TITLE
CARDS-2609: Configurable actions on user dashboard and related views

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -44,12 +44,18 @@ import NewFormDialog from "./NewFormDialog.jsx";
 import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
 
 function FormView(props) {
-  const { questionnaire, expanded, disableHeader, disableAvatar, topPagination, classes } = props;
+  const { extension, questionnaire, expanded, disableHeader, disableAvatar, topPagination, classes } = props;
 
   const [ title, setTitle ] = useState(props.title);
   const [ subtitle, setSubtitle ] = useState(props.subtitle);
   const [ qFilter, setQFilter ] = useState();
   const [ filtersJsonString, setFiltersJsonString ] = useState(new URLSearchParams(window.location.hash.substring(1)).get("forms:filters"));
+
+  const disableExpansion = extension?.["cards:disableExpansion"] || props.disableExpansion
+  const disableActions = extension?.["cards:disableActions"] || props.disableActions
+  const disableCreation = extension?.["cards:disableCreation"] || props.disableCreation
+  const admin = extension?.["cards:admin"] || props.admin
+  const baseURL = "/content.html" + admin ? "/admin" : ""
 
   // Column configuration for the LiveTables
   const columns = [
@@ -129,9 +135,9 @@ function FormView(props) {
           </>
         }
         action={
-          !expanded &&
+          !expanded && !disableExpansion &&
           <Tooltip title="Expand">
-            <Link to={"/content.html/Forms#" + new URLSearchParams({"forms:activeTab" : tabs?.[activeTab] || "", "forms:filters" : filtersJsonString || ""}).toString()} underline="hover">
+            <Link to={baseURL + "/Forms#" + new URLSearchParams({"forms:activeTab" : tabs?.[activeTab] || "", "forms:filters" : filtersJsonString || ""}).toString()} underline="hover">
               <IconButton size="large">
                 <LaunchIcon/>
               </IconButton>
@@ -150,14 +156,20 @@ function FormView(props) {
           filters
           questionnaire={questionnaire}
           entryType="Form"
-          actions={actions}
+          actions={ disableActions ? undefined : actions}
           disableTopPagination={!topPagination}
           onFiltersChange={(str) => { setFiltersJsonString(str); }}
           filtersJsonString={filtersJsonString}
+          admin={admin}
         />
       }
-      { expanded &&
-        <NewFormDialog presetPath={questionnaire} withButton buttonTitle="New questionnaire" />
+      { expanded && !disableCreation &&
+        <NewFormDialog
+          presetPath={questionnaire}
+          withButton
+          buttonTitle="New questionnaire"
+          admin={admin}
+        />
       }
       </CardContent>
     </Card>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -28,11 +28,15 @@ import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
 import { usePageNameWriterContext } from "../themePage/Page.jsx";
 
 function Forms(props) {
-  const { location, classes } = props;
+  const { location, extension, classes } = props;
   const questionnaire = /questionnaire=([^&]+)/.exec(location.search)?.[1];
   const pageNameWriter = usePageNameWriterContext();
 
   const entry = /Forms\/([^.\/]+)/.exec(location.pathname);
+  const disableActions = extension?.["cards:disableActions"]
+  const disableDeletion = extension?.["cards:disableDeletion"]
+  const disableMoving = extension?.["cards:disableMoving"]
+  const admin = extension?.["cards:admin"]
 
   // When moving from a specific form to the "Forms" page, ensure that the title properly changes
   useEffect(() => {
@@ -42,7 +46,14 @@ function Forms(props) {
   }, [entry]);
 
   if (entry) {
-    return <Form id={entry[1]} key={location.pathname} contentOffset={props.contentOffset} />;
+    return <Form
+      id={entry[1]}
+      key={location.pathname}
+      contentOffset={props.contentOffset}
+      disableDeletion={disableDeletion}
+      disableMoving={disableMoving}
+      admin={admin}
+      />;
   }
 
   const columns = [
@@ -55,7 +66,7 @@ function Forms(props) {
     {
       "key": "",
       "label": "Subject",
-      "format": (row) => (row.subject ? getHierarchy(row.subject) : ''),
+      "format": (row) => (row.subject ? getHierarchy(row.subject, undefined, undefined, admin) : ''),
     },
     {
       "key": "questionnaire/title",
@@ -81,6 +92,8 @@ function Forms(props) {
           expanded
           columns={columns}
           questionnaire={questionnaire}
+          disableActions={disableActions}
+          admin={admin}
         />
       </Grid>
     </Grid>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -34,6 +34,7 @@ function Forms(props) {
 
   const entry = /Forms\/([^.\/]+)/.exec(location.pathname);
   const disableActions = extension?.["cards:disableActions"]
+  const disableCreation = extension?.["cards:disableCreation"]
   const disableDeletion = extension?.["cards:disableDeletion"]
   const disableMoving = extension?.["cards:disableMoving"]
   const admin = extension?.["cards:admin"]
@@ -93,6 +94,7 @@ function Forms(props) {
           columns={columns}
           questionnaire={questionnaire}
           disableActions={disableActions}
+          disableCreation={disableCreation}
           admin={admin}
         />
       </Grid>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -188,7 +188,7 @@ function LiveTable(props) {
 
   let makeRow = (entry, i) => {
     return (
-      <TableRow key={entry["@path"] + i}>
+      <TableRow key={entry["@path"] + i} className={classes.dataRow}>
         { columns ?
           (
             columns.map((column, index) => makeCell(entry, column, index))

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -46,7 +46,7 @@ const PROGRESS_SELECT_SUBJECT = 1;
  * @param {presetPath} string The questionnaire to use automatically, if any.
  */
 function NewFormDialog(props) {
-  const { classes, presetPath, currentSubject, theme, open, onClose, withButton, buttonTitle } = {open: false, ...props };
+  const { classes, presetPath, currentSubject, theme, open, onClose, withButton, buttonTitle, admin } = {open: false, ...props };
   const [ dialogOpen, setDialogOpen ] = useState(false);
   const [ newSubjectPopperOpen, setNewSubjectPopperOpen ] = useState(false);
   const [ initialized, setInitialized ] = useState(false);
@@ -108,7 +108,7 @@ function NewFormDialog(props) {
           // Redirect the user to the new uuid
           // FIXME: Would be better to somehow obtain the router prefix from props
           // but that is not currently possible
-          props.history.push("/content.html" + URL + '.edit');
+          props.history.push("/content.html" + (admin ? "/admin" : "") + URL + '.edit');
         } else {
           return(Promise.reject(response));
         }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
@@ -45,7 +45,7 @@ import NewItemButton from "../components/NewItemButton.jsx";
 import { NewSubjectDialog } from "../questionnaire/SubjectSelector.jsx";
 
 function SubjectView(props) {
-  const { expanded, disableHeader, disableAvatar, topPagination, classes } = props;
+  const { expanded, disableHeader, disableAvatar, topPagination, extension, classes } = props;
   const [ newSubjectPopperOpen, setNewSubjectPopperOpen ] = useState(false);
   const [ activeTab, setActiveTab ] = useState(0);
   const [ subjectTypes, setSubjectTypes] = useState([])
@@ -53,6 +53,12 @@ function SubjectView(props) {
   const [ columns, setColumns ] = React.useState(props.columns || null);
   const [ filtersJsonString, setFiltersJsonString ] = useState(new URLSearchParams(window.location.hash.substring(1)).get("subjects:filters"));
   const hasSubjects = tabsLoading === false && subjectTypes.length > 0;
+
+  const disableExpansion = extension?.["cards:disableExpansion"] || props.disableExpansion
+  const disableActions = extension?.["cards:disableActions"] || props.disableActions
+  const disableCreation = extension?.["cards:disableCreation"] || props.disableCreation
+  const admin = extension?.["cards:admin"] || props.admin
+  const baseURL = "/content.html" + admin ? "/admin" : ""
 
   const activeTabParam = new URLSearchParams(window.location.hash.substring(1)).get("subjects:activeTab");
 
@@ -134,9 +140,9 @@ function SubjectView(props) {
             </Tabs>
         }
         action={
-          !expanded &&
+          !expanded && !disableExpansion &&
           <Tooltip title="Expand">
-            <Link to={"/content.html/Subjects#" + new URLSearchParams({"subjects:activeTab" : subjectTypes?.[activeTab]?.['@name'] || "", "subjects:filters" : filtersJsonString || ""}).toString()} underline="hover">
+            <Link to={baseURL + "/Subjects#" + new URLSearchParams({"subjects:activeTab" : subjectTypes?.[activeTab]?.['@name'] || "", "subjects:filters" : filtersJsonString || ""}).toString()} underline="hover">
               <IconButton size="large">
                 <LaunchIcon/>
               </IconButton>
@@ -154,16 +160,17 @@ function SubjectView(props) {
               customUrl={'/Subjects.paginate?fieldname=type&fieldvalue='+ encodeURIComponent(subjectTypes[activeTab]["jcr:uuid"])}
               defaultLimit={10}
               entryType="Subject"
-              actions={actions}
+              actions={ disableActions ? undefined : actions}
               disableTopPagination={!topPagination}
               filters
               onFiltersChange={(str) => setFiltersJsonString(str)}
               filtersJsonString={filtersJsonString}
+              admin={admin}
             />
           : <Typography>No results</Typography>
       }
       </CardContent>
-      {expanded &&
+      {expanded && !disableCreation &&
       <>
         <NewItemButton
            onClick={() => {setNewSubjectPopperOpen(true)}}
@@ -172,6 +179,7 @@ function SubjectView(props) {
           onClose={() => { setNewSubjectPopperOpen(false);}}
           onSubmit={() => { setNewSubjectPopperOpen(false);}}
           open={newSubjectPopperOpen}
+          admin={admin}
         />
       </>
       }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
@@ -91,6 +91,7 @@ function Subjects(props) {
           expanded
           columns={columns}
           disableActions={disableActions}
+          disableCreation={disableCreation}
           admin={admin}
         />
       </Grid>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
@@ -28,8 +28,13 @@ import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 import { usePageNameWriterContext } from "../themePage/Page.jsx";
 
 function Subjects(props) {
-  const { classes } = props;
+  const { extension, classes } = props;
   const entry = getSubjectIdFromPath(location.pathname);
+
+  const disableActions = extension?.["cards:disableActions"]
+  const disableCreation = extension?.["cards:disableCreation"]
+  const disableDeletion = extension?.["cards:disableDeletion"]
+  const admin = extension?.["cards:admin"]
 
   // Clear the page name overwriting if moving from a specific Subject to the Subjects page
   const pageNameWriter = usePageNameWriterContext();
@@ -40,7 +45,14 @@ function Subjects(props) {
   }, [entry]);
 
   if (entry) {
-    return <Subject id={entry} contentOffset={props.contentOffset} key={entry} />;
+    return <Subject
+      id={entry}
+      contentOffset={props.contentOffset}
+      key={entry}
+      disableDeletion={disableDeletion}
+      disableCreation={disableCreation}
+      admin={admin}
+      />;
   }
 
   const columns = [
@@ -58,7 +70,7 @@ function Subjects(props) {
     {
       "key": "",
       "label": "Parents",
-      "format": (row) => (row['parents'] ? getHierarchy(row['parents']) : ''),
+      "format": (row) => (row['parents'] ? getHierarchy(row['parents'], undefined, undefined, admin) : ''),
     },
     {
       "key": "jcr:created",
@@ -78,6 +90,8 @@ function Subjects(props) {
         <SubjectView
           expanded
           columns={columns}
+          disableActions={disableActions}
+          admin={admin}
         />
       </Grid>
     </Grid>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -94,7 +94,9 @@ function UserDashboard(props) {
           dashboardExtensions.map((extension, index) => {
             let Extension = extension["cards:extensionRender"];
             return <Grid item xs={12} xl={6} key={"extension-" + index} className={classes.dashboardEntry}>
-              <Extension />
+              <Extension
+                extension={extension}
+                />
             </Grid>
           })
         }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/tableStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/tableStyle.jsx
@@ -65,6 +65,9 @@ const liveTableStyle = theme => ({
             float : "right"
         }
     },
+    dataRow: {
+        height: "3em"
+    },
 });
 
 export default liveTableStyle;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -72,7 +72,7 @@ import SessionExpiryWarningModal from "./SessionExpiryWarningModal.jsx";
  * @param {string} id the identifier of a form; this is the JCR node name
  */
 function Form (props) {
-  let { classes, id, contentOffset } = props;
+  let { classes, id, contentOffset, disableDeletion, disableMoving, admin } = props;
   let { mode, className, disableHeader, disableButton, doneButtonStyle, doneIcon, doneLabel, onDone, questionnaireAddons, paginationProps } = props;
   // Record if the form was already checked out before opening it, which may indicate that another user is editing, or it is being edited in a different tab
   let [ wasCheckedOut, setWasCheckedOut ] = useState(false);
@@ -157,7 +157,7 @@ function Form (props) {
   let formNode = React.useRef();
   let pageNameWriter = usePageNameWriterContext();
   const formURL = `/Forms/${id}`;
-  const urlBase = "/content.html";
+  const baseURL = "/content.html" + (admin ? "/admin" : "");
   const isEdit = window.location.pathname.endsWith(".edit") || mode == "edit";
   const isSummary = window.location.pathname.endsWith(".summary") || mode == "summary";
   let globalLoginDisplay = useContext(GlobalLoginContext);
@@ -387,23 +387,23 @@ function Form (props) {
     saveData(event);
   }
 
-  let onEdit = (event) => {
+  let onEdit = (url) => {
     // Redirect the user to the edit form mode
-    props.history.push(urlBase + formURL + '.edit' + window.location.hash);
+    props.history.push(url + '.edit' + window.location.hash);
   }
 
-  let onClose = (event) => {
+  let onClose = (url) => {
     // Redirect the user to the view form mode
     // ...but only after the Form has been saved and checked-in
     saveDataWithCheckin(undefined, () => {
         removeWindowHandlers && removeWindowHandlers();
-        props.history.push(urlBase + formURL);
+        props.history.push(url);
     });
   }
 
-  let onDelete = () => {
+  let onDelete = (baseURL, data) => {
     removeWindowHandlers && removeWindowHandlers();
-    props.history.push(urlBase + (data?.subject?.['@path'] || ''));
+    props.history.push(baseURL + (data?.subject?.['@path'] || ''));
   }
 
   let title = data?.questionnaire?.title || id || "";
@@ -443,86 +443,97 @@ function Form (props) {
     );
   }
 
-  let dropdownList = (
-                  <List>
-                    { isEdit ?
-                    <ListItem className={classes.actionsMenuItem}>
-                      <Button onClick={() => {setSelectorDialogOpen(true); setActionsMenu(null)}}>
-                        Change subject
-                      </Button>
-                    </ListItem>
-                    : <>
-                    <ListItem className={classes.actionsMenuItem}>
-                      <PrintButton
-                         variant="text"
-                         size="medium"
-                         resourcePath={formURL}
-                         resourceData={data}
-                         breadcrumb={getTextHierarchy(data?.subject, true)}
-                         date={DateTime.fromISO(data['jcr:created']).toLocaleString(DateTime.DATE_MED)}
-                         onClose={() => { setActionsMenu(null); }}
-                       />
-                    </ListItem>
-                    <ListItem className={classes.actionsMenuItem}>
-                      <Button
-                         size="medium"
-                         onClick={() => {
-                         window.open(formURL + ".txt");
-                         setActionsMenu(null);
-                        }}>
-                        Export as text
-                      </Button>
-                    </ListItem>
-                    </> }
-                    <ListItem className={classes.actionsMenuItem}>
-                      <DeleteButton
-                          entryPath={data ? data["@path"] : formURL}
-                          entryName={getEntityIdentifier(data)}
-                          entryType="Form"
-                          onComplete={onDelete}
-                          variant="text"
-                          size="medium"
-                        />
-                    </ListItem>
-                  </List>
-  )
+  let dropdownEntries = []
+  if (!isEdit) {
+    dropdownEntries.push(
+      <ListItem className={classes.actionsMenuItem}>
+        <PrintButton
+          variant="text"
+          size="medium"
+          resourcePath={formURL}
+          resourceData={data}
+          breadcrumb={getTextHierarchy(data?.subject, true)}
+          date={DateTime.fromISO(data['jcr:created']).toLocaleString(DateTime.DATE_MED)}
+          onClose={() => { setActionsMenu(null); }}
+        />
+      </ListItem>
+    )
+    dropdownEntries.push(
+      <ListItem className={classes.actionsMenuItem}>
+        <Button
+          size="medium"
+          onClick={() => {
+          window.open(formURL + ".txt");
+          setActionsMenu(null);
+          }}>
+          Export as text
+        </Button>
+      </ListItem>
+    )
+  } else if (!disableMoving) {
+    dropdownEntries.push(
+      <ListItem className={classes.actionsMenuItem}>
+        <Button onClick={() => {setSelectorDialogOpen(true); setActionsMenu(null)}}>
+          Change subject
+        </Button>
+      </ListItem>
+    )
+  }
+  if (!disableDeletion) {
+    dropdownEntries.push(
+      <ListItem className={classes.actionsMenuItem}>
+        <DeleteButton
+            entryPath={data ? data["@path"] : formURL}
+            entryName={getEntityIdentifier(data)}
+            entryType="Form"
+            onComplete={(event) => onDelete(baseURL, data)}
+            variant="text"
+            size="medium"
+          />
+      </ListItem>
+    )
+  }
 
   let formMenu = (
             <div className={classes.actionsMenu}>
                 {isEdit ?
-                  <Tooltip title="Save and view" onClick={onClose}>
+                  <Tooltip title="Save and view" onClick={() => onClose(baseURL + formURL)}>
                     <IconButton color="primary" size="large">
                       <DoneIcon />
                     </IconButton>
                   </Tooltip>
                   :
                   <Tooltip title="Edit">
-                    <IconButton color="primary" onClick={onEdit} size="large">
+                    <IconButton color="primary" onClick={() => onEdit(baseURL + formURL)} size="large">
                       <EditIcon />
                     </IconButton>
                   </Tooltip>
                 }
-                <Tooltip title="More actions" onClick={(event) => {setActionsMenu(event.currentTarget)}}>
-                  <IconButton size="large">
-                    <MoreIcon fontSize="small" />
-                  </IconButton>
-                </Tooltip>
-                { !actionsMenu && <div style={{display: "none"}}>{ dropdownList }</div> }
-                <Popover
-                    open={Boolean(actionsMenu)}
-                    anchorEl={actionsMenu}
-                    onClose={() => {setActionsMenu(null)}}
-                    anchorOrigin={{
-                        vertical: 'bottom',
-                        horizontal: 'right',
-                    }}
-                    transformOrigin={{
-                        vertical: 'top',
-                        horizontal: 'right',
-                    }}
-                >
-                  { dropdownList }
-                </Popover>
+                {dropdownEntries.length > 0 &&
+                  <>
+                    <Tooltip title="More actions" onClick={(event) => {setActionsMenu(event.currentTarget)}}>
+                      <IconButton size="large">
+                        <MoreIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                    { !actionsMenu && <div style={{display: "none"}}><List>{dropdownEntries}</List></div> }
+                    <Popover
+                        open={Boolean(actionsMenu)}
+                        anchorEl={actionsMenu}
+                        onClose={() => {setActionsMenu(null)}}
+                        anchorOrigin={{
+                            vertical: 'bottom',
+                            horizontal: 'right',
+                        }}
+                        transformOrigin={{
+                            vertical: 'top',
+                            horizontal: 'right',
+                        }}
+                    >
+                      <List>{dropdownEntries}</List>
+                    </Popover>
+                  </>
+                }
             </div>
   )
 
@@ -537,10 +548,10 @@ function Form (props) {
         <Typography variant="overline">
           {"Related: "}
           {validLinks.length == 1 ?
-              validLinks.map(link => <Link key={link["@name"]} to={"/content.html" + link["to"]}>{link["resourceLabel"]}</Link>)
+              validLinks.map(link => <Link key={link["@name"]} to={baseURL + link["to"]}>{link["resourceLabel"]}</Link>)
               :
               <List dense disablePadding>
-              {validLinks.map(link => <ListItem key={link["@name"]}><Link to={"/content.html" + link["to"]}>{link["resourceLabel"]}</Link></ListItem>)}
+              {validLinks.map(link => <ListItem key={link["@name"]}><Link to={baseURL + link["to"]}>{link["resourceLabel"]}</Link></ListItem>)}
               </List>
           }
         </Typography>
@@ -561,7 +572,7 @@ function Form (props) {
         { !disableHeader &&
         <ResourceHeader
           title={title}
-          breadcrumbs={[<Breadcrumbs separator="/">{getHierarchyAsList(data?.subject).map(a => <Typography variant="overline" key={a}>{a}</Typography>)}</Breadcrumbs>]}
+          breadcrumbs={[<Breadcrumbs separator="/">{getHierarchyAsList(data?.subject, undefined, admin).map(a => <Typography variant="overline" key={a}>{a}</Typography>)}</Breadcrumbs>]}
           tags={ statusFlags?.map( item => (
             <Chip
               label={item[0].toUpperCase() + item.slice(1).toLowerCase()}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -79,7 +79,7 @@ let createQueryURL = (query, type) => {
  */
 
 function Subject(props) {
-  let { id, classes, maxDisplayed, pageSize, history } = props;
+  let { id, classes, maxDisplayed, pageSize, history, disableDeletion, disableCreation, admin } = props;
   const [ currentSubject, setCurrentSubject ] = useState();
   const [ currentSubjectId, setCurrentSubjectId ] = useState(id);
   const [ activeTab, setActiveTab ] = useState(0);
@@ -89,6 +89,8 @@ function Subject(props) {
   // handleDisplay() to a utility file for SubjectContainer and SubjectTimeline.
   const tabs = ["Chart", "Timeline"]
   const location = useLocation();
+
+  const baseURL = "/content.html" + (admin ? "/admin" : "");
 
   useEffect(() => {
     let newId = getSubjectIdFromPath(location.pathname);
@@ -118,9 +120,26 @@ function Subject(props) {
 
   return (
     <React.Fragment>
-      <NewFormDialog currentSubject={currentSubject} withButton buttonTitle={ "New questionnaire for this " + (currentSubject?.type?.label || "Subject") } />
+      {!disableCreation &&
+        <NewFormDialog
+          currentSubject={currentSubject}
+          withButton
+          buttonTitle={ "New questionnaire for this " + (currentSubject?.type?.label || "Subject") }
+          admin={admin}
+        />
+      }
       <Grid container spacing={4} direction="column" className={classes.subjectContainer}>
-        <SubjectHeader id={currentSubjectId} key={"SubjectHeader"} pageTitle={pageTitle} classes={classes} getSubject={handleSubject} history={history} contentOffset={props.contentOffset}/>
+        <SubjectHeader
+          id={currentSubjectId}
+          key={"SubjectHeader"}
+          pageTitle={pageTitle}
+          classes={classes}
+          getSubject={handleSubject}
+          history={history}
+          contentOffset={props.contentOffset}
+          disableDeletion={disableDeletion}
+          admin={admin}
+        />
         <Grid item>
           <Tabs className={classes.subjectTabs} value={activeTab} onChange={(event, value) => {
             setTab(value);
@@ -140,6 +159,8 @@ function Subject(props) {
               maxDisplayed={maxDisplayed}
               pageSize={pageSize}
               subject={currentSubject}
+              disableDeletion={disableDeletion}
+              baseURL={baseURL}
             />
           : <Grid item>
             <SubjectTimeline
@@ -161,7 +182,7 @@ function Subject(props) {
  * Component that recursively gets and displays the selected subject and its related SubjectTypes
  */
 function SubjectContainer(props) {
-  let { id, classes, level, maxDisplayed, pageSize, subject } = props;
+  let { id, classes, level, maxDisplayed, pageSize, subject, disableDeletion, baseURL } = props;
   // Error message set when fetching the data from the server fails
   let [ error, setError ] = useState();
   // hold related subjects
@@ -220,7 +241,18 @@ function SubjectContainer(props) {
 
   return (
     subject && <React.Fragment>
-      <SubjectMember classes={classes} id={id} level={currentLevel} data={subject} maxDisplayed={maxDisplayed} pageSize={pageSize} onDelete={() => {setDeleted(true)}} childSubjects={relatedSubjects}/>
+      <SubjectMember
+        classes={classes}
+        id={id}
+        level={currentLevel}
+        data={subject}
+        maxDisplayed={maxDisplayed}
+        pageSize={pageSize}
+        onDelete={() => {setDeleted(true)}}
+        childSubjects={relatedSubjects}
+        disableDeletion={disableDeletion}
+        baseURL={baseURL}
+      />
     </React.Fragment>
   );
 }
@@ -229,7 +261,7 @@ function SubjectContainer(props) {
  * Component that displays the header for the selected subject and its SubjectType
  */
 function SubjectHeader(props) {
-  let { id, classes, getSubject, history, pageTitle } = props;
+  let { id, classes, getSubject, history, pageTitle, disableDeletion, admin } = props;
   // This holds the full form JSON, once it is received from the server
   let [ subject, setSubject ] = useState(null);
   // Error message set when fetching the data from the server fails
@@ -296,24 +328,26 @@ function SubjectHeader(props) {
   let title = `${label || "Subject"} ${identifier}`;
   let path = subject?.data?.["@path"] || "/Subjects/" + id;
   let subjectMenu = (
-            <div className={classes.actionsMenu}>
-               <PrintButton
-                 resourcePath={path}
-                 resourceData={subject?.data}
-                 breadcrumb={pageTitle}
-                 date={DateTime.fromISO(subject?.data['jcr:created']).toLocaleString(DateTime.DATE_MED)}
-               />
-               <DeleteButton
-                 entryPath={path}
-                 entryName={getEntityIdentifier(subject?.data)}
-                 entryType="Subject"
-                 entryLabel={label}
-                 onComplete={handleDeletion}
-                 size="large"
-               />
-            </div>
+    <div className={classes.actionsMenu}>
+      <PrintButton
+        resourcePath={path}
+        resourceData={subject?.data}
+        breadcrumb={pageTitle}
+        date={DateTime.fromISO(subject?.data['jcr:created']).toLocaleString(DateTime.DATE_MED)}
+      />
+      {!disableDeletion &&
+        <DeleteButton
+          entryPath={path}
+          entryName={getEntityIdentifier(subject?.data)}
+          entryType="Subject"
+          entryLabel={label}
+          onComplete={handleDeletion}
+          size="large"
+        />
+      }
+    </div>
   );
-  let parentDetails = (subject?.data?.['parents'] && getHierarchyAsList(subject.data['parents'], true) || [getHomepageLink(subject?.data)]);;
+  let parentDetails = (subject?.data?.['parents'] && getHierarchyAsList(subject.data['parents'], true, admin) || [getHomepageLink(subject?.data, admin)]);;
 
   return (
     subject?.data &&
@@ -348,7 +382,7 @@ function SubjectHeader(props) {
  * Component that displays all forms related to a Subject. Do not use directly, use SubjectMember instead.
  */
 function SubjectMemberInternal (props) {
-  let { classes, data, id, level, maxDisplayed, onDelete, pageSize, childSubjects } = props;
+  let { classes, data, id, level, maxDisplayed, onDelete, pageSize, childSubjects, disableDeletion, baseURL } = props;
   // Error message set when fetching the data from the server fails
   let [ error, setError ] = useState();
   // Whether a subject is expanded and displaying its forms
@@ -426,24 +460,27 @@ function SubjectMemberInternal (props) {
       </IconButton>
     </Tooltip>
   )
-  let action = <>
-                 <PrintButton
-                   resourcePath={path}
-                   resourceData={data}
-                   breadcrumb={getTextHierarchy(data, true)}
-                   date={DateTime.fromISO(data['jcr:created']).toLocaleString(DateTime.DATE_MED)}
-                   className={classes.childSubjectHeaderButton}
-                   disableShortcut
-                 />
-                 <DeleteButton
-                   entryPath={path}
-                   entryName={getEntityIdentifier(data)}
-                   entryType="Subject"
-                   entryLabel={label}
-                   onComplete={onDelete}
-                   className={classes.childSubjectHeaderButton}
-                 />
-               </>
+  let action =
+    <>
+      <PrintButton
+        resourcePath={path}
+        resourceData={data}
+        breadcrumb={getTextHierarchy(data, true)}
+        date={DateTime.fromISO(data['jcr:created']).toLocaleString(DateTime.DATE_MED)}
+        className={classes.childSubjectHeaderButton}
+        disableShortcut
+      />
+      {!disableDeletion &&
+        <DeleteButton
+          entryPath={path}
+          entryName={getEntityIdentifier(data)}
+          entryType="Subject"
+          entryLabel={label}
+          onComplete={onDelete}
+          className={classes.childSubjectHeaderButton}
+        />
+      }
+    </>
 
   let tags = statusFlags?.map( item => (
       <Chip
@@ -464,7 +501,7 @@ function SubjectMemberInternal (props) {
             <Grid item xs={false}>{avatar}</Grid>
             <Grid item xs={true}>
               <Typography variant="overline">
-                 {label} <Link to={"/content.html" + path} underline="hover">{identifier}</Link>
+                 {label} <Link to={baseURL + path} underline="hover">{identifier}</Link>
               </Typography>
             </Grid>
             <Grid item xs="3.5">{tags}</Grid>
@@ -557,7 +594,7 @@ function SubjectMemberInternal (props) {
                                        <Avatar className={classes.subjectFormAvatar}><FormIcon/></Avatar>
                                      </Grid>
                                      <Grid item xs={false}>
-                                       <Link to={"/content.html" + row.original["@path"]} underline="hover">
+                                       <Link to={baseURL + row.original["@path"]} underline="hover">
                                          {questionnaireTitle}
                                        </Link>
                                        <Typography variant="caption" component="div" color="textSecondary">
@@ -592,18 +629,20 @@ function SubjectMemberInternal (props) {
                 enableRowActions
                 positionActionsColumn="last"
                 renderRowActions={({ row }) => (
-                    <Box sx={{ display: 'flex', flexWrap: 'nowrap'}}>
-                      <EditButton
-                        entryPath={row.original["@path"]}
-                        entryType="Form"
-                      />
+                  <Box sx={{ display: 'flex', flexWrap: 'nowrap'}}>
+                    <EditButton
+                      entryPath={row.original["@path"]}
+                      entryType="Form"
+                    />
+                    {!disableDeletion &&
                       <DeleteButton
                         entryPath={row.original["@path"]}
                         entryName={getEntityIdentifier(row.original)}
                         entryType="Form"
                         onComplete={fetchTableData}
                       />
-                    </Box>
+                    }
+                  </Box>
                 )}
               />
             </Grid>
@@ -617,7 +656,17 @@ function SubjectMemberInternal (props) {
           {childSubjects.map( (subject, i) => {
             // Render the container again for each child subject
             return(
-              <SubjectContainer key={i} classes={classes} path={subject["@path"]} level={level+1} maxDisplayed={maxDisplayed} pageSize={pageSize} subject={subject}/>
+              <SubjectContainer
+                key={i}
+                classes={classes}
+                path={subject["@path"]}
+                level={level+1}
+                maxDisplayed={maxDisplayed}
+                pageSize={pageSize}
+                subject={subject}
+                disableDeletion={disableDeletion}
+                baseURL={baseURL}
+              />
             )
           })}
         </Grid>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectIdentifier.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectIdentifier.jsx
@@ -24,10 +24,15 @@ function defaultCreator (node) {
   return {to: "/content.html" + node["@path"]}
 }
 
+function adminCreator (node) {
+  return {to: "/content.html/admin" + node["@path"]}
+}
+
 // Extract the subject id from the subject path
 // returns null if the parameter is not a valid subject path (expected format: Subjects/<id>)
-export function getHomepageLink (subjectNode) {
-  let props = defaultCreator({"@path": `/Subjects#subjects:activeTab=${subjectNode?.type?.["@name"]}`});
+export function getHomepageLink (subjectNode, admin=false) {
+  let creator = admin ? adminCreator : defaultCreator;
+  let props = creator({"@path": `/Subjects#subjects:activeTab=${subjectNode?.type?.["@name"]}`});
   return (<Link {...props} underline="hover">{subjectNode?.type?.subjectListLabel || "Subjects"}</Link>);
 }
 
@@ -39,13 +44,12 @@ export function getSubjectIdFromPath (path) {
 }
 
 // Recursive function to get a flat list of parents
-export function getHierarchy (node, RenderComponent, propsCreator) {
+export function getHierarchy (node, RenderComponent, propsCreator, admin=false) {
   let HComponent = RenderComponent || Link;
-  let hpropsCreator = propsCreator || defaultCreator;
-  let props = hpropsCreator(node);
+  let props = propsCreator || (admin ? adminCreator(node) : defaultCreator(node));
   let output = <React.Fragment>{node.type.label} <HComponent {...props}>{node.identifier}</HComponent></React.Fragment>;
   if (node["parents"] && node["parents"].type) {
-    let ancestors = getHierarchy(node["parents"], HComponent, propsCreator);
+    let ancestors = getHierarchy(node["parents"], HComponent, propsCreator, admin);
     return <React.Fragment>{ancestors} / {output}</React.Fragment>
   } else {
     return output;
@@ -65,19 +69,19 @@ export function getTextHierarchy (node, withType = false) {
 }
 
 // Recursive function to get the list of ancestors as an array
-export function getHierarchyAsList (node, includeHomepage) {
+export function getHierarchyAsList (node, includeHomepage, admin=false) {
   if (!node?.type) {
-    return includeHomepage ? [getHomepageLink()] : [];
+    return includeHomepage ? [getHomepageLink(undefined, admin)] : [];
   }
-  let props = defaultCreator(node);
+  let props = admin ? adminCreator(node) : defaultCreator(node);
   let parent = <>{node.type.label} <Link {...props} underline="hover">{node.identifier}</Link></>;
   if (node["parents"]) {
-    let ancestors = getHierarchyAsList(node["parents"]);
+    let ancestors = getHierarchyAsList(node["parents"], undefined, admin);
     ancestors.push(parent);
     return ancestors;
   } else {
     let result = [parent];
-    includeHomepage && result.unshift(getHomepageLink(node));
+    includeHomepage && result.unshift(getHomepageLink(node, admin));
     return result;
   }
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -421,7 +421,7 @@ export const parseToArray = (object) => {
  * @param {bool} open If true, this dialog is open
  */
 export function NewSubjectDialog (props) {
-  const { allowedTypes, currentSubject, disabled, onClose, onSubmit, open, disableRedirect } = props;
+  const { allowedTypes, currentSubject, disabled, onClose, onSubmit, open, disableRedirect, admin } = props;
   const [ error, setError ] = useState("");
   const [ newSubjectName, setNewSubjectName ] = useState([""]);
   const [ newSubjectType, setNewSubjectType ] = useState([""]);
@@ -452,7 +452,7 @@ export function NewSubjectDialog (props) {
       let subjectId = getSubjectIdFromPath(subject);
       if (!disableRedirect && subjectId) {
         history.push({
-          pathname: "/content.html/Subjects/" + subjectId
+          pathname: "/content.html" + (admin ? "/admin" : "") + "/Subjects/" + subjectId
         });
         return;
       } else {

--- a/modules/homepage/src/main/frontend/src/themePage/index.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/index.jsx
@@ -84,7 +84,7 @@ class Main extends React.Component {
             exact={Boolean(route["cards:exactURLMatch"])}
             render={(props) => {
                 let ThisComponent = route["cards:extensionRender"];
-                let newProps = {...props, contentOffset: this.state.contentOffset };
+                let newProps = {...props, contentOffset: this.state.contentOffset, extension: route };
                 let title = " | " + this.state.title;
                 return (
                   <Page title={title} pageDefaultName={route["cards:extensionName"]}>


### PR DESCRIPTION
- Add support for UI extensions to configure what actions should be allowed
  - Adds support for disableDeletion, disableMoving and disableCreation to form and subject clinician UIs where applicable
  - Adds support for disableActions and disableExpansion to subject and form dashboard views
- Add support for seperate admin extensions for the clinician UIs
  - This allows seperate action configurations for admin and non-admin views

Within built in CARDS runmodes, these configurations are unused. This means that no UI changes should be detected when running CARDS in any built in runmode.

To Test:
As these configurations are unused, all UIs within this branch should remain untouched. Instructions on what should be tested to ensure this can be found in the related [SPARC pull request](https://github.com/data-team-uhn/sparc/pull/47). That PR also contains instructions and configurations for testing when functionality has been changed.