### PR TITLE
CARDS-2671: After changing the password, a confirmation alert is displayed in the wrong place

### DIFF
--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/AdminNavbarLinks.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/AdminNavbarLinks.jsx
@@ -189,6 +189,8 @@ function HeaderLinks (props) {
             className: classes.successSnackbar,
           },
         }}
+        sx={{ ml: "130px" }}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
         autoHideDuration={6000}
         onClose={() => setPwdResetSuccessSnackbarOpen(false)}
         message="Password successfully changed"

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/AdminNavbarLinks.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/AdminNavbarLinks.jsx
@@ -189,8 +189,7 @@ function HeaderLinks (props) {
             className: classes.successSnackbar,
           },
         }}
-        sx={{ ml: "130px" }}
-        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
         autoHideDuration={6000}
         onClose={() => setPwdResetSuccessSnackbarOpen(false)}
         message="Password successfully changed"

--- a/modules/principals/src/main/frontend/src/Userboard/Users/changeuserpassworddialogue.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Users/changeuserpassworddialogue.jsx
@@ -16,7 +16,7 @@
 */
 
 import React from "react";
-import { Alert, Button, Grid, Dialog, DialogTitle, DialogContent, TextField, Tooltip } from "@mui/material";
+import { Alert, Button, Dialog, DialogTitle, DialogContent, TextField, Tooltip } from "@mui/material";
 import { withStyles } from 'tss-react/mui';
 import { Formik } from "formik";
 import * as Yup from "yup";
@@ -218,17 +218,15 @@ class ChangeUserPasswordDialogue extends React.Component {
             >
                 <DialogTitle>Change User Password for {this.props.name}</DialogTitle>
                 <DialogContent>
-                    <Grid container>
-                        {this.state.error && <Alert severity="error">{this.state.error}</Alert>}
-                        <Formik
-                          initialValues={values}
-                          validationSchema={validationSchemaObj}
-                          onSubmit={this.handlePasswordChange}
-                          onReset={() => this.handleCloseDialog(false)}
-                          >
-                          {props => <FormFieldsComponent {...props} requireOldPassword={requireOldPassword} />}
-                        </Formik>
-                    </Grid>
+                    {this.state.error && <Alert severity="error">{this.state.error}</Alert>}
+                    <Formik
+                      initialValues={values}
+                      validationSchema={validationSchemaObj}
+                      onSubmit={this.handlePasswordChange}
+                      onReset={() => this.handleCloseDialog(false)}
+                      >
+                      {props => <FormFieldsComponent {...props} requireOldPassword={requireOldPassword} />}
+                    </Formik>
                 </DialogContent>
             </Dialog>
         );

--- a/modules/principals/src/main/frontend/src/Userboard/Users/changeuserpassworddialogue.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Users/changeuserpassworddialogue.jsx
@@ -16,7 +16,7 @@
 */
 
 import React from "react";
-import { Button, Grid, Dialog, DialogTitle, DialogContent, TextField, Tooltip, Typography } from "@mui/material";
+import { Alert, Button, Grid, Dialog, DialogTitle, DialogContent, TextField, Tooltip } from "@mui/material";
 import { withStyles } from 'tss-react/mui';
 import { Formik } from "formik";
 import * as Yup from "yup";
@@ -219,7 +219,7 @@ class ChangeUserPasswordDialogue extends React.Component {
                 <DialogTitle>Change User Password for {this.props.name}</DialogTitle>
                 <DialogContent>
                     <Grid container>
-                        {this.state.error && <Typography component="h2" className={classes.errorMessage}>{this.state.error}</Typography>}
+                        {this.state.error && <Alert severity="error">{this.state.error}</Alert>}
                         <Formik
                           initialValues={values}
                           validationSchema={validationSchemaObj}


### PR DESCRIPTION
[CARDS-2671](https://phenotips.atlassian.net/issues/CARDS-2671) fixes success change password message appearance
[misc] commit also fixes the change password error styling. 
Regression for error styling was introduced in [this commit](https://github.com/data-team-uhn/cards/commit/a42650dc3ff22cd85da80f3bf23d538020ba018b), where `errorMessage` style class was removed and `Alert` used to display login errors. 

[CARDS-2671]: https://phenotips.atlassian.net/browse/CARDS-2671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ