### PR TITLE
CARDS-2717: Add belongsToSurvey script for updating old forms

### DIFF
--- a/modules/data-model/links/api/src/main/java/io/uhndata/cards/links/api/LinkUtils.java
+++ b/modules/data-model/links/api/src/main/java/io/uhndata/cards/links/api/LinkUtils.java
@@ -66,6 +66,15 @@ public interface LinkUtils
     Collection<Link> getLinksOfType(Node source, String type);
 
     /**
+     * Retrieve all the links from a resource of a desired link type.
+     *
+     * @param source the node to get links from
+     * @param type the node holding the link definition to filter by
+     * @return a collection of links, may be empty
+     */
+    Collection<Link> getLinksOfType(Node source, Node type);
+
+    /**
      * Retrieve all the links to a resource.
      *
      * @param source the node to get links pointing to

--- a/modules/data-model/links/impl/src/main/java/io/uhndata/cards/links/internal/LinkUtilsImpl.java
+++ b/modules/data-model/links/impl/src/main/java/io/uhndata/cards/links/internal/LinkUtilsImpl.java
@@ -114,19 +114,25 @@ public final class LinkUtilsImpl extends AbstractNodeUtils implements LinkUtils
     public Collection<Link> getLinksOfType(Node source, String type)
     {
         try {
-            Collection<Link> links = getLinks(source);
             Node linkDefinition = getLinkType(source.getSession(), type);
-            return links.stream().filter(link -> {
-                try {
-                    return link.getDefinition().getNode().getPath().equals(linkDefinition.getPath());
-                } catch (RepositoryException e) {
-                    return false;
-                }
-            }).collect(Collectors.toList());
+            return getLinksOfType(source, linkDefinition);
         } catch (RepositoryException e) {
             LOGGER.warn("Failed to retrieve links of type {} for node {}", type, source, e);
             return new ArrayList<Link>();
         }
+    }
+
+    @Override
+    public Collection<Link> getLinksOfType(Node source, Node linkDefinition)
+    {
+        Collection<Link> links = getLinks(source);
+        return links.stream().filter(link -> {
+            try {
+                return link.getDefinition().getNode().getPath().equals(linkDefinition.getPath());
+            } catch (RepositoryException e) {
+                return false;
+            }
+        }).collect(Collectors.toList());
     }
 
     private Node getLinkType(Session session, String type)

--- a/prems-resources/clinical-data/pom.xml
+++ b/prems-resources/clinical-data/pom.xml
@@ -64,6 +64,7 @@
               SLING-INF/content/libs/cards/conf/Media.json;path:=/libs/cards/conf/Media;overwriteProperties:=true,
               SLING-INF/content/libs/cards/conf/AppName.json;path:=/libs/cards/conf/AppName;overwrite:=true,
               SLING-INF/content/libs/cards/conf/ThemeColor.json;path:=/libs/cards/conf/ThemeColor;overwrite:=true,
+              SLING-INF/content/libs/cards/Questionnaire/;path:=/libs/cards/Questionnaire/;overwriteProperties:=true;uninstall:=true,
               SLING-INF/content/apps/cards/config/CopyAnswers;path:=/apps/cards/config/CopyAnswers;overwriteProperties:=true;uninstall:=true,
               SLING-INF/content/apps/cards/mailTemplates;path:=/apps/cards/mailTemplates;overwrite:=true,
               SLING-INF/content/apps/cards/clinics/CPES/mailTemplates;path:=/apps/cards/clinics/CPES/mailTemplates;overwrite:=true,

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/Questionnaire/addBelongsToSurveyLinks.html.esp
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/Questionnaire/addBelongsToSurveyLinks.html.esp
@@ -1,0 +1,241 @@
+<%--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+--%>
+<html>
+<head>
+<title>Update last modified date</title>
+</head>
+<body>
+<%
+
+// This script updates all forms of a specific questionnaire to link to the most recent
+// Survey Events form for the visit that includes this form
+//
+// This script applies to a specific questionnaire, so identifying the
+// questionnaire of the forms to be updated is done simply by accessing it in
+// the browser, e.g. /Questionnaires/OAIP.addBelongsToSurveyLinks.html
+
+response.setContentType('text/html');
+
+// Without confirm=1 in the URL, we don't do any actual changes.
+let dryRun = request.getParameter("confirm") != "1";
+
+let clinics = {};
+let surveyEventsQuestionnaire = null;
+let surveyEventsClinicQuestion = null;
+let belongsToSurveyLinkPath = "/apps/cards/LinkDefinitions/belongsToSurvey";
+let belongsToSurveyLinkType = null;
+
+
+/**
+ * Prepare a list of clinic mappings.
+ * This maps all the ClinicMapping paths to a list of questionnaire UUIDs that belong to that clinic
+ */
+let getClinicMapping = function() {
+  let query = "SELECT * FROM [cards:ClinicMapping] AS f";
+  let clinics = currentSession.getWorkspace().getQueryManager().createQuery(query, "JCR-SQL2").execute().getNodes();
+  while (clinics.hasNext()) {
+    getClinic(clinics.next());
+  }
+}
+
+/*
+ * For a given clinic, prepare a list of questionnaires that are a part of the clinic.
+ * This is stored into the clinics global variable
+ */
+let getClinic = function(clinic) {
+  dryRun && out.println("<li>" + clinic + ": [");
+  // Get the QuestionnaireSet for the clinic
+  let survey = currentSession.getNode("/Survey/" + clinic.getProperty("survey").getString());
+
+  let data = [];
+  let surveyRefs = survey.getNodes();
+  // Iterate through all the child nodes of the Survey QuestionnaireSet
+  for (var i = 0; i < surveyRefs.length; ++i) {
+    let surveyRef = surveyRefs[i];
+    if ("cards:QuestionnaireRef".equals(surveyRef.getPrimaryNodeType().getName())) {
+      // The result of getIdentifer does not like to be forced into a Javascript String type:
+      // .toString(), new String(), String.valueOf() all return an object, not a string.
+      // Use string concatenation to force it into a Javascript string.
+      let form = "" + surveyRef.getProperty("questionnaire").getNode().getIdentifier();
+      data.push(form);
+      dryRun && out.print(form);
+      if (i < surveyRefs.length - 1) {
+        dryRun && out.print(", ");
+      }
+    }
+  }
+  clinics[clinic.getPath()] = data;
+  dryRun && out.print("]");
+}
+
+/**
+ * Find all forms that need to be updated and add a belongsToSurvey link if required.
+ */
+let fixAllForms = function() {
+  let questionnaire = currentSession.getNode("/Questionnaires/Survey events");
+  // Store values as UUID strings for easy comparison with references
+  surveyEventsClinicQuestion = questionnaire.getNode("assigned_survey").getProperty("jcr:uuid").toString();
+  surveyEventsQuestionnaire = questionnaire.getProperty("jcr:uuid").toString();
+  belongsToSurveyLinkType = currentSession.getNode(belongsToSurveyLinkPath);
+
+  // Get all forms of the specified type
+  let query = "SELECT * FROM [cards:Form] AS f WHERE f.'questionnaire' = '" + currentNode.getIdentifier() + "'";
+  let forms = currentSession.getWorkspace().getQueryManager().createQuery(query, "JCR-SQL2").execute().getNodes();
+  while (forms.hasNext()) {
+    updateForm(forms.next());
+  }
+}
+
+/**
+ * Update a form with the balongsToSurvey link if required.
+ * The node must be a form (cards:Form).
+ *
+ * @param form a form node
+ */
+let updateForm = function(form) {
+  // Check if the current form has a belongs to survey link. Exit if so.
+  if (form.hasNode("cards:links")) {
+    let links = form.getNode("cards:links").getNodes();
+    for (var i = 0; i < links.length; ++i) {
+      if (belongsToSurveyLinkPath == links[i].getProperty("type").getNode().getPath().toString()) {
+        // Already has a belongs to survey link, exit
+        return;
+      }
+    }
+  }
+
+  // Get ready to find and store the most recent applicable survey events form
+  let subject = form.getProperty("subject").getNode();
+  let subjectReferences = subject.getReferences("subject");
+  let questionnaire = form.getProperty("questionnaire").toString();
+
+  let surveyEventsForm = null;
+  let surveyEventsDate = null;
+
+  // Search the subject's forms for an applicable survey events form
+  while (subjectReferences.hasNext()) {
+    let referencedForm = subjectReferences.next().getParent();
+    let referencedQuestionnaire = referencedForm.getProperty("questionnaire");
+
+    if (referencedQuestionnaire.toString() == surveyEventsQuestionnaire) {
+      // Found a survey Events form.
+      // Compare it's clinic answer to the clinics mapping to see if the
+      // triggering form is included in this survey events form.
+      let clinic = getClinicFromSurveyEventsForm(referencedForm);
+      if (clinic && clinics[clinic] && clinics[clinic].includes(questionnaire)) {
+        // Check to make sure this is a more recent survey events form than the current saved
+        // survey events form, if this is not the first
+        let currentDate = referencedForm.getProperty("jcr:created").getDate();
+        if (surveyEventsForm == null || currentDate.after(surveyEventsDate)) {
+          // This is the most recent applicable survey events form so far. Save it
+          surveyEventsForm = referencedForm;
+          surveyEventsDate = currentDate;
+        }
+      }
+    }
+  }
+
+  if (surveyEventsForm) {
+    out.println("<li>Linking form <a href='/content.html" + form + "'><tt>" + getFormName(form) + "</tt></a> (modified " + form.getProperty("jcr:lastModified").getString() + ") to survey <a href='/content.html" + surveyEventsForm + "'><tt>" + getFormName(surveyEventsForm) + "</tt></a></li>");
+    if (!dryRun) {
+      createLink(form, surveyEventsForm);
+    }
+  }
+}
+
+/**
+ * Add a belongsToSurvey link from a form to a survey events form
+ * @param source The form that shoulf have the belongsToSurvey link added
+ * @param destination The Survey Events form to link to
+ */
+let createLink = function(source, destination) {
+  let linksContainer;
+  // Get or create the form's links container
+  if (source.hasNode("cards:links")) {
+    linksContainer = source.getNode("cards:links");
+  } else {
+    linksContainer = source.addNode("cards:links", 	"cards:Links");
+    linksContainer.setProperty("form", source);
+  }
+  let link = linksContainer.addNode(uuid(), "cards:WeakLink");
+  link.setProperty("form", source);
+  link.setProperty("label", "Belongs to Survey");
+  link.setProperty("reference", destination);
+  link.setProperty("type", belongsToSurveyLinkType);
+}
+
+/**
+ * Find the clinic answer, if present, for a given survey events form
+ * @param form The survey events form to search for a clinic
+ * @returns the value of the clinic answer, or null if not present.
+ *          Should be a path to a clinic mapping.
+ */
+let getClinicFromSurveyEventsForm = function(form) {
+  let nodes = form.getNodes();
+  // Iterate through all the child nodes of the form
+  for (var i = 0; i < nodes.length; ++i) {
+    let child = nodes[i];
+    if (child.hasProperty("question") && child.getProperty("question").toString() == surveyEventsClinicQuestion) {
+      // Found the clinic question. Get the clinic
+      return child.hasProperty("value") ? child.getProperty("value").toString() : null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Generate a version 4 UUID
+ */
+let uuid = function() {
+  let d = '';
+  while (d.length < 32) d += Math.random().toString(16).substr(2);
+  const vr = ((parseInt(d.substr(16, 1), 16) & 0x3) | 0x8).toString(16);
+  return `${d.substr(0, 8)}-${d.substr(8, 4)}-4${d.substr(13, 3)}-${vr}${d.substr(17, 3)}-${d.substr(20, 12)}`;
+}
+
+/**
+ * Compute the name of a form, in the format "Subject label / Questionnaire title".
+ *
+ * @param form a Form node
+ * @return the form name as a string
+ */
+let getFormName = function(form) {
+  return result = form.getProperty("subject").getNode().getProperty("identifier") + " / " + form.getProperty("questionnaire").getNode().getProperty("title");
+}
+
+// All definitions done, perform the actual work
+
+dryRun && out.println("<h2>Dry run, here is what will be done:</h2>");
+dryRun && out.println("<h2>Clinic Mapping:</h2>");
+dryRun && out.println("<ul>");
+getClinicMapping()
+dryRun && out.println("</ul>");
+
+out.println("<h2>Data changes:</h2>");
+out.println("<ol>");
+fixAllForms()
+out.println("</ol>");
+if (request.getParameter("confirm") == "1") {
+    currentSession.save();
+    out.println("<p>Changes performed.<p>")
+} else {
+  out.println("<p><a href='" + request.getPathInfo() + "?confirm=1" + (request.getQueryString() ? "&" + request.getQueryString() : "") + "'>Confirm?</a></p>");
+}
+
+%>
+</body>
+</html>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/Questionnaire/addBelongsToSurveyLinks.html.esp
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/Questionnaire/addBelongsToSurveyLinks.html.esp
@@ -16,7 +16,7 @@
 --%>
 <html>
 <head>
-<title>Update last modified date</title>
+<title>Add missing belongsToSurvey links to legacy forms</title>
 </head>
 <body>
 <%
@@ -32,6 +32,10 @@ response.setContentType('text/html');
 
 // Without confirm=1 in the URL, we don't do any actual changes.
 let dryRun = request.getParameter("confirm") != "1";
+let pendingChanges = 0;
+
+let formUtils = sling.getService(Packages.io.uhndata.cards.forms.api.FormUtils);
+let linkUtils = sling.getService(Packages.io.uhndata.cards.links.api.LinkUtils);
 
 let clinics = {};
 let surveyEventsQuestionnaire = null;
@@ -88,7 +92,7 @@ let getClinic = function(clinic) {
 let fixAllForms = function() {
   let questionnaire = currentSession.getNode("/Questionnaires/Survey events");
   // Store values as UUID strings for easy comparison with references
-  surveyEventsClinicQuestion = questionnaire.getNode("assigned_survey").getProperty("jcr:uuid").toString();
+  surveyEventsClinicQuestion = questionnaire.getNode("assigned_survey");
   surveyEventsQuestionnaire = questionnaire.getProperty("jcr:uuid").toString();
   belongsToSurveyLinkType = currentSession.getNode(belongsToSurveyLinkPath);
 
@@ -108,18 +112,12 @@ let fixAllForms = function() {
  */
 let updateForm = function(form) {
   // Check if the current form has a belongs to survey link. Exit if so.
-  if (form.hasNode("cards:links")) {
-    let links = form.getNode("cards:links").getNodes();
-    for (var i = 0; i < links.length; ++i) {
-      if (belongsToSurveyLinkPath == links[i].getProperty("type").getNode().getPath().toString()) {
-        // Already has a belongs to survey link, exit
-        return;
-      }
-    }
+  if (!linkUtils.getLinksOfType(form, belongsToSurveyLinkType).isEmpty()) {
+    return;
   }
 
   // Get ready to find and store the most recent applicable survey events form
-  let subject = form.getProperty("subject").getNode();
+  let subject = formUtils.getSubject(form);
   let subjectReferences = subject.getReferences("subject");
   let questionnaire = form.getProperty("questionnaire").toString();
 
@@ -150,7 +148,10 @@ let updateForm = function(form) {
   }
 
   if (surveyEventsForm) {
-    out.println("<li>Linking form <a href='/content.html" + form + "'><tt>" + getFormName(form) + "</tt></a> (modified " + form.getProperty("jcr:lastModified").getString() + ") to survey <a href='/content.html" + surveyEventsForm + "'><tt>" + getFormName(surveyEventsForm) + "</tt></a></li>");
+    out.println("<li>Linking form <a href='/content.html" + form + "'><tt>" + getFormName(form)
+      + "</tt></a> (modified " + form.getProperty("jcr:lastModified").getString()
+      + ") to survey <a href='/content.html" + surveyEventsForm
+      + "'><tt>" + getFormName(surveyEventsForm) + "</tt></a></li>");
     if (!dryRun) {
       createLink(form, surveyEventsForm);
     }
@@ -159,23 +160,16 @@ let updateForm = function(form) {
 
 /**
  * Add a belongsToSurvey link from a form to a survey events form
- * @param source The form that shoulf have the belongsToSurvey link added
+ * @param source The form that should have the belongsToSurvey link added
  * @param destination The Survey Events form to link to
  */
 let createLink = function(source, destination) {
-  let linksContainer;
-  // Get or create the form's links container
-  if (source.hasNode("cards:links")) {
-    linksContainer = source.getNode("cards:links");
-  } else {
-    linksContainer = source.addNode("cards:links", 	"cards:Links");
-    linksContainer.setProperty("form", source);
+  pendingChanges++;
+  linkUtils.addLink(source, destination, belongsToSurveyLinkType, "Belongs to Survey");
+  if (pendingChanges >= 100) {
+    currentSession.save();
+    pendingChanges = 0;
   }
-  let link = linksContainer.addNode(uuid(), "cards:WeakLink");
-  link.setProperty("form", source);
-  link.setProperty("label", "Belongs to Survey");
-  link.setProperty("reference", destination);
-  link.setProperty("type", belongsToSurveyLinkType);
 }
 
 /**
@@ -185,16 +179,8 @@ let createLink = function(source, destination) {
  *          Should be a path to a clinic mapping.
  */
 let getClinicFromSurveyEventsForm = function(form) {
-  let nodes = form.getNodes();
-  // Iterate through all the child nodes of the form
-  for (var i = 0; i < nodes.length; ++i) {
-    let child = nodes[i];
-    if (child.hasProperty("question") && child.getProperty("question").toString() == surveyEventsClinicQuestion) {
-      // Found the clinic question. Get the clinic
-      return child.hasProperty("value") ? child.getProperty("value").toString() : null;
-    }
-  }
-  return null;
+  let answer = formUtils.getAnswer(form, surveyEventsClinicQuestion)
+  return answer == null ? null : formUtils.getValue(answer).toString();
 }
 
 /**
@@ -214,7 +200,7 @@ let uuid = function() {
  * @return the form name as a string
  */
 let getFormName = function(form) {
-  return result = form.getProperty("subject").getNode().getProperty("identifier") + " / " + form.getProperty("questionnaire").getNode().getProperty("title");
+  return result = formUtils.getSubject(form).getProperty("identifier") + " / " + formUtils.getQuestionnaire(form).getProperty("title");
 }
 
 // All definitions done, perform the actual work
@@ -229,7 +215,7 @@ out.println("<h2>Data changes:</h2>");
 out.println("<ol>");
 fixAllForms()
 out.println("</ol>");
-if (request.getParameter("confirm") == "1") {
+if (!dryRun) {
     currentSession.save();
     out.println("<p>Changes performed.<p>")
 } else {

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/Questionnaire/addBelongsToSurveyLinks.html.esp
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/libs/cards/Questionnaire/addBelongsToSurveyLinks.html.esp
@@ -32,7 +32,6 @@ response.setContentType('text/html');
 
 // Without confirm=1 in the URL, we don't do any actual changes.
 let dryRun = request.getParameter("confirm") != "1";
-let pendingChanges = 0;
 
 let formUtils = sling.getService(Packages.io.uhndata.cards.forms.api.FormUtils);
 let linkUtils = sling.getService(Packages.io.uhndata.cards.links.api.LinkUtils);
@@ -164,12 +163,7 @@ let updateForm = function(form) {
  * @param destination The Survey Events form to link to
  */
 let createLink = function(source, destination) {
-  pendingChanges++;
   linkUtils.addLink(source, destination, belongsToSurveyLinkType, "Belongs to Survey");
-  if (pendingChanges >= 100) {
-    currentSession.save();
-    pendingChanges = 0;
-  }
 }
 
 /**
@@ -216,7 +210,6 @@ out.println("<ol>");
 fixAllForms()
 out.println("</ol>");
 if (!dryRun) {
-    currentSession.save();
     out.println("<p>Changes performed.<p>")
 } else {
   out.println("<p><a href='" + request.getPathInfo() + "?confirm=1" + (request.getQueryString() ? "&" + request.getQueryString() : "") + "'>Confirm?</a></p>");


### PR DESCRIPTION
Adds a new script, addBelongsToSurveyLinks.html.esp, that searches through all existing forms for a given questionnaire and adds belongsToSurvey links from those forms to the relevant survey events form

Testing:
1. Launch in Prems mode
2. Create a bunch of visits, filling out the following questions in the visit information form to generate Survey event forms and patient forms:
  a. Clinic (Make sure to make some inpatient clinics for testing further down)
  b. Date
3. Edit the Clinic on some of those visits to generate additional survey event and patient data forms (eg. update some Inpatient clinics to Inpatient + Integrated Care)
4. Using composum, delete some of the links
5. Navigate to http://localhost:8080/Questionnaires/OAIP.addBelongsToSurveyLinks.html and verify that all the Inpatient forms with deleted links are listed
6. Click the Confirm link at the bottom of the change to apply the changes
7. Using Composum or the CARDS UI, verify that all the Inpatient forms are linked to the appropriate SUrvey Events form
8. Repeat step 7 for all the questionnaires that had deleted links (Replace OAIP in the link with OED, PMOO, YVM, CPESIC, Rehab and/or IC as applicable)