### PR TITLE
CARDS-2628: Information nodes crash print preview

### DIFF
--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/AbstractFormToStringSerializer.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/AbstractFormToStringSerializer.java
@@ -410,8 +410,6 @@ public abstract class AbstractFormToStringSerializer
             } else if (json.containsKey(QUESTION_KEY)) {
                 uuid = json.get(QUESTION_KEY).getValueType() == ValueType.OBJECT
                     ? json.getJsonObject(QUESTION_KEY).getString(UUID_KEY) : json.getString(QUESTION_KEY);
-            } else if (QuestionnaireUtils.INFORMATION_NODETYPE.equals(json.getString(PRIMARY_TYPE_KEY))) {
-                uuid = json.getString(UUID_KEY);
             }
             return uuid;
         }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/AbstractFormToStringSerializer.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/AbstractFormToStringSerializer.java
@@ -50,6 +50,8 @@ public abstract class AbstractFormToStringSerializer
     private static final String PRIMARY_TYPE_KEY = "jcr:primaryType";
     private static final String UUID_KEY = "jcr:uuid";
 
+    private static final String PATH_KEY = "@path";
+
     protected String toString(final Resource originalResource)
     {
         // The proper serialization depends on "deep", "dereference" and "labels", but we may allow other JSON
@@ -383,8 +385,8 @@ public abstract class AbstractFormToStringSerializer
             this.definitionUuids = definition.values().stream()
                 .filter(value -> ValueType.OBJECT.equals(value.getValueType()))
                 .map(JsonValue::asJsonObject)
-                .filter(value -> value.containsKey(UUID_KEY))
-                .map(value -> value.getString(UUID_KEY))
+                .filter(value -> value.containsKey(UUID_KEY) || value.containsKey(PATH_KEY))
+                .map(value -> value.containsKey(UUID_KEY) ? value.getString(UUID_KEY) : value.getString(PATH_KEY))
                 .collect(Collectors.toList());
         }
 
@@ -410,6 +412,8 @@ public abstract class AbstractFormToStringSerializer
             } else if (json.containsKey(QUESTION_KEY)) {
                 uuid = json.get(QUESTION_KEY).getValueType() == ValueType.OBJECT
                     ? json.getJsonObject(QUESTION_KEY).getString(UUID_KEY) : json.getString(QUESTION_KEY);
+            } else if (QuestionnaireUtils.INFORMATION_NODETYPE.equals(json.getString(PRIMARY_TYPE_KEY))) {
+                uuid = json.getString(PATH_KEY);
             }
             return uuid;
         }

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/InformationNodesTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/InformationNodesTest.xml
@@ -18,16 +18,16 @@
 -->
 
 <node>
-	<name>SectionsWithInfoNodesTest</name>
+	<name>InformationNodesTest</name>
 	<primaryNodeType>cards:Questionnaire</primaryNodeType>
 	<property>
 		<name>title</name>
-		<value>Sections with only Information nodes Test</value>
+		<value>Information Nodes Test</value>
 		<type>String</type>
 	</property>
 	<property>
 		<name>description</name>
-		<value>CARDS-2590: Sections with only Information nodes displayed in view mode</value>
+		<value>CARDS-2590, CARDS-2628</value>
 		<type>String</type>
 	</property>
 	<property>
@@ -340,5 +340,215 @@
 			<value>success</value>
 			<type>String</type>
 		</property>
+	</node>
+	<node>
+		<name>ordered-information</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>compact</name>
+			<value>False</value>
+			<type>Boolean</type>
+		</property>
+		<property>
+			<name>description</name>
+			<value>4 information boxes displayed in all modes mode in ascending numerical order</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>default</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>label</name>
+			<value>S3: Ordered Section</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>recurrent</name>
+			<value>False</value>
+			<type>Boolean</type>
+		</property>
+		<node>
+			<name>ordered1</name>
+			<primaryNodeType>cards:Information</primaryNodeType>
+			<property>
+				<name>formMode</name>
+				<value>any</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>1. Information</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>type</name>
+				<value>success</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>ordered2</name>
+			<primaryNodeType>cards:Information</primaryNodeType>
+			<property>
+				<name>formMode</name>
+				<value>any</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>2. Information</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>type</name>
+				<value>success</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>ordered3</name>
+			<primaryNodeType>cards:Information</primaryNodeType>
+			<property>
+				<name>formMode</name>
+				<value>any</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>3. Information</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>type</name>
+				<value>success</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>ordered4</name>
+			<primaryNodeType>cards:Information</primaryNodeType>
+			<property>
+				<name>formMode</name>
+				<value>any</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>4. Information</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>type</name>
+				<value>success</value>
+				<type>String</type>
+			</property>
+		</node>
+	</node>
+	<node>
+		<name>recurrent-ordered-information</name>
+		<primaryNodeType>cards:Section</primaryNodeType>
+		<property>
+			<name>compact</name>
+			<value>False</value>
+			<type>Boolean</type>
+		</property>
+		<property>
+			<name>description</name>
+			<value>4 information boxes displayed in all modes mode in ascending numerical order inside a recurrent section</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>displayMode</name>
+			<value>default</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>label</name>
+			<value>S4: Recurrent Ordered Section</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>recurrent</name>
+			<value>True</value>
+			<type>Boolean</type>
+		</property>
+		<node>
+			<name>recurrentordered1</name>
+			<primaryNodeType>cards:Information</primaryNodeType>
+			<property>
+				<name>formMode</name>
+				<value>any</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>1. Information</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>type</name>
+				<value>success</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>recurrentordered2</name>
+			<primaryNodeType>cards:Information</primaryNodeType>
+			<property>
+				<name>formMode</name>
+				<value>any</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>2. Information</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>type</name>
+				<value>success</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>recurrentordered3</name>
+			<primaryNodeType>cards:Information</primaryNodeType>
+			<property>
+				<name>formMode</name>
+				<value>any</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>3. Information</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>type</name>
+				<value>success</value>
+				<type>String</type>
+			</property>
+		</node>
+		<node>
+			<name>recurrentordered4</name>
+			<primaryNodeType>cards:Information</primaryNodeType>
+			<property>
+				<name>formMode</name>
+				<value>any</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>text</name>
+				<value>4. Information</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>type</name>
+				<value>success</value>
+				<type>String</type>
+			</property>
+		</node>
 	</node>
 </node>


### PR DESCRIPTION
As information nodes do not have a UUID, do not attempt to sort them by UUID during serialization

Adds test cases to ensure they still appear in the correct order to the renamed InformationNodesTest form (Previously SectionsWithInfoNodesTest)

To test:
- Create a new form containing an information node with formMode: any
- Save and view the form
- Enter print preview. Ensure that the preview loads and the information node is in the correct order