### PR TITLE
CARDS-2613: Units of measurement for numeric answers should support superscript

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
@@ -283,13 +283,12 @@ function NumberQuestion(props) {
   let rangeErrorMessage = "The range is invalid: the lower limit must be less than or equal to the upper limit";
 
   let rangeDisplayFormatter = function(label, idx) {
-    if (idx > 0 || !(initialValue?.length)) return '';
-    let limits = initialValue.slice(0, 2);
-    // In case of invalid data (only one limit of the range is available)
-    if (limits.length == 1) {
-      limits.push("");
-    }
-    return limits.join(' - ');
+    if (idx != 1) return '';
+    return (
+      <FormattedText>
+        { `${initialValue?.[0]} &mdash; ${label}` }
+      </FormattedText>
+    );
   }
 
   let markdownFormatter = function(label, idx) {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
@@ -330,7 +330,7 @@ function NumberQuestion(props) {
 
   return (
     <Question
-      defaultDisplayFormatter={isRange ? rangeDisplayFormatter : unitOfMeasurement ? markdownFormatter : undefined}
+      defaultDisplayFormatter={isRange ? rangeDisplayFormatter : markdownFormatter }
       compact={isRange}
       disableInstructions
       {...props}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
@@ -37,6 +37,7 @@ import AnswerInstructions from "./AnswerInstructions";
 import Question from "./Question";
 import QuestionnaireStyle from "./QuestionnaireStyle";
 import MultipleChoice from "./MultipleChoice";
+import FormattedText from "../components/FormattedText";
 
 import AnswerComponentManager from "./AnswerComponentManager";
 
@@ -131,7 +132,7 @@ const useSliderStyles = makeStyles(theme => ({
 //    />
 function NumberQuestion(props) {
   const { existingAnswer, errorText, classes, pageActive, disableValueInstructions, ...rest} = props;
-  const { dataType,displayMode, minAnswers, minValue, maxValue, disableMinMaxValueEnforcement, messageForValuesOutsideMinMax, isRange,
+  const { dataType,displayMode, minAnswers, minValue, maxValue, disableMinMaxValueEnforcement, messageForValuesOutsideMinMax, isRange, unitOfMeasurement,
     sliderStep, sliderMarkStep, sliderOrientation, minValueLabel, maxValueLabel }
     = {sliderOrientation: "horizontal", ...props.questionDefinition, ...props};
   const answerNodeType = props.answerNodeType || DATA_TO_NODE_TYPE[dataType];
@@ -248,8 +249,8 @@ function NumberQuestion(props) {
     inputComponent: NumberFormatCustom, // Used to override a TextField's type
     className: classes.textField
   };
-  if (props.questionDefinition && props.questionDefinition.unitOfMeasurement) {
-    muiInputProps.endAdornment = <InputAdornment position="end">{props.questionDefinition.unitOfMeasurement}</InputAdornment>;
+  if (unitOfMeasurement) {
+    muiInputProps.endAdornment = <InputAdornment position="end"><FormattedText>{unitOfMeasurement}</FormattedText></InputAdornment>;
   }
 
   let hasAnswerOptions = !!(props.defaults || Object.values(props.questionDefinition).some(value => value['jcr:primaryType'] == 'cards:AnswerOption'));
@@ -291,6 +292,10 @@ function NumberQuestion(props) {
     return limits.join(' - ');
   }
 
+  let markdownFormatter = function(label, idx) {
+    return <FormattedText>{label}</FormattedText>;
+  }
+
   let setValue = function(fn, value) {
     let number = Number(value);
     if (dataType === "long" && !isNaN(number)) {
@@ -326,7 +331,7 @@ function NumberQuestion(props) {
 
   return (
     <Question
-      defaultDisplayFormatter={isRange? rangeDisplayFormatter : undefined}
+      defaultDisplayFormatter={isRange ? rangeDisplayFormatter : unitOfMeasurement ? markdownFormatter : undefined}
       compact={isRange}
       disableInstructions
       {...props}


### PR DESCRIPTION
Jira issue: https://phenotips.atlassian.net/browse/CARDS-2613

Also includes [CARDS-2615](https://phenotips.atlassian.net/browse/CARDS-2615): _Unit of measurement is not displayed for ranges in view mode_

To test, create a number question (long, decimal or double) and set the unit of measurement to `m<sup>2</sup>` for m<sup>2</sup>.

With markdown enabled in this field, one can technically set any kind of formatted text as the unit of measurement, including headings and tables. This should be ok because specifying the unit of measurement is a superuser (admin) feature and is expected to be used responsibly.

Limitation: we don't currently interpret the unit of measurement as markdown when we display it in the questionnaire designer. This is not considered urgent and can be done in a subsequent iteration.

[CARDS-2615]: https://phenotips.atlassian.net/browse/CARDS-2615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ