### PR TITLE
[misc] Fix Tooltip positioning for LiveTable Edit action

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -74,8 +74,8 @@ function FormView(props) {
     },
   ]
   const actions = {
-    "delete": DeleteButton,
-    "edit": EditButton
+    "edit": EditButton,
+    "delete": DeleteButton   
   }
   const [ enabledActions, setEnabledActions ] = useState(actions);
   let isActionEnabled = (action) => (!!!actionSwitches || !!(actionSwitches[action]()));

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -19,7 +19,7 @@
 
 import React, { useState, useEffect, useContext } from "react";
 import { Paper, Table, TableHead, TableBody, TableRow, TableCell, TablePagination } from "@mui/material";
-import { Card, CardHeader, CardContent, CardActions, Typography, Button, LinearProgress } from "@mui/material";
+import { Card, CardHeader, CardContent, CardActions, Typography, Button, LinearProgress, Stack } from "@mui/material";
 import { withStyles } from 'tss-react/mui';
 import { Link } from 'react-router';
 import { DateTime } from "luxon";
@@ -267,7 +267,13 @@ function LiveTable(props) {
         extensionURL={extensionURL}
       />
     });
-    return <TableCell key={index} className={classes.tableActions}>{content}</TableCell>;
+    return (
+      <TableCell key={index}>
+        <Stack direction="row" sx={{justifyContent: "flex-end", my: .5}}>
+        { content }
+        </Stack>
+      </TableCell>
+    );
   }
 
   let getNestedValue = (entry, path) => {


### PR DESCRIPTION
Before:
![1](https://github.com/user-attachments/assets/6d08aa56-792d-4b4a-95c2-80c6ad8bc54a)

After:
![image](https://github.com/user-attachments/assets/13e4fa24-06ea-4f3a-a66f-42b3abed0c2e)

Note:
Tooltips for Edit and Delete buttons are on the different height due to the [margin-bottom styling](https://github.com/data-team-uhn/cards/blob/dev/modules/data-entry/src/main/frontend/src/dataHomepage/tableStyle.jsx#L68) applied for buttons and the difference in buttons rendering.

