### PR TITLE
CARDS-2636: Creating a new subject while trying to change a form's subject doesn't actually perform the change

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -639,6 +639,7 @@ function Form (props) {
                 onError={setSelectorDialogError}
                 title="Set subject"
                 selectedQuestionnaire={data?.questionnaire}
+                disableRedirect
               />
             }
             {changedSubject &&

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -715,10 +715,11 @@ export function NewSubjectDialog (props) {
  * @param {func} onChange Callback for when the user changes their selection
  * @param {func} onClose Callback for when the user closes this dialog
  * @param {func} onError Callback for when an error occurs during subject selection
+ * @param {bool} disableRedirect Whether to disable the default behavior of redirecting to the newly created subject upon successful creation
  * @param {string} title Title of the dialog, if any
  */
 function UnstyledSelectorDialog (props) {
-  const { allowedTypes, classes, currentSubject, disabled, open, onChange, onClose, onError, title, selectedQuestionnaire, ...rest } = props;
+  const { allowedTypes, classes, currentSubject, disabled, open, onChange, onClose, onError, title, selectedQuestionnaire, disableRedirect, ...rest } = props;
   const [ subjects, setSubjects ] = useState([]);
   const [ selectedSubject, setSelectedSubject ] = useState();
   const [ newSubjectPopperOpen, setNewSubjectPopperOpen ] = useState(false);
@@ -783,6 +784,7 @@ function UnstyledSelectorDialog (props) {
       onClose={() => { setNewSubjectPopperOpen(false); }}
       onSubmit={handleSubmitNew}
       open={open && newSubjectPopperOpen}
+      disableRedirect={disableRedirect}
       />
     <ResponsiveDialog title={title} open={open} onClose={onClose}>
       <DialogContent dividers className={classes.dialogContentWithTable}>


### PR DESCRIPTION
[CARDS-2636](https://phenotips.atlassian.net/browse/CARDS-2636)
To test:
- Create a form with a new subject. 
- Edit the form, start changing the subject
- Try to create a new subject

Exspected correct behaviour: you will NOT be redirected to the new subject page, and the form to subject link will be updated.

[CARDS-2636]: https://phenotips.atlassian.net/browse/CARDS-2636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ