### PR TITLE
CARDS-2647: Change the button order on several administration dialogs

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
@@ -458,17 +458,17 @@ function Filters(props) {
         </DialogContent>
         <DialogActions>
           <Button
+            variant="outlined"
+            onClick={closeDialog}
+            >
+            {'Cancel'}
+          </Button>
+          <Button
             variant="contained"
             color="primary"
             onClick={saveFilters}
             >
             {'Apply'}
-          </Button>
-          <Button
-            variant="outlined"
-            onClick={closeDialog}
-            >
-            {'Cancel'}
           </Button>
         </DialogActions>
       </ResponsiveDialog>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTypeDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTypeDialog.jsx
@@ -282,6 +282,7 @@ function SubjectTypeDialog(props) {
         {error && <Typography color='error'>{error}</Typography>}
       </DialogContent>
       <DialogActions className={classes.dialogActions}>
+        <Button variant="outlined" size="small" onClick={close}>Close</Button>
         <Button
           disabled={!isEdit && (!label || isDuplicateLabel)
                   || isEdit && (currentSubjectType["cards:defaultOrder"] == order &&
@@ -299,7 +300,6 @@ function SubjectTypeDialog(props) {
          >
           { isEdit ? "Save" : "Create" }
         </Button>
-        <Button variant="outlined" size="small" onClick={close}>Close</Button>
       </DialogActions>
     </Dialog>
   );

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditDialog.jsx
@@ -211,6 +211,12 @@ let EditDialog = (props) => {
           </DialogContent>
           <DialogActions>
             <Button
+              variant='outlined'
+              onClick={() => { setOpen(false); onCancel && onCancel();}}
+            >
+              {'Cancel'}
+            </Button>
+            <Button
               ref={saveButtonRef}
               type='submit'
               variant='contained'
@@ -221,12 +227,6 @@ let EditDialog = (props) => {
               lastSaveStatus === true ? 'Saved' :
               lastSaveStatus === false ? 'Save failed, log in and try again?' :
               'Save'}
-            </Button>
-            <Button
-              variant='outlined'
-              onClick={() => { setOpen(false); onCancel && onCancel();}}
-            >
-              {'Cancel'}
             </Button>
           </DialogActions>
        </Dialog>

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/NewQuestionnaireDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/NewQuestionnaireDialog.jsx
@@ -97,7 +97,13 @@ function NewQuestionnaireDialog(props) {
           >  
         </TextField>
         </DialogContent>
-         <DialogActions>
+        <DialogActions>
+          <Button
+            variant="outlined"
+            onClick={onClose}
+            >
+            Cancel
+          </Button>
           <Button
             variant="contained"
             color="primary"
@@ -105,12 +111,6 @@ function NewQuestionnaireDialog(props) {
             disabled={!title}
             >
             Create
-          </Button>
-          <Button
-            variant="outlined"
-            onClick={onClose}
-            >
-            Cancel
           </Button>
         </DialogActions>
       </Dialog>

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/addusertogroupdialogue.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/addusertogroupdialogue.jsx
@@ -131,8 +131,8 @@ class AddUserToGroupDialogue extends React.Component {
                     </Grid>
                 </DialogContent>
                 <DialogActions className={classes.dialogActions}>
+                    <Button variant="outlined" size="small" onClick={() => this.handleExit()}>Close</Button>   
                     <Button variant="contained" size="small" color="primary" onClick={() => this.handleAddUsers()}>Add</Button>
-                    <Button variant="outlined" size="small" onClick={() => this.handleExit()}>Close</Button>
                 </DialogActions>
             </Dialog>
         );

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/creategroupdialogue.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/creategroupdialogue.jsx
@@ -78,8 +78,8 @@ class CreateGroupDialogue extends React.Component {
                     {this.state.error && <Typography color='error'>{this.state.error}</Typography>}
                 </DialogContent>
                 <DialogActions className={classes.dialogActions}>
-                    <Button color="primary" variant="contained" size="small" onClick={(event) => { event.preventDefault(); this.handleCreateGroup(); }}>Create Group</Button>
                     <Button variant="outlined" size="small" onClick={this.props.handleClose}>Close</Button>
+                    <Button color="primary" variant="contained" size="small" onClick={(event) => { event.preventDefault(); this.handleCreateGroup(); }}>Create Group</Button>
                 </DialogActions>
             </Dialog>
         );

--- a/modules/principals/src/main/frontend/src/Userboard/Users/changeuserpassworddialogue.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Users/changeuserpassworddialogue.jsx
@@ -98,7 +98,6 @@ class FormFields extends React.Component {
           className={classes.form}
           required
         />
-        <Button variant="outlined" size="small" className={classes.formAction} onClick={handleReset}>Close</Button>
         { !isValid ?
           // Render hover over and button
           <React.Fragment>
@@ -111,6 +110,7 @@ class FormFields extends React.Component {
           // Else just render the button
           <Button type="submit" variant="contained" color="primary" size="small" className={classes.formAction} disabled={!isValid}>Change User Password</Button>
         }
+        <Button variant="outlined" size="small" className={classes.formAction} onClick={handleReset}>Close</Button>
       </form>
     );
   }

--- a/modules/principals/src/main/frontend/src/Userboard/deleteprincipaldialogue.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/deleteprincipaldialogue.jsx
@@ -58,8 +58,8 @@ class DeletePrincipalDialogue extends React.Component {
                     <Typography variant="body1">Are you sure you want to delete {this.props.type} {this.props.name}?</Typography>
                 </DialogContent>
                 <DialogActions className={classes.dialogActions}>
-                    <Button variant="contained" color="error" size="small" onClick={() => this.handleDelete()}>Delete</Button>
                     <Button variant="outlined" size="small" onClick={() => this.props.handleClose()}>Close</Button>
+                    <Button variant="contained" color="error" size="small" onClick={() => this.handleDelete()}>Delete</Button>
                 </DialogActions>
             </Dialog>
         );

--- a/modules/vocabularies/src/main/frontend/src/bioportalApiKey.jsx
+++ b/modules/vocabularies/src/main/frontend/src/bioportalApiKey.jsx
@@ -167,8 +167,8 @@ export function BioPortalApiKey(props) {
            { getBioportalKeyInfo(true) }
           </DialogContent>
           <DialogActions>
-            <Button variant="contained" className={classes.vocabularyAction} onClick={() => {addNewKey()}}>Update</Button>
             <Button variant="outlined" className={classes.vocabularyAction} onClick={() => {setDisplayPopup(false)}}>Cancel</Button>
+            <Button variant="contained" className={classes.vocabularyAction} onClick={() => {addNewKey()}}>Update</Button>
           </DialogActions>
       </Dialog>
     </React.Fragment>

--- a/modules/vocabularies/src/main/frontend/src/vocabularyAction.jsx
+++ b/modules/vocabularies/src/main/frontend/src/vocabularyAction.jsx
@@ -225,8 +225,8 @@ export default function VocabularyAction(props) {
       </DialogContent>
 
       <DialogActions>
-        <Button onClick={handleUninstall} variant="contained" color="primary" className={classes.vocabularyAction + " " + classes.uninstall}>Uninstall</Button>
         <Button onClick={handleClose} variant="outlined" className={classes.vocabularyAction}>Cancel</Button>
+        <Button onClick={handleUninstall} variant="contained" color="primary" className={classes.vocabularyAction + " " + classes.uninstall}>Uninstall</Button>
       </DialogActions>
 
     </Dialog>

--- a/modules/vocabularies/src/main/frontend/src/vocabularyAction.jsx
+++ b/modules/vocabularies/src/main/frontend/src/vocabularyAction.jsx
@@ -158,6 +158,11 @@ export default function VocabularyAction(props) {
 
   return(
     <React.Fragment>
+    {exit && (
+      <Tooltip title="Close">
+        <Button onClick={exit} variant="outlined" className={classes.vocabularyAction}>Close</Button>
+      </Tooltip>
+    )}
     {(phase == Phase["Not Installed"]) && (
       <Tooltip title="Install this vocabulary">
         <Button onClick={install} variant="contained" className={classes.vocabularyAction + " " + classes.install}>Install</Button>
@@ -188,11 +193,6 @@ export default function VocabularyAction(props) {
     {(phase == Phase["Latest"]) && (
       <Tooltip title="Remove this vocabulary">
         <Button onClick={handleOpen} variant="contained" className={classes.vocabularyAction + " " + classes.uninstall}>Uninstall</Button>
-      </Tooltip>
-    )}
-    {exit && (
-      <Tooltip title="Close">
-        <Button onClick={exit} variant="outlined" className={classes.vocabularyAction}>Close</Button>
       </Tooltip>
     )}
     <Dialog onClose={handleClose} open={displayPopup}>

--- a/modules/vocabularies/src/main/frontend/src/vocabularyDetails.jsx
+++ b/modules/vocabularies/src/main/frontend/src/vocabularyDetails.jsx
@@ -96,6 +96,9 @@ export default function VocabularyDetails(props) {
         </DialogContent>
 
         <DialogActions>
+          {(phase == Phase["Latest"] || phase == Phase["Update Available"]) && 
+            <Button onClick={() => {setBrowserOpened(true);}} variant="contained" className={classes.browseAction} color="primary">Browse</Button>
+          }
           <VocabularyAction
             install={install}
             uninstall={uninstall}
@@ -103,9 +106,6 @@ export default function VocabularyDetails(props) {
             exit={handleClose}
             vocabulary={vocabulary}
           />
-          {(phase == Phase["Latest"] || phase == Phase["Update Available"]) && 
-            <Button onClick={() => {setBrowserOpened(true);}} variant="contained" className={classes.browseAction} color="primary">Browse</Button>
-          }
         </DialogActions>
 
       </Dialog>

--- a/modules/vocabularies/src/main/frontend/src/vocabularyDetails.jsx
+++ b/modules/vocabularies/src/main/frontend/src/vocabularyDetails.jsx
@@ -96,9 +96,6 @@ export default function VocabularyDetails(props) {
         </DialogContent>
 
         <DialogActions>
-          {(phase == Phase["Latest"] || phase == Phase["Update Available"]) && 
-            <Button onClick={() => {setBrowserOpened(true);}} variant="contained" className={classes.browseAction} color="primary">Browse</Button>
-          }
           <VocabularyAction
             install={install}
             uninstall={uninstall}
@@ -106,6 +103,9 @@ export default function VocabularyDetails(props) {
             exit={handleClose}
             vocabulary={vocabulary}
           />
+          {(phase == Phase["Latest"] || phase == Phase["Update Available"]) && 
+            <Button onClick={() => {setBrowserOpened(true);}} variant="contained" className={classes.browseAction} color="primary">Browse</Button>
+          }
         </DialogActions>
 
       </Dialog>


### PR DESCRIPTION
[CARDS-2647](https://phenotips.atlassian.net/issues/CARDS-2647) Affected dialogs:
- Administration -> Creation dialogs for Subject Type, Questionnaire, Group
- Administration -> Questionnaire editing, all the form element editing dialogs
- Administration -> Vocabularies -> About
- User administration -> Change Password and Delete dialogs
- Group administration -> Delete Group, Add User to Group
- Dashboard -> Filters


[CARDS-2647]: https://phenotips.atlassian.net/browse/CARDS-2647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ