### PR TITLE
CARDS-2625: Replace deprecated react-beautiful-dnd with pragmatic-drag-and-drop

### DIFF
--- a/aggregated-frontend/src/main/frontend/yarn.lock
+++ b/aggregated-frontend/src/main/frontend/yarn.lock
@@ -15,6 +15,82 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@atlaskit/ds-lib@^3.2.0", "@atlaskit/ds-lib@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@atlaskit/ds-lib/-/ds-lib-3.3.0.tgz#b2088eabf5bfbda3889577c1562e79a84cfdb782"
+  integrity sha512-8bgJRFvL4C9dOc3XQ0nJLze4OSXtfemmE2os2h/T80hSdQO57hPMnXB22Pl6nT/6nEP7kZ4kAH6hDuJ3vBUNPA==
+  dependencies:
+    "@atlaskit/platform-feature-flags" "^0.3.0"
+    "@babel/runtime" "^7.0.0"
+    bind-event-listener "^3.0.0"
+    react-uid "^2.2.0"
+
+"@atlaskit/motion@^1.9.0":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@atlaskit/motion/-/motion-1.9.3.tgz#94ae7ed21253c6198eac5a2d7281ec80d85a7ac6"
+  integrity sha512-DQplpASqBLtPyZUwRSdLW6z+SmDvyMZtGNw7LPTVtFbIdCEoTSbsI6K0hJJ4in8pdE26xv9NHm0FkbSuk84njw==
+  dependencies:
+    "@atlaskit/ds-lib" "^3.2.0"
+    "@babel/runtime" "^7.0.0"
+    "@emotion/react" "^11.7.1"
+    bind-event-listener "^3.0.0"
+
+"@atlaskit/platform-feature-flags@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@atlaskit/platform-feature-flags/-/platform-feature-flags-0.3.0.tgz#94dfa0a4ef0a140f6ab0a6de006464de925ecea7"
+  integrity sha512-/0u5fFJ0Rw2j4M5wzsXgaHO6Ey12oekPCDTRvmmAIp4GO9T2Swbl80bavLAPSOmSHMhHTSuvRxiJveZXfQ21IQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
+"@atlaskit/pragmatic-drag-and-drop-flourish@^1.1.0":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@atlaskit/pragmatic-drag-and-drop-flourish/-/pragmatic-drag-and-drop-flourish-1.1.3.tgz#9a17604a4af6424c9e4135a5f7e7b525e6ce6b32"
+  integrity sha512-pBVwD8oo4dVsOCavIxqitVg3XucG1HYH/qTJP5zRt36r1ErJ23x9iLx9X7Zr62ZJRlsCZzz7esHNGPbfr5TNAQ==
+  dependencies:
+    "@atlaskit/motion" "^1.9.0"
+    "@atlaskit/tokens" "^3.0.0"
+    "@babel/runtime" "^7.0.0"
+
+"@atlaskit/pragmatic-drag-and-drop-hitbox@^1.0.0", "@atlaskit/pragmatic-drag-and-drop-hitbox@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@atlaskit/pragmatic-drag-and-drop-hitbox/-/pragmatic-drag-and-drop-hitbox-1.0.3.tgz#fcce42f5e2c5a26007f4422397acad29608d3784"
+  integrity sha512-/Sbu/HqN2VGLYBhnsG7SbRNg98XKkbF6L7XDdBi+izRybfaK1FeMfodPpm/xnBHPJzwYMdkE0qtLyv6afhgMUA==
+  dependencies:
+    "@atlaskit/pragmatic-drag-and-drop" "^1.1.0"
+    "@babel/runtime" "^7.0.0"
+
+"@atlaskit/pragmatic-drag-and-drop-react-drop-indicator@^1.1.3":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/-/pragmatic-drag-and-drop-react-drop-indicator-1.1.4.tgz#415bb92dfbf7332fb59f29ffe38e62deae8d1812"
+  integrity sha512-AgbY3ZcuMgxNzCruhCu/hocv9JDi+VJSwr7QpzJQmVkxWxEkUBZmSHXBMwAZ+pFsxHH97eG/y+nuOxTIUDdnJA==
+  dependencies:
+    "@atlaskit/pragmatic-drag-and-drop" "^1.4.0"
+    "@atlaskit/pragmatic-drag-and-drop-hitbox" "^1.0.0"
+    "@atlaskit/tokens" "^3.0.0"
+    "@babel/runtime" "^7.0.0"
+    "@emotion/react" "^11.7.1"
+
+"@atlaskit/pragmatic-drag-and-drop@^1.1.0", "@atlaskit/pragmatic-drag-and-drop@^1.1.11", "@atlaskit/pragmatic-drag-and-drop@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@atlaskit/pragmatic-drag-and-drop/-/pragmatic-drag-and-drop-1.4.0.tgz#0e3441b2549adcc41e0cacac33d33bc71952f9f8"
+  integrity sha512-qRY3PTJIcxfl/QB8Gwswz+BRvlmgAC5pB+J2hL6dkIxgqAgVwOhAamMUKsrOcFU/axG2Q7RbNs1xfoLKDuhoPg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    bind-event-listener "^3.0.0"
+    raf-schd "^4.0.3"
+
+"@atlaskit/tokens@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@atlaskit/tokens/-/tokens-3.0.0.tgz#d71ae1e5da6280dd6692a4c7891a180c2c8a06ba"
+  integrity sha512-RvZooPRoAx+4YhsKY8UCjKz94WRoOjgM3aJEKMBpYT8TVv8iF7+NPU1mkMgAswxutyhurU6f2EcXGMZUhAnfsg==
+  dependencies:
+    "@atlaskit/ds-lib" "^3.3.0"
+    "@atlaskit/platform-feature-flags" "^0.3.0"
+    "@babel/runtime" "^7.0.0"
+    "@babel/traverse" "^7.23.2"
+    "@babel/types" "^7.20.0"
+    bind-event-listener "^3.0.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.18.6", "@babel/code-frame@^7.22.13":
   version "7.22.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz#e3c1c099402598483b7a8c46a721d1038803755e"
@@ -251,10 +327,20 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz#533f36457a25814cf1df6488523ad547d784a99f"
   integrity sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==
 
+"@babel/helper-string-parser@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz#1aabb72ee72ed35789b4bbcad3ca2862ce614e8c"
+  integrity sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==
+
 "@babel/helper-validator-identifier@^7.22.20":
   version "7.22.20"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz#c4ae002c61d2879e724581d96665583dbc1dc0e0"
   integrity sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==
+
+"@babel/helper-validator-identifier@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz#24b64e2c3ec7cd3b3c547729b8d16871f22cbdc7"
+  integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
 
 "@babel/helper-validator-option@^7.18.6", "@babel/helper-validator-option@^7.21.0", "@babel/helper-validator-option@^7.22.15":
   version "7.22.15"
@@ -971,7 +1057,7 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@7.21.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.10.5", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.15.4", "@babel/runtime@^7.17.2", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.6", "@babel/runtime@^7.20.7", "@babel/runtime@^7.21.0", "@babel/runtime@^7.23.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@7.21.0", "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.10.5", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.15.4", "@babel/runtime@^7.17.2", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.6", "@babel/runtime@^7.20.7", "@babel/runtime@^7.21.0", "@babel/runtime@^7.23.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
   integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
@@ -1002,6 +1088,14 @@
     "@babel/types" "^7.23.0"
     debug "^4.1.0"
     globals "^11.1.0"
+
+"@babel/types@^7.20.0":
+  version "7.26.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.3.tgz#37e79830f04c2b5687acc77db97fbc75fb81f3c0"
+  integrity sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==
+  dependencies:
+    "@babel/helper-string-parser" "^7.25.9"
+    "@babel/helper-validator-identifier" "^7.25.9"
 
 "@babel/types@^7.21.0", "@babel/types@^7.21.4", "@babel/types@^7.22.15", "@babel/types@^7.22.19", "@babel/types@^7.22.5", "@babel/types@^7.23.0", "@babel/types@^7.4.4":
   version "7.23.0"
@@ -1108,6 +1202,23 @@
     source-map "^0.5.7"
     stylis "4.2.0"
 
+"@emotion/babel-plugin@^11.13.5":
+  version "11.13.5"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz#eab8d65dbded74e0ecfd28dc218e75607c4e7bc0"
+  integrity sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.16.7"
+    "@babel/runtime" "^7.18.3"
+    "@emotion/hash" "^0.9.2"
+    "@emotion/memoize" "^0.9.0"
+    "@emotion/serialize" "^1.3.3"
+    babel-plugin-macros "^3.1.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^4.0.0"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+    stylis "4.2.0"
+
 "@emotion/cache@^11.10.5", "@emotion/cache@^11.11.0":
   version "11.11.0"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.11.0.tgz#809b33ee6b1cb1a625fef7a45bc568ccd9b8f3ff"
@@ -1119,10 +1230,26 @@
     "@emotion/weak-memoize" "^0.3.1"
     stylis "4.2.0"
 
+"@emotion/cache@^11.14.0":
+  version "11.14.0"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.14.0.tgz#ee44b26986eeb93c8be82bb92f1f7a9b21b2ed76"
+  integrity sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==
+  dependencies:
+    "@emotion/memoize" "^0.9.0"
+    "@emotion/sheet" "^1.4.0"
+    "@emotion/utils" "^1.4.2"
+    "@emotion/weak-memoize" "^0.4.0"
+    stylis "4.2.0"
+
 "@emotion/hash@^0.9.0", "@emotion/hash@^0.9.1":
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.1.tgz#4ffb0055f7ef676ebc3a5a91fb621393294e2f43"
   integrity sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==
+
+"@emotion/hash@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.2.tgz#ff9221b9f58b4dfe61e619a7788734bd63f6898b"
+  integrity sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==
 
 "@emotion/is-prop-valid@^1.2.0":
   version "1.2.1"
@@ -1135,6 +1262,11 @@
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.1.tgz#c1ddb040429c6d21d38cc945fe75c818cfb68e17"
   integrity sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==
+
+"@emotion/memoize@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.9.0.tgz#745969d649977776b43fc7648c556aaa462b4102"
+  integrity sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==
 
 "@emotion/react@11.10.5":
   version "11.10.5"
@@ -1150,6 +1282,20 @@
     "@emotion/weak-memoize" "^0.3.0"
     hoist-non-react-statics "^3.3.1"
 
+"@emotion/react@^11.7.1":
+  version "11.14.0"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.14.0.tgz#cfaae35ebc67dd9ef4ea2e9acc6cd29e157dd05d"
+  integrity sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@emotion/babel-plugin" "^11.13.5"
+    "@emotion/cache" "^11.14.0"
+    "@emotion/serialize" "^1.3.3"
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.2.0"
+    "@emotion/utils" "^1.4.2"
+    "@emotion/weak-memoize" "^0.4.0"
+    hoist-non-react-statics "^3.3.1"
+
 "@emotion/serialize@^1.1.1", "@emotion/serialize@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.1.2.tgz#017a6e4c9b8a803bd576ff3d52a0ea6fa5a62b51"
@@ -1161,10 +1307,26 @@
     "@emotion/utils" "^1.2.1"
     csstype "^3.0.2"
 
+"@emotion/serialize@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.3.3.tgz#d291531005f17d704d0463a032fe679f376509e8"
+  integrity sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==
+  dependencies:
+    "@emotion/hash" "^0.9.2"
+    "@emotion/memoize" "^0.9.0"
+    "@emotion/unitless" "^0.10.0"
+    "@emotion/utils" "^1.4.2"
+    csstype "^3.0.2"
+
 "@emotion/sheet@^1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.2.2.tgz#d58e788ee27267a14342303e1abb3d508b6d0fec"
   integrity sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==
+
+"@emotion/sheet@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.4.0.tgz#c9299c34d248bc26e82563735f78953d2efca83c"
+  integrity sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==
 
 "@emotion/styled@11.10.5":
   version "11.10.5"
@@ -1178,6 +1340,11 @@
     "@emotion/use-insertion-effect-with-fallbacks" "^1.0.0"
     "@emotion/utils" "^1.2.0"
 
+"@emotion/unitless@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.10.0.tgz#2af2f7c7e5150f497bdabd848ce7b218a27cf745"
+  integrity sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==
+
 "@emotion/unitless@^0.8.1":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.8.1.tgz#182b5a4704ef8ad91bde93f7a860a88fd92c79a3"
@@ -1188,15 +1355,30 @@
   resolved "https://registry.yarnpkg.com/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz#08de79f54eb3406f9daaf77c76e35313da963963"
   integrity sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==
 
+"@emotion/use-insertion-effect-with-fallbacks@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz#8a8cb77b590e09affb960f4ff1e9a89e532738bf"
+  integrity sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==
+
 "@emotion/utils@^1.2.0", "@emotion/utils@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.2.1.tgz#bbab58465738d31ae4cb3dbb6fc00a5991f755e4"
   integrity sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==
 
+"@emotion/utils@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.4.2.tgz#6df6c45881fcb1c412d6688a311a98b7f59c1b52"
+  integrity sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==
+
 "@emotion/weak-memoize@^0.3.0", "@emotion/weak-memoize@^0.3.1":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz#d0fce5d07b0620caa282b5131c297bb60f9d87e6"
   integrity sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==
+
+"@emotion/weak-memoize@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz#5e13fac887f08c44f76b0ccaf3370eb00fec9bb6"
+  integrity sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
 
 "@eslint/eslintrc@^1.4.1":
   version "1.4.1"
@@ -1610,14 +1792,6 @@
   dependencies:
     "@types/unist" "^2"
 
-"@types/hoist-non-react-statics@^3.3.0":
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz#6bba74383cdab98e8db4e20ce5b4a6b98caed010"
-  integrity sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==
-  dependencies:
-    "@types/react" "*"
-    hoist-non-react-statics "^3.3.0"
-
 "@types/html-minifier-terser@^6.0.0":
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz#4fc33a00c1d0c16987b1a20cf92d20614c55ac35"
@@ -1676,16 +1850,6 @@
   version "15.7.9"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.9.tgz#b6f785caa7ea1fe4414d9df42ee0ab67f23d8a6d"
   integrity sha512-n1yyPsugYNSmHgxDFjicaI2+gCNjsBck8UX9kuofAKlc0h1bL+20oSF72KeNaW2DUlesbEVCFgyV2dPGTiY42g==
-
-"@types/react-redux@^7.1.20":
-  version "7.1.34"
-  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.34.tgz#83613e1957c481521e6776beeac4fd506d11bd0e"
-  integrity sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==
-  dependencies:
-    "@types/hoist-non-react-statics" "^3.3.0"
-    "@types/react" "*"
-    hoist-non-react-statics "^3.3.0"
-    redux "^4.0.0"
 
 "@types/react-transition-group@^4.4.5":
   version "4.4.8"
@@ -2117,6 +2281,11 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
+bind-event-listener@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bind-event-listener/-/bind-event-listener-3.0.0.tgz#c90f9a7fcb65cac21045f810c20ef7e647a74921"
+  integrity sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==
+
 boolbase@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
@@ -2395,13 +2564,6 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-css-box-model@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.1.tgz#59951d3b81fd6b2074a62d49444415b0d2b4d7c1"
-  integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
-  dependencies:
-    tiny-invariant "^1.0.6"
 
 css-loader@6.7.3:
   version "6.7.3"
@@ -4284,11 +4446,6 @@ mdast-util-to-string@^3.0.0, mdast-util-to-string@^3.1.0:
   dependencies:
     "@types/mdast" "^3.0.0"
 
-memoize-one@^5.1.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
-  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
-
 merge-source-map@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
@@ -5027,7 +5184,7 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-raf-schd@^4.0.2:
+raf-schd@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
   integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
@@ -5045,19 +5202,6 @@ raphael@2.3.0:
   integrity sha512-w2yIenZAQnp257XUWGni4bLMVxpUpcIl7qgxEgDIXtmSypYtlNxfXWpOBxs7LBTps5sDwhRnrToJrMUrivqNTQ==
   dependencies:
     eve-raphael "0.5.0"
-
-react-beautiful-dnd@13.1.1:
-  version "13.1.1"
-  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz#b0f3087a5840920abf8bb2325f1ffa46d8c4d0a2"
-  integrity sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==
-  dependencies:
-    "@babel/runtime" "^7.9.2"
-    css-box-model "^1.2.0"
-    memoize-one "^5.1.1"
-    raf-schd "^4.0.2"
-    react-redux "^7.2.0"
-    redux "^4.0.4"
-    use-memo-one "^1.1.1"
 
 react-dom@^18.0.0:
   version "18.2.0"
@@ -5094,11 +5238,6 @@ react-is@^16.10.2, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.6.3, react-
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
-
-react-is@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
-  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-markdown@~8.0.0:
   version "8.0.7"
@@ -5147,18 +5286,6 @@ react-popper@^2.3.0:
   dependencies:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
-
-react-redux@^7.2.0:
-  version "7.2.9"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.9.tgz#09488fbb9416a4efe3735b7235055442b042481d"
-  integrity sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==
-  dependencies:
-    "@babel/runtime" "^7.15.4"
-    "@types/react-redux" "^7.1.20"
-    hoist-non-react-statics "^3.3.2"
-    loose-envify "^1.4.0"
-    prop-types "^15.7.2"
-    react-is "^17.0.2"
 
 react-router-dom@5.2.0:
   version "5.2.0"
@@ -5215,6 +5342,13 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
+react-uid@^2.2.0:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/react-uid/-/react-uid-2.3.3.tgz#6a485ccc868555997f3506c6db97a3e735d97adf"
+  integrity sha512-iNpDovcb9qBpBTo8iUgqRSQOS8GV3bWoNaTaUptHkXtAooXSo0OWe7vN6TqqB8x3x0bNBbQx96kkmSltQ5h9kQ==
+  dependencies:
+    tslib "^2.0.0"
+
 react@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
@@ -5249,13 +5383,6 @@ rechoir@^0.7.0:
   integrity sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==
   dependencies:
     resolve "^1.9.0"
-
-redux@^4.0.0, redux@^4.0.4:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
-  integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
-  dependencies:
-    "@babel/runtime" "^7.9.2"
 
 refractor@^4.8.0:
   version "4.8.1"
@@ -5904,12 +6031,12 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
-tiny-invariant@^1.0.2, tiny-invariant@^1.0.6:
+tiny-invariant@^1.0.2:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.1.tgz#8560808c916ef02ecfd55e66090df23a4b7aa642"
   integrity sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==
 
-tiny-invariant@^1.3.1:
+tiny-invariant@^1.3.1, tiny-invariant@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
@@ -5943,6 +6070,11 @@ tslib@^1.10.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.0.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tslib@^2.0.3:
   version "2.6.2"
@@ -6125,11 +6257,6 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
-
-use-memo-one@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.3.tgz#2fd2e43a2169eabc7496960ace8c79efef975e99"
-  integrity sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==
 
 util-deprecate@^1.0.2:
   version "1.0.2"

--- a/modules/data-entry/src/main/frontend/package.json
+++ b/modules/data-entry/src/main/frontend/package.json
@@ -44,7 +44,6 @@
     "cornerstone-wado-image-loader": "4.6.0",
     "dicom-parser": "1.8.20",
     "react": "^18.0.0",
-    "react-beautiful-dnd": "13.1.1",
     "react-dom": "^18.0.0",
     "react-number-format": "5.1.2",
     "react-phone-input-2": "2.15.1",
@@ -55,6 +54,11 @@
     "luxon": "3.2.1",
     "prop-types": "15.8.1",
     "uuid": "9.0.0",
-    "@uiw/react-md-editor": "3.20.2"
+    "@uiw/react-md-editor": "3.20.2",
+    "@atlaskit/pragmatic-drag-and-drop": "^1.1.11",
+    "@atlaskit/pragmatic-drag-and-drop-flourish": "^1.1.0",
+    "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
+    "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator": "^1.1.3",
+    "tiny-invariant": "^1.3.3"
   }
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/AnswerOptions.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/AnswerOptions.jsx
@@ -41,15 +41,13 @@ import EditorInput from "./EditorInput";
 import QuestionComponentManager from "./QuestionComponentManager";
 import ValueComponentManager from "./ValueComponentManager";
 import MarkdownText from "./MarkdownText";
-import CloseIcon from '@mui/icons-material/Close';
 import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
 import NotesIcon from '@mui/icons-material/Notes';
 import { stringToHash } from "../escape.jsx";
-import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
-import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 
 import ComposedIcon from "../components/ComposedIcon.jsx";
+import DroppableAnswerOptionList from "./DroppableAnswerOptionList.jsx";
 
 let extractSortedOptions = (data) => {
   return Object.values(data).filter(value => value['jcr:primaryType'] == 'cards:AnswerOption'
@@ -77,6 +75,9 @@ const useStyles = makeStyles(theme => ({
         paddingLeft: theme.spacing(1),
       },
     },
+    optionsList: {
+      position: 'relative',
+    },
     answerOptionReadonly: {
       "& .MuiInput-underline:before" : {
         borderBottom: "0 none !important",
@@ -103,6 +104,9 @@ const useStyles = makeStyles(theme => ({
         justifyContent: "flex-end",
         padding: theme.spacing(1,2),
       },
+    },
+    optionDisabled: {
+      opacity: 0.5,
     },
 }));
 
@@ -169,24 +173,6 @@ let AnswerOptions = (props) => {
       duplicateSetter: setIsNoneDuplicate
     }
   ];
-
-  let getItemStyle = (isDragging, draggableStyle) => ({
-    // change background colour if dragging
-    borderStyle: isDragging ? "dashed" : undefined,
-    borderWidth: isDragging ? "2px" : undefined,
-    ...draggableStyle
-  });
-
-  let onDragEnd = (result) => {
-    // dropped outside the list
-    if (!result.destination) {
-      return;
-    }
-    let oldOptions = options.slice();
-    const [removed] = oldOptions.splice(result.source.index, 1);
-    oldOptions.splice(result.destination.index, 0, removed);
-    setOptions(oldOptions);
-  }
 
   // Clear local state when data changes
   useEffect(() => {
@@ -385,83 +371,13 @@ let AnswerOptions = (props) => {
         <input type='hidden' name={`${value['@path']}@Delete`} value="0" key={value['@path']} />
       )}
       { generateSpecialOptions(0) }
-      <DragDropContext onDragEnd={onDragEnd}>
-        <Droppable droppableId="droppable">
-          {(provided, snapshot) => (
-            <div
-              {...provided.droppableProps}
-              ref={provided.innerRef}
-            >
-              { options.map((value, index) =>
-                <Draggable key={value.value} draggableId={value.value} index={index}>
-                  { (provided, snapshot) => (
-                    <Grid container
-                      direction="row"
-                      justifyContent="space-between"
-                      alignItems="stretch"
-                      className={classes.answerOption}
-                      key={value.value}
-                      ref={provided.innerRef}
-                      {...provided.draggableProps}
-                      style={getItemStyle(
-                          snapshot.isDragging,
-                          provided.draggableProps.style
-                      )}
-                    >
-                      <Grid item xs={1}>
-                        <Tooltip title="Drag to reorder">
-                          <IconButton {...provided.dragHandleProps} className={classes.optionsDragIndicator}>
-                            <DragIndicatorIcon />
-                          </IconButton>
-                        </Tooltip>
-                      </Grid>
-                      <Grid item xs={8}>
-                        <input type='hidden' name={`${value['@path']}/jcr:primaryType`} value={'cards:AnswerOption'} />
-                        <input type='hidden' name={`${value['@path']}/label`} value={value.label} />
-                        <input type='hidden' name={`${value['@path']}/value`} value={value.value} />
-                        <input type='hidden' name={`${value['@path']}/defaultOrder`} value={index+1} />
-                        <input type="hidden" name={`${value['@path']}/description`} value={value.description || ''} />
-                        <input type="hidden" name={`${value['@path']}/isDefault`} value={value.isDefault || false} />
-                        <input type="hidden" name={`${value['@path']}/isDefault@TypeHint`} value="Boolean" />
-                        <Tooltip title="Selected by default">
-                          <Checkbox
-                            color="secondary"
-                            checked={value.isDefault}
-                            onChange={(event) => {
-                              setOptions(old => {
-                                var _new = old.slice();
-                                _new[index].isDefault = !!(event?.target?.checked);
-                                return _new;
-                              });
-                            }}/>
-                        </Tooltip>
-                        <TextField
-                          variant="standard"
-                          InputProps={{
-                            readOnly: true,
-                          }}
-                          className={classes.answerOptionReadonly}
-                          defaultValue={value.label? value.value + " = " + value.label : value.value}
-                          multiline
-                        />
-                      </Grid>
-                      <Grid item xs={3} className={classes.answerOptionActions}>
-                        {generateDescriptionIcon(value, index, false)}
-                        <Tooltip title="Delete option">
-                          <IconButton onClick={() => { deleteOption(index); }} className={classes.answerOptionButton}>
-                            <CloseIcon/>
-                          </IconButton>
-                        </Tooltip>
-                      </Grid>
-                    </Grid>
-                  ) }
-                </Draggable>
-              )}
-              {provided.placeholder}
-            </div>
-          )}
-        </Droppable>
-      </DragDropContext>
+      <DroppableAnswerOptionList
+        options={options}
+        setOptions={setOptions}
+        deleteOption={deleteOption}
+        generateDescriptionIcon={generateDescriptionIcon}
+        classes={classes}
+      />
       <TextField
         fullWidth
         variant="standard"

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/DroppableAnswerOption.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/DroppableAnswerOption.jsx
@@ -93,8 +93,8 @@ function DroppableAnswerOption(props) {
         onDrop() {
             setDraggableState({ type: 'idle' });
         },
-    }), 
-    dropTargetForElements({
+      }),
+      dropTargetForElements({
         element,
         canDrop({ source }) {
             // not allowing dropping on yourself

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/DroppableAnswerOption.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/DroppableAnswerOption.jsx
@@ -21,7 +21,6 @@ import React, { useEffect, useRef, useState } from "react";
 import { createPortal } from 'react-dom';
 import PropTypes from "prop-types";
 import {
-  Box,
   Checkbox,
   Grid,
   IconButton,
@@ -139,25 +138,25 @@ function DroppableAnswerOption(props) {
     }));
   }, [value]);
 
-  return (
-    <React.Fragment>
-      <div className={classes.optionsList}>
-        <Grid container
+  let generateOption = (isPerview) => {
+    return (
+      <Grid container
           data-option-id={value.value}
           direction="row"
           justifyContent="space-between"
           alignItems="stretch"
-          className={classes.answerOption + ' ' + (draggableState.type === "dragging" ? classes.optionDisabled : "")}
+          className={classes.answerOption + ' ' + (!isPerview && draggableState.type === "dragging" ? classes.optionDisabled : "")}
           ref={ref}
         >
           <Grid item xs={1}>
-            <Tooltip title="Drag to reorder">
+            <Tooltip title={!isPerview ? "Drag to reorder" : ""}>
               <IconButton className={classes.optionsDragIndicator}>
                 <DragIndicatorIcon />
               </IconButton>
             </Tooltip>
           </Grid>
           <Grid item xs={8}>
+            {!isPerview && <span>
             <input type='hidden' name={`${value['@path']}/jcr:primaryType`} value={'cards:AnswerOption'} />
             <input type='hidden' name={`${value['@path']}/label`} value={value.label} />
             <input type='hidden' name={`${value['@path']}/value`} value={value.value} />
@@ -165,6 +164,7 @@ function DroppableAnswerOption(props) {
             <input type="hidden" name={`${value['@path']}/description`} value={value.description || ''} />
             <input type="hidden" name={`${value['@path']}/isDefault`} value={value.isDefault || false} />
             <input type="hidden" name={`${value['@path']}/isDefault@TypeHint`} value="Boolean" />
+            </span>}
             <Tooltip title="Selected by default">
               <Checkbox
                 color="secondary"
@@ -196,22 +196,19 @@ function DroppableAnswerOption(props) {
             </Tooltip>
           </Grid>
         </Grid>
-       {draggableState?.type === 'dragging-over' && draggableState?.closestEdge &&
-         (<DropIndicator edge={draggableState.closestEdge} gap={'8px'}/>)}
+	)
+  }
+
+  return (
+    <React.Fragment>
+      <div className={classes.optionsList}>
+        {generateOption(false)}
+        {draggableState?.type === 'dragging-over' && draggableState?.closestEdge &&
+          (<DropIndicator edge={draggableState.closestEdge} gap={'8px'}/>)}
       </div>
       { draggableState.type === "preview" &&
         createPortal(
-           <Grid container direction="row" justifyContent="space-between" alignItems="stretch" className={classes.answerOption}>
-             <Grid item xs={1}> <IconButton className={classes.optionsDragIndicator}> <DragIndicatorIcon /> </IconButton> </Grid>
-             <Grid item xs={8}>
-               <Checkbox color="secondary" checked={value.isDefault}/>
-               <TextField variant="standard" className={classes.answerOptionReadonly} defaultValue={value.label? value.value + " = " + value.label : value.value} multiline />
-             </Grid>
-             <Grid item xs={3} className={classes.answerOptionActions}>
-               {generateDescriptionIcon(value, index, false)}
-               <IconButton className={classes.answerOptionButton}> <CloseIcon/> </IconButton>
-             </Grid>
-          </Grid>,
+           generateOption(true),
           draggableState.container
         )}
     </React.Fragment>

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/DroppableAnswerOption.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/DroppableAnswerOption.jsx
@@ -1,0 +1,228 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from 'react-dom';
+import PropTypes from "prop-types";
+import {
+  Box,
+  Checkbox,
+  Grid,
+  IconButton,
+  TextField,
+  Tooltip,
+} from "@mui/material";
+import CloseIcon from '@mui/icons-material/Close';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+
+import { draggable, dropTargetForElements, } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { setCustomNativeDragPreview } from '@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview';
+import { pointerOutsideOfPreview } from '@atlaskit/pragmatic-drag-and-drop/element/pointer-outside-of-preview';
+import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';
+import { attachClosestEdge, extractClosestEdge, } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
+import { DropIndicator } from "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/box";
+import invariant from 'tiny-invariant';
+
+
+const valueKey = Symbol("value"); // creates a unique property keys
+
+function getOptionData(value) {
+  return { [valueKey]: true, valueId: value.value };
+}
+
+export function isOptionData(data) {
+  return data[valueKey] === true;
+}
+
+function DroppableAnswerOption(props) {
+  const { classes, value, index, deleteOption, generateDescriptionIcon } = props;
+
+  const ref = useRef(null);
+
+  /* Object to maintain the draggable state
+    type DraggableState =
+      | { type: "idle" }
+      | { type: "preview"; container: HTMLElement }
+      | { type: "dragging" }
+      | { type: 'dragging-over'; closestEdge: Edge | null }
+  */
+  const [draggableState, setDraggableState] = useState({ type: 'idle' });
+
+  useEffect(() => {
+    const element = ref.current;
+    invariant(element);
+
+    const data = getOptionData(value);
+
+    return combine(
+      draggable({
+        element,
+        getInitialData() {
+            return data;
+        },
+        onGenerateDragPreview({ nativeSetDragImage }) {
+            setCustomNativeDragPreview({
+                nativeSetDragImage,
+                getOffset: pointerOutsideOfPreview({
+                    x: '4px',
+                    y: '4px',
+                }),
+                render({ container }) {
+                    setDraggableState({ type: 'preview', container });
+                },
+            });
+        },
+        onDragStart() {
+            setDraggableState({ type: "dragging" });
+        },
+        onDrop() {
+            setDraggableState({ type: 'idle' });
+        },
+    }), 
+    dropTargetForElements({
+        element,
+        canDrop({ source }) {
+            // not allowing dropping on yourself
+            if (source.element === element) {
+                return false;
+            }
+            // only allowing options to be dropped on me
+            return isOptionData(source.data);
+        },
+        getData({ input }) {
+            return attachClosestEdge(data, {
+                element,
+                input,
+                allowedEdges: ['top', 'bottom'],
+            });
+        },
+        getIsSticky() {
+            return true;
+        },
+        onDragEnter({ self }) {
+            const closestEdge = extractClosestEdge(self.data);
+            setDraggableState({ type: 'dragging-over', closestEdge });
+        },
+        onDrag({ self }) {
+            const closestEdge = extractClosestEdge(self.data);
+            // Only need to update react state if nothing has changed.
+            // Prevents re-rendering.
+            setDraggableState((current) => {
+               if (current.type === 'dragging-over' && current.closestEdge === closestEdge) {
+                  return current;
+               }
+               return { type: 'dragging-over', closestEdge };
+            });
+        },
+        onDragLeave() {
+            setDraggableState({ type: 'idle' });
+        },
+        onDrop() {
+            setDraggableState({ type: 'idle' });
+        },
+    }));
+  }, [value]);
+
+  return (
+    <React.Fragment>
+      <div className={classes.optionsList}>
+        <Grid container
+          data-option-id={value.value}
+          direction="row"
+          justifyContent="space-between"
+          alignItems="stretch"
+          className={classes.answerOption + ' ' + (draggableState.type === "dragging" ? classes.optionDisabled : "")}
+          ref={ref}
+        >
+          <Grid item xs={1}>
+            <Tooltip title="Drag to reorder">
+              <IconButton className={classes.optionsDragIndicator}>
+                <DragIndicatorIcon />
+              </IconButton>
+            </Tooltip>
+          </Grid>
+          <Grid item xs={8}>
+            <input type='hidden' name={`${value['@path']}/jcr:primaryType`} value={'cards:AnswerOption'} />
+            <input type='hidden' name={`${value['@path']}/label`} value={value.label} />
+            <input type='hidden' name={`${value['@path']}/value`} value={value.value} />
+            <input type='hidden' name={`${value['@path']}/defaultOrder`} value={index+1} />
+            <input type="hidden" name={`${value['@path']}/description`} value={value.description || ''} />
+            <input type="hidden" name={`${value['@path']}/isDefault`} value={value.isDefault || false} />
+            <input type="hidden" name={`${value['@path']}/isDefault@TypeHint`} value="Boolean" />
+            <Tooltip title="Selected by default">
+              <Checkbox
+                color="secondary"
+                checked={value.isDefault}
+                onChange={(event) => {
+                  setOptions(old => {
+                    var _new = old.slice();
+                    _new[index].isDefault = !!(event?.target?.checked);
+                    return _new;
+                  });
+                }}/>
+            </Tooltip>
+            <TextField
+              variant="standard"
+              InputProps={{
+                readOnly: true,
+              }}
+              className={classes.answerOptionReadonly}
+              defaultValue={value.label? value.value + " = " + value.label : value.value}
+              multiline
+            />
+          </Grid>
+          <Grid item xs={3} className={classes.answerOptionActions}>
+            {generateDescriptionIcon(value, index, false)}
+            <Tooltip title="Delete option">
+              <IconButton onClick={() => { deleteOption(index); }} className={classes.answerOptionButton}>
+                <CloseIcon/>
+              </IconButton>
+            </Tooltip>
+          </Grid>
+        </Grid>
+       {draggableState?.type === 'dragging-over' && draggableState?.closestEdge &&
+         (<DropIndicator edge={draggableState.closestEdge} gap={'8px'}/>)}
+      </div>
+      { draggableState.type === "preview" &&
+        createPortal(
+           <Grid container direction="row" justifyContent="space-between" alignItems="stretch" className={classes.answerOption}>
+             <Grid item xs={1}> <IconButton className={classes.optionsDragIndicator}> <DragIndicatorIcon /> </IconButton> </Grid>
+             <Grid item xs={8}>
+               <Checkbox color="secondary" checked={value.isDefault}/>
+               <TextField variant="standard" className={classes.answerOptionReadonly} defaultValue={value.label? value.value + " = " + value.label : value.value} multiline />
+             </Grid>
+             <Grid item xs={3} className={classes.answerOptionActions}>
+               {generateDescriptionIcon(value, index, false)}
+               <IconButton className={classes.answerOptionButton}> <CloseIcon/> </IconButton>
+             </Grid>
+          </Grid>,
+          draggableState.container
+        )}
+    </React.Fragment>
+  )
+}
+
+DroppableAnswerOption.propTypes = {
+  value: PropTypes.object.isRequired,
+  index: PropTypes.number.isRequired,
+  deleteOption: PropTypes.func.isRequired,
+  generateDescriptionIcon: PropTypes.func.isRequired,
+};
+
+export default DroppableAnswerOption;

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/DroppableAnswerOptionList.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/DroppableAnswerOptionList.jsx
@@ -1,0 +1,103 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import React, { useEffect } from "react";
+import { flushSync } from 'react-dom';
+import PropTypes from "prop-types";
+
+import DroppableAnswerOption, { isOptionData } from './DroppableAnswerOption.jsx';
+
+import { monitorForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { extractClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
+import { reorderWithEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/util/reorder-with-edge';
+import { triggerPostMoveFlash } from '@atlaskit/pragmatic-drag-and-drop-flourish/trigger-post-move-flash';
+
+function DroppableAnswerOptionList(props) {
+  const { classes, options, setOptions, deleteOption, generateDescriptionIcon } = props;
+
+  useEffect(() => {
+    return monitorForElements({
+        canMonitor({ source }) {
+            return isOptionData(source.data);
+        },
+        onDrop({ location, source }) {
+            const target = location.current.dropTargets[0];
+            if (!target) {
+                return;
+            }
+
+            const sourceData = source.data;
+            const targetData = target.data;
+            if (!isOptionData(sourceData) || !isOptionData(targetData)) {
+                return;
+            }
+
+            const indexOfSource = options.findIndex((option) => option.value === sourceData.valueId);
+            const indexOfTarget = options.findIndex((option) => option.value === targetData.valueId);
+            if (indexOfTarget < 0 || indexOfSource < 0) {
+                return;
+            }
+
+            const closestEdgeOfTarget = extractClosestEdge(targetData);
+            // Using `flushSync` so we can query the DOM straight after this line
+            flushSync(() => {
+                let reorderedList = reorderWithEdge({
+                    list: options,
+                    startIndex: indexOfSource,
+                    indexOfTarget,
+                    closestEdgeOfTarget,
+                    axis: 'vertical',
+                });
+                setOptions(reorderedList);
+            });
+            // Being simple and just querying for the task after the drop.
+            // We could use react context to register the element in a lookup,
+            // and then we could retrieve that element after the drop and use
+            // `triggerPostMoveFlash`. But this gets the job done.
+            const element = document.querySelector(`[data-option-id="${sourceData.valueId}"]`);
+            if (element instanceof HTMLElement) {
+                triggerPostMoveFlash(element);
+            }
+        },
+    });
+  }, [options]);
+
+  return (
+    <React.Fragment>
+      {options && options.map((value, index) =>
+          <DroppableAnswerOption
+            key={value.value}
+            value={value}
+            index={index}
+            deleteOption={deleteOption}
+            generateDescriptionIcon={generateDescriptionIcon}
+            classes={classes}
+          />
+        )}
+    </React.Fragment>
+  );
+}
+
+DroppableAnswerOptionList.propTypes = {
+  options: PropTypes.array.isRequired,
+  deleteOption: PropTypes.func.isRequired,
+  generateDescriptionIcon: PropTypes.func.isRequired,
+};
+
+export default DroppableAnswerOptionList;


### PR DESCRIPTION
[CARDS-2625](https://phenotips.atlassian.net/browse/CARDS-2625) Replace deprecated `react-beautiful-dnd` with `pragmatic-drag-and-drop`

Affected component: Admin->Questionnaire wizard -> Question with `Min answers:` >=1, `Display mode: list` 
To test new drag-and-drop create 4 options `Data type: long` like `1=a`, `2=b`, ... etc, (naming is for comfort of tracking options reordering). Try to move them around, save and re-open.

[CARDS-2625]: https://phenotips.atlassian.net/browse/CARDS-2625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ