### PR TITLE
CARDS-2652: Ensure consistent Cancel label in dialogs

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTypeDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTypeDialog.jsx
@@ -282,7 +282,7 @@ function SubjectTypeDialog(props) {
         {error && <Typography color='error'>{error}</Typography>}
       </DialogContent>
       <DialogActions className={classes.dialogActions}>
-        <Button variant="outlined" size="small" onClick={close}>Close</Button>
+        <Button variant="outlined" size="small" onClick={close}>Cancel</Button>
         <Button
           disabled={!isEdit && (!label || isDuplicateLabel)
                   || isEdit && (currentSubjectType["cards:defaultOrder"] == order &&

--- a/modules/login/src/main/frontend/src/login/signUpForm.js
+++ b/modules/login/src/main/frontend/src/login/signUpForm.js
@@ -277,13 +277,14 @@ class SignUpForm extends React.Component {
         </ErrorDialog>
         <div className={classes.main}>
           <Formik
-            render={props => <FormFieldsComponent {...props} />}
             initialValues={values}
             validationSchema={validationSchema}
             onSubmit={this.submitValues}
             onReset={this.props.handleExit}
             innerRef={el => (this.form = el)}
-          />
+          >
+            {props => <FormFieldsComponent {...props} />}
+          </Formik>
         </div>
       </React.Fragment>
     );

--- a/modules/login/src/main/frontend/src/login/signUpForm.js
+++ b/modules/login/src/main/frontend/src/login/signUpForm.js
@@ -41,7 +41,7 @@ class FormFields extends React.Component {
     const { classes } = this.props;
 
     const {
-      values: { username, email, password, confirmPassword, loginOnSuccess },
+      values: { username, email, password, confirmPassword, loginOnSuccess, closeButtonText, submitButtonText },
       errors,
       touched,
       handleSubmit,
@@ -122,7 +122,7 @@ class FormFields extends React.Component {
         <Grid container direction="row" justifyContent="flex-end" alignItems="center" className={classes.actions}>
           { !loginOnSuccess &&
             <Grid item>
-              <Button variant="outlined" size="small" onClick={handleReset} className={classes.submit + " " + classes.closeButton}>Close</Button>
+              <Button variant="outlined" size="small" onClick={handleReset} className={classes.submit + " " + classes.closeButton}>{closeButtonText}</Button>
             </Grid>
           }
           <Grid item>
@@ -131,16 +131,16 @@ class FormFields extends React.Component {
             <Tooltip title="You must fill in all fields.">
               <div>
                 { loginOnSuccess ?
-                  <Button type="submit" variant="contained" color="primary" disabled={!isValid} className={classes.submit} fullWidth >Submit</Button> :
-                  <Button type="submit" variant="contained" color="primary" disabled={!isValid} className={classes.submit + " " + classes.closeButton} size="small">Submit</Button>
+                  <Button type="submit" variant="contained" color="primary" disabled={!isValid} className={classes.submit} fullWidth >{submitButtonText}</Button> :
+                  <Button type="submit" variant="contained" color="primary" disabled={!isValid} className={classes.submit + " " + classes.closeButton} size="small">{submitButtonText}</Button>
                 }
               </div>
             </Tooltip>
             :
             // Else just render the button
             ( loginOnSuccess ?
-              <Button type="submit" variant="contained" color="primary" disabled={!isValid} className={classes.submit} fullWidth >Submit</Button> :
-              <Button type="submit" variant="contained" color="primary" disabled={!isValid} className={classes.submit + " " + classes.closeButton} size="small">Submit</Button>
+              <Button type="submit" variant="contained" color="primary" disabled={!isValid} className={classes.submit} fullWidth >{submitButtonText}</Button> :
+              <Button type="submit" variant="contained" color="primary" disabled={!isValid} className={classes.submit + " " + classes.closeButton} size="small">{submitButtonText}</Button>
             )
           }
           </Grid>
@@ -245,7 +245,15 @@ class SignUpForm extends React.Component {
 
   render() {
     const { classes } = this.props;
-    const values = { username: "", email: "", confirmPassword: "", password: "", loginOnSuccess: this.props.loginOnSuccess };
+    const values = {
+      username: "",
+      email: "",
+      confirmPassword: "",
+      password: "",
+      loginOnSuccess: this.props.loginOnSuccess,
+      closeButtonText: this.props.closeButtonText || "Close",
+      submitButtonText: this.props.submitButtonText || "Submit"
+    };
 
     const validationSchema = Yup.object({
       email: Yup.string("Enter your email")

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/addusertogroupdialogue.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/addusertogroupdialogue.jsx
@@ -131,7 +131,7 @@ class AddUserToGroupDialogue extends React.Component {
                     </Grid>
                 </DialogContent>
                 <DialogActions className={classes.dialogActions}>
-                    <Button variant="outlined" size="small" onClick={() => this.handleExit()}>Close</Button>   
+                    <Button variant="outlined" size="small" onClick={() => this.handleExit()}>Cancel</Button>
                     <Button variant="contained" size="small" color="primary" onClick={() => this.handleAddUsers()}>Add</Button>
                 </DialogActions>
             </Dialog>

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/creategroupdialogue.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/creategroupdialogue.jsx
@@ -78,7 +78,7 @@ class CreateGroupDialogue extends React.Component {
                     {this.state.error && <Typography color='error'>{this.state.error}</Typography>}
                 </DialogContent>
                 <DialogActions className={classes.dialogActions}>
-                    <Button variant="outlined" size="small" onClick={this.props.handleClose}>Close</Button>
+                    <Button variant="outlined" size="small" onClick={this.props.handleClose}>Cancel</Button>
                     <Button color="primary" variant="contained" size="small" onClick={(event) => { event.preventDefault(); this.handleCreateGroup(); }}>Create Group</Button>
                 </DialogActions>
             </Dialog>

--- a/modules/principals/src/main/frontend/src/Userboard/Users/changeuserpassworddialogue.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Users/changeuserpassworddialogue.jsx
@@ -110,7 +110,7 @@ class FormFields extends React.Component {
           // Else just render the button
           <Button type="submit" variant="contained" color="primary" size="small" className={classes.formAction} disabled={!isValid}>Change User Password</Button>
         }
-        <Button variant="outlined" size="small" className={classes.formAction} onClick={handleReset}>Close</Button>
+        <Button variant="outlined" size="small" className={classes.formAction} onClick={handleReset}>Cancel</Button>
       </form>
     );
   }

--- a/modules/principals/src/main/frontend/src/Userboard/Users/createuserdialogue.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Users/createuserdialogue.jsx
@@ -47,7 +47,13 @@ class CreateUserDialogue extends React.Component {
                 <DialogTitle>Register a new user</DialogTitle>
                 <DialogContent>
                   <Grid container>
-                    <SignUpForm loginOnSuccess={false} handleSuccess={() => this.handleCreateUser()} handleExit={() => this.props.handleClose()}/>
+                    <SignUpForm
+                      loginOnSuccess={false}
+                      handleSuccess={() => this.handleCreateUser()}
+                      handleExit={() => this.props.handleClose()}
+                      closeButtonText="Cancel"
+                      submitButtonText="Create account"
+                    />
                   </Grid>
                 </DialogContent>
             </Dialog>

--- a/modules/principals/src/main/frontend/src/Userboard/deleteprincipaldialogue.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/deleteprincipaldialogue.jsx
@@ -58,7 +58,7 @@ class DeletePrincipalDialogue extends React.Component {
                     <Typography variant="body1">Are you sure you want to delete {this.props.type} {this.props.name}?</Typography>
                 </DialogContent>
                 <DialogActions className={classes.dialogActions}>
-                    <Button variant="outlined" size="small" onClick={() => this.props.handleClose()}>Close</Button>
+                    <Button variant="outlined" size="small" onClick={() => this.props.handleClose()}>Cancel</Button>
                     <Button variant="contained" color="error" size="small" onClick={() => this.handleDelete()}>Delete</Button>
                 </DialogActions>
             </Dialog>


### PR DESCRIPTION
[CARDS-2652](https://phenotips.atlassian.net/issues/CARDS-2652) Replaced “Close” with “Cancel” in the following: dialogs:
- Administration → Subject Types → Create
- Administration → Users → Create, Change password, Delete
- Administration → Groups → Create, Add user to group, Delete

the OK button should be labeled “Create account” instead of “Submit”:
- Administration → Users → Create

[CARDS-2652]: https://phenotips.atlassian.net/browse/CARDS-2652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ