### PR TITLE
CARDS-2688: Hide locked incomplete forms from locking incomplete warning

### DIFF
--- a/modules/locking/src/main/frontend/src/locking/SubjectLockAction.jsx
+++ b/modules/locking/src/main/frontend/src/locking/SubjectLockAction.jsx
@@ -231,7 +231,7 @@ function SubjectLockAction(props) {
 
   let getChildSubjects = (subject, subjects) => {
     Object.values(subject).forEach((child) => {
-      if (child["jcr:primaryType"] == "cards:Subject" && child["@path"].startsWith(subject["@path"])) {
+      if (child["jcr:primaryType"] == "cards:Subject" && child["@path"].startsWith(subject["@path"]) && !child["cards:lock"]) {
         subjects.push(child["jcr:uuid"]);
         getChildSubjects(child, subjects);
       }


### PR DESCRIPTION
specs: [CARDS-2688](https://phenotips.atlassian.net/browse/CARDS-2688)

[CARDS-2688]: https://phenotips.atlassian.net/browse/CARDS-2688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ