### PR TITLE
CARDS-2609: Configurable actions on user dashboard and related views

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/EditButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/EditButton.jsx
@@ -33,7 +33,7 @@ function EditButton(props) {
     entryType = "",
     size = "large",
     className,
-    admin,
+    extensionURL,
     onClick
   } = props;
 
@@ -48,7 +48,7 @@ function EditButton(props) {
         ?
         innerButton
         :
-        <Link to={(admin ? "../content.html/admin" : "../content.html") + entryPath + ".edit"} underline="hover">
+        <Link to={(extensionURL ? "../content.html/" + extensionURL : "../content.html") + entryPath + ".edit"} underline="hover">
           {innerButton}
         </Link>
       }
@@ -61,7 +61,7 @@ EditButton.propTypes = {
   entryType: PropTypes.string,
   size: PropTypes.oneOf(["small", "medium", "large"]),
   className: PropTypes.string,
-  admin: PropTypes.bool,
+  extensionURL: PropTypes.string,
   onClick: PropTypes.func
 }
 

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -44,12 +44,15 @@ import NewFormDialog from "./NewFormDialog.jsx";
 import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
 
 function FormView(props) {
-  const { questionnaire, expanded, disableHeader, disableAvatar, topPagination, classes } = props;
+  const { extension, questionnaire, expanded, disableHeader, disableAvatar, topPagination, classes } = props;
 
   const [ title, setTitle ] = useState(props.title);
   const [ subtitle, setSubtitle ] = useState(props.subtitle);
   const [ qFilter, setQFilter ] = useState();
   const [ filtersJsonString, setFiltersJsonString ] = useState(new URLSearchParams(window.location.hash.substring(1)).get("forms:filters"));
+
+  const admin = extension?.["cards:admin"] || props.admin
+  const baseURL = "../content.html" + admin ? "/admin" : ""
 
   // Column configuration for the LiveTables
   const columns = [
@@ -131,7 +134,7 @@ function FormView(props) {
         action={
           !expanded &&
           <Tooltip title="Expand">
-            <Link to={"../content.html/Forms#" + new URLSearchParams({"forms:activeTab" : tabs?.[activeTab] || "", "forms:filters" : filtersJsonString || ""}).toString()} underline="hover">
+            <Link to={baseURL + "/Forms#" + new URLSearchParams({"forms:activeTab" : tabs?.[activeTab] || "", "forms:filters" : filtersJsonString || ""}).toString()} underline="hover">
               <IconButton size="large">
                 <LaunchIcon/>
               </IconButton>
@@ -154,10 +157,16 @@ function FormView(props) {
           disableTopPagination={!topPagination}
           onFiltersChange={(str) => { setFiltersJsonString(str); }}
           filtersJsonString={filtersJsonString}
+          admin={admin}
         />
       }
       { expanded &&
-        <NewFormDialog presetPath={questionnaire} withButton buttonTitle="New questionnaire" />
+        <NewFormDialog
+          presetPath={questionnaire}
+          withButton
+          buttonTitle="New questionnaire"
+          admin={admin}
+        />
       }
       </CardContent>
     </Card>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -44,15 +44,15 @@ import NewFormDialog from "./NewFormDialog.jsx";
 import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
 
 function FormView(props) {
-  const { extension, questionnaire, expanded, disableHeader, disableAvatar, topPagination, classes } = props;
+  const { extension, actionSwitches, questionnaire, expanded, disableHeader, disableAvatar, topPagination, classes } = props;
 
   const [ title, setTitle ] = useState(props.title);
   const [ subtitle, setSubtitle ] = useState(props.subtitle);
   const [ qFilter, setQFilter ] = useState();
   const [ filtersJsonString, setFiltersJsonString ] = useState(new URLSearchParams(window.location.hash.substring(1)).get("forms:filters"));
 
-  const admin = extension?.["cards:admin"] || props.admin
-  const baseURL = "../content.html" + admin ? "/admin" : ""
+  const extensionURL = extension?.["cards:extensionURL"] || props.extensionURL || ""
+  const baseURL = "../content.html" + extensionURL ? "/" + extensionURL : ""
 
   // Column configuration for the LiveTables
   const columns = [
@@ -73,10 +73,15 @@ function FormView(props) {
       "format": "string",
     },
   ]
-  const actions = [
-    DeleteButton,
-    EditButton
-  ]
+  const actions = {
+    "delete": DeleteButton,
+    "edit": EditButton
+  }
+  const [ enabledActions, setEnabledActions ] = useState(actions);
+  let isActionEnabled = (action) => (!!!actionSwitches || !!(actionSwitches[action]()));
+  useEffect(() => {
+    setEnabledActions(Object.entries(actions).filter(entry => isActionEnabled(entry[0])).map(entry => entry[1]));
+  }, [actionSwitches])
 
   const tabFilter = {
     "Questionnaires" : '&includeallstatus=true',
@@ -132,7 +137,7 @@ function FormView(props) {
           </>
         }
         action={
-          !expanded &&
+          !expanded && isActionEnabled("expand") &&
           <Tooltip title="Expand">
             <Link to={baseURL + "/Forms#" + new URLSearchParams({"forms:activeTab" : tabs?.[activeTab] || "", "forms:filters" : filtersJsonString || ""}).toString()} underline="hover">
               <IconButton size="large">
@@ -153,19 +158,19 @@ function FormView(props) {
           filters
           questionnaire={questionnaire}
           entryType="Form"
-          actions={actions}
+          actions={enabledActions.length > 0 ? enabledActions : undefined}
           disableTopPagination={!topPagination}
           onFiltersChange={(str) => { setFiltersJsonString(str); }}
           filtersJsonString={filtersJsonString}
-          admin={admin}
+          extensionURL={extensionURL}
         />
       }
-      { expanded &&
+      { expanded && isActionEnabled("create") &&
         <NewFormDialog
           presetPath={questionnaire}
           withButton
           buttonTitle="New questionnaire"
-          admin={admin}
+          extensionURL={extensionURL}
         />
       }
       </CardContent>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -26,7 +26,8 @@ import FormView from "./FormView.jsx";
 import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
 
 function Forms(props) {
-  const { classes } = props;
+  const { extension, classes } = props;
+  const admin = extension?.["cards:admin"] || props.admin;
   const location = useLocation();
   const questionnaire = /questionnaire=([^&]+)/.exec(location.search)?.[1];
 
@@ -40,7 +41,7 @@ function Forms(props) {
     {
       "key": "",
       "label": "Subject",
-      "format": (row) => (row.subject ? getHierarchy(row.subject) : ''),
+      "format": (row) => (row.subject ? getHierarchy(row.subject, undefined, undefined, admin) : ''),
     },
     {
       "key": "questionnaire/title",

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -26,12 +26,13 @@ import FormView from "./FormView.jsx";
 import { getEntityIdentifier } from "../themePage/EntityIdentifier.jsx";
 
 function Forms(props) {
-  const { extension, classes } = props;
-  const admin = extension?.["cards:admin"] || props.admin;
+  const { extension, classes, columns, actionSwitches } = props;
   const location = useLocation();
   const questionnaire = /questionnaire=([^&]+)/.exec(location.search)?.[1];
 
-  const columns = [
+  const extensionURL = extension?.["cards:extensionURL"]
+
+  const defaultColumns = [
     {
       "key": "@name",
       "label": "Identifier",
@@ -41,7 +42,7 @@ function Forms(props) {
     {
       "key": "",
       "label": "Subject",
-      "format": (row) => (row.subject ? getHierarchy(row.subject, undefined, undefined, admin) : ''),
+      "format": (row) => (row.subject ? getHierarchy(row.subject, undefined, undefined, extensionURL) : ''),
     },
     {
       "key": "questionnaire/title",
@@ -65,8 +66,10 @@ function Forms(props) {
       <Grid className={classes.dashboardEntry} size={12}>
         <FormView
           expanded
-          columns={columns}
+          columns={columns || defaultColumns}
           questionnaire={questionnaire}
+          extensionURL={extensionURL}
+          actionSwitches={actionSwitches}
         />
       </Grid>
     </Grid>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -54,7 +54,6 @@ function LiveTable(props) {
     filters,
     entryType,
     actions,
-    admin,
     extensionURL,
     disableTopPagination,
     disableBottomPagination,
@@ -234,9 +233,7 @@ function LiveTable(props) {
       content = _formatDate(content, format);
     }
 
-    // allow livetable to link to components in the admin dashboard
-    // if livetable item must link to a component within the admin dashboard, set "admin": true
-    let pathPrefix = ((extensionURL || admin) ? "../content.html/" + (extensionURL ? extensionURL : "admin") : "../content.html");
+    let pathPrefix = (extensionURL ? "../content.html/" + extensionURL : "../content.html");
 
     if (column.link) {
       if (column.link === 'path') {

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -55,6 +55,7 @@ function LiveTable(props) {
     entryType,
     actions,
     admin,
+    extensionURL,
     disableTopPagination,
     disableBottomPagination,
     onDataReceived,
@@ -204,7 +205,7 @@ function LiveTable(props) {
 
   let makeRow = (entry, i) => {
     return (
-      <TableRow key={entry["@path"] + i}>
+      <TableRow key={entry["@path"] + i} className={classes.dataRow}>
         { columns ?
           (
             columns.map((column, index) => makeCell(entry, column, index))
@@ -214,7 +215,7 @@ function LiveTable(props) {
             <TableCell><a href={entry["@path"]}>{entry.title}</a></TableCell>
           )
         }
-        { actions ? makeActions(entry, actions, columns ? columns.count : 0) : null}
+        { actions && actions.length > 0 ? makeActions(entry, actions, columns ? columns.count : 0) : null}
       </TableRow>
     );
   };
@@ -235,7 +236,7 @@ function LiveTable(props) {
 
     // allow livetable to link to components in the admin dashboard
     // if livetable item must link to a component within the admin dashboard, set "admin": true
-    let pathPrefix = (admin ? "../content.html/admin" : "../content.html");
+    let pathPrefix = ((extensionURL || admin) ? "../content.html/" + (extensionURL ? extensionURL : "admin") : "../content.html");
 
     if (column.link) {
       if (column.link === 'path') {
@@ -266,7 +267,8 @@ function LiveTable(props) {
         onComplete={refresh}
         entryType={entryType}
         entryLabel={entry["jcr:primaryType"] == "cards:Subject" ? entry.type?.label : undefined}
-        admin={admin} />
+        extensionURL={extensionURL}
+      />
     });
     return <TableCell key={index} className={classes.tableActions}>{content}</TableCell>;
   }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -54,7 +54,7 @@ function NewFormDialog(props) {
     onClose,
     withButton,
     buttonTitle,
-    admin
+    extensionURL
   } = props;
 
   const [ dialogOpen, setDialogOpen ] = useState(false);
@@ -119,7 +119,7 @@ function NewFormDialog(props) {
           // Redirect the user to the new uuid
           // FIXME: Would be better to somehow obtain the router prefix from props
           // but that is not currently possible
-          navigate("/content.html" + (admin ? "/admin" : "") + URL + '.edit');
+          navigate("/content.html" + (extensionURL ? "/" + extensionURL : "") + URL + '.edit');
         } else {
           return(Promise.reject(response));
         }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -53,7 +53,8 @@ function NewFormDialog(props) {
     open = false,
     onClose,
     withButton,
-    buttonTitle
+    buttonTitle,
+    admin
   } = props;
 
   const [ dialogOpen, setDialogOpen ] = useState(false);
@@ -118,7 +119,7 @@ function NewFormDialog(props) {
           // Redirect the user to the new uuid
           // FIXME: Would be better to somehow obtain the router prefix from props
           // but that is not currently possible
-          navigate("/content.html" + URL + '.edit');
+          navigate("/content.html" + (admin ? "/admin" : "") + URL + '.edit');
         } else {
           return(Promise.reject(response));
         }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
@@ -72,7 +72,7 @@ function Questionnaires(props) {
               <EditButton
                 entryType={entryType}
                 entryPath={row.original["@path"]}
-                admin
+                extensionURL="admin"
               />
               <ExportButton
                 entryPath={row.original["@path"]}
@@ -85,7 +85,6 @@ function Questionnaires(props) {
                 entryName={row.original.title}
                 onComplete={dialogSuccess}
                 entryType={entryType}
-                admin
               />
             </Box>
           )

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
@@ -110,7 +110,6 @@ function SubjectTypes(props) {
                 entryName={row.original.label}
                 onComplete={dialogSuccess}
                 entryType={entryType}
-                admin
               />
             </Box>
         )

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
@@ -45,7 +45,7 @@ import NewItemButton from "../components/NewItemButton.jsx";
 import { NewSubjectDialog } from "../questionnaire/SubjectSelector.jsx";
 
 function SubjectView(props) {
-  const { expanded, disableHeader, disableAvatar, topPagination, classes } = props;
+  const { expanded, disableHeader, disableAvatar, topPagination, extension, classes } = props;
   const [ newSubjectPopperOpen, setNewSubjectPopperOpen ] = useState(false);
   const [ activeTab, setActiveTab ] = useState(0);
   const [ subjectTypes, setSubjectTypes] = useState([])
@@ -53,6 +53,9 @@ function SubjectView(props) {
   const [ columns, setColumns ] = React.useState(props.columns || null);
   const [ filtersJsonString, setFiltersJsonString ] = useState(new URLSearchParams(window.location.hash.substring(1)).get("subjects:filters"));
   const hasSubjects = tabsLoading === false && subjectTypes.length > 0;
+  const admin = extension?.["cards:admin"] || props.admin
+  const baseURL = "../content.html" + admin ? "/admin" : ""
+
   const activeTabParam = new URLSearchParams(window.location.hash.substring(1)).get("subjects:activeTab");
 
   const globalLoginDisplay = useContext(GlobalLoginContext);
@@ -135,7 +138,7 @@ function SubjectView(props) {
         action={
           !expanded &&
           <Tooltip title="Expand">
-            <Link to={"../content.html/Subjects#" + new URLSearchParams({"subjects:activeTab" : subjectTypes?.[activeTab]?.['@name'] || "", "subjects:filters" : filtersJsonString || ""}).toString()} underline="hover">
+            <Link to={baseURL + "/Subjects#" + new URLSearchParams({"subjects:activeTab" : subjectTypes?.[activeTab]?.['@name'] || "", "subjects:filters" : filtersJsonString || ""}).toString()} underline="hover">
               <IconButton size="large">
                 <LaunchIcon/>
               </IconButton>
@@ -158,6 +161,7 @@ function SubjectView(props) {
               filters
               onFiltersChange={(str) => setFiltersJsonString(str)}
               filtersJsonString={filtersJsonString}
+              admin={admin}
             />
           : <Typography sx={{pl: 1}}>No results</Typography>
       }
@@ -171,6 +175,7 @@ function SubjectView(props) {
           onClose={() => { setNewSubjectPopperOpen(false);}}
           onSubmit={() => { setNewSubjectPopperOpen(false);}}
           open={newSubjectPopperOpen}
+          admin={admin}
         />
       </>
       }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useContext } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import LiveTable from "./LiveTable.jsx";
 
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
@@ -45,7 +45,7 @@ import NewItemButton from "../components/NewItemButton.jsx";
 import { NewSubjectDialog } from "../questionnaire/SubjectSelector.jsx";
 
 function SubjectView(props) {
-  const { expanded, disableHeader, disableAvatar, topPagination, extension, classes } = props;
+  const { expanded, actionSwitches, disableHeader, disableAvatar, topPagination, extension, classes } = props;
   const [ newSubjectPopperOpen, setNewSubjectPopperOpen ] = useState(false);
   const [ activeTab, setActiveTab ] = useState(0);
   const [ subjectTypes, setSubjectTypes] = useState([])
@@ -53,8 +53,9 @@ function SubjectView(props) {
   const [ columns, setColumns ] = React.useState(props.columns || null);
   const [ filtersJsonString, setFiltersJsonString ] = useState(new URLSearchParams(window.location.hash.substring(1)).get("subjects:filters"));
   const hasSubjects = tabsLoading === false && subjectTypes.length > 0;
-  const admin = extension?.["cards:admin"] || props.admin
-  const baseURL = "../content.html" + admin ? "/admin" : ""
+
+  const extensionURL = extension?.["cards:extensionURL"] || props.extensionURL || ""
+  const baseURL = "../content.html" + extensionURL ? "/" + extensionURL : ""
 
   const activeTabParam = new URLSearchParams(window.location.hash.substring(1)).get("subjects:activeTab");
 
@@ -79,9 +80,14 @@ function SubjectView(props) {
       "format": "string",
     },
   ]
-  const actions = [
-    DeleteWithRefreshButton
-  ]
+  const actions = {
+    "delete": DeleteWithRefreshButton
+  }
+  const [ enabledActions, setEnabledActions ] = useState(actions);
+  let isActionEnabled = (action) => (!!!actionSwitches || !!(actionSwitches[action]()));
+  useEffect(() => {
+    setEnabledActions(Object.entries(actions).filter(entry => isActionEnabled(entry[0])).map(entry => entry[1]));
+  }, [actionSwitches])
 
   let fetchSubjectTypes = () => {
     let url = new URL("/query", window.location.origin);
@@ -136,7 +142,7 @@ function SubjectView(props) {
             </Tabs>
         }
         action={
-          !expanded &&
+          !expanded && isActionEnabled("expand") &&
           <Tooltip title="Expand">
             <Link to={baseURL + "/Subjects#" + new URLSearchParams({"subjects:activeTab" : subjectTypes?.[activeTab]?.['@name'] || "", "subjects:filters" : filtersJsonString || ""}).toString()} underline="hover">
               <IconButton size="large">
@@ -156,17 +162,17 @@ function SubjectView(props) {
               customUrl={'/Subjects.paginate?fieldname=type&fieldvalue='+ encodeURIComponent(subjectTypes[activeTab]["jcr:uuid"])}
               defaultLimit={10}
               entryType="Subject"
-              actions={actions}
+              actions={enabledActions.length > 0 ? enabledActions : undefined}
               disableTopPagination={!topPagination}
               filters
               onFiltersChange={(str) => setFiltersJsonString(str)}
               filtersJsonString={filtersJsonString}
-              admin={admin}
+              extensionURL={extensionURL}
             />
           : <Typography sx={{pl: 1}}>No results</Typography>
       }
       </CardContent>
-      {expanded &&
+      {expanded && isActionEnabled("create") &&
       <>
         <NewItemButton
            onClick={() => {setNewSubjectPopperOpen(true)}}
@@ -175,7 +181,7 @@ function SubjectView(props) {
           onClose={() => { setNewSubjectPopperOpen(false);}}
           onSubmit={() => { setNewSubjectPopperOpen(false);}}
           open={newSubjectPopperOpen}
-          admin={admin}
+          extensionURL={extensionURL}
         />
       </>
       }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
@@ -26,10 +26,10 @@ import { withStyles } from 'tss-react/mui';
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 
 function Subjects(props) {
-  const { extension, classes } = props;
-  const admin = extension?.["cards:admin"]
+  const { extension, classes, actionSwitches, columns } = props;
+  const extensionURL = extension?.["cards:extensionURL"]
 
-  const columns = [
+  const defaultColumns = [
     {
       "key": "identifier",
       "label": "Identifier",
@@ -44,7 +44,7 @@ function Subjects(props) {
     {
       "key": "",
       "label": "Parents",
-      "format": (row) => (row['parents'] ? getHierarchy(row['parents'], undefined, undefined, admin) : ''),
+      "format": (row) => (row['parents'] ? getHierarchy(row['parents'], undefined, undefined, extensionURL) : ''),
     },
     {
       "key": "jcr:created",
@@ -63,8 +63,9 @@ function Subjects(props) {
       <Grid className={classes.dashboardEntry} size={12}>
         <SubjectView
           expanded
-          columns={columns}
-          admin={admin}
+          columns={columns || defaultColumns}
+          extensionURL={extensionURL}
+          actionSwitches={actionSwitches}
         />
       </Grid>
     </Grid>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
@@ -26,7 +26,8 @@ import { withStyles } from 'tss-react/mui';
 import QuestionnaireStyle from "../questionnaire/QuestionnaireStyle.jsx";
 
 function Subjects(props) {
-  const { classes } = props;
+  const { extension, classes } = props;
+  const admin = extension?.["cards:admin"]
 
   const columns = [
     {
@@ -43,7 +44,7 @@ function Subjects(props) {
     {
       "key": "",
       "label": "Parents",
-      "format": (row) => (row['parents'] ? getHierarchy(row['parents']) : ''),
+      "format": (row) => (row['parents'] ? getHierarchy(row['parents'], undefined, undefined, admin) : ''),
     },
     {
       "key": "jcr:created",
@@ -63,6 +64,7 @@ function Subjects(props) {
         <SubjectView
           expanded
           columns={columns}
+          admin={admin}
         />
       </Grid>
     </Grid>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -94,7 +94,9 @@ function UserDashboard(props) {
           dashboardExtensions.map((extension, index) => {
             let Extension = extension["cards:extensionRender"];
             return <Grid size={{ xs: 12, xl: dashboardExtensions.length > 1 ? 6 : 12}} key={"extension-" + index} className={classes.dashboardEntry}>
-              <Extension />
+              <Extension
+                extension={extension}
+                />
             </Grid>
           })
         }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -171,6 +171,7 @@ function UserDashboard(props) {
             onClose={onClose}
             onSubmit={onClose}
             key={"extensionDialog-" + index}
+            extension={extension}
             />
         })
       }

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/tableStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/tableStyle.jsx
@@ -68,6 +68,9 @@ const liveTableStyle = theme => ({
             marginBottom: theme.spacing(0.5),
         }
     },
+    dataRow: {
+        height: "3em"
+    },
 });
 
 export default liveTableStyle;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -72,8 +72,8 @@ import SessionExpiryWarningModal from "./SessionExpiryWarningModal.jsx";
  * <Form />
  */
 function Form (props) {
-  let { classes, contentOffset } = props;
-  let { mode, className, disableHeader, disableButton, doneButtonStyle, doneIcon, doneLabel, onDone, questionnaireAddons, paginationProps } = props;
+  let { classes, contentOffset, admin } = props;
+  let { mode, className, actionSwitches, disableHeader, disableButton, doneButtonStyle, doneIcon, doneLabel, onDone, questionnaireAddons, paginationProps } = props;
   // Record if the form was already checked out before opening it, which may indicate that another user is editing, or it is being edited in a different tab
   let [ wasCheckedOut, setWasCheckedOut ] = useState(false);
   // This holds the full form JSON, once it is received from the server
@@ -169,7 +169,7 @@ function Form (props) {
   let formNode = React.useRef();
   let pageNameWriter = usePageNameWriterContext();
   const formURL = `/Forms/${id}`;
-  const urlBase = "/content.html";
+  const baseURL = "/content.html" + (admin ? "/admin" : "");
   let globalLoginDisplay = useContext(GlobalLoginContext);
 
   useEffect(() => {
@@ -405,7 +405,7 @@ function Form (props) {
 
   let onEdit = (event) => {
     // Redirect the user to the edit form mode
-    navigate(urlBase + formURL + '.edit' + window.location.hash);
+    navigate(baseURL + formURL + '.edit' + window.location.hash);
   }
 
   let onClose = (event) => {
@@ -413,13 +413,13 @@ function Form (props) {
     // ...but only after the Form has been saved and checked-in
     saveDataWithCheckin(undefined, () => {
         removeWindowHandlers?.();
-        navigate(urlBase + formURL);
+        navigate(baseURL + formURL);
     });
   }
 
   let onDelete = () => {
     removeWindowHandlers?.();
-    navigate(urlBase + (data?.subject?.['@path'] || ''));
+    navigate(baseURL + (data?.subject?.['@path'] || ''));
   }
 
   let title = data?.questionnaire?.title || id || "";
@@ -553,10 +553,10 @@ function Form (props) {
         <Typography variant="overline">
           {"Related: "}
           {validLinks.length == 1 ?
-              validLinks.map(link => <Link key={link["@name"]} to={"../content.html" + link["to"]}>{link["resourceLabel"]}</Link>)
+              validLinks.map(link => <Link key={link["@name"]} to={"../" + baseURL + link["to"]}>{link["resourceLabel"]}</Link>)
               :
               <List dense disablePadding>
-              {validLinks.map(link => <ListItem key={link["@name"]}><Link to={"../content.html" + link["to"]}>{link["resourceLabel"]}</Link></ListItem>)}
+              {validLinks.map(link => <ListItem key={link["@name"]}><Link to={"../" + baseURL + link["to"]}>{link["resourceLabel"]}</Link></ListItem>)}
               </List>
           }
         </Typography>
@@ -577,7 +577,7 @@ function Form (props) {
         { !disableHeader &&
         <ResourceHeader
           title={title}
-          breadcrumbs={[<Breadcrumbs separator="/">{getHierarchyAsList(data?.subject).map(a => <Typography variant="overline" key={a}>{a}</Typography>)}</Breadcrumbs>]}
+          breadcrumbs={[<Breadcrumbs separator="/">{getHierarchyAsList(data?.subject, undefined, admin).map(a => <Typography variant="overline" key={a}>{a}</Typography>)}</Breadcrumbs>]}
           tags={ statusFlags?.map( item => (
             <Chip
               label={item[0].toUpperCase() + item.slice(1).toLowerCase()}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -72,7 +72,7 @@ import SessionExpiryWarningModal from "./SessionExpiryWarningModal.jsx";
  * <Form />
  */
 function Form (props) {
-  let { classes, contentOffset, admin } = props;
+  let { classes, contentOffset, extensionURL } = props;
   let { mode, className, actionSwitches, disableHeader, disableButton, doneButtonStyle, doneIcon, doneLabel, onDone, questionnaireAddons, paginationProps } = props;
   // Record if the form was already checked out before opening it, which may indicate that another user is editing, or it is being edited in a different tab
   let [ wasCheckedOut, setWasCheckedOut ] = useState(false);
@@ -169,7 +169,7 @@ function Form (props) {
   let formNode = React.useRef();
   let pageNameWriter = usePageNameWriterContext();
   const formURL = `/Forms/${id}`;
-  const baseURL = "/content.html" + (admin ? "/admin" : "");
+  const baseURL = "/content.html" + (extensionURL ? "/" + extensionURL : "");
   let globalLoginDisplay = useContext(GlobalLoginContext);
 
   useEffect(() => {
@@ -577,7 +577,7 @@ function Form (props) {
         { !disableHeader &&
         <ResourceHeader
           title={title}
-          breadcrumbs={[<Breadcrumbs separator="/">{getHierarchyAsList(data?.subject, undefined, admin).map(a => <Typography variant="overline" key={a}>{a}</Typography>)}</Breadcrumbs>]}
+          breadcrumbs={[<Breadcrumbs separator="/">{getHierarchyAsList(data?.subject, undefined, extensionURL).map(a => <Typography variant="overline" key={a}>{a}</Typography>)}</Breadcrumbs>]}
           tags={ statusFlags?.map( item => (
             <Chip
               label={item[0].toUpperCase() + item.slice(1).toLowerCase()}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -553,10 +553,10 @@ function Form (props) {
         <Typography variant="overline">
           {"Related: "}
           {validLinks.length == 1 ?
-              validLinks.map(link => <Link key={link["@name"]} to={"../" + baseURL + link["to"]}>{link["resourceLabel"]}</Link>)
+              validLinks.map(link => <Link key={link["@name"]} to={".." + baseURL + link["to"]}>{link["resourceLabel"]}</Link>)
               :
               <List dense disablePadding>
-              {validLinks.map(link => <ListItem key={link["@name"]}><Link to={"../" + baseURL + link["to"]}>{link["resourceLabel"]}</Link></ListItem>)}
+              {validLinks.map(link => <ListItem key={link["@name"]}><Link to={".." + baseURL + link["to"]}>{link["resourceLabel"]}</Link></ListItem>)}
               </List>
           }
         </Typography>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -160,6 +160,7 @@ function Subject(props) {
               subject={currentSubject}
               fetchSubjectData={fetchRelatedRef.current}
               baseURL={baseURL}
+              extensionURL={extensionURL}
             />
           : <Grid>
             <SubjectTimeline
@@ -179,7 +180,7 @@ function Subject(props) {
  * Component that recursively gets and displays the selected subject and its related SubjectTypes
  */
 function SubjectContainer(props) {
-  let { id, classes, level, maxDisplayed, pageSize, subject, fetchSubjectData, baseURL } = props;
+  let { id, classes, level, maxDisplayed, pageSize, subject, fetchSubjectData, baseURL, extensionURL } = props;
   // Error message set when fetching the data from the server fails
   let [ error, setError ] = useState();
   // hold related subjects
@@ -249,6 +250,7 @@ function SubjectContainer(props) {
         childSubjects={relatedSubjects}
         fetchSubjectData={fetchSubjectData}
         baseURL={baseURL}
+        extensionURL={extensionURL}
       />
     </React.Fragment>
   );
@@ -387,7 +389,7 @@ function SubjectHeader(props) {
  * Component that displays all forms related to a Subject. Do not use directly, use SubjectMember instead.
  */
 function SubjectMemberInternal (props) {
-  let { classes, data, id, level, maxDisplayed, onDelete, pageSize, childSubjects, fetchSubjectData, baseURL } = props;
+  let { classes, data, id, level, maxDisplayed, onDelete, pageSize, childSubjects, fetchSubjectData, baseURL, extensionURL } = props;
   // Error message set when fetching the data from the server fails
   let [ error, setError ] = useState();
   // Whether a subject is expanded and displaying its forms
@@ -643,6 +645,7 @@ function SubjectMemberInternal (props) {
                     <EditButton
                       entryPath={row.original["@path"]}
                       entryType="Form"
+                      extensionURL={extensionURL}
                     />
                     <DeleteButton
                       entryPath={row.original["@path"]}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -81,7 +81,7 @@ let createQueryURL = (query, type) => {
 
 function Subject(props) {
   checkPropTypes(Subject, props);
-  let { classes, maxDisplayed = 4, pageSize = 10, admin } = props;
+  let { classes, maxDisplayed = 4, pageSize = 10, extensionURL } = props;
   const [ currentSubject, setCurrentSubject ] = useState();
   const [ activeTab, setActiveTab ] = useState(0);
   const fetchRelatedRef = useRef();
@@ -94,7 +94,7 @@ function Subject(props) {
   const navigate = useNavigate();
   const currentSubjectId = getSubjectIdFromPath(location.pathname);
 
-  const baseURL = "../content.html" + (admin ? "/admin" : "");
+  const baseURL = "../content.html" + (extensionURL ? "/" + extensionURL : "");
 
   useEffect(() => {
     if (location.hash.length > 0 && tabs.includes(location.hash.substring(1))) {
@@ -126,7 +126,7 @@ function Subject(props) {
         currentSubject={currentSubject}
         withButton
         buttonTitle={ "New questionnaire for this " + (currentSubject?.type?.label || "Subject") }
-        admin={admin}
+        extensionURL={extensionURL}
       />
       <Grid container spacing={4} direction="column" className={classes.subjectContainer}>
         <SubjectHeader
@@ -137,7 +137,7 @@ function Subject(props) {
           getSubject={handleSubject}
           reloadSubject={fetchRelatedRef}
           contentOffset={props.contentOffset}
-          admin={admin}
+          extensionURL={extensionURL}
         />
         <Grid>
           <Tabs className={classes.subjectTabs} value={activeTab} onChange={(event, value) => {
@@ -258,7 +258,7 @@ function SubjectContainer(props) {
  * Component that displays the header for the selected subject and its SubjectType
  */
 function SubjectHeader(props) {
-  let { id, classes, getSubject, pageTitle, reloadSubject, admin } = props;
+  let { id, classes, getSubject, pageTitle, reloadSubject, extensionURL } = props;
   // This holds the full form JSON, once it is received from the server
   let [ subject, setSubject ] = useState(null);
   // Error message set when fetching the data from the server fails
@@ -351,7 +351,7 @@ function SubjectHeader(props) {
               />
             </div>
   );
-  let parentDetails = (subject?.data?.['parents'] && getHierarchyAsList(subject.data['parents'], true, admin) || [getHomepageLink(subject?.data, admin)]);;
+  let parentDetails = (subject?.data?.['parents'] && getHierarchyAsList(subject.data['parents'], true, extensionURL) || [getHomepageLink(subject?.data, extensionURL)]);;
 
   return (
     subject?.data &&

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -81,7 +81,7 @@ let createQueryURL = (query, type) => {
 
 function Subject(props) {
   checkPropTypes(Subject, props);
-  let { classes, maxDisplayed = 4, pageSize = 10 } = props;
+  let { classes, maxDisplayed = 4, pageSize = 10, admin } = props;
   const [ currentSubject, setCurrentSubject ] = useState();
   const [ activeTab, setActiveTab ] = useState(0);
   const fetchRelatedRef = useRef();
@@ -93,6 +93,8 @@ function Subject(props) {
   const location = useLocation();
   const navigate = useNavigate();
   const currentSubjectId = getSubjectIdFromPath(location.pathname);
+
+  const baseURL = "../content.html" + (admin ? "/admin" : "");
 
   useEffect(() => {
     if (location.hash.length > 0 && tabs.includes(location.hash.substring(1))) {
@@ -120,7 +122,12 @@ function Subject(props) {
 
   return (
     <React.Fragment>
-      <NewFormDialog currentSubject={currentSubject} withButton buttonTitle={ "New questionnaire for this " + (currentSubject?.type?.label || "Subject") } />
+      <NewFormDialog
+        currentSubject={currentSubject}
+        withButton
+        buttonTitle={ "New questionnaire for this " + (currentSubject?.type?.label || "Subject") }
+        admin={admin}
+      />
       <Grid container spacing={4} direction="column" className={classes.subjectContainer}>
         <SubjectHeader
           id={currentSubjectId}
@@ -130,6 +137,7 @@ function Subject(props) {
           getSubject={handleSubject}
           reloadSubject={fetchRelatedRef}
           contentOffset={props.contentOffset}
+          admin={admin}
         />
         <Grid>
           <Tabs className={classes.subjectTabs} value={activeTab} onChange={(event, value) => {
@@ -151,6 +159,7 @@ function Subject(props) {
               pageSize={pageSize}
               subject={currentSubject}
               fetchSubjectData={fetchRelatedRef.current}
+              baseURL={baseURL}
             />
           : <Grid>
             <SubjectTimeline
@@ -170,7 +179,7 @@ function Subject(props) {
  * Component that recursively gets and displays the selected subject and its related SubjectTypes
  */
 function SubjectContainer(props) {
-  let { id, classes, level, maxDisplayed, pageSize, subject, fetchSubjectData } = props;
+  let { id, classes, level, maxDisplayed, pageSize, subject, fetchSubjectData, baseURL } = props;
   // Error message set when fetching the data from the server fails
   let [ error, setError ] = useState();
   // hold related subjects
@@ -239,6 +248,7 @@ function SubjectContainer(props) {
         onDelete={() => {setDeleted(true)}}
         childSubjects={relatedSubjects}
         fetchSubjectData={fetchSubjectData}
+        baseURL={baseURL}
       />
     </React.Fragment>
   );
@@ -248,7 +258,7 @@ function SubjectContainer(props) {
  * Component that displays the header for the selected subject and its SubjectType
  */
 function SubjectHeader(props) {
-  let { id, classes, getSubject, pageTitle, reloadSubject } = props;
+  let { id, classes, getSubject, pageTitle, reloadSubject, admin } = props;
   // This holds the full form JSON, once it is received from the server
   let [ subject, setSubject ] = useState(null);
   // Error message set when fetching the data from the server fails
@@ -341,7 +351,7 @@ function SubjectHeader(props) {
               />
             </div>
   );
-  let parentDetails = (subject?.data?.['parents'] && getHierarchyAsList(subject.data['parents'], true) || [getHomepageLink(subject?.data)]);;
+  let parentDetails = (subject?.data?.['parents'] && getHierarchyAsList(subject.data['parents'], true, admin) || [getHomepageLink(subject?.data, admin)]);;
 
   return (
     subject?.data &&
@@ -377,7 +387,7 @@ function SubjectHeader(props) {
  * Component that displays all forms related to a Subject. Do not use directly, use SubjectMember instead.
  */
 function SubjectMemberInternal (props) {
-  let { classes, data, id, level, maxDisplayed, onDelete, pageSize, childSubjects, fetchSubjectData } = props;
+  let { classes, data, id, level, maxDisplayed, onDelete, pageSize, childSubjects, fetchSubjectData, baseURL } = props;
   // Error message set when fetching the data from the server fails
   let [ error, setError ] = useState();
   // Whether a subject is expanded and displaying its forms
@@ -500,7 +510,7 @@ function SubjectMemberInternal (props) {
             <Grid size="auto">{avatar}</Grid>
             <Grid size="grow">
               <Typography variant="overline">
-                 {label} <Link to={"../content.html" + path} underline="hover">{identifier}</Link>
+                 {label} <Link to={baseURL + path} underline="hover">{identifier}</Link>
               </Typography>
             </Grid>
             <Grid size={{xs: 3.5}}>{tags}</Grid>
@@ -594,7 +604,7 @@ function SubjectMemberInternal (props) {
                                        <Avatar className={classes.subjectFormAvatar}><FormIcon/></Avatar>
                                      </Grid>
                                      <Grid size="auto">
-                                       <Link to={"../content.html" + row.original["@path"]} underline="hover">
+                                       <Link to={baseURL + row.original["@path"]} underline="hover">
                                          {questionnaireTitle}
                                        </Link>
                                        <Typography variant="caption" component="div" color="textSecondary">
@@ -629,18 +639,18 @@ function SubjectMemberInternal (props) {
                 enableRowActions
                 positionActionsColumn="last"
                 renderRowActions={({ row }) => (
-                    <Box sx={{ display: 'flex', flexWrap: 'nowrap'}}>
-                      <EditButton
-                        entryPath={row.original["@path"]}
-                        entryType="Form"
-                      />
-                      <DeleteButton
-                        entryPath={row.original["@path"]}
-                        entryName={getEntityIdentifier(row.original)}
-                        entryType="Form"
-                        onComplete={fetchTableData}
-                      />
-                    </Box>
+                  <Box sx={{ display: 'flex', flexWrap: 'nowrap'}}>
+                    <EditButton
+                      entryPath={row.original["@path"]}
+                      entryType="Form"
+                    />
+                    <DeleteButton
+                      entryPath={row.original["@path"]}
+                      entryName={getEntityIdentifier(row.original)}
+                      entryType="Form"
+                      onComplete={fetchTableData}
+                    />
+                  </Box>
                 )}
               />
             </Grid>
@@ -663,6 +673,7 @@ function SubjectMemberInternal (props) {
                 pageSize={pageSize}
                 subject={subject}
                 fetchSubjectData={fetchSubjectData}
+                baseURL={baseURL}
               />
             )
           })}

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectIdentifier.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectIdentifier.jsx
@@ -24,10 +24,15 @@ function defaultCreator (node) {
   return {to: "../content.html" + node["@path"]}
 }
 
+function adminCreator (node) {
+  return {to: "../content.html/admin" + node["@path"]}
+}
+
 // Extract the subject id from the subject path
 // returns null if the parameter is not a valid subject path (expected format: Subjects/<id>)
-export function getHomepageLink (subjectNode) {
-  let props = defaultCreator({"@path": `/Subjects#subjects:activeTab=${subjectNode?.type?.["@name"]}`});
+export function getHomepageLink (subjectNode, admin=false) {
+  let creator = admin ? adminCreator : defaultCreator;
+  let props = creator({"@path": `/Subjects#subjects:activeTab=${subjectNode?.type?.["@name"]}`});
   return (<Link {...props} underline="hover">{subjectNode?.type?.subjectListLabel || "Subjects"}</Link>);
 }
 
@@ -39,13 +44,12 @@ export function getSubjectIdFromPath (path) {
 }
 
 // Recursive function to get a flat list of parents
-export function getHierarchy (node, RenderComponent, propsCreator) {
+export function getHierarchy (node, RenderComponent, propsCreator, admin=false) {
   let HComponent = RenderComponent || Link;
-  let hpropsCreator = propsCreator || defaultCreator;
-  let props = hpropsCreator(node);
+  let props = propsCreator || (admin ? adminCreator(node) : defaultCreator(node));
   let output = <React.Fragment>{node.type.label} <HComponent {...props}>{node.identifier}</HComponent></React.Fragment>;
   if (node["parents"]?.type) {
-    let ancestors = getHierarchy(node["parents"], HComponent, propsCreator);
+    let ancestors = getHierarchy(node["parents"], HComponent, propsCreator, admin);
     return <React.Fragment>{ancestors} / {output}</React.Fragment>
   } else {
     return output;
@@ -65,19 +69,19 @@ export function getTextHierarchy (node, withType = false) {
 }
 
 // Recursive function to get the list of ancestors as an array
-export function getHierarchyAsList (node, includeHomepage) {
+export function getHierarchyAsList (node, includeHomepage, admin=false) {
   if (!node?.type) {
-    return includeHomepage ? [getHomepageLink()] : [];
+    return includeHomepage ? [getHomepageLink(undefined, admin)] : [];
   }
-  let props = defaultCreator(node);
+  let props = admin ? adminCreator(node) : defaultCreator(node);
   let parent = <>{node.type.label} <Link {...props} underline="hover">{node.identifier}</Link></>;
   if (node["parents"]) {
-    let ancestors = getHierarchyAsList(node["parents"]);
+    let ancestors = getHierarchyAsList(node["parents"], undefined, admin);
     ancestors.push(parent);
     return ancestors;
   } else {
     let result = [parent];
-    includeHomepage && result.unshift(getHomepageLink(node));
+    includeHomepage && result.unshift(getHomepageLink(node, admin));
     return result;
   }
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectIdentifier.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectIdentifier.jsx
@@ -55,6 +55,19 @@ export function getHierarchy (node, RenderComponent, propsCreator, extensionURL=
   }
 }
 
+// Recursive function to get a flat list of parents with no subject labels
+export function getShortHierarchy (node, RenderComponent, propsCreator, extensionURL="") {
+  let HComponent = RenderComponent || Link;
+  let props = propsCreator || extensionCreator(node, extensionURL);
+  let output = <HComponent {...props}>{node.identifier}</HComponent>;
+  if (node["parents"] && node["parents"].type) {
+    let ancestors = getShortHierarchy(node["parents"], HComponent, propsCreator, extensionURL);
+    return <React.Fragment>{ancestors} / {output}</React.Fragment>
+  } else {
+    return output;
+  }
+}
+
 // Recursive function to get a flat list of parents with no links and subject labels
 export function getTextHierarchy (node, withType = false) {
   let type = withType ? (node?.["type"]?.["@name"] + " "): "";

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectIdentifier.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectIdentifier.jsx
@@ -24,15 +24,14 @@ function defaultCreator (node) {
   return {to: "../content.html" + node["@path"]}
 }
 
-function adminCreator (node) {
-  return {to: "../content.html/admin" + node["@path"]}
+function extensionCreator(node, extensionURL) {
+  return extensionURL ? {to: "../content.html/" + extensionURL + node["@path"]} : defaultCreator(node)
 }
 
 // Extract the subject id from the subject path
 // returns null if the parameter is not a valid subject path (expected format: Subjects/<id>)
-export function getHomepageLink (subjectNode, admin=false) {
-  let creator = admin ? adminCreator : defaultCreator;
-  let props = creator({"@path": `/Subjects#subjects:activeTab=${subjectNode?.type?.["@name"]}`});
+export function getHomepageLink (subjectNode, extensionURL="") {
+  let props = extensionCreator({"@path": `/Subjects#subjects:activeTab=${subjectNode?.type?.["@name"]}`}, extensionURL);
   return (<Link {...props} underline="hover">{subjectNode?.type?.subjectListLabel || "Subjects"}</Link>);
 }
 
@@ -44,12 +43,12 @@ export function getSubjectIdFromPath (path) {
 }
 
 // Recursive function to get a flat list of parents
-export function getHierarchy (node, RenderComponent, propsCreator, admin=false) {
+export function getHierarchy (node, RenderComponent, propsCreator, extensionURL="") {
   let HComponent = RenderComponent || Link;
-  let props = propsCreator || (admin ? adminCreator(node) : defaultCreator(node));
+  let props = propsCreator || extensionCreator(node, extensionURL);
   let output = <React.Fragment>{node.type.label} <HComponent {...props}>{node.identifier}</HComponent></React.Fragment>;
   if (node["parents"]?.type) {
-    let ancestors = getHierarchy(node["parents"], HComponent, propsCreator, admin);
+    let ancestors = getHierarchy(node["parents"], HComponent, propsCreator, extensionURL);
     return <React.Fragment>{ancestors} / {output}</React.Fragment>
   } else {
     return output;
@@ -69,19 +68,19 @@ export function getTextHierarchy (node, withType = false) {
 }
 
 // Recursive function to get the list of ancestors as an array
-export function getHierarchyAsList (node, includeHomepage, admin=false) {
+export function getHierarchyAsList (node, includeHomepage, extensionURL="") {
   if (!node?.type) {
-    return includeHomepage ? [getHomepageLink(undefined, admin)] : [];
+    return includeHomepage ? [getHomepageLink(undefined, extensionURL)] : [];
   }
-  let props = admin ? adminCreator(node) : defaultCreator(node);
+  let props = extensionCreator(node, extensionURL);
   let parent = <>{node.type.label} <Link {...props} underline="hover">{node.identifier}</Link></>;
   if (node["parents"]) {
-    let ancestors = getHierarchyAsList(node["parents"], undefined, admin);
+    let ancestors = getHierarchyAsList(node["parents"], undefined, extensionURL);
     ancestors.push(parent);
     return ancestors;
   } else {
     let result = [parent];
-    includeHomepage && result.unshift(getHomepageLink(node, admin));
+    includeHomepage && result.unshift(getHomepageLink(node, extensionURL));
     return result;
   }
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -420,7 +420,7 @@ export const parseToArray = (object) => {
  * @param {bool} open If true, this dialog is open
  */
 export function NewSubjectDialog (props) {
-  const { allowedTypes, currentSubject, disabled, onClose, onSubmit, open, disableRedirect } = props;
+  const { allowedTypes, currentSubject, disabled, onClose, onSubmit, open, disableRedirect, admin } = props;
   const [ error, setError ] = useState("");
   const [ newSubjectName, setNewSubjectName ] = useState([""]);
   const [ newSubjectType, setNewSubjectType ] = useState([""]);
@@ -450,7 +450,7 @@ export function NewSubjectDialog (props) {
       // redirect to the new just created subject page
       let subjectId = getSubjectIdFromPath(subject);
       if (!disableRedirect && subjectId) {
-        navigate("/content.html/Subjects/" + subjectId);
+        navigate("/content.html" + (admin ? "/admin" : "") + "/Subjects/" + subjectId);
         return;
       } else {
         onSubmit(subject);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -420,7 +420,7 @@ export const parseToArray = (object) => {
  * @param {bool} open If true, this dialog is open
  */
 export function NewSubjectDialog (props) {
-  const { allowedTypes, currentSubject, disabled, onClose, onSubmit, open, disableRedirect, admin } = props;
+  const { allowedTypes, currentSubject, disabled, onClose, onSubmit, open, disableRedirect, extensionURL } = props;
   const [ error, setError ] = useState("");
   const [ newSubjectName, setNewSubjectName ] = useState([""]);
   const [ newSubjectType, setNewSubjectType ] = useState([""]);
@@ -450,7 +450,7 @@ export function NewSubjectDialog (props) {
       // redirect to the new just created subject page
       let subjectId = getSubjectIdFromPath(subject);
       if (!disableRedirect && subjectId) {
-        navigate("/content.html" + (admin ? "/admin" : "") + "/Subjects/" + subjectId);
+        navigate("/content.html" + (extensionURL ? "/" + extensionURL : "") + "/Subjects/" + subjectId);
         return;
       } else {
         onSubmit(subject);

--- a/modules/homepage/src/main/frontend/src/themePage/index.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/index.jsx
@@ -72,7 +72,7 @@ function Main(props) {
     let title = " | " + docTitle;
     return (
       <Page title={title} pageDefaultName={route["cards:extensionName"]}>
-        <ThisComponent contentOffset={contentOffset} />
+        <ThisComponent contentOffset={contentOffset} extension={route} />
       </Page>
       );
   };

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/ClinicDashboard.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/ClinicDashboard.jsx
@@ -210,7 +210,7 @@ function ClinicDashboard(props) {
           dashboardExtensions.map((extension, index) => {
             let Extension = extension["cards:extensionRender"];
             return <Grid size={{xs:12, xl:6}} key={`extension-${clinicId}-${index}`} className={classes.dashboardEntry}>
-              <Extension data={extension["cards:data"]} color={getColor(index)} visitInfo={visitInfo} clinicId={clinicId} dashboardConfig={dashboardConfig}/>
+              <Extension data={extension["cards:data"]} color={getColor(index)} visitInfo={visitInfo} clinicId={clinicId} dashboardConfig={dashboardConfig} extension={extension} />
             </Grid>
           })
         }

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Footer.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Footer.jsx
@@ -63,7 +63,7 @@ export default function Footer (props) {
     {
       footerExtensions.map((extension, index) => {
         let Extension = extension["cards:extensionRender"];
-        return <Extension key={index} />
+        return <Extension key={index} extension={extension} />
       })
     }
     </Toolbar>


### PR DESCRIPTION
Implement configurable clinician views for the dashboard, form and subject lists
- Adds actionSwitches which allow buttons and other actions to be enabled or disabled on these views
- Adds options to existing views and buttons to support different URLs extensions enabling them to be reused between different paths (admin vs. non-admin)
- Add support for customizing the columns shown in FormViews

To be built and run alongside [SPARC-36](https://github.com/data-team-uhn/sparc/pull/47)

[SPARC-36]: https://phenotips.atlassian.net/browse/SPARC-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ