### PR TITLE
[misc] Fixed lock button size to be consistent with others

### DIFF
--- a/modules/locking/src/main/frontend/src/locking/SubjectLockAction.jsx
+++ b/modules/locking/src/main/frontend/src/locking/SubjectLockAction.jsx
@@ -50,7 +50,7 @@ function SubjectLockAction(props) {
   const {
     subject,
     reloadSubject,
-    size,
+    size="large",
     variant = "icon",
     className
   } = props;
@@ -346,8 +346,8 @@ function SubjectLockAction(props) {
           <Tooltip title={buttonText}>
             <IconButton component="span" onClick={openDialog} className={className} size={size}>
               { isLocked
-                ? <LockOpenIcon fontSize={size}/>
-                : <LockIcon fontSize={size}/>
+                ? <LockOpenIcon fontSize={size == "small" ? size : undefined}/>
+                : <LockIcon fontSize={size == "small" ? size : undefined}/>
               }
             </IconButton>
           </Tooltip>


### PR DESCRIPTION
Before:
<img width="337" height="229" alt="image" src="https://github.com/user-attachments/assets/0a9d5e96-3dd8-4c2b-a859-cc054eb885c5" />

After:
<img width="317" height="224" alt="image" src="https://github.com/user-attachments/assets/c185459d-00e6-4b02-a104-8d85baba8ae7" />

