### PR TITLE
 CARDS-2618: Replace Livetable with MaterialReactTable in administration screens

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/EditButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/EditButton.jsx
@@ -38,11 +38,11 @@ function EditButton(props) {
         </IconButton>
 
   return (
-	<Tooltip title={entryType ? "Edit " + entryType.toLowerCase() : "Edit"}>
-	  { onClick
-	    ?
-	    innerButton
-	    :
+    <Tooltip title={entryType ? "Edit " + entryType.toLowerCase() : "Edit"}>
+      { onClick
+        ?
+        innerButton
+        :
         <Link to={(admin ? "/content.html/admin" : "/content.html") + entryPath + ".edit"} underline="hover">
           {innerButton}
         </Link>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/EditButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/EditButton.jsx
@@ -30,18 +30,24 @@ import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
  * A component that renders an icon to open the edit URL for an entry or to use local edit dialog.
  */
 function EditButton(props) {
-  const { entryPath, entryType, size, className, admin, onClick, useEditDialog } = props;
+  const { entryPath, entryType, size, className, admin, onClick } = props;
 
-  let innerButton = <Tooltip title={entryType ? "Edit " + entryType : "Edit"}>
+  let innerButton =
         <IconButton className={className} size={size} onClick={onClick}>
           <EditIcon />
         </IconButton>
-      </Tooltip>
 
-  return useEditDialog ? innerButton : (
-    <Link to={(admin ? "/content.html/admin" : "/content.html") + entryPath + ".edit"} underline="hover">
-     {innerButton}
-    </Link>
+  return (
+	<Tooltip title={entryType ? "Edit " + entryType.toLowerCase() : "Edit"}>
+	  { onClick
+	    ?
+	    innerButton
+	    :
+        <Link to={(admin ? "/content.html/admin" : "/content.html") + entryPath + ".edit"} underline="hover">
+          {innerButton}
+        </Link>
+      }
+    </Tooltip>
   )
 }
 
@@ -51,7 +57,7 @@ EditButton.propTypes = {
   size: PropTypes.oneOf(["small", "medium", "large"]),
   className: PropTypes.string,
   admin: PropTypes.bool,
-  useEditDialog: PropTypes.bool,
+  onClick: PropTypes.func
 }
 
 EditButton.defaultProps = {

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/EditButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/EditButton.jsx
@@ -27,17 +27,20 @@ import { Link } from 'react-router-dom';
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 
 /**
- * A component that renders an icon to open the edit URL for an entry.
+ * A component that renders an icon to open the edit URL for an entry or to use local edit dialog.
  */
 function EditButton(props) {
-  const { entryPath, entryType, size, className, admin } = props;
-  return(
-    <Link to={(admin ? "/content.html/admin" : "/content.html") + entryPath + ".edit"} underline="hover">
-      <Tooltip title={entryType ? "Edit " + entryType.toLowerCase() : "Edit"}>
-        <IconButton className={className} size={size}>
+  const { entryPath, entryType, size, className, admin, onClick, useEditDialog } = props;
+
+  let innerButton = <Tooltip title={entryType ? "Edit " + entryType : "Edit"}>
+        <IconButton className={className} size={size} onClick={onClick}>
           <EditIcon />
         </IconButton>
       </Tooltip>
+
+  return useEditDialog ? innerButton : (
+    <Link to={(admin ? "/content.html/admin" : "/content.html") + entryPath + ".edit"} underline="hover">
+     {innerButton}
     </Link>
   )
 }
@@ -48,6 +51,7 @@ EditButton.propTypes = {
   size: PropTypes.oneOf(["small", "medium", "large"]),
   className: PropTypes.string,
   admin: PropTypes.bool,
+  useEditDialog: PropTypes.bool,
 }
 
 EditButton.defaultProps = {

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
@@ -53,11 +53,14 @@ function Questionnaires(props) {
   let columns = [
     {
       header: "Title",
+      accessorKey: "title",
       Cell: ({ row }) => (<Link to={"/content.html/admin" + row.original["@path"]} underline="hover">{row.original.title}</Link>),
     },
     {
       header: "Created on",
+      accessorKey: "jcr:created",
       Cell: ({ row }) => _formatDate(row.original["jcr:created"], "yyyy-MM-dd HH:mm"),
+      sortingFn: 'datetime',
       size: 20,
     },
     {

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
@@ -68,7 +68,7 @@ function Questionnaires(props) {
       accessorKey: "description",
       header: "Description",
       enableSorting: false,
-      Cell: ({ row }) => <FormattedText>{row.original.description}</FormattedText>,
+      Cell: ({ row }) => <FormattedText variant="caption">{row.original.description}</FormattedText>,
     },
   ]
 

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
@@ -26,6 +26,7 @@ import DeleteButton from "./DeleteButton.jsx";
 import EditButton from "./EditButton.jsx";
 import ExportButton from "./ExportButton.jsx";
 import { DateTime } from "luxon";
+import FormattedText from "../components/FormattedText.jsx";
 
 // Convert a date into the given format string
 // If the date is invalid (usually because it is missing), return ""
@@ -66,6 +67,7 @@ function Questionnaires(props) {
     {
       accessorKey: "description",
       header: "Description",
+      Cell: ({ row }) => <FormattedText>{row.original.description}</FormattedText>,
     },
   ]
 

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
@@ -67,6 +67,7 @@ function Questionnaires(props) {
     {
       accessorKey: "description",
       header: "Description",
+      enableSorting: false,
       Cell: ({ row }) => <FormattedText>{row.original.description}</FormattedText>,
     },
   ]

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
@@ -16,17 +16,35 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
+import React, { useState } from "react";
+import { Link } from 'react-router-dom';
+import { Box } from "@mui/material";
 import Questionnaire from "../questionnaire/Questionnaire.jsx";
 import AdminResourceListing from "../adminDashboard/AdminResourceListing.jsx";
 import NewQuestionnaireDialog from "../questionnaireEditor/NewQuestionnaireDialog.jsx";
 import DeleteButton from "./DeleteButton.jsx";
 import EditButton from "./EditButton.jsx";
 import ExportButton from "./ExportButton.jsx";
-import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
+import { DateTime } from "luxon";
+
+// Convert a date into the given format string
+// If the date is invalid (usually because it is missing), return ""
+let _formatDate = (date, formatString) => {
+  let dateObj = DateTime.fromISO(date);
+  if (dateObj.isValid) {
+    return dateObj.toFormat(formatString);
+  }
+  return "";
+};
+
 
 function Questionnaires(props) {
+  const [ questionnairesData, setQuestionnairesData ] = useState([]);
+  const [ dialogOpen, setDialogOpen ] = useState(false);
+  const [ updateData, setUpdateData ] = useState(0);
+
   const entry = /Questionnaires\/([^.]+)/.exec(location.pathname);
+  const entryType = "Questionnaire";
 
   if (entry) {
     return <Questionnaire id={entry[1]} key={location.pathname} contentOffset={props.contentOffset}/>;
@@ -34,39 +52,80 @@ function Questionnaires(props) {
 
   let columns = [
     {
-      "key": "title",
-      "label": "Title",
-      "format": getEntityIdentifier,
-      "link": "dashboard+path",
+      header: "Title",
+      Cell: ({ row }) => (<Link to={"/content.html/admin" + row.original["@path"]} underline="hover">{row.original.title}</Link>),
     },
     {
-      "key": "jcr:created",
-      "label": "Created on",
-      "format": "date:yyyy-MM-dd HH:mm",
+      header: "Created on",
+      Cell: ({ row }) => _formatDate(row.original["jcr:created"], "yyyy-MM-dd HH:mm"),
+      size: 20,
     },
     {
-      "key": "jcr:createdBy",
-      "label": "Created by",
-      "format": "string",
+      accessorKey: "description",
+      header: "Description",
     },
   ]
-  const actions = [
-    DeleteButton,
-    ExportButton,
-    EditButton
-  ]
+
+  let makeActions = ({ row }) => {
+    return (
+            <Box sx={{ display: 'flex', flexWrap: 'nowrap', float: 'right'}}>
+              <EditButton
+                entryType={entryType}
+                entryPath={row.original["@path"]}
+                admin
+              />
+              <ExportButton
+                entryPath={row.original["@path"]}
+                entryName={row.original.title}
+                entityData={row.original}
+                entryType={entryType}
+                size="medium"
+              />
+              <DeleteButton
+                entryPath={row.original["@path"]}
+                entryName={row.original.title}
+                onComplete={dialogSuccess}
+                entryType={entryType}
+                admin
+              />
+            </Box>
+          )
+  }
+
+  let customFilterFn = (row, id, filterValue) => {
+    let title = row.original.title || "";
+    let description = row.original.description || "";
+    return title.toLowerCase().includes(filterValue.toLowerCase()) || description.toLowerCase().includes(filterValue.toLowerCase());
+  }
+
+  let dialogClose = () => {
+    setDialogOpen(false);
+  }
+
+  // If an entity was successfully added or deleted, trigger the table fetch
+  let dialogSuccess = () => {
+    setUpdateData((old) => (old+1));
+  }
 
   return (
     <>
       <AdminResourceListing
         title="Questionnaires"
-        action={
-          <NewQuestionnaireDialog />
-        }
+        buttonProps={{
+          title: "New questionnaire",
+          onClick: () => setDialogOpen(true)
+        }}
         columns={columns}
-        actions={actions}
-        entryType={"Questionnaire"}
-        admin={true}
+        tableActions={makeActions}
+        entryType={entryType}
+        updateData={updateData}
+        onDataReceived={setQuestionnairesData}
+        customFilter={customFilterFn}
+      />
+      <NewQuestionnaireDialog
+        open={dialogOpen}
+        onClose={dialogClose}
+        questionnaires={questionnairesData}
       />
     </>
   );

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
@@ -16,14 +16,14 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect } from "react";
-
-import { IconButton, Tooltip } from "@mui/material";
+import React, { useState } from "react";
+import { Box } from "@mui/material";
 import { Link } from 'react-router-dom';
-import SubjectTypeDialog from "../questionnaire/SubjectTypeDialog.jsx";
 import AdminResourceListing from "../adminDashboard/AdminResourceListing.jsx";
+import SubjectTypeDialog from "../questionnaire/SubjectTypeDialog.jsx";
 import DeleteButton from "./DeleteButton.jsx";
-import EditIcon from "@mui/icons-material/Edit";
+import EditButton from "./EditButton.jsx";
+
 
 // Get a flat list of subject type parents as labels separated by " / "
 function getTextHierarchy (path, subjectTypes) {
@@ -36,79 +36,77 @@ function getTextHierarchy (path, subjectTypes) {
   return hierarchy;
 }
 
-function EditSubjectTypeButton(props) {
-  const { onClick } = props;
-  return(
-    <Tooltip title={"Edit Subject Type"}>
-      <IconButton onClick={onClick} size="large">
-        <EditIcon />
-      </IconButton>
-    </Tooltip>
-  )
-}
-
 function SubjectTypes(props) {
   const [ dialogOpen, setDialogOpen ] = useState(false);
-  const [ updateData, setUpdateData ] = useState(false);
+  const [ updateData, setUpdateData ] = useState(0);
   const [ subjectTypeData, setSubjectTypeData ] = useState([]);
   const [ currentSubjectType, setCurrentSubjectType ] = useState(null);
   const [ isEdit, setIsEdit ] = useState(false);
+
+  const entryType = "Subject Type";
   const columns = [
     {
-      "key": "",
-      "label": "Subject Type",
-      "format": (row) => (getTextHierarchy(row['@path'], subjectTypeData)),
+      header: "Subject Type",
+      size: 100,
+      Cell: ({ row }) => (getTextHierarchy(row.original['@path'], subjectTypeData)),
     },
     {
-      "key": "subjectListLabel",
-      "label": "Subject list label",
-      "format": "string",
+      header: "Subject label",
+      accessorKey: 'subjectListLabel',
+      size: 80,
     },
     {
-      "key": "",
-      "label": "Subjects",
-      "format": (row) => (row.instanceCount ? <Link to={"/content.html/Subjects#" + row['@name']} title={"Show subjects of type " + row.label} underline="hover">{row.instanceCount}</Link> : "0"),
+      header: "Subjects",
+      size: 20,
+      Cell: ({ row }) => (row.original.instanceCount ? <Link to={"/content.html/Subjects#" + row.original['@name']} title={"Show subjects of type " + row.original.label} underline="hover">{row.original.instanceCount}</Link> : "0"),
     },
     {
-      "key": "cards:defaultOrder",
-      "label": "Default Order",
-      "format": "string",
+      header: "Default Order",
+      accessorKey: 'cards:defaultOrder',
+      size: 20,
     },
+/*    {
+      header: "Id Pattern",
+      accessorKey: 'idPattern',
+    },*/
     {
-      "key": "jcr:createdBy",
-      "label": "Created by",
-      "format": "string",
-    },
-    {
-      "key": "",
-      "label": "Actions",
-      "type": "actions",
-      "format": (row) => (<>
-                            <DeleteButton
-                              entryPath={row["@path"]}
-                              entryName={row.label}
-                              onComplete={() => { setUpdateData(true); }}
-                              entryType={"Subject Type"}
-                              admin={true}
-                            />
-                            <EditSubjectTypeButton
-                              onClick={() => {setIsEdit(true); setCurrentSubjectType(row); setDialogOpen(true);}}
-                            />
-                          </>),
+      header: "Pattern Hint",
+      accessorKey: 'idPatternHint',
     },
   ]
-
-  // When the subject data is changed, set the update data flag to false
-  useEffect(() => {
-    if (subjectTypeData){
-      setUpdateData(false);
-    }
-  }, [subjectTypeData]);
 
   let onClose = () => {
     setDialogOpen(false);
     setIsEdit(false);
-    setCurrentSubjectType(null);
+    setCurrentSubjectType();
+  }
+
+  // If an entity was successfully added or deleted, trigger the table fetch
+  let dialogSuccess = () => {
+    setUpdateData((old) => (old+1));
+  }
+
+  let makeActions = ({ row }) => (
+            <Box sx={{ display: 'flex', flexWrap: 'nowrap', float: 'right'}}>
+              <EditButton
+                entryType={entryType}
+                onClick={() => {setIsEdit(true); setCurrentSubjectType(row.original); setDialogOpen(true);}}
+                useEditDialog
+              />
+              <DeleteButton
+                entryPath={row.original["@path"]}
+                entryName={row.original.label}
+                onComplete={dialogSuccess}
+                entryType={entryType}
+                admin
+              />
+            </Box>
+        )
+
+  let customFilterFn = (row, id, filterValue) => {
+    let path = row.original['@path'] || "";
+    let label = row.original.subjectListLabel || "";
+    return path.toLowerCase().includes(filterValue.toLowerCase()) || label.toLowerCase().includes(filterValue.toLowerCase());
   }
 
   return (
@@ -119,24 +117,24 @@ function SubjectTypes(props) {
         title: "New subject type",
         onClick: () => setDialogOpen(true)
       }}
-      resourceSelectors=".instanceCount"
       columns={columns}
-      entryType={"Subject Type"}
-      admin={true}
+      tableActions={makeActions}
+      entryType="SubjectType"
       disableTopPagination={true}
       updateData={updateData}
       onDataReceived={setSubjectTypeData}
+      resourceSelectors=".instanceCount"
+      customFilter={customFilterFn}
     />
-    { dialogOpen &&
-        <SubjectTypeDialog
-          onClose={() => { onClose(); }}
-          onSubmit={() => { onClose(); setUpdateData(true); }}
-          open={dialogOpen}
-          data={subjectTypeData}
-          isEdit={isEdit}
-          currentSubjectType={currentSubjectType}
-        />
-     }
+
+    <SubjectTypeDialog
+      open={dialogOpen}
+      onClose={onClose}
+      onSuccess={dialogSuccess}
+      data={subjectTypeData}
+      isEdit={isEdit}
+      currentSubjectType={currentSubjectType}
+    />
   </>
   );
 }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
@@ -67,10 +67,11 @@ function SubjectTypes(props) {
       accessorKey: 'cards:defaultOrder',
       size: 20,
     },
-/*    {
+    {
       header: "Id pattern",
       accessorKey: 'idPattern',
-    },*/
+      enableSorting: false,
+    },
     {
       header: "Id pattern hint",
       accessorKey: 'idPatternHint',

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
@@ -100,7 +100,6 @@ function SubjectTypes(props) {
               <EditButton
                 entryType={entryType}
                 onClick={() => {setIsEdit(true); setCurrentSubjectType(row.original); setDialogOpen(true);}}
-                useEditDialog
               />
               <DeleteButton
                 entryPath={row.original["@path"]}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
@@ -46,33 +46,33 @@ function SubjectTypes(props) {
   const entryType = "Subject Type";
   const columns = [
     {
-      header: "Subject Type",
+      header: "Subject type",
       size: 100,
       accessorFn: (row) => getTextHierarchy(row['@path'], subjectTypeData),
       Cell: ({ row }) => (getTextHierarchy(row.original['@path'], subjectTypeData)),
     },
     {
-      header: "Subject label",
+      header: "Subject list label",
       accessorKey: 'subjectListLabel',
       size: 80,
     },
     {
-      header: "Subjects",
+      header: "Number of subjects",
       size: 20,
       accessorFn: (row) => row.instanceCount || 0,
       Cell: ({ row }) => (row.original.instanceCount ? <Link to={"/content.html/Subjects#" + row.original['@name']} title={"Show subjects of type " + row.original.label} underline="hover">{row.original.instanceCount}</Link> : "0"),
     },
     {
-      header: "Default Order",
+      header: "Order",
       accessorKey: 'cards:defaultOrder',
       size: 20,
     },
 /*    {
-      header: "Id Pattern",
+      header: "Id pattern",
       accessorKey: 'idPattern',
     },*/
     {
-      header: "Pattern Hint",
+      header: "Id pattern hint",
       accessorKey: 'idPatternHint',
       enableSorting: false,
     },

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
@@ -48,6 +48,7 @@ function SubjectTypes(props) {
     {
       header: "Subject Type",
       size: 100,
+      accessorFn: (row) => getTextHierarchy(row['@path'], subjectTypeData),
       Cell: ({ row }) => (getTextHierarchy(row.original['@path'], subjectTypeData)),
     },
     {
@@ -58,6 +59,7 @@ function SubjectTypes(props) {
     {
       header: "Subjects",
       size: 20,
+      accessorFn: (row) => row.instanceCount || 0,
       Cell: ({ row }) => (row.original.instanceCount ? <Link to={"/content.html/Subjects#" + row.original['@name']} title={"Show subjects of type " + row.original.label} underline="hover">{row.original.instanceCount}</Link> : "0"),
     },
     {

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
@@ -81,9 +81,18 @@ function SubjectTypes(props) {
     setCurrentSubjectType();
   }
 
-  // If an entity was successfully added or deleted, trigger the table fetch
-  let dialogSuccess = () => {
-    setUpdateData((old) => (old+1));
+  // If an entity was successfully added or deleted, trigger the table add new data, if passed on, or refresh
+  let dialogSuccess = (newData) => {
+    if (newData) {
+      let addedEvent = new CustomEvent('MaterialTableAppend', {
+        bubbles: true,
+        cancelable: true,
+        detail: newData
+      });
+      document.dispatchEvent(addedEvent);
+    } else {
+      setUpdateData((old) => (old+1));
+    }
   }
 
   let makeActions = ({ row }) => (

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
@@ -74,6 +74,7 @@ function SubjectTypes(props) {
     {
       header: "Pattern Hint",
       accessorKey: 'idPatternHint',
+      enableSorting: false,
     },
   ]
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTypeDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTypeDialog.jsx
@@ -15,7 +15,7 @@
   under the License.
 */
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 import { Button, Grid, Dialog, DialogTitle, DialogActions, DialogContent, MenuItem, TextField, Typography, Select, FormHelperText } from "@mui/material";
 
@@ -24,16 +24,16 @@ import withStyles from '@mui/styles/withStyles';
 import QuestionnaireStyle from "./QuestionnaireStyle.jsx";
 
 function SubjectTypeDialog(props) {
-  const { open, onClose, onSubmit, data, isEdit, currentSubjectType, classes } = props;
+  const { open, onClose, onSuccess, data, isEdit, currentSubjectType, classes } = props;
   const initialParent = currentSubjectType?.["@path"].replace("/" + currentSubjectType["@name"], "") || "/SubjectTypes";
   const subjectTypes = !isEdit ? data : data.filter(item => item["jcr:uuid"] != currentSubjectType["jcr:uuid"]);
 
-  const [ label, setLabel ] = useState(isEdit ? currentSubjectType.label : "");
+  const [ label, setLabel ] = useState("");
   const [ parentSubject, setParentSubject ] = useState(initialParent);
-  const [ order, setOrder ] = useState(currentSubjectType && currentSubjectType["cards:defaultOrder"] ? currentSubjectType["cards:defaultOrder"] : 0);
-  const [ subjectListLabel, setSubjectListLabel ] = useState(currentSubjectType?.subjectListLabel || "");
-  const [ idPattern, setIdPattern ] = useState(currentSubjectType?.idPattern || "");
-  const [ idPatternHint, setIdPatternHint ] = useState(currentSubjectType?.idPatternHint || "");
+  const [ order, setOrder ] = useState(0);
+  const [ subjectListLabel, setSubjectListLabel ] = useState("");
+  const [ idPattern, setIdPattern ] = useState("");
+  const [ idPatternHint, setIdPatternHint ] = useState("");
 
   const [ error, setError ] = useState(null);
   const [ isDuplicateLabel, setIsDuplicateLabel ] = useState(false);
@@ -58,6 +58,16 @@ function SubjectTypeDialog(props) {
       setIsInvalidRegexp(true);
     }
   }
+
+  useEffect(() => {
+    if (isEdit && currentSubjectType) {
+      setLabel(currentSubjectType.label);
+      setOrder(currentSubjectType["cards:defaultOrder"] || 0);
+      setSubjectListLabel(currentSubjectType?.subjectListLabel || "");
+      setIdPattern(currentSubjectType?.idPattern || "");
+      setIdPatternHint(currentSubjectType?.idPatternHint || "");
+    }
+  }, [currentSubjectType]);
 
   let handleSubjectType = () => {
     setError("");
@@ -110,7 +120,8 @@ function SubjectTypeDialog(props) {
         if (isEdit && initialParent != parentSubject) {
           moveSubjectType();
         } else {
-          onSubmit();
+          onSuccess();
+          close();
         }
     });
   }
@@ -131,7 +142,8 @@ function SubjectTypeDialog(props) {
           return;
         }
 
-        onSubmit();
+        onSuccess();
+        close();
     });
   }
 
@@ -151,7 +163,7 @@ function SubjectTypeDialog(props) {
     <Dialog
       maxWidth="sm"
       open={open}
-      onClose={onClose}
+      onClose={close}
     >
       <DialogTitle>{isEdit ? "Modify " + currentSubjectType.label : "Create New Subject Type"}</DialogTitle>
       <DialogContent>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTypeDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTypeDialog.jsx
@@ -29,7 +29,7 @@ function SubjectTypeDialog(props) {
   const subjectTypes = !isEdit ? data : data.filter(item => item["jcr:uuid"] != currentSubjectType["jcr:uuid"]);
 
   const [ label, setLabel ] = useState("");
-  const [ parentSubject, setParentSubject ] = useState(initialParent);
+  const [ parent, setParent ] = useState(initialParent);
   const [ order, setOrder ] = useState(0);
   const [ subjectListLabel, setSubjectListLabel ] = useState("");
   const [ idPattern, setIdPattern ] = useState("");
@@ -62,7 +62,7 @@ function SubjectTypeDialog(props) {
   useEffect(() => {
     if (isEdit && currentSubjectType) {
       setLabel(currentSubjectType.label);
-      setParentSubject(initialParent);
+      setParent(initialParent);
       setOrder(currentSubjectType["cards:defaultOrder"] || 0);
       setSubjectListLabel(currentSubjectType?.subjectListLabel || "");
       setIdPattern(currentSubjectType?.idPattern || "");
@@ -95,7 +95,7 @@ function SubjectTypeDialog(props) {
           currentSubjectType["idPattern"] === idPattern &&
           currentSubjectType["idPatternHint"] === idPatternHint) {
         // if nothing changed except parent - just move the node
-        if (initialParent != parentSubject) {
+        if (initialParent != parent) {
           moveSubjectType();
         } else {
           close();
@@ -111,7 +111,7 @@ function SubjectTypeDialog(props) {
       }
     }
 
-    fetch(isEdit ? currentSubjectType["@path"] : parentSubject, {
+    fetch(isEdit ? currentSubjectType["@path"] : parent, {
         method: 'POST',
         body: formData
     })
@@ -122,12 +122,12 @@ function SubjectTypeDialog(props) {
         }
 
         // If parent changed we need to move the node
-        if (isEdit && initialParent != parentSubject) {
+        if (isEdit && initialParent != parent) {
           moveSubjectType();
         } else {
           if (!isEdit) {
             formInfo["@name"] = label;
-            formInfo["@path"] = parentSubject + "/" + label;
+            formInfo["@path"] = parent + "/" + label;
             onSuccess(formInfo);
           } else {
             onSuccess();
@@ -140,7 +140,7 @@ function SubjectTypeDialog(props) {
   let moveSubjectType = () => {
     let formData = new FormData();
     formData.append(':operation', 'move');
-    formData.append(':dest', !parentSubject.endsWith("/") ? parentSubject + "/" : parentSubject);
+    formData.append(':dest', !parent.endsWith("/") ? parent + "/" : parent);
     formData.append(':replace', true);
 
     fetch(currentSubjectType["@path"], {
@@ -161,7 +161,7 @@ function SubjectTypeDialog(props) {
   let close = () => {
     setError("");
     setLabel("");
-    setParentSubject("/SubjectTypes");
+    setParent("/SubjectTypes");
     setOrder(0);
     setSubjectListLabel("");
     setIdPattern("");
@@ -206,8 +206,8 @@ function SubjectTypeDialog(props) {
                   disabled={isEdit && currentSubjectType.instanceCount != undefined && currentSubjectType.instanceCount > 0}
                   labelId="parent"
                   label="optional"
-                  value={parentSubject}
-                  onChange={(event) => { setParentSubject(event.target.value); setError(""); }}
+                  value={parent}
+                  onChange={(event) => { setParent(event.target.value); setError(""); }}
                   displayEmpty
                 >
                   <MenuItem key="none" value="/SubjectTypes">
@@ -285,7 +285,7 @@ function SubjectTypeDialog(props) {
         <Button
           disabled={!isEdit && (!label || isDuplicateLabel)
                   || isEdit && (currentSubjectType["cards:defaultOrder"] == order &&
-                                initialParent == parentSubject &&
+                                initialParent == parent &&
                                 currentSubjectType["label"] == label &&
                                 currentSubjectType["subjectListLabel"] == subjectListLabel &&
                                 currentSubjectType?.["idPattern"] == idPattern &&

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTypeDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTypeDialog.jsx
@@ -96,6 +96,7 @@ function SubjectTypeDialog(props) {
         // if nothing changed except parent - just move the node
         if (initialParent != parent) {
           moveSubjectType();
+          return;
         } else {
           close();
           return;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTypeDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTypeDialog.jsx
@@ -89,7 +89,6 @@ function SubjectTypeDialog(props) {
       formData.append(':content', JSON.stringify(formInfo));
     } else {
       if (currentSubjectType["cards:defaultOrder"] == order &&
-          currentSubjectType["cards:defaultOrder"] == order &&
           currentSubjectType["label"] === label &&
           currentSubjectType["subjectListLabel"] === subjectListLabel &&
           currentSubjectType["idPattern"] === idPattern &&

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTypeDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTypeDialog.jsx
@@ -62,6 +62,7 @@ function SubjectTypeDialog(props) {
   useEffect(() => {
     if (isEdit && currentSubjectType) {
       setLabel(currentSubjectType.label);
+      setParentSubject(initialParent);
       setOrder(currentSubjectType["cards:defaultOrder"] || 0);
       setSubjectListLabel(currentSubjectType?.subjectListLabel || "");
       setIdPattern(currentSubjectType?.idPattern || "");
@@ -73,29 +74,33 @@ function SubjectTypeDialog(props) {
     setError("");
     let formData = new FormData();
 
-    if (!isEdit) {
-      let formInfo = {};
-      formInfo["jcr:primaryType"] = "cards:SubjectType";
-      formInfo["label"] = label;
-      formInfo["cards:defaultOrder"] = order;
-      formInfo["subjectListLabel"] = subjectListLabel;
-      formInfo["idPattern"] = idPattern;
-      formInfo["idPatternHint"] = idPatternHint;
+    let formInfo = {};
+    formInfo["jcr:primaryType"] = "cards:SubjectType";
+    formInfo["label"] = label;
+    formInfo["cards:defaultOrder"] = order;
+    formInfo["subjectListLabel"] = subjectListLabel;
+    formInfo["idPattern"] = idPattern;
+    formInfo["idPatternHint"] = idPatternHint;
 
+    if (!isEdit) {
       formData.append(':contentType', 'json');
       formData.append(':operation', 'import');
       formData.append(':nameHint', label);
       formData.append(':content', JSON.stringify(formInfo));
     } else {
-      // if nothing changed - just move the node
       if (currentSubjectType["cards:defaultOrder"] == order &&
           currentSubjectType["cards:defaultOrder"] == order &&
           currentSubjectType["label"] === label &&
           currentSubjectType["subjectListLabel"] === subjectListLabel &&
           currentSubjectType["idPattern"] === idPattern &&
           currentSubjectType["idPatternHint"] === idPatternHint) {
-        moveSubjectType();
-        return;
+        // if nothing changed except parent - just move the node
+        if (initialParent != parentSubject) {
+          moveSubjectType();
+        } else {
+          close();
+          return;
+        }
       } else {
         // Update all the changes first
         formData.append("cards:defaultOrder", order);
@@ -120,7 +125,13 @@ function SubjectTypeDialog(props) {
         if (isEdit && initialParent != parentSubject) {
           moveSubjectType();
         } else {
-          onSuccess();
+          if (!isEdit) {
+            formInfo["@name"] = label;
+            formInfo["@path"] = parentSubject + "/" + label;
+            onSuccess(formInfo);
+          } else {
+            onSuccess();
+          }
           close();
         }
     });
@@ -150,7 +161,7 @@ function SubjectTypeDialog(props) {
   let close = () => {
     setError("");
     setLabel("");
-    setParentSubject("");
+    setParentSubject("/SubjectTypes");
     setOrder(0);
     setSubjectListLabel("");
     setIdPattern("");

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/NewQuestionnaireDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/NewQuestionnaireDialog.jsx
@@ -22,59 +22,41 @@ import { withRouter } from "react-router-dom";
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField, Typography } from "@mui/material";
 import withStyles from '@mui/styles/withStyles';
 import { v4 as uuidv4 } from 'uuid';
-import NewItemButton from "../components/NewItemButton.jsx";
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 
 function NewQuestionnaireDialog(props) {
-  const [ open, setOpen ] = useState(false);
-  const [ isFetching, setFetching ] = useState(false);
+  const { open, onClose, questionnaires } = props;
   const [ error, setError ] = useState("");
   const [ duplicateTitle, setDuplicateTitle ] = useState(false);
   const [ title, setTitle ] = useState("");
-  const [ questionnaires, setQuestionnaires ] = useState([]);
 
-  let openDialog = () => {
-    setOpen(true);
-    setDuplicateTitle(false);
-    setError("");
-    // Determine what questionnaires are available
-    if (questionnaires.length === 0) {
-      // Send a fetch request to determine the questionnaires available
-      fetch('/query?query=' + encodeURIComponent('select * from [cards:Questionnaire]'))
-        .then((response) => response.ok ? response.json() : Promise.reject(response))
-        .then((json) => {setQuestionnaires(json["rows"])})
-        .finally(() => {setFetching(false)});
-      setFetching(true);
-    }
-  }
-
-  let createForm = () => {
+  let createQuestionnaire = () => {
     setError("");
 
-    // Make a POST request to create a new form, with a randomly generated UUID
+    // Make a POST request to create a new questionnaire, with a randomly generated UUID
     const URL = "/Questionnaires/" + uuidv4();
     var request_data = new FormData();
     request_data.append('jcr:primaryType', 'cards:Questionnaire');
     request_data.append('title', title);
     fetch( URL, { method: 'POST', body: request_data })
       .then( (response) => {
-        setFetching(false);
         if (response.ok) {
           // Redirect the user to the new uuid
           // FIXME: Would be better to somehow obtain the router prefix from props
           // but that is not currently possible
+          onClose();
           props.history.push("/content.html/admin" + URL + ".edit");
         } else {
           return(Promise.reject(response));
         }
       })
       .catch(parseErrorResponse);
-    setFetching(true);
   }
+
   let parseErrorResponse = (response) => {
-    setFetching(false);
     setError(`New questionnaire request failed with error code ${response.status}: ${response.statusText}`);
   }
+
   let handleChangeTitle = (value) => {
     // Check if a questionnaire with the given title exists already
     const titles = questionnaires.filter(questionnaire => questionnaire.title == value);
@@ -90,7 +72,7 @@ function NewQuestionnaireDialog(props) {
 
   return (
     <React.Fragment>
-       <Dialog open={open} onClose={() => { setOpen(false); }} autoFocus={false}>
+       <Dialog open={open} onClose={onClose} autoFocus={false}>
         <DialogTitle id="new-questionnaire-title">
           Create a new questionnaire
         </DialogTitle>
@@ -102,7 +84,7 @@ function NewQuestionnaireDialog(props) {
             inputProps={{
               onKeyDown: (event) => {
                 if (event.key == 'Enter' && title) {
-                  createForm();
+                  createQuestionnaire();
                 }
               }
             }}
@@ -113,30 +95,25 @@ function NewQuestionnaireDialog(props) {
             error={duplicateTitle}
             helperText={duplicateTitle ? "A questionnaire with this name already exists" : " "}
           >  
-          </TextField>
+        </TextField>
         </DialogContent>
          <DialogActions>
           <Button
             variant="contained"
             color="primary"
-            onClick={createForm}
+            onClick={createQuestionnaire}
             disabled={!title}
             >
-            {'Create'}
+            Create
           </Button>
           <Button
             variant="outlined"
-            onClick={() => { setOpen(false); }}
+            onClick={onClose}
             >
-            {'Cancel'}
+            Cancel
           </Button>
         </DialogActions>
       </Dialog>
-      <NewItemButton
-           title="New questionnaire"
-           onClick={() => { openDialog(); }}
-           inProgress={!open && isFetching}
-      />
     </React.Fragment>
   )
 }

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminResourceListing.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminResourceListing.jsx
@@ -123,7 +123,7 @@ function AdminResourceListing(props) {
         filterFns={{
             myCustomFilterFn: customFilter,
           }}
-        globalFilterFn="myCustomFilterFn"
+        globalFilterFn={customFilter ? "myCustomFilterFn" : "contains"}
       />
     </AdminScreen>
   );

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminResourceListing.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminResourceListing.jsx
@@ -25,7 +25,7 @@ import MaterialReactTable from "material-react-table";
 
 
 function AdminResourceListing(props) {
-  const { title, columns, tableActions, buttonProps, customUrl, entryType, resourceSelectors, updateData,
+  const { title, columns, tableActions, buttonProps, dataUrl, entryType, resourceSelectors, updateData,
     onDataReceived, customFilter, ...rest } = props;
 
   const [ data, setData ] = useState([]);
@@ -41,7 +41,7 @@ function AdminResourceListing(props) {
       setIsRefetching(true);
     }
 
-    const urlBase = customUrl || '/query?query=' + encodeURIComponent('select * from [cards:'+ entryType+']');
+    const urlBase = dataUrl || '/query?query=' + encodeURIComponent('select * from [cards:'+ entryType+']');
     let url = new URL(urlBase, window.location.origin);
     resourceSelectors && url.searchParams.set("resourceSelectors", resourceSelectors);
     url.searchParams.set("limit", 1000);

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminResourceListing.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminResourceListing.jsx
@@ -89,9 +89,7 @@ function AdminResourceListing(props) {
       action={buttonProps ? <NewItemButton {...buttonProps}/> : action}
     >
       <MaterialReactTable
-        enableColumnActions={false}
         enableColumnFilters={false}
-        enableSorting={false}
         positionToolbarAlertBanner="none"
         muiSearchTextFieldProps={{ autoFocus: true }}
         initialState={{ showGlobalFilter: true }}

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminResourceListing.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminResourceListing.jsx
@@ -54,6 +54,13 @@ function AdminResourceListing(props) {
     setIsRefetching(false);
   };
 
+  let addData = (event) => {
+    if (event.detail) {
+      const newEntry = event.detail;
+      setData([...data, newEntry]);;
+    }
+  }
+
   // Fetch data from the server
   useEffect(() => {
     fetchData();
@@ -66,6 +73,15 @@ function AdminResourceListing(props) {
     }
   }, [updateData]);
 
+  // When data is created, add it to the table
+  useEffect(() => {
+    // subscribe event
+    window.addEventListener("MaterialTableAppend", addData);
+    return () => {
+      // unsubscribe event
+      document.removeEventListener("MaterialTableAppend", addData);
+    };
+  });
 
   return (
     <AdminScreen

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminResourceListing.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminResourceListing.jsx
@@ -16,23 +16,98 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
+import React, { useState, useContext, useEffect } from "react";
 
 import AdminScreen from "./AdminScreen.jsx";
-import LiveTable from "../dataHomepage/LiveTable.jsx";
 import NewItemButton from "../components/NewItemButton.jsx";
+import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
+import MaterialReactTable from "material-react-table";
+
 
 function AdminResourceListing(props) {
-  const { title, action, buttonProps, ...rest } = props;
+  const { title, columns, tableActions, buttonProps, customUrl, entryType, resourceSelectors, updateData,
+    onDataReceived, customFilter, ...rest } = props;
+
+  const [ data, setData ] = useState([]);
+  const [ isLoading, setIsLoading ] = useState(false);
+  const [ isRefetching, setIsRefetching ] = useState(false);
+
+  const globalLoginDisplay = useContext(GlobalLoginContext);
+
+  const fetchData = async () => {
+    if (!data.length) {
+      setIsLoading(true);
+    } else {
+      setIsRefetching(true);
+    }
+
+    const urlBase = customUrl || '/query?query=' + encodeURIComponent('select * from [cards:'+ entryType+']');
+    let url = new URL(urlBase, window.location.origin);
+    resourceSelectors && url.searchParams.set("resourceSelectors", resourceSelectors);
+    url.searchParams.set("limit", 1000);
+    const response = await fetchWithReLogin(globalLoginDisplay, url);
+    const json = await response.json();
+    setData(json["rows"]);
+    onDataReceived && onDataReceived(json.rows);
+
+    setIsLoading(false);
+    setIsRefetching(false);
+  };
+
+  // Fetch data from the server
+  useEffect(() => {
+    fetchData();
+  }, [ ]);
+
+  // When new data is added, add a new row to the table.
+  useEffect(() => {
+    if (updateData) {
+      fetchData();
+    }
+  }, [updateData]);
+
 
   return (
     <AdminScreen
       title={title}
       action={buttonProps ? <NewItemButton {...buttonProps}/> : action}
     >
-      <LiveTable
-        disableTopPagination={true}
-        {...rest}
+      <MaterialReactTable
+        enableColumnActions={false}
+        enableColumnFilters={false}
+        enableSorting={false}
+        positionToolbarAlertBanner="none"
+        muiSearchTextFieldProps={{ autoFocus: true }}
+        initialState={{ showGlobalFilter: true }}
+        state={{ isLoading: isLoading, showProgressBars: isRefetching }}
+        columns={columns}
+        data={data}
+        muiTablePaperProps={{ elevation: 0 }}
+        muiTableHeadCellProps={{
+            sx: (theme) => ({
+              background: theme.palette.grey['200'],
+            }),
+          }}
+        displayColumnDefOptions={{
+            'mrt-row-actions': {
+              muiTableHeadCellProps: {align: 'right'},
+              muiTableBodyCellProps: {
+                sx: {
+                  padding: '0',
+                },
+              },
+            },
+            'mrt-row-expand': {
+              size: 8,
+            },
+          }}
+        enableRowActions={tableActions}
+        positionActionsColumn="last"
+        renderRowActions={tableActions}
+        filterFns={{
+            myCustomFilterFn: customFilter,
+          }}
+        globalFilterFn="myCustomFilterFn"
       />
     </AdminScreen>
   );

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
@@ -41,9 +41,8 @@ function Clinics(props) {
   let columns = Object.keys(clinicsSpecs).filter((stat) => !Array.isArray(clinicsSpecs[stat]))
     .map((stat) => {
       return {
-        key: stat,
-        label: camelCaseToWords(stat),
-        format: clinicsSpecs[stat]
+        accessorKey: stat,
+        header: camelCaseToWords(stat)
       };
     });
 
@@ -66,14 +65,17 @@ function Clinics(props) {
             setDialogOpen(true);
             setIsNewClinic(true);
           },
-          inProgress: (dialogOpen && isNewClinic)
         }}
         columns={columns}
         entryType={"Survey/ClinicMapping"}
         customUrl={"Survey/ClinicMapping.paginate"}
-        admin={true}
       />
-      <OnboardNewClinicDialog open={dialogOpen} onClose={dialogClose} onSuccess={dialogSuccess} isNewClinic={isNewClinic} />
+      <OnboardNewClinicDialog
+        open={dialogOpen}
+        onClose={dialogClose}
+        onSuccess={dialogSuccess}
+        isNewClinic={isNewClinic}
+      />
     </>
   );
 }

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
@@ -43,7 +43,7 @@ function Clinics(props) {
       return {
         accessorKey: stat,
         header: camelCaseToWords(stat),
-        enableSorting: stat != "emergencyContac" || stat != "description",
+        enableSorting: stat != "emergencyContact" || stat != "description",
       };
     });
 

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
@@ -68,7 +68,7 @@ function Clinics(props) {
         }}
         columns={columns}
         entryType={"Survey/ClinicMapping"}
-        customUrl={"Survey/ClinicMapping.paginate"}
+        dataUrl={"Survey/ClinicMapping.paginate"}
       />
       <OnboardNewClinicDialog
         open={dialogOpen}

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
@@ -55,12 +55,6 @@ function Clinics(props) {
     setDialogOpen(false);
   }
 
-  let customFilterFn = (row, id, filterValue) => {
-    let name = row.original.clinicName || "";
-    let displayName = row.original.displayName || "";
-    return name.toLowerCase().includes(filterValue.toLowerCase()) || displayName.toLowerCase().includes(filterValue.toLowerCase());
-  }
-
   return (
     <>
       <AdminResourceListing
@@ -75,7 +69,6 @@ function Clinics(props) {
         columns={columns}
         entryType={"Survey/ClinicMapping"}
         dataUrl={"Survey/ClinicMapping.paginate"}
-        customFilter={customFilterFn}
       />
       <OnboardNewClinicDialog
         open={dialogOpen}

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
@@ -55,6 +55,12 @@ function Clinics(props) {
     setDialogOpen(false);
   }
 
+  let customFilterFn = (row, id, filterValue) => {
+    let name = row.original.clinicName || "";
+    let displayName = row.original.displayName || "";
+    return name.toLowerCase().includes(filterValue.toLowerCase()) || displayName.toLowerCase().includes(filterValue.toLowerCase());
+  }
+
   return (
     <>
       <AdminResourceListing
@@ -69,6 +75,7 @@ function Clinics(props) {
         columns={columns}
         entryType={"Survey/ClinicMapping"}
         dataUrl={"Survey/ClinicMapping.paginate"}
+        customFilter={customFilterFn}
       />
       <OnboardNewClinicDialog
         open={dialogOpen}

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
@@ -42,7 +42,8 @@ function Clinics(props) {
     .map((stat) => {
       return {
         accessorKey: stat,
-        header: camelCaseToWords(stat)
+        header: camelCaseToWords(stat),
+        enableSorting: stat != "emergencyContac" || stat != "description",
       };
     });
 

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
@@ -43,7 +43,7 @@ function Clinics(props) {
       return {
         accessorKey: stat,
         header: camelCaseToWords(stat),
-        enableSorting: stat != "emergencyContact" || stat != "description",
+        enableSorting: stat != "emergencyContact" && stat != "description",
       };
     });
 

--- a/modules/statistics/src/main/frontend/src/Statistics/AdminStatistics.jsx
+++ b/modules/statistics/src/main/frontend/src/Statistics/AdminStatistics.jsx
@@ -17,30 +17,28 @@
 //  under the License.
 //
 import React, { useContext, useEffect, useState } from "react";
-import { Link } from "react-router-dom";
 import { v4 as uuidv4 } from 'uuid';
-import { 
+import {
+  Box,
   Button,
   DialogActions,
   DialogContent,
   DialogTitle,
   Grid,
-  IconButton,
-  Tooltip,
   Typography
 } from "@mui/material";
 import withStyles from '@mui/styles/withStyles';
 import statisticsStyle from "./statisticsStyle.jsx";
 import ResponsiveDialog from "../components/ResponsiveDialog.jsx";
 import AdminResourceListing from "../adminDashboard/AdminResourceListing.jsx";
+import EditButton from "../dataHomepage/EditButton.jsx";
 import DeleteButton from "../dataHomepage/DeleteButton.jsx";
 import Fields from "../questionnaireEditor/Fields.jsx";
-import EditIcon from "@mui/icons-material/Edit";
 import { camelCaseToWords } from "../questionnaireEditor/LabeledField.jsx";
 import { fetchWithReLogin, GlobalLoginContext } from "../login/loginDialogue.js";
 
 /**
- * Create the LiveTable cell contents for a given node. This generates a link to the
+ * Create the MaterialTable cell contents for a given node. This generates a link to the
  * given node (via its admin page), or returns the node's label if no valid link can be made.
  *
  * @param {Object} node The cards:SubjectType or cards:Question node to generate a link for
@@ -68,17 +66,6 @@ function createTableCell(node) {
 
 }
 
-function EditStatisticButton(props) {
-  const { onClick } = props;
-  return(
-    <Tooltip title={"Edit Statistic"}>
-      <IconButton onClick={onClick} size="large">
-        <EditIcon />
-      </IconButton>
-    </Tooltip>
-  )
-}
-
 function AdminStatistics(props) {
   const { classes } = props;
   const [ dialogOpen, setDialogOpen ] = useState(false);
@@ -88,54 +75,50 @@ function AdminStatistics(props) {
   const [ newStat, setNewStat ] = useState(true);
   const [ currentId, setCurrentId ] = useState();
 
+  const entryType = "Statistic";
+
   let columns = [
     {
-      "key": "name",
-      "label": "Name",
-      "format": "string",
+      accessorKey: "name",
+      header: "Name",
     },
     {
-      "key": "type",
-      "label": "Type",
-      "format": "string",
+      accessorKey: "type",
+      header: "Type",
     },
     {
-      "key": "xVar",
-      "label": "X-axis",
-      "format": (stat) => createTableCell(stat?.xVar),
+      header: "X-axis",
+      Cell: ({ row }) => (createTableCell(row.original.xVar)),
     },
     {
-      "key": "yVar",
-      "label": "Y-axis",
-      "format": (stat) => createTableCell(stat?.yVar),
+      header: "Y-axis",
+      Cell: ({ row }) => (createTableCell(row.original.yVar)),
     },
     {
-      "key": "splitVar",
-      "label": "Split",
-      "format": (stat) => createTableCell(stat?.splitVar),
+      header: "Split",
+      Cell: ({ row }) => (createTableCell(row.original.splitVar)),
     },
     {
-      "key": "order",
-      "label": "Order",
-      "format": "string",
-    },
-    {
-      "key": "",
-      "label": "Actions",
-      "type": "actions",
-      "format": (row) => (<>
-                            <DeleteButton
-                              entryPath={row["@path"]}
-                              entryName={row.name}
-                              onComplete={dialogSuccess}
-                              entryType={"Statistic"}
-                            />
-                            <EditStatisticButton
-                              onClick={() => {setDialogOpen(true); setNewStat(false); setCurrentId(row["@name"]);}}
-                            />
-                          </>),
+      accessorKey: "order",
+      header: "Order",
     },
   ]
+
+  let makeActions = ({ row }) => (
+          <Box sx={{ display: 'flex', flexWrap: 'nowrap'}}>
+            <EditButton
+              entryType={entryType}
+              onClick={() => {setDialogOpen(true); setNewStat(false); setCurrentId(row.original["@name"]);}}
+              useEditDialog
+            />
+            <DeleteButton
+              entryPath={row.original["@path"]}
+              entryName={row.original.name}
+              onComplete={dialogSuccess}
+              entryType={entryType}
+            />
+          </Box>
+        )
 
   let dialogClose = () => {
     setDialogOpen(false);
@@ -157,14 +140,20 @@ function AdminStatistics(props) {
             setNewStat(true);
             setCurrentId();
           },
-          inProgress: (dialogOpen && newStat)
         }}
         columns={columns}
-        entryType={"Statistic"}
-        admin={true}
+        entryType={entryType}
+        tableActions={makeActions}
         updateData={numNewEntries}
       />
-      <StatisticDialog open={dialogOpen} onClose={dialogClose} classes={classes} onSuccess={dialogSuccess} isNewStatistic={newStat} currentId={currentId}/>
+      <StatisticDialog
+        open={dialogOpen}
+        onClose={dialogClose}
+        onSuccess={dialogSuccess}
+        classes={classes}
+        isNewStatistic={newStat}
+        currentId={currentId}
+      />
     </>
   );
 }

--- a/modules/statistics/src/main/frontend/src/Statistics/AdminStatistics.jsx
+++ b/modules/statistics/src/main/frontend/src/Statistics/AdminStatistics.jsx
@@ -109,7 +109,6 @@ function AdminStatistics(props) {
             <EditButton
               entryType={entryType}
               onClick={() => {setDialogOpen(true); setNewStat(false); setCurrentId(row.original["@name"]);}}
-              useEditDialog
             />
             <DeleteButton
               entryPath={row.original["@path"]}

--- a/modules/statistics/src/main/frontend/src/Statistics/AdminStatistics.jsx
+++ b/modules/statistics/src/main/frontend/src/Statistics/AdminStatistics.jsx
@@ -88,17 +88,17 @@ function AdminStatistics(props) {
     },
     {
       header: "X-axis",
-      accessorKey: "xVar",
+      accessorFn: (row) => createTableCell(row.xVar),
       Cell: ({ row }) => (createTableCell(row.original.xVar)),
     },
     {
       header: "Y-axis",
-      accessorKey: "yVar",
+      accessorFn: (row) => createTableCell(row.yVar),
       Cell: ({ row }) => (createTableCell(row.original.yVar)),
     },
     {
       header: "Split",
-      accessorKey: "splitVar",
+      accessorFn: (row) => createTableCell(row.splitVar),
       Cell: ({ row }) => (createTableCell(row.original.splitVar)),
     },
     {

--- a/modules/statistics/src/main/frontend/src/Statistics/AdminStatistics.jsx
+++ b/modules/statistics/src/main/frontend/src/Statistics/AdminStatistics.jsx
@@ -108,7 +108,7 @@ function AdminStatistics(props) {
   ]
 
   let makeActions = ({ row }) => (
-          <Box sx={{ display: 'flex', flexWrap: 'nowrap'}}>
+          <Box sx={{ display: 'flex', flexWrap: 'nowrap', float: 'right'}}>
             <EditButton
               entryType={entryType}
               onClick={() => {setDialogOpen(true); setNewStat(false); setCurrentId(row.original["@name"]);}}

--- a/modules/statistics/src/main/frontend/src/Statistics/AdminStatistics.jsx
+++ b/modules/statistics/src/main/frontend/src/Statistics/AdminStatistics.jsx
@@ -88,14 +88,17 @@ function AdminStatistics(props) {
     },
     {
       header: "X-axis",
+      accessorKey: "xVar",
       Cell: ({ row }) => (createTableCell(row.original.xVar)),
     },
     {
       header: "Y-axis",
+      accessorKey: "yVar",
       Cell: ({ row }) => (createTableCell(row.original.yVar)),
     },
     {
       header: "Split",
+      accessorKey: "splitVar",
       Cell: ({ row }) => (createTableCell(row.original.splitVar)),
     },
     {


### PR DESCRIPTION
[CARDS-2618](https://phenotips.atlassian.net/browse/CARDS-2618): Replace Livetable with MaterialReactTable in administration screens

Affected Administration components:
- Subject types
- Clinics
- Statistics
- Questionnaires

Dataflow change:
On the Subject types page the newly created subjet type immediately appears in the table after successful creation

[CARDS-2618]: https://phenotips.atlassian.net/browse/CARDS-2618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ