### PR TITLE
CARDS-2694: Make 1 instead of 0 the default value for the maxAnswers property of cards:Section nodes

### DIFF
--- a/modules/data-model/forms/api/src/main/resources/SLING-INF/nodetypes/forms.cnd
+++ b/modules/data-model/forms/api/src/main/resources/SLING-INF/nodetypes/forms.cnd
@@ -327,7 +327,7 @@
   - minAnswers (long) = '0'
 
   // Same as for cards:Question.
-  - maxAnswers (long) = '0'
+  - maxAnswers (long) = '1'
 
   // Which type of data is being recorded?
   // The possible values are limited to:


### PR DESCRIPTION
Specs: [CARDS-2694](https://phenotips.atlassian.net/browse/CARDS-2694)

[CARDS-2694]: https://phenotips.atlassian.net/browse/CARDS-2694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ