### PR TITLE
CARDS-2646: Selectable area question type: any selection doesn't remove the required marker until the form is saved

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/SelectableAreaQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SelectableAreaQuestion.jsx
@@ -333,6 +333,7 @@ function SelectableAreaQuestion(props) {
 
   return (
     <Question
+      currentAnswers={notApplicableChecked ? 1 : selection.length}
       {...props}
       preventDefaultView
       >


### PR DESCRIPTION
[CARDS-2646](https://phenotips.atlassian.net/browse/CARDS-2646) To test:
- start the sparc project
- start filling out an “Assessing pain” form
- for the first question “Please select all body areas where the patient feels pain” click on any body part or “None” 

Expected behaviour: “This question is required” should have become grey 

[CARDS-2646]: https://phenotips.atlassian.net/browse/CARDS-2646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ