### PR TITLE
CARDS-2633: Adding a new child subject under a subject with an invalid indentifier fails

### DIFF
--- a/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectIdPatternValidator.java
+++ b/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectIdPatternValidator.java
@@ -24,6 +24,7 @@ import javax.jcr.RepositoryException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.spi.commit.DefaultValidator;
 import org.apache.jackrabbit.oak.spi.commit.Validator;
@@ -48,17 +49,29 @@ public class SubjectIdPatternValidator extends DefaultValidator
 
     private final SubjectUtils subjectUtils;
 
-    public SubjectIdPatternValidator(final SubjectTypeUtils subjectTypeUtils, final SubjectUtils subjectUtils)
+    private final NodeState currentNode;
+
+    public SubjectIdPatternValidator(final SubjectTypeUtils subjectTypeUtils, final SubjectUtils subjectUtils,
+        final NodeState currentNode)
     {
         this.subjectTypeUtils = subjectTypeUtils;
         this.subjectUtils = subjectUtils;
+        this.currentNode = currentNode;
+    }
+
+    @Override
+    public void propertyChanged(PropertyState before, PropertyState after) throws CommitFailedException
+    {
+        // catch identifier changes
+        if ("identifier".equals(after.getName())) {
+            childNodeAdded(null, this.currentNode);
+        }
     }
 
     @Override
     public Validator childNodeChanged(final String name, final NodeState before, final NodeState after)
-        throws CommitFailedException
     {
-        return childNodeAdded(name, after);
+        return new SubjectIdPatternValidator(this.subjectTypeUtils, this.subjectUtils, after);
     }
 
     @Override

--- a/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectIdPatternValidator.java
+++ b/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectIdPatternValidator.java
@@ -63,8 +63,8 @@ public class SubjectIdPatternValidator extends DefaultValidator
     public void propertyChanged(PropertyState before, PropertyState after) throws CommitFailedException
     {
         // catch identifier changes
-        if ("identifier".equals(after.getName())) {
-            childNodeAdded(null, this.currentNode);
+        if ("identifier".equals(after.getName()) && this.subjectUtils.isSubject(this.currentNode)) {
+            validateIdPattern(this.currentNode);
         }
     }
 

--- a/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectIdPatternValidatorProvider.java
+++ b/modules/data-model/subjects/impl/src/main/java/io/uhndata/cards/subjects/internal/SubjectIdPatternValidatorProvider.java
@@ -44,6 +44,6 @@ public class SubjectIdPatternValidatorProvider extends ValidatorProvider
     @Override
     protected Validator getRootValidator(NodeState before, NodeState after, CommitInfo info)
     {
-        return new SubjectIdPatternValidator(this.subjectTypeUtils, this.subjectUtils);
+        return new SubjectIdPatternValidator(this.subjectTypeUtils, this.subjectUtils, after);
     }
 }


### PR DESCRIPTION
[CARDS-2633](https://phenotips.atlassian.net/browse/CARDS-2633): Adding a new child subject under a subject with an invalid indentifier fails

To reproduce:

- start in prems mode
- create a new visit v1 and a new patient p1
- in administration, add an identifier pattern to the Patient subject type ^[0-9]{3}$ (three digits)
- try to create a new visit under p1, it fails because p1 has an invalid identifier

This should be allowed.

[CARDS-2633]: https://phenotips.atlassian.net/browse/CARDS-2633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ