### PR TITLE
CARDS-2521: WSORD when filter forms on the dashboard by Survey events  / Discharged

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionUtilities.jsx
@@ -113,7 +113,7 @@ export default class DateQuestionUtilities {
       'd':'month',
       'M':'year'
     };
-    let truncateTo;
+    let truncateTo = 'millisecond';
     for (let [formatSpecifier, targetPrecision] of Object.entries(truncate)) {
       if (toFormat.indexOf(formatSpecifier) < 0) {
         truncateTo = targetPrecision;

--- a/modules/patient-portal/src/main/resources/SLING-INF/content/Questionnaires/Survey events.xml
+++ b/modules/patient-portal/src/main/resources/SLING-INF/content/Questionnaires/Survey events.xml
@@ -125,7 +125,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>yyyy-MM-dd'T'HH:mm:ss.SSSz</value>
+			<value>yyyy-MM-dd'T'HH:mm:ss</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -218,7 +218,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>yyyy-MM-dd'T'HH:mm:ss.SSSz</value>
+			<value>yyyy-MM-dd'T'HH:mm:ss</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -257,7 +257,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>yyyy-MM-dd'T'HH:mm:ss.SSSz</value>
+			<value>yyyy-MM-dd'T'HH:mm:ss</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -291,7 +291,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>yyyy-MM-dd'T'HH:mm:ss.SSSz</value>
+			<value>yyyy-MM-dd'T'HH:mm:ss</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -325,7 +325,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>yyyy-MM-dd'T'HH:mm:ss.SSSz</value>
+			<value>yyyy-MM-dd'T'HH:mm:ss</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -359,7 +359,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>yyyy-MM-dd'T'HH:mm:ss.SSSz</value>
+			<value>yyyy-MM-dd'T'HH:mm:ss</value>
 			<type>String</type>
 		</property>
 		<property>

--- a/modules/patient-portal/src/main/resources/SLING-INF/content/Questionnaires/Survey events.xml
+++ b/modules/patient-portal/src/main/resources/SLING-INF/content/Questionnaires/Survey events.xml
@@ -125,7 +125,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>yyyy-MM-dd'T'HH:mm:ss.sssZ</value>
+			<value>yyyy-MM-dd'T'HH:mm:ss.SSSz</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -218,7 +218,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>yyyy-MM-dd'T'HH:mm:ss.sssZ</value>
+			<value>yyyy-MM-dd'T'HH:mm:ss.SSSz</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -257,7 +257,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>yyyy-MM-dd'T'HH:mm:ss.sssZ</value>
+			<value>yyyy-MM-dd'T'HH:mm:ss.SSSz</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -291,7 +291,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>yyyy-MM-dd'T'HH:mm:ss.sssZ</value>
+			<value>yyyy-MM-dd'T'HH:mm:ss.SSSz</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -325,7 +325,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>yyyy-MM-dd'T'HH:mm:ss.sssZ</value>
+			<value>yyyy-MM-dd'T'HH:mm:ss.SSSz</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -359,7 +359,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>yyyy-MM-dd'T'HH:mm:ss.sssZ</value>
+			<value>yyyy-MM-dd'T'HH:mm:ss.SSSz</value>
 			<type>String</type>
 		</property>
 		<property>


### PR DESCRIPTION
This is draft PR to discuss [CARDS-2521](https://phenotips.atlassian.net/browse/CARDS-2521): WSORD when filter forms on the dashboard by Survey events / Discharged

Problems that caused issues are in parsing `yyyy-MM-dd'T'HH:mm:ss.sssZ` strings from `Survey events.xml` as date format:
- MUI: The token "sssZ" is not supported by the Date and Time, date format tokens are case sensitve where `s` code seconds and `S` milliseconds
- Internal code for parsing jsx date/time formats was not counting on formats containing all possible tokens including milliseconds

Steps to test:
- start in `prems` mode
- add a dashboard filter on "Invitation email sent on"
- new filter should apprear

Problems remaining after token parsing fix - try to set a date and observe a mess:
- MUI X `DateTimePicker` component does not support milliseconds view, it supports only six views: `day`, `month`, `year`, `hours`, `minutes` and `seconds`. Meaning there is no way to set any decimal fractions of a second for provided date-time questions format of Survey events.

Possible solutions:
- Drop everything after seconds in formatting dates for Survey events
- Make a cusom DatePicker to support our needs, if milliseconds are indeed needed

[CARDS-2521]: https://phenotips.atlassian.net/browse/CARDS-2521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ