### PR TITLE
[misc] <sly> markup present in the HTML of generic error pages

### DIFF
--- a/modules/commons/src/main/resources/SLING-INF/content/apps/sling/servlet/errorhandler/default.esp
+++ b/modules/commons/src/main/resources/SLING-INF/content/apps/sling/servlet/errorhandler/default.esp
@@ -97,9 +97,7 @@ if ("application/json".equals(request.getHeader("Accept"))) {
   </head>
   <body>
     <div id="main-error-container"></div>
-    <sly data-sly-use.assets="/libs/cards/resources/assets">
-      <script src="/libs/cards/resources/${assets['cards-commons.GenericErrorPage.js']}"></script>
-    </sly>
+    <script src="/libs/cards/resources/${assets['cards-commons.GenericErrorPage.js']}"></script>
   </body>
 </html>
 <%


### PR DESCRIPTION
`<sly>` makes sense in `.htl` scripts, which are processed serverside and interpreted as needed. However, the generic error page outputs plain HTML that is not interpreted for htl processing, so that element ends up in the actual HTML sent to the browser. It is there as a bad copy/paste from htl files.

To test: login as admin, open `http://localhost:8080/libs/` and check the HTML source of the file, make sure there is no `<sly` element. Also make sure the error page still renders properly.