### PR TITLE
CARDS-2700: QuestionnaireAutocomplete showing sections in conditional value reference select after questionnaire add/remove entry

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
@@ -44,7 +44,7 @@ import DeleteButton from "../dataHomepage/DeleteButton";
 import ExportButton from "../dataHomepage/ExportButton";
 import QuestionnaireStyle, { FORM_ENTRY_CONTAINER_PROPS } from "./QuestionnaireStyle";
 import { blue, blueGrey, cyan, deepPurple, indigo, orange, purple } from '@mui/material/colors';
-import { ENTRY_TYPES } from "./FormEntry";
+import { ENTRY_TYPES, QUESTION_TYPES } from "./FormEntry";
 import Fields from "../questionnaireEditor/Fields";
 import LabeledField from "../questionnaireEditor/LabeledField";
 import CreationMenu from "../questionnaireEditor/CreationMenu";
@@ -390,7 +390,7 @@ let QuestionnaireContents = (props) => {
 
   useEffect(() => {
     // Load initial data
-    changeQuestionnaireContext(findQuestionnaireEntries(data, ["cards:Question"]));
+    changeQuestionnaireContext(findQuestionnaireEntries(data, QUESTION_TYPES));
     // Clear context when unmounting component
     return (() => changeQuestionnaireContext([]));
   }, []);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
@@ -538,7 +538,7 @@ let QuestionnaireEntry = (props) => {
   let changeQuestionnaireContext = useQuestionnaireWriterContext();
 
   let updateContext = (data) => {
-    let vars = findQuestionnaireEntries({data: data});
+    let vars = findQuestionnaireEntries({data: data}, QUESTION_TYPES);
     changeQuestionnaireContext((oldContext) => {
        let newContext = oldContext || [];
        vars.forEach(v => {


### PR DESCRIPTION
To reproduce:

load a form in editor, add a conditional and check the possible options in autocomplete
add or delete an entry to questionnaire and then go back to creating a conditional. Options should incorrectly include the section
I was only able to reproduce the issue after adding a new entry and causing changeQuestionnaireContext to trigger.

The questionnaire reader state (only used by conditional input atm) is not explicitly specifying entry types to look for options in the conditional autocomplete (should only include question entries).