### PR TITLE
[misc] Update gitignore for Your Experience backup exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ node_modules
 # Running instance
 /sling/
 /.cards-data/
+/logs/backupExport/
 /distribution/sling/
 /distribution/launcher/
 /.metadata/


### PR DESCRIPTION
Daily exports added in CARDS-2599 lead to extra backup files whenever a dev instance of Your Experience is run overnight with data.

![image](https://github.com/user-attachments/assets/5b4edbba-efe5-49a4-b83d-8541b0782791)

