### PR TITLE
CARDS-2695: Display the project version (when available) along with the CARDS version in the cards meta footer

### DIFF
--- a/modules/commons/src/main/resources/SLING-INF/content/apps/sling/servlet/errorhandler/default.esp
+++ b/modules/commons/src/main/resources/SLING-INF/content/apps/sling/servlet/errorhandler/default.esp
@@ -58,7 +58,7 @@ if ("application/json".equals(request.getHeader("Accept"))) {
   let version = currentSession.getNode("/libs/cards/conf/Version").getProperty("Version").getString();
   let appName = currentSession.getNode("/libs/cards/conf/AppName").getProperty("AppName").getString();
   let platformName = currentSession.getNode("/libs/cards/conf/PlatformName").getProperty("PlatformName").getString();
-  let appVersion = currentSession.getNode("/libs/cards/conf/AppVersion").getProperty("AppVersion").getString();
+  let appVersion = currentSession.propertyExists("/libs/cards/conf/AppVersion/AppVersion") ? currentSession.getProperty("/libs/cards/conf/AppVersion/AppVersion").getString() : "";
   let colors = currentSession.getNode("/libs/cards/conf/ThemeColor");
   let media = currentSession.getNode("/libs/cards/conf/Media");
   let assets = currentSession.getNode("/libs/cards/resources/assets");

--- a/modules/commons/src/main/resources/SLING-INF/content/apps/sling/servlet/errorhandler/default.esp
+++ b/modules/commons/src/main/resources/SLING-INF/content/apps/sling/servlet/errorhandler/default.esp
@@ -58,6 +58,7 @@ if ("application/json".equals(request.getHeader("Accept"))) {
   let version = currentSession.getNode("/libs/cards/conf/Version").getProperty("Version").getString();
   let appName = currentSession.getNode("/libs/cards/conf/AppName").getProperty("AppName").getString();
   let platformName = currentSession.getNode("/libs/cards/conf/PlatformName").getProperty("PlatformName").getString();
+  let appVersion = currentSession.getNode("/libs/cards/conf/AppVersion").getProperty("AppVersion").getString();
   let colors = currentSession.getNode("/libs/cards/conf/ThemeColor");
   let media = currentSession.getNode("/libs/cards/conf/Media");
   let assets = currentSession.getNode("/libs/cards/resources/assets");
@@ -71,6 +72,7 @@ if ("application/json".equals(request.getHeader("Accept"))) {
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="version" content="${Packages.org.apache.commons.text.StringEscapeUtils.escapeXml11(version)}">
     <meta name="platformName" content="${Packages.org.apache.commons.text.StringEscapeUtils.escapeXml11(platformName)}">
+    <meta name="appVersion" content="${Packages.org.apache.commons.text.StringEscapeUtils.escapeXml11(appVersion)}">
     <meta name="title" content="${Packages.org.apache.commons.text.StringEscapeUtils.escapeXml11(appName)}">
     <title>${Packages.org.apache.commons.text.StringEscapeUtils.escapeXml11(appName)}</title>
     <meta name="statusCode" content="${Packages.org.apache.commons.text.StringEscapeUtils.escapeXml11(statusCode)}">

--- a/modules/commons/src/main/resources/SLING-INF/content/libs/sling/servlet/errorhandler/404.html
+++ b/modules/commons/src/main/resources/SLING-INF/content/libs/sling/servlet/errorhandler/404.html
@@ -35,6 +35,11 @@
       <meta name="title" content="${config['AppName']}">
       <title>${config.AppName}</title>
     </sly>
+    <sly data-sly-use.config="/libs/cards/conf/AppVersion">
+      <sly data-sly-test="${config.AppVersion}">
+        <meta name="appVersion" content="${config['AppVersion']}">
+      </sly>
+    </sly>
     <sly data-sly-use.config="/libs/cards/conf/ThemeColor">
       <sly data-sly-repeat="${config.valueMap.entrySet.iterator}">
         <meta name="${item.key}" content="${item.value}">

--- a/modules/data-model/items/api/src/main/resources/SLING-INF/content/libs/cards/Item/header.html
+++ b/modules/data-model/items/api/src/main/resources/SLING-INF/content/libs/cards/Item/header.html
@@ -33,6 +33,11 @@
       <meta name="title" content="${config['AppName']}">
       <title>${config.AppName}</title>
     </sly>
+    <sly data-sly-use.config="/libs/cards/conf/AppVersion">
+      <sly data-sly-test="${config.AppVersion}">
+        <meta name="appVersion" content="${config['AppVersion']}">
+      </sly>
+    </sly>
     <sly data-sly-use.config="/libs/cards/conf/ThemeColor">
       <sly data-sly-repeat="${config.valueMap.entrySet.iterator}">
         <meta name="${item.key}" content="${item.value}">

--- a/modules/homepage/src/main/frontend/src/themePage/Sidebar/AppInfo.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Sidebar/AppInfo.jsx
@@ -24,13 +24,17 @@ function AppInfo (props) {
   const { textVariant, showTeamInfo } = props;
   let variant = textVariant || "subtitle2";
 
-  let platformName = document.querySelector('meta[name="platformName"]')?.content;
   let appName = document.querySelector('meta[name="title"]')?.content;
-  let version = document.querySelector('meta[name="version"]')?.content;
+  let appVersion = document.querySelector('meta[name="appVersion"]')?.content;
+  let platformName = document.querySelector('meta[name="platformName"]')?.content;
+  let platformVersion = document.querySelector('meta[name="version"]')?.content;
 
   return (
     <>
-      <Typography variant={variant} component="div">{appName ?  appName + " | " : ''} {platformName} {version ? "v" + version : ''}</Typography>
+      {appName &&
+        <Typography variant={variant} component="div">{appName} {appVersion ? "v" + appVersion : ''}</Typography>
+      }
+      <Typography variant={variant} component="div">{platformName} {platformVersion ? "v" + platformVersion : ''}</Typography>
       {showTeamInfo &&
         <Typography variant={variant} component="div">
           by
@@ -42,7 +46,7 @@ function AppInfo (props) {
         </Typography>
       }
     </>
-    );
+  );
 }
 
 export default AppInfo;

--- a/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/TokenExpired/html.html
+++ b/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/TokenExpired/html.html
@@ -35,6 +35,11 @@
       <meta name="title" content="${config['AppName']}">
       <title>${config.AppName}</title>
     </sly>
+    <sly data-sly-use.config="/libs/cards/conf/AppVersion">
+      <sly data-sly-test="${config.AppVersion}">
+        <meta name="appVersion" content="${config['AppVersion']}">
+      </sly>
+    </sly>
     <sly data-sly-use.config="/libs/cards/conf/ThemeColor">
       <sly data-sly-repeat="${config.valueMap.entrySet.iterator}">
         <meta name="${item.key}" content="${item.value}">

--- a/modules/utils/src/main/resources/SLING-INF/content/libs/cards/conf/AppVersion.json
+++ b/modules/utils/src/main/resources/SLING-INF/content/libs/cards/conf/AppVersion.json
@@ -1,0 +1,3 @@
+{
+  "jcr:primaryType": "nt:unstructured"
+}


### PR DESCRIPTION
Specs: [CARDS-2695](https://phenotips.atlassian.net/browse/CARDS-2695)

To test [sparc](https://github.com/data-team-uhn/sparc), [corpath](https://github.com/data-team-uhn/corpath), [cards-project-template](https://github.com/data-team-uhn/cards-project-template) projects
- build the `cards` branch
- build the project branch related to this PR for [spark](https://github.com/data-team-uhn/sparc/compare/main...SPARC-51), [corpath](https://github.com/data-team-uhn/corpath/tree/CORPATH-22), [cards-project-template](https://github.com/data-team-uhn/cards-project-template/tree/CPT-3)
- observe the project version along with the project version in the meta footer on it's own line separate from the cards version

[CARDS-2695]: https://phenotips.atlassian.net/browse/CARDS-2695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ