### PR TITLE
CARDS-2684: Print functionality is broken

### DIFF
--- a/aggregated-frontend/src/main/frontend/package.json
+++ b/aggregated-frontend/src/main/frontend/package.json
@@ -36,7 +36,7 @@
     "react-phone-input-2": "2.15.1",
     "react-google-autocomplete": "2.7.5",
     "react-router-dom": "5.2.0",
-    "react-to-print": "3.0.6",
+    "react-to-print": "3.1.0",
     "material-react-table": "1.10.0",
     "uuid": "11.1.0",
     "@atlaskit/pragmatic-drag-and-drop": "1.5.2",

--- a/aggregated-frontend/src/main/frontend/yarn.lock
+++ b/aggregated-frontend/src/main/frontend/yarn.lock
@@ -5788,10 +5788,10 @@ react-smooth@^4.0.4:
     prop-types "^15.8.1"
     react-transition-group "^4.4.5"
 
-react-to-print@3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/react-to-print/-/react-to-print-3.0.6.tgz#5044f8c6603218d1869350054d805141f9e4286d"
-  integrity sha512-K/jFxkUifbfVnu1XyinM6AB6zAq0VMw0lH/6WJpkdlChoqqvEOE/BGOxYN2xOmu8f72isTTU5DNatK/j0Lfc+Q==
+react-to-print@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-to-print/-/react-to-print-3.1.0.tgz#70f2f3e43314ce9e71bb0a69fad47208e89c1320"
+  integrity sha512-hiJZVmJtaRm9EHoUTG2bordyeRxVSGy9oFVV7fSvzOWwctPp6jbz2R6NFkaokaTYBxC7wTM/fMV5eCXsNpEwsA==
 
 react-transition-group@^4.4.5:
   version "4.4.5"

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
@@ -139,11 +139,9 @@ function PrintPreview(props) {
 
   let globalLoginDisplay = useContext(GlobalLoginContext);
 
-  const ref = useRef(null);
+  const contentRef = useRef(null);
 
-  const handlePrint = useReactToPrint({
-    content: () => ref.current,
-  });
+  const handlePrint = useReactToPrint({ contentRef });
 
   useEffect(() => {
     open && fetchWithReLogin(globalLoginDisplay, resourcePath + '.md')
@@ -176,7 +174,7 @@ function PrintPreview(props) {
   return (<>
     { open && content &&
       <Card
-        ref={ref}
+        ref={contentRef}
         elevation={0}
         className={classes.printPreview + " " + classes.printTarget}
         >


### PR DESCRIPTION
Caused by `react-to-print` version upgrade from 2.14.4 to 3.0.6  https://github.com/data-team-uhn/cards/pull/1943.

Also upgrading `react-to-print` to the newest 3.1.0.