### PR TITLE
CARDS-2669: Recurrent sections: if the section label contains markdown, the label of the button to add a new instance will display uninterpreted markdown syntax

### DIFF
--- a/aggregated-frontend/src/main/frontend/package.json
+++ b/aggregated-frontend/src/main/frontend/package.json
@@ -49,6 +49,7 @@
     "tss-react": "4.9.16",
     "yup": "0.32.11",
     "raphael": "2.3.0",
+    "remove-markdown": "0.6.2",
     "google-palette": "1.1.1",
     "recharts": "2.15.2"
   },

--- a/aggregated-frontend/src/main/frontend/yarn.lock
+++ b/aggregated-frontend/src/main/frontend/yarn.lock
@@ -5309,6 +5309,11 @@ remove-accents@0.4.2:
   resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
   integrity sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==
 
+remove-markdown@0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/remove-markdown/-/remove-markdown-0.6.2.tgz#8e6a8d1b148569cc4df0404b60b0a42fb49840b5"
+  integrity sha512-EijDXJZbzpGbQBd852ViUzcqgpMujthM+SAEHiWCMcZonRbZ+xViWKLJA/vrwbDwYdxrs1aFDjpBhcGrZoJRGA==
+
 renderkid@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-3.0.0.tgz#5fd823e4d6951d37358ecc9a58b1f06836b6268a"

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -314,11 +314,12 @@ function Section(props) {
             size="small"
             variant="contained"
             color="success"
+            startIcon={<Add />}
             onClick={() => {
               setInstanceLabels((oldLabels) => [...oldLabels, uuidv4()]);
             }}
             >
-            <Add fontSize="small" sx={{ m: "0 2px 2px -4px" }}/> {removeMd(sectionDefinition["label"])}
+            {removeMd(sectionDefinition["label"])}
           </Button>
         </Grid>}
         {/* Remove any cards:AnswerSections that we have created by using an @Delete suffix */

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -38,6 +38,7 @@ import ConditionalSingle from "./ConditionalSingle";
 import FormattedText from "../components/FormattedText.jsx";
 import { v4 as uuidv4 } from 'uuid';
 import { checkPropTypes } from "../propTypes";
+import removeMd from 'remove-markdown';
 
 const ID_STATE_KEY = ":AccessCount";
 
@@ -317,7 +318,7 @@ function Section(props) {
               setInstanceLabels((oldLabels) => [...oldLabels, uuidv4()]);
             }}
             >
-            <Add fontSize="small" /> {sectionDefinition["label"]}
+            <Add fontSize="small" sx={{ m: "0 2px 2px -4px" }}/> {removeMd(sectionDefinition["label"])}
           </Button>
         </Grid>}
         {/* Remove any cards:AnswerSections that we have created by using an @Delete suffix */


### PR DESCRIPTION
Specs:[ CARDS-2669](https://phenotips.atlassian.net/browse/CARDS-2669)
Button text escaped