### PR TITLE
CARDS-2685 - User experience improvement: in a single-select multiplechoice answer with input, the input should be cleared when not selected

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -420,6 +420,7 @@ function MultipleChoice(props) {
             onBlur={separatorDetected ? ()=>{} : () => acceptEnteredOption()}
             slotProps={{
               htmlInput: Object.assign({
+                style: isRadio && ghostName && !ghostSelected ? {opacity: 0} : undefined,
                 onKeyDown: (event) => {
                   if (event.key == 'Enter') {
                     // We need to stop the event so that it doesn't trigger a form submission


### PR DESCRIPTION
How to test:
* the `Multiple Choice Test` questionnaire in `--test` mode - test all multiple choice variations to ensure there are no regressions
* the `Laboratory Results` and `Historical Lab Results` questionnaires in `corpath` (`main` branch)