### PR TITLE
CARDS-2665: Add support for configuring the precision of decimal/double answers

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
@@ -133,7 +133,7 @@ const useSliderStyles = makeStyles(theme => ({
 function NumberQuestion(props) {
   const { existingAnswer, errorText, classes, pageActive, disableValueInstructions, ...rest} = props;
   const { dataType,displayMode, minAnswers, minValue, maxValue, disableMinMaxValueEnforcement, messageForValuesOutsideMinMax, isRange, unitOfMeasurement,
-    sliderStep, sliderMarkStep, sliderOrientation, minValueLabel, maxValueLabel }
+    sliderStep, sliderMarkStep, sliderOrientation, minValueLabel, maxValueLabel, decimalScale }
     = {sliderOrientation: "horizontal", ...props.questionDefinition, ...props};
   const answerNodeType = props.answerNodeType || DATA_TO_NODE_TYPE[dataType];
   const valueType = props.valueType || DATA_TO_VALUE_TYPE[dataType];
@@ -243,7 +243,7 @@ function NumberQuestion(props) {
     min: minValue,
     max: maxValue,
     allowNegative: (typeof minValue === "undefined" || minValue < 0 || disableMinMaxValueEnforcement),
-    decimalScale: dataType === "long" ? 0 : undefined
+    decimalScale: dataType === "long" ? 0 : (decimalScale ?? undefined)
   };
   const muiInputProps = {
     inputComponent: NumberFormatCustom, // Used to override a TextField's type

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/NumberInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/NumberInput.jsx
@@ -33,7 +33,7 @@ import ValueComponentManager from "./ValueComponentManager";
 let NumberInput = (props) => {
   let { objectKey, data, hint } = props;
   const type = props.value?.charAt(0).toUpperCase() + props.value?.slice(1).toLowerCase();
-  const defaultValue = type === "Long" ? (objectKey == "maxAnswers" ? 1 : 0) : '';
+  const defaultValue = type === "Long" ? (objectKey == "maxAnswers" ? 1 : objectKey == "minAnswers" ? 0 : '') : '';
   const minValue = type === "Long" ? 0 : '';
   const isMax = type === "Long" && objectKey.startsWith('max');
 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -197,6 +197,7 @@
           "user": {
             "minAnswers": "long",
             "maxAnswers": "long",
+            "decimalScale": "long",
             "minValue": "double",
             "maxValue": "double",
             "disableMinMaxValueEnforcement" : "boolean",
@@ -261,6 +262,7 @@
           "user": {
             "minAnswers": "long",
             "maxAnswers": "long",
+            "decimalScale": "long",
             "minValue": "double",
             "maxValue": "double",
             "disableMinMaxValueEnforcement" : "boolean",

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -197,13 +197,13 @@
           "user": {
             "minAnswers": "long",
             "maxAnswers": "long",
-            "decimalScale": "long",
             "minValue": "double",
             "maxValue": "double",
             "disableMinMaxValueEnforcement" : "boolean",
             "messageForValuesOutsideMinMax" : "markdown",
             "displayMode": {
               "input": {
+                "decimalScale": "long",
                 "isRange" : "boolean"
               },
               "list": {
@@ -214,6 +214,7 @@
                 }
               },
               "list+input" : {
+                "decimalScale": "long",
                 "compact" : "boolean",
                 "answerOptions" : {
                   "type": "numberOptions",
@@ -262,13 +263,13 @@
           "user": {
             "minAnswers": "long",
             "maxAnswers": "long",
-            "decimalScale": "long",
             "minValue": "double",
             "maxValue": "double",
             "disableMinMaxValueEnforcement" : "boolean",
             "messageForValuesOutsideMinMax" : "markdown",
             "displayMode": {
               "input": {
+                "decimalScale": "long",
                 "isRange" : "boolean"
               },
               "slider": {

--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/nodetypes/forms.cnd
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/nodetypes/forms.cnd
@@ -179,6 +179,9 @@
   // This will be displayed as an input end adornment.
   - unitOfMeasurement (string)
 
+  // For decimal and double answers, the number of digits allowed after the decimal point
+  - decimalScale (long)
+
   // For date answers, the format in which to display (and accept as input) the date.
   // This is a SimpleDateFormat compatible string.
   - dateFormat (string)


### PR DESCRIPTION
To test:
* create/use a questionnaire with decimal and double questions
* from the questionnaire wizard set the Decimal scale property of the questions to a value such as 1 or 2
* test that only that many decimals can be entered in the answers
OR
* test in the `corpath` project according to the instructions from https://github.com/data-team-uhn/corpath/pull/17.