### PR TITLE
CARDS-2657: Add jcr:uuid to cards:Information nodes

### DIFF
--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/nodetypes/forms.cnd
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/nodetypes/forms.cnd
@@ -251,7 +251,7 @@
 //-----------------------------------------------------------------------------
 // An informative formatted text (markdown). Can be displayed in edit mode to guide
 // the user through filling out a form, or in view mode to explain the data.
-[cards:Information] > cards:ResourcePart
+[cards:Information] > cards:ResourcePart, mix:referenceable
   // Attributes
 
   // The main sub-item of a section is its text.


### PR DESCRIPTION
As expected, this requires that UUIDs are added manually before upgrading, or else the upgrade will fail.