### PR TITLE
CARDS-2619: In the New subject dialog with a single subject type, that type is not always selected automatically

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -100,11 +100,12 @@ function UnstyledNewSubjectDialog (props) {
     validateSubjectId(type, value);
   }
 
-  // Auto-select on each dialog open if there's only one valid SubjectType given in allowedTypes
+  // Auto-select on each dialog open if there's only one valid SubjectType given in allowedTypes or data
   useEffect(() => {
-    if (open && allowedTypes?.length) {
-      allowedTypes.length === 1 && changeType(allowedTypes[0]);
-      setRowCount(allowedTypes?.length);
+    let types = allowedTypes?.length ? allowedTypes : data;
+    if (open && types?.length) {
+      types.length === 1 && changeType(types[0]);
+      setRowCount(types?.length);
     }
   }, [allowedTypes, open]);
 


### PR DESCRIPTION
[CARDS-2619](https://phenotips.atlassian.net/browse/CARDS-2619): In the New subject dialog with a single subject type, that type is not always selected automatically

The casue of problem was that `allowedTypes` is `undefined` for the workflow below.

Steps to test:

-ensure there is only ONE subject type in cards (e.g. Patient)
- From the Dashboard or the Patients page, start creating a new Patient
- When the dialog first opens the “Patient” subject type is pre-selected
- Click CANCEL before creating the patient
- Start the same creation process again → this time the “Patient” subject type should be again selected

[CARDS-2619]: https://phenotips.atlassian.net/browse/CARDS-2619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ