### PR TITLE
[misc] JS console error when displaying a question with answer options in the questionnaire editor

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/AnswerOptions.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/AnswerOptions.jsx
@@ -463,7 +463,7 @@ let AnswerOptionList = (props) => {
   let answerOptions = Object.values(data ||{}).filter(value => value['jcr:primaryType'] == 'cards:AnswerOption')
                       .sort((option1, option2) => (option1.defaultOrder - option2.defaultOrder));
   return (
-    answerOptions.map(item => <div key={item['jcr:uuid']}>{(item.label || item.value) + (item.label ? (" (" + item.value + ")") : "")}</div>)
+    answerOptions.map(item => <div key={item['jcr:uuid'] || item.value}>{(item.label || item.value) + (item.label ? (" (" + item.value + ")") : "")}</div>)
   );
 }
 


### PR DESCRIPTION
Since answer options don't have a UUID, the keys are missing so React complains about non-unique keys in a list.