### PR TITLE
[tests] Removed unsupported date formats from tests

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionFull.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionFull.jsx
@@ -45,7 +45,7 @@ import DateQuestionUtilities from "./DateQuestionUtilities";
 // Sample usage:
 //<DateQuestion
 //  text="Please enter a date-time in 2019"
-//  dateFormat="yyyy-MM-dd HH:mm:ss"
+//  dateFormat="yyyy-MM-dd HH:mm"
 //  lowerLimit="2019-01-01"
 //  upperLimit="today"
 //  type="timestamp"

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionYear.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionYear.jsx
@@ -41,8 +41,7 @@ import DateQuestionUtilities from "./DateQuestionUtilities";
 //
 // Sample usage:
 //<DateQuestionYear
-//  text="Please enter a date-time in 2019"
-//  dateFormat="yyyy-MM-dd HH:mm:ss"
+//  text="Please enter a year"
 //  lowerLimit="2019"
 //  upperLimit="today"
 //  type="timestamp"

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ComputedTest.xml
@@ -806,7 +806,7 @@ return result;
 			</property>
 			<property>
 				<name>dateFormat</name>
-				<value>MM/yyyy</value>
+				<value>yyyy/MM</value>
 				<type>String</type>
 			</property>
 			<property>
@@ -845,7 +845,7 @@ return result;
 			</property>
 			<property>
 				<name>dateFormat</name>
-				<value>MM/yyyy</value>
+				<value>yyyy/MM</value>
 				<type>String</type>
 			</property>
 		</node>
@@ -884,7 +884,7 @@ return result;
 			</property>
 			<property>
 				<name>dateFormat</name>
-				<value>MM/yyyy</value>
+				<value>yyyy/MM</value>
 				<type>String</type>
 			</property>
 		</node>
@@ -986,11 +986,11 @@ return result;
 			</property>
 		</node>
 		<node>
-			<name>dateAnswerHourMinuteSecondInput</name>
+			<name>dateAnswerHourMinuteInput</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
 				<name>text</name>
-				<value>Pick a date and time down to seconds</value>
+				<value>Pick a date and time down to minutes</value>
 				<type>String</type>
 			</property>
 			<property>
@@ -1000,7 +1000,7 @@ return result;
 			</property>
 			<property>
 				<name>dateFormat</name>
-				<value>yyyy-MM-dd HH:mm:ss</value>
+				<value>yyyy-MM-dd HH:mm</value>
 				<type>String</type>
 			</property>
 			<property>
@@ -1010,11 +1010,11 @@ return result;
 			</property>
 		</node>
 		<node>
-			<name>dateAnswerHourMinuteSecond</name>
+			<name>dateAnswerHourMinute</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
 				<name>text</name>
-				<value>Date, include time down to seconds</value>
+				<value>Date, include time down to minutes</value>
 				<type>String</type>
 			</property>
 			<property>
@@ -1034,21 +1034,21 @@ return result;
 			</property>
 			<property>
 				<name>expression</name>
-				<value>return @{dateAnswerHourMinuteSecondInput}</value>
+				<value>return @{dateAnswerHourMinuteInput}</value>
 				<type>String</type>
 			</property>
 			<property>
 				<name>dateFormat</name>
-				<value>yyyy-MM-dd HH:mm:ss</value>
+				<value>yyyy-MM-dd HH:mm</value>
 				<type>String</type>
 			</property>
 		</node>
 		<node>
-			<name>dateAnswerHourMinuteSecondHidden</name>
+			<name>dateAnswerHourMinuteHidden</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
 				<name>text</name>
-				<value>Date, include time down to seconds hidden</value>
+				<value>Date, include time down to minutes hidden</value>
 				<type>String</type>
 			</property>
 			<property>
@@ -1073,12 +1073,12 @@ return result;
 			</property>
 			<property>
 				<name>expression</name>
-				<value>return @{dateAnswerHourMinuteSecondInput}</value>
+				<value>return @{dateAnswerHourMinuteInput}</value>
 				<type>String</type>
 			</property>
 			<property>
 				<name>dateFormat</name>
-				<value>yyyy-MM-dd HH:mm:ss</value>
+				<value>yyyy-MM-dd HH:mm</value>
 				<type>String</type>
 			</property>
 		</node>
@@ -1613,7 +1613,7 @@ return result;
 				<type>String</type>
 			</property>
 		</node>
-		<node>
+		<!-- <node>
 			<name>timeAnswerHourMinuteSecondInput</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
@@ -1670,7 +1670,7 @@ return result;
 				<value>hh:mm:ss</value>
 				<type>String</type>
 			</property>
-		</node>
+		</node> -->
 		<node>
 			<name>timeAnswerHourMinuteSecondHidden</name>
 			<primaryNodeType>cards:Question</primaryNodeType>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/DateFormatsTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/DateFormatsTest.xml
@@ -61,7 +61,7 @@
 			<type>Long</type>
 		</property>
 	</node>
-	<node>
+	<!-- <node>
 		<name>monthyear</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
@@ -84,7 +84,7 @@
 			<value>1</value>
 			<type>Long</type>
 		</property>
-	</node>
+	</node> -->
 	<node>
 		<name>yearmonth</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
@@ -133,7 +133,7 @@
 			<type>Long</type>
 		</property>
 	</node>
-	<node>
+	<!-- <node>
 		<name>monthdayyear</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
@@ -156,7 +156,7 @@
 			<value>1</value>
 			<type>Long</type>
 		</property>
-	</node>
+	</node> -->
 	<node>
 		<name>yearmonthdayhourminute</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
@@ -181,7 +181,7 @@
 			<type>Long</type>
 		</property>
 	</node>
-	<node>
+	<!-- <node>
 		<name>yearmonthdayhourminutesecond</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
@@ -204,8 +204,8 @@
 			<value>1</value>
 			<type>Long</type>
 		</property>
-	</node>
-	<!-- <node>
+	</node> -->
+	<node>
 		<name>yearint</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
@@ -233,8 +233,8 @@
 			<value>interval</value>
 			<type>String</type>
 		</property>
-	</node> -->
-	<node>
+	</node>
+	<!-- <node>
 		<name>monthyearint</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
@@ -262,7 +262,7 @@
 			<value>interval</value>
 			<type>String</type>
 		</property>
-	</node>
+	</node> -->
 	<node>
 		<name>yearmonthint</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
@@ -321,7 +321,7 @@
 			<type>String</type>
 		</property>
 	</node>
-	<node>
+	<!-- <node>
 		<name>monthdayyearint</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
@@ -349,7 +349,7 @@
 			<value>interval</value>
 			<type>String</type>
 		</property>
-	</node>
+	</node> -->
 	<node>
 		<name>yearmonthdayhourminuteint</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
@@ -379,7 +379,7 @@
 			<type>String</type>
 		</property>
 	</node>
-	<node>
+	<!-- <node>
 		<name>yearmonthdayhourminutesecondint</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
@@ -407,7 +407,7 @@
 			<value>interval</value>
 			<type>String</type>
 		</property>
-	</node>
+	</node> -->
 	<node>
 		<name>absoluteyearupper</name>
 		<primaryNodeType>cards:Question</primaryNodeType>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ServersideComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ServersideComputedTest.xml
@@ -148,7 +148,7 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>MM/yyyy</value>
+			<value>yyyy/MM</value>
 			<type>String</type>
 		</property>
 	</node>
@@ -176,7 +176,7 @@
 			<type>String</type>
 		</property>
 	</node>
-	<node>
+	<!-- <node>
 		<name>dateQuestionSeconds</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
@@ -199,7 +199,7 @@
 			<value>yyyy/MM/DD HH:mm:ss</value>
 			<type>String</type>
 		</property>
-	</node>
+	</node> -->
 	<node>
 		<name>longQuestion</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
@@ -307,7 +307,7 @@
 			<type>String</type>
 		</property>
 	</node>
-	<node>
+	<!-- <node>
 		<name>timeQuestionSeconds</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
@@ -330,7 +330,7 @@
 			<value>hh:mm:ss</value>
 			<type>String</type>
 		</property>
-	</node>
+	</node> -->
 	<node>
 		<name>timeQuestionMinutes</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
@@ -720,7 +720,7 @@ The entered month
 			</property>
 			<property>
 				<name>dateFormat</name>
-				<value>MM/yyyy</value>
+				<value>yyyy/MM</value>
 				<type>String</type>
 			</property>
 			<property>
@@ -767,7 +767,7 @@ The entered datetime
 				<type>String</type>
 			</property>
 		</node>
-		<node>
+		<!-- <node>
 			<name>conditionalQuestionDateSeconds</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
@@ -804,7 +804,7 @@ The entered datetime with seconds
 				<value>return @{dateQuestionSeconds}</value>
 				<type>String</type>
 			</property>
-		</node>
+		</node> -->
 		<node>
 			<name>conditionalQuestionLong</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
@@ -982,7 +982,7 @@ The entered time
 				<type>String</type>
 			</property>
 		</node>
-		<node>
+		<!-- <node>
 			<name>conditionalQuestionTimeSeconds</name>
 			<primaryNodeType>cards:Question</primaryNodeType>
 			<property>
@@ -1019,7 +1019,7 @@ The entered time with seconds
 				<value>return @{timeQuestionSeconds}</value>
 				<type>String</type>
 			</property>
-		</node>
+		</node> -->
 		<node>
 			<name>conditionalQuestionTimeMinutes</name>
 			<primaryNodeType>cards:Question</primaryNodeType>


### PR DESCRIPTION
The following date formats can not be parsed correctly in the input fields:
- `MM-dd-yyyy`
- `MM/yyyy`
- `yyyy-MM-dd HH:mm:ss`
- `hh:mm:ss`

All related tests are altered or commented out 