### PR TITLE
CARDS-2718: Installing the latest version of HANCESTRO fails

### DIFF
--- a/modules/vocabularies/src/main/java/io/uhndata/cards/vocabularies/internal/OntologyIndexerUtils.java
+++ b/modules/vocabularies/src/main/java/io/uhndata/cards/vocabularies/internal/OntologyIndexerUtils.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.jcr.ItemExistsException;
@@ -97,12 +98,13 @@ public final class OntologyIndexerUtils
                 String[] valuesArray = entry.getValue().toArray(ArrayUtils.EMPTY_STRING_ARRAY);
                 // Sometimes the source may contain more than one label or description, but we can't allow that.
                 // Always use one value for these special fields.
-                if (("label".equals(entry.getKey()) || "description".equals(entry.getKey())
-                    || "isRoot".equals(entry.getKey()))
-                        && valuesArray.length == 1) {
-                    vocabularyTermNode.setProperty(entry.getKey(), valuesArray[0]);
+                if (Set.of("label", "description", "isRoot").contains(entry.getKey())) {
+                    // the label can have more than one value in array, should be skipped in that case
+                    if (valuesArray.length == 1) {
+                        vocabularyTermNode.setProperty(entry.getKey(), valuesArray[0]);
+                    }
                 } else {
-                    vocabularyTermNode.setProperty(entry.getKey(), valuesArray);
+                    vocabularyTermNode.setProperty(entry.getKey().replace(":", "_"), valuesArray);
                 }
             }
         } catch (RepositoryException e) {


### PR DESCRIPTION
Specs: [CARDS-2718](https://phenotips.atlassian.net/issues/CARDS-2718)

There were 2 problems:
- unable to process props with keys containing ":"
- unable to set multivalue values to a single-valued props like `label`. 

[CARDS-2718]: https://phenotips.atlassian.net/browse/CARDS-2718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ