### PR TITLE
Refactored the Downtime Banner and Demo Warning Banner components to reduce custom styling

### DIFF
--- a/modules/demo-banner/src/main/frontend/src/demoBanner.jsx
+++ b/modules/demo-banner/src/main/frontend/src/demoBanner.jsx
@@ -20,41 +20,18 @@
 import React from "react";
 
 import {
+  Alert,
   AppBar,
-  Grid,
-  Toolbar,
-  Typography
 } from '@mui/material';
-import { useTheme } from '@mui/material/styles';
-import { withStyles } from 'tss-react/mui';
-
-import WarningIcon from '@mui/icons-material/Warning';
-
-const appbarStyle = theme => ({
-  root: {
-    backgroundColor: theme.palette.warning.main
-  }
-});
 
 export default function DemoBanner(props) {
-  const StyledAppBar = withStyles(AppBar, appbarStyle);
-  const theme = useTheme();
 
   return (
-    <StyledAppBar position="fixed" style={props.style} ref={props.onRender}>
-      <Toolbar>
-      <Grid container spacing={1} justifyContent="center" alignItems="center" wrap="nowrap">
-        <Grid sx={{ minWidth: theme.spacing(6)}}><WarningIcon/></Grid>
-        <Grid>
-        <Typography variant="subtitle2">
-          This installation is for demo purposes only.
-          Data entered here can be accessed by anyone and is
-          periodically deleted. Do not enter any real
-          data / patient identifiable information.
-        </Typography>
-        </Grid>
-      </Grid>
-      </Toolbar>
-    </StyledAppBar>
+    <AppBar position="fixed" style={props.style} ref={props.onRender}>
+      <Alert variant="filled" square severity="warning" sx={{justifyContent: "center"}}>
+        This installation is for demo purposes only.
+        Do not enter any real data / patient identifiable information.
+      </Alert>
+    </AppBar>
   );
 }

--- a/modules/downtime-warning-banner/src/main/frontend/src/downtimeBanner.jsx
+++ b/modules/downtime-warning-banner/src/main/frontend/src/downtimeBanner.jsx
@@ -19,42 +19,18 @@
 
 import React, { useState, useEffect } from "react";
 import {
+  Alert,
   AppBar,
-  Avatar,
-  Grid,
-  Toolbar,
-  Typography,
 } from '@mui/material';
-import { withStyles } from 'tss-react/mui';
-import { useTheme } from '@mui/material/styles';
 import BuildIcon from '@mui/icons-material/Build';
 
-const appbarStyle = theme => ({
-  root: {
-    backgroundColor: theme.palette.info.main,
-    "& .MuiAvatar-root" : {
-      backgroundColor: theme.palette.background.paper,
-      color: theme.palette.info.main
-    },
-    "& b": {
-      backgroundColor: theme.palette.action.selected,
-      padding: "2px 4px",
-      borderRadius: "2px",
-    }
-  }
-});
-
 export default function DowntimeWarning(props) {
-  const StyledAppBar = withStyles(AppBar, appbarStyle);
-  const appName = document.querySelector('meta[name="title"]')?.content;
-
   // The the configuration values specified by the Administration
   const [ enabled, setEnabled ] = useState(false);
   const [ fromDate, setFromDate ] = useState();
   const [ toDate, setToDate ] = useState();
   // Error message set when fetching the data from the server fails
   const [ error, setError ] = useState();
-  const theme = useTheme();
 
   // Load the configurations only once, upon initialization
   useEffect(() => {
@@ -89,18 +65,13 @@ export default function DowntimeWarning(props) {
   }
 
   return (
-    <StyledAppBar position="fixed" style={props.style} ref={props.onRender}>
-      <Toolbar>
-      {error && <Typography color='error'>{errorText}</Typography>}
-      <Grid container spacing={1} justifyContent="center" alignItems="center" wrap="nowrap">
-        <Grid sx={{ minWidth: theme.spacing(6)}}><Avatar><BuildIcon/></Avatar></Grid>
-        <Grid>
-        <Typography variant="body2">
-          {appName} will be down for maintenance from <b>{fromDate}</b> to <b>{toDate}</b>. We appologize for the inconvenience this may cause.
-        </Typography>
-        </Grid>
-      </Grid>
-      </Toolbar>
-    </StyledAppBar>
+    <AppBar position="fixed" style={props.style} ref={props.onRender}>
+      { error &&
+        <Alert variant="filled" square severity="error" sx={{justifyContent: "center"}}>{error}</Alert>
+      }
+      <Alert variant="filled" square severity="info" icon={<BuildIcon/>} sx={{justifyContent: "center"}}>
+        Scheduled Maintenance: {fromDate} - {toDate}
+      </Alert>
+    </AppBar>
   );
 }


### PR DESCRIPTION
* Used an `Alert` instead of a Toolbar+Grid to display the icon on the side of the message in banners
* Specific to Downtime banner:
  * Shorter message
  * Fixed WSORD in case of an error (caused by attempt to display `errorText` which does not exist)

Before:

![image](https://github.com/user-attachments/assets/9fcac0a1-4ff0-47b4-a1f1-33a5fc06b064)

After:

![image](https://github.com/user-attachments/assets/50be97f3-cd0a-40e2-9608-d384b010cf49)

![image](https://github.com/user-attachments/assets/30a6de3b-cb6a-455c-97a5-d00c139102dd)

![image](https://github.com/user-attachments/assets/c5cbe877-c323-4d47-992f-921aa0324bc8)

![image](https://github.com/user-attachments/assets/db256337-7e7d-460e-87a6-280eeb380757)