### PR TITLE
CARDS-2565: User Dashboard: If there is only one dashboard view, display it full width

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -93,7 +93,7 @@ function UserDashboard(props) {
         {
           dashboardExtensions.map((extension, index) => {
             let Extension = extension["cards:extensionRender"];
-            return <Grid item xs={12} xl={6} key={"extension-" + index} className={classes.dashboardEntry}>
+            return <Grid item xs={12} xl={dashboardExtensions.length > 1 ? 6 : 12} key={"extension-" + index} className={classes.dashboardEntry}>
               <Extension />
             </Grid>
           })


### PR DESCRIPTION
[CARDS-2565](https://phenotips.atlassian.net/browse/CARDS-2565) To test:
- set `cards:defaultDisabled` to `true` in modules/data-model/subjects/impl/src/main/resources/SLING-INF/content/Extensions/DashboardViews/SubjectView.json
- buld & run cards, open home dashboard page
Expected behaviour: there is only one forms view extension with full width size

[CARDS-2565]: https://phenotips.atlassian.net/browse/CARDS-2565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ