### PR TITLE
CARDS-2674: Questionnaire export no longer shows questions/sections to include/exclude

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
@@ -83,7 +83,6 @@ function Questionnaires(props) {
               <ExportButton
                 entryPath={row.original["@path"]}
                 entryName={row.original.title}
-                entityData={row.original}
                 entryType={entryType}
                 size="medium"
               />


### PR DESCRIPTION
[CARDS-2674](https://phenotips.atlassian.net/browse/CARDS-2674) 
Fixed regression of [CARDS-2618](https://github.com/data-team-uhn/cards/commit/fa6932077bb75914407c7f9c67098bed5543191d)

[CARDS-2674]: https://phenotips.atlassian.net/browse/CARDS-2674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CARDS-2618]: https://phenotips.atlassian.net/browse/CARDS-2618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ