### PR TITLE
CARDS-2712: Visit forms are sometimes displayed on the patient chart

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -92,9 +92,14 @@ function Subject(props) {
   const tabs = ["Chart", "Timeline"]
   const location = useLocation();
   const navigate = useNavigate();
-  const currentSubjectId = getSubjectIdFromPath(location.pathname);
+  const [ currentSubjectId, setCurrentSubjectId ] = useState(getSubjectIdFromPath(location.pathname));
 
   useEffect(() => {
+    let newId = getSubjectIdFromPath(location.pathname);
+    if (newId !== currentSubjectId) {
+      setCurrentSubject(undefined);
+      setCurrentSubjectId(newId);
+    }
     if (location.hash.length > 0 && tabs.includes(location.hash.substring(1))) {
       setActiveTab(tabs.indexOf(location.hash.substring(1)));
     }


### PR DESCRIPTION
[CARDS-2712](https://phenotips.atlassian.net/browse/CARDS-2712). To reproduce:
- start in prems mode
- fill in Visit Information (ED+IP+IC) and Patient Information forms
- switch between the visit and the patient several times, make sure the PI displays in the patient chart and the VI+ED+IP+IC forms display in the visit chart

[CARDS-2712]: https://phenotips.atlassian.net/browse/CARDS-2712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ