### PR TITLE
CARDS-2634: Exporting to S3 fails

### DIFF
--- a/modules/s3-export/pom.xml
+++ b/modules/s3-export/pom.xml
@@ -68,10 +68,5 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-osgi</artifactId>
-      <version>1.12.779</version>
-    </dependency>
   </dependencies>
 </project>

--- a/modules/s3-export/src/main/features/feature.json
+++ b/modules/s3-export/src/main/features/feature.json
@@ -22,7 +22,7 @@
       "start-order":"26"
     },
     {
-      "id":"com.amazonaws:aws-java-sdk-osgi:1.12.779",
+      "id":"com.amazonaws:aws-java-sdk-osgi:1.12.460",
       "start-order":"26"
     },
     {


### PR DESCRIPTION
Downgrade aws-sdk version to the latest version that works

- Build with `mvn clean install -Pdocker`
- In `compose-cluster` make a docker-compose file with `python3 generate_compose_yaml.py --dev_docker_image  --composum --cards_project cards4heracles --s3_test_container --oak_filesystem` then start it up with `docker-compose build && docker-compose up`
- visit `http://localhost:9001/` and create a bucket named `uhn`
- create a form and fill in the data so it's complete (participant status is small and doesn't take long to complete)
- open `http://localhost:8080/Subjects.export?config=Heracles%20-%20Subjects%20with%20Data`
- open `http://localhost:9001/buckets/uhn/browse` and check that the subject JSON is present
- shut down and cleanup with `docker-compose rm -vf && ./cleanup.sh`
