### PR TITLE
CARDS-2725: Add option to remove @ from CSV export headers

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/ExportButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/ExportButton.jsx
@@ -190,14 +190,15 @@ function ExportButton(props) {
       path += ".csvHeader:raw";
     }
     if (csvReplaceColumnLabels) {
-      csvReplaceColumnLabels.split(",").forEach(replacement => {
+      // Split at commas or newlines, trimming whitespace before or after these delimiters
+      csvReplaceColumnLabels.split(/\s*[,\n]\s*/).forEach(replacement => {
         path += ".csvReplaceColumnLabels:" + encodeURIComponent(encodeURIComponent(replacement));
-      })
+      });
     }
     if (csvReplaceColumnIds) {
-      csvReplaceColumnIds.split(",").forEach(replacement => {
+      csvReplaceColumnIds.split(/\s*[,\n]\s*/).forEach(replacement => {
         path += ".csvReplaceColumnIds:" + encodeURIComponent(encodeURIComponent(replacement));
-      })
+      });
     }
     if (selectedEntityIds.length > 0) {
       path +=  ".questionnaireFilter";
@@ -351,7 +352,7 @@ function ExportButton(props) {
             <Grid size={8}>
               <TextField
                 variant="standard"
-                helperText="Regex based replace all. Format: <regex to find>=<value to replace with>,<regex2>=<value2>,..."
+                helperText="List of pairs `<regex to find>=<value to replace with>` separated by commas or newlines. Example: <regex_1>=<value_1>,<regex_2>=<value_2>,..."
                 placeholder="@=#"
                 value={csvReplaceColumnLabels}
                 onChange={(event) => setCsvReplaceColumnLabels(event.target.value)}
@@ -365,7 +366,7 @@ function ExportButton(props) {
             <Grid size={8}>
               <TextField
                 variant="standard"
-                helperText="Regex based replace all. Format: <regex to find>=<value to replace with>,<regex2>=<value2>,..."
+                helperText="List of pairs `<regex to find>=<value to replace with>` separated by commas or newlines."
                 placeholder="@=#"
                 value={csvReplaceColumnIds}
                 onChange={(event) => setCsvReplaceColumnIds(event.target.value)}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/ExportButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/ExportButton.jsx
@@ -90,6 +90,7 @@ function ExportButton(props) {
     fileFormat : ".csv",
     hasHeaderLabels: true,
     hasHeaderIdentifiers: false,
+    csvReplacement: "",
     hasAnswerLabels: false,
     columnSelectionMode: "exclude",
     statusSelectionMode: "status",
@@ -109,6 +110,7 @@ function ExportButton(props) {
   // to enable identifiers, add .csvHeader:raw
   const [ hasHeaderLabels, setHeaderLabels ] = useState(DEFAULTS.hasHeaderLabels);
   const [ hasHeaderIdentifiers, setHeaderIdentifiers ] = useState(DEFAULTS.hasHeaderIdentifiers);
+  const [ csvReplacement, setCsvReplacement ] = useState(DEFAULTS.csvReplacement);
   // Specifies if the .labels processor is enabled (disabled by default for values)
   const [ hasAnswerLabels, setAnswerLabels ] = useState(DEFAULTS.hasAnswerLabels);
 
@@ -185,6 +187,11 @@ function ExportButton(props) {
     }
     if (hasHeaderIdentifiers) {
       path += ".csvHeader:raw";
+    }
+    if (csvReplacement) {
+      csvReplacement.split(",").forEach(replacement => {
+        path += ".csvColumnReplace:" + encodeURIComponent(encodeURIComponent(replacement));
+      })
     }
     if (selectedEntityIds.length > 0) {
       path +=  ".questionnaireFilter";
@@ -330,6 +337,18 @@ function ExportButton(props) {
                   />
                 }
                 label="Identifiers"
+              />
+            </Grid>
+          </Grid>
+          <Grid container alignItems='center' className={classes.container}>
+            <Grid size={4}><Typography variant="subtitle2">Header replacement:</Typography></Grid>
+            <Grid size={8}>
+              <TextField
+                variant="standard"
+                label="Regex based replace"
+                placeholder="/@=#,/_=-"
+                value={csvReplacement}
+                onChange={(event) => setCsvReplacement(event.target.value)}
               />
             </Grid>
           </Grid>

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/ExportButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/ExportButton.jsx
@@ -110,7 +110,8 @@ function ExportButton(props) {
   // to enable identifiers, add .csvHeader:raw
   const [ hasHeaderLabels, setHeaderLabels ] = useState(DEFAULTS.hasHeaderLabels);
   const [ hasHeaderIdentifiers, setHeaderIdentifiers ] = useState(DEFAULTS.hasHeaderIdentifiers);
-  const [ csvReplacement, setCsvReplacement ] = useState(DEFAULTS.csvReplacement);
+  const [ csvReplaceColumnLabels, setCsvReplaceColumnLabels ] = useState(DEFAULTS.csvReplacement);
+  const [ csvReplaceColumnIds, setCsvReplaceColumnIds ] = useState(DEFAULTS.csvReplacement);
   // Specifies if the .labels processor is enabled (disabled by default for values)
   const [ hasAnswerLabels, setAnswerLabels ] = useState(DEFAULTS.hasAnswerLabels);
 
@@ -188,9 +189,14 @@ function ExportButton(props) {
     if (hasHeaderIdentifiers) {
       path += ".csvHeader:raw";
     }
-    if (csvReplacement) {
-      csvReplacement.split(",").forEach(replacement => {
-        path += ".csvColumnReplace:" + encodeURIComponent(encodeURIComponent(replacement));
+    if (csvReplaceColumnLabels) {
+      csvReplaceColumnLabels.split(",").forEach(replacement => {
+        path += ".csvReplaceColumnLabels:" + encodeURIComponent(encodeURIComponent(replacement));
+      })
+    }
+    if (csvReplaceColumnIds) {
+      csvReplaceColumnIds.split(",").forEach(replacement => {
+        path += ".csvReplaceColumnIds:" + encodeURIComponent(encodeURIComponent(replacement));
       })
     }
     if (selectedEntityIds.length > 0) {
@@ -341,18 +347,33 @@ function ExportButton(props) {
             </Grid>
           </Grid>
           <Grid container alignItems='center' className={classes.container}>
-            <Grid size={4}><Typography variant="subtitle2">Header replacement:</Typography></Grid>
+            <Grid size={4}><Typography variant="subtitle2">Header label replacement:</Typography></Grid>
             <Grid size={8}>
               <TextField
                 variant="standard"
-                label="Regex based replace"
-                placeholder="/@=#,/_=-"
-                value={csvReplacement}
-                onChange={(event) => setCsvReplacement(event.target.value)}
+                helperText="Regex based replace all. Format: <regex to find>=<value to replace with>,<regex2>=<value2>,..."
+                placeholder="@=#"
+                value={csvReplaceColumnLabels}
+                onChange={(event) => setCsvReplaceColumnLabels(event.target.value)}
+                fullwidth
+                multiline
               />
             </Grid>
           </Grid>
-
+          <Grid container alignItems='center' className={classes.container}>
+            <Grid size={4}><Typography variant="subtitle2">Header Id replacement:</Typography></Grid>
+            <Grid size={8}>
+              <TextField
+                variant="standard"
+                helperText="Regex based replace all. Format: <regex to find>=<value to replace with>,<regex2>=<value2>,..."
+                placeholder="@=#"
+                value={csvReplaceColumnIds}
+                onChange={(event) => setCsvReplaceColumnIds(event.target.value)}
+                fullwidth
+                multiline
+              />
+            </Grid>
+          </Grid>
           <Grid container alignItems='center' className={classes.container}>
             <Grid size={4}><Typography variant="subtitle2">Data format:</Typography></Grid>
             <Grid size={8}>

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/DataProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/DataProcessor.java
@@ -19,7 +19,6 @@
 package io.uhndata.cards.forms.internal.serialize;
 
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -46,6 +45,7 @@ import io.uhndata.cards.forms.api.QuestionnaireUtils;
 import io.uhndata.cards.serialize.DataFilters;
 import io.uhndata.cards.serialize.DataFiltersParser;
 import io.uhndata.cards.serialize.spi.ResourceJsonProcessor;
+import io.uhndata.cards.utils.SelectorUtils;
 
 /**
  * Serialize a subject or questionnaire along with its forms. The name of this processor is {@code data}.
@@ -104,12 +104,7 @@ public class DataProcessor implements ResourceJsonProcessor
 
         this.filters.set(this.filtersParser.parseFilters(this.selectors.get()));
 
-        final Map<String, String> optionsMap = new HashMap<>();
-        Arrays.asList(this.selectors.get().split("(?<!\\\\)(?:\\\\\\\\)*\\.")).stream()
-            .filter(s -> StringUtils.startsWith(s, "dataOption:"))
-            .map(s -> StringUtils.substringAfter(s, "dataOption:"))
-            .forEach(s -> optionsMap.put(StringUtils.substringBefore(s, "="),
-                StringUtils.substringAfter(s, "=").replaceAll("\\\\\\.", ".")));
+        final Map<String, String> optionsMap = SelectorUtils.parseOptionsToMap("dataOption:", this.selectors.get());
         this.options.set(optionsMap);
 
         setDisplayLevel(optionsMap.get("descendantData"));

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/QuestionnaireToCsvProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/QuestionnaireToCsvProcessor.java
@@ -19,6 +19,8 @@
 package io.uhndata.cards.forms.internal.serialize;
 
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -27,6 +29,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import javax.jcr.query.Query;
 import javax.json.JsonArray;
@@ -133,12 +138,14 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
             // Collect all the headers from the configuration, questions and any other hardcoded columns
             processHeaders(questionnaire, resolver, csvData, columns, rawColumns, extraColumns, resolutionPathInfo);
 
+            List<StringPair> replacements = extractArgumentPairs("csvColumnReplace", resolutionPathInfo);
+
             // Print header
             if (!resolutionPathInfo.contains("-csvHeader:labels")) {
-                csvPrinter.printRecord(columns);
+                printRecordWithReplacements(columns, replacements, csvPrinter);
             }
             if (resolutionPathInfo.contains("csvHeader:raw")) {
-                csvPrinter.printRecord(rawColumns);
+                printRecordWithReplacements(rawColumns, replacements, csvPrinter);
             }
 
             // Aggregate form answers to the csvData collector for the CSV output
@@ -153,6 +160,51 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
             LOGGER.error("Error in CSV export of {} questionnaire", questionnaire.getString("@name"));
         }
         return null;
+    }
+
+    private List<StringPair> extractArgumentPairs(final String name, final String resolutionPathInfo)
+    {
+        String decodedPath = URLDecoder.decode(resolutionPathInfo, StandardCharsets.UTF_8);
+        List<StringPair> result = new ArrayList<>();
+        int startIndex = decodedPath.indexOf(name);
+        while (startIndex > 0) {
+            // Search for headers with the format:
+            // .csvIncludeFields:<value>=<label>
+            int endIndex = decodedPath.indexOf(".", startIndex + 1);
+            if (endIndex < 0) {
+                endIndex = decodedPath.length();
+            }
+
+            String[] pieces = decodedPath.substring(startIndex + INCLUDE_FIELDS.length(), endIndex)
+                .split("=", 2);
+            String left = pieces[0];
+            String right = pieces.length == 2 ? pieces[1] : pieces[0];
+
+            result.add(new StringPair(left, right));
+            startIndex = decodedPath.indexOf(INCLUDE_FIELDS, endIndex);
+        }
+
+        return result;
+    }
+
+    private void printRecordWithReplacements(List<String> records, List<StringPair> replacements,
+        CSVPrinter csvPrinter)
+        throws IOException
+    {
+        if (replacements.size() > 0) {
+            List<Pattern> patterns = replacements.stream().map(replacement -> Pattern.compile(replacement.getLeft()))
+                .collect(Collectors.toList());
+            csvPrinter.printRecord(records.stream().map(record -> {
+                String result = record;
+                for (int i = 0; i < patterns.size(); i++) {
+                    Matcher matcher = patterns.get(i).matcher(record);
+                    result = matcher.replaceAll(replacements.get(i).getRight());
+                }
+                return result;
+            }).collect(Collectors.toList()));
+        } else {
+            csvPrinter.printRecord(records);
+        }
     }
 
     private void processHeaders(final JsonObject questionnaire, final ResourceResolver resolver,
@@ -193,27 +245,9 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
         final List<String> rawColumns, final Map<String, String> extraColumns, final String resolutionPathInfo)
     {
         // Collect any other columns specified by the export configuration
-        int startIndex = resolutionPathInfo.indexOf(INCLUDE_FIELDS);
-        while (startIndex > 0) {
-            // Search for headers with the format:
-            // .csvIncludeFields:<value>=<label>
-            int endIndex = resolutionPathInfo.indexOf(".", startIndex + 1);
-            if (endIndex < 0) {
-                endIndex = resolutionPathInfo.length();
-            }
-
-            String[] pieces = resolutionPathInfo.substring(startIndex + INCLUDE_FIELDS.length(), endIndex)
-                .split("=", 2);
-            String value = pieces[0];
-            String label = pieces.length == 2 ? pieces[1] : pieces[0];
-
-            // If label is in quotes, remove them
-            if (label.startsWith("\"") && label.endsWith("\"")) {
-                label = label.substring(1, label.length() - 1);
-            }
-
-            recordColumn(label, value, csvData, columns, rawColumns, extraColumns);
-            startIndex = resolutionPathInfo.indexOf(INCLUDE_FIELDS, endIndex);
+        List<StringPair> headers = extractArgumentPairs(INCLUDE_FIELDS, resolutionPathInfo);
+        for (StringPair header : headers) {
+            recordColumn(header.getRight(), header.getLeft(), csvData, columns, rawColumns, extraColumns);
         }
     }
 
@@ -466,6 +500,28 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
             return StringUtils.substringAfterLast(((JsonString) value).getString(), "/");
         } else {
             return value.toString();
+        }
+    }
+
+    private class StringPair
+    {
+        private String left;
+        private String right;
+
+        StringPair(String left, String right)
+        {
+            this.left = left;
+            this.right = right;
+        }
+
+        String getLeft()
+        {
+            return this.left;
+        }
+
+        String getRight()
+        {
+            return this.right;
         }
     }
 }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/QuestionnaireToCsvProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/QuestionnaireToCsvProcessor.java
@@ -19,8 +19,6 @@
 package io.uhndata.cards.forms.internal.serialize;
 
 import java.io.IOException;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -43,6 +41,7 @@ import javax.json.JsonValue.ValueType;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
@@ -52,6 +51,7 @@ import org.slf4j.LoggerFactory;
 
 import io.uhndata.cards.serialize.spi.ResourceCSVProcessor;
 import io.uhndata.cards.serialize.spi.SelectorDetails;
+import io.uhndata.cards.utils.SelectorUtils;
 
 /**
  * CSV serializer that can process Questionnaires.
@@ -66,13 +66,14 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
     private static final String IDENTIFIER_HEADER = "Identifier";
 
     private static final String CREATED_HEADER = "Created";
+
     private static final String LAST_MODIFIED_HEADER = "Last modified";
 
     private static final String PRIMARY_TYPE_PROP = "jcr:primaryType";
 
     private static final String UUID_PROP = "jcr:uuid";
 
-    private static final String INCLUDE_FIELDS = ".csvIncludeFields:";
+    private static final String INCLUDE_FIELDS = "csvIncludeFields:";
 
     @Override
     public boolean canProcess(final Resource resource)
@@ -138,14 +139,15 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
             // Collect all the headers from the configuration, questions and any other hardcoded columns
             processHeaders(questionnaire, resolver, csvData, columns, rawColumns, extraColumns, resolutionPathInfo);
 
-
             // Print header
             if (!resolutionPathInfo.contains("-csvHeader:labels")) {
-                List<StringPair> replacements = extractArgumentPairs(".csvReplaceColumnLabels:", resolutionPathInfo);
+                List<Pair<Pattern, String>> replacements =
+                    extractArgumentPairs("csvReplaceColumnLabels:", resolutionPathInfo);
                 printRecordWithReplacements(columns, replacements, csvPrinter);
             }
             if (resolutionPathInfo.contains("csvHeader:raw")) {
-                List<StringPair> replacements = extractArgumentPairs(".csvReplaceColumnIds:", resolutionPathInfo);
+                List<Pair<Pattern, String>> replacements =
+                    extractArgumentPairs("csvReplaceColumnIds:", resolutionPathInfo);
                 printRecordWithReplacements(rawColumns, replacements, csvPrinter);
             }
 
@@ -163,43 +165,22 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
         return null;
     }
 
-    private List<StringPair> extractArgumentPairs(final String name, final String resolutionPathInfo)
+    private List<Pair<Pattern, String>> extractArgumentPairs(final String name, final String resolutionPathInfo)
     {
-        String decodedPath = URLDecoder.decode(resolutionPathInfo, StandardCharsets.UTF_8);
-        List<StringPair> result = new ArrayList<>();
-        int startIndex = decodedPath.indexOf(name);
-        while (startIndex > 0) {
-            // Search for headers with the format:
-            // .csvIncludeFields:<value>=<label>
-            int endIndex = decodedPath.indexOf(".", startIndex + 1);
-            if (endIndex < 0) {
-                endIndex = decodedPath.length();
-            }
-
-            String[] pieces = decodedPath.substring(startIndex + name.length(), endIndex)
-                .split("=", 2);
-            String left = pieces[0];
-            String right = pieces.length == 2 ? pieces[1] : pieces[0];
-
-            result.add(new StringPair(left, right));
-            startIndex = decodedPath.indexOf(name, endIndex);
-        }
-
-        return result;
+        return SelectorUtils.parseOptions(name, resolutionPathInfo).stream()
+            .map(pair -> Pair.of(Pattern.compile(pair.getKey()), pair.getValue())).collect(Collectors.toList());
     }
 
-    private void printRecordWithReplacements(List<String> records, List<StringPair> replacements,
+    private void printRecordWithReplacements(List<String> records, List<Pair<Pattern, String>> replacements,
         CSVPrinter csvPrinter)
         throws IOException
     {
         if (replacements.size() > 0) {
-            List<Pattern> patterns = replacements.stream().map(replacement -> Pattern.compile(replacement.getLeft()))
-                .collect(Collectors.toList());
             csvPrinter.printRecord(records.stream().map(record -> {
                 String result = record;
-                for (int i = 0; i < patterns.size(); i++) {
-                    Matcher matcher = patterns.get(i).matcher(result);
-                    result = matcher.replaceAll(replacements.get(i).getRight());
+                for (Pair<Pattern, String> replacement : replacements) {
+                    Matcher matcher = replacement.getKey().matcher(result);
+                    result = matcher.replaceAll(replacement.getValue());
                 }
                 return result;
             }).collect(Collectors.toList()));
@@ -246,8 +227,8 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
         final List<String> rawColumns, final Map<String, String> extraColumns, final String resolutionPathInfo)
     {
         // Collect any other columns specified by the export configuration
-        List<StringPair> headers = extractArgumentPairs(INCLUDE_FIELDS, resolutionPathInfo);
-        for (StringPair header : headers) {
+        List<Pair<String, String>> headers = SelectorUtils.parseOptions(INCLUDE_FIELDS, resolutionPathInfo);
+        for (Pair<String, String> header : headers) {
             recordColumn(header.getRight(), header.getLeft(), csvData, columns, rawColumns, extraColumns);
         }
     }
@@ -501,28 +482,6 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
             return StringUtils.substringAfterLast(((JsonString) value).getString(), "/");
         } else {
             return value.toString();
-        }
-    }
-
-    private class StringPair
-    {
-        private String left;
-        private String right;
-
-        StringPair(String left, String right)
-        {
-            this.left = left;
-            this.right = right;
-        }
-
-        String getLeft()
-        {
-            return this.left;
-        }
-
-        String getRight()
-        {
-            return this.right;
         }
     }
 }

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/QuestionnaireToCsvProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/QuestionnaireToCsvProcessor.java
@@ -182,7 +182,7 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
             String right = pieces.length == 2 ? pieces[1] : pieces[0];
 
             result.add(new StringPair(left, right));
-            startIndex = decodedPath.indexOf(INCLUDE_FIELDS, endIndex);
+            startIndex = decodedPath.indexOf(name, endIndex);
         }
 
         return result;
@@ -198,7 +198,7 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
             csvPrinter.printRecord(records.stream().map(record -> {
                 String result = record;
                 for (int i = 0; i < patterns.size(); i++) {
-                    Matcher matcher = patterns.get(i).matcher(record);
+                    Matcher matcher = patterns.get(i).matcher(result);
                     result = matcher.replaceAll(replacements.get(i).getRight());
                 }
                 return result;

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/QuestionnaireToCsvProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/QuestionnaireToCsvProcessor.java
@@ -138,13 +138,14 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
             // Collect all the headers from the configuration, questions and any other hardcoded columns
             processHeaders(questionnaire, resolver, csvData, columns, rawColumns, extraColumns, resolutionPathInfo);
 
-            List<StringPair> replacements = extractArgumentPairs("csvColumnReplace", resolutionPathInfo);
 
             // Print header
             if (!resolutionPathInfo.contains("-csvHeader:labels")) {
+                List<StringPair> replacements = extractArgumentPairs(".csvReplaceColumnLabels:", resolutionPathInfo);
                 printRecordWithReplacements(columns, replacements, csvPrinter);
             }
             if (resolutionPathInfo.contains("csvHeader:raw")) {
+                List<StringPair> replacements = extractArgumentPairs(".csvReplaceColumnIds:", resolutionPathInfo);
                 printRecordWithReplacements(rawColumns, replacements, csvPrinter);
             }
 
@@ -175,7 +176,7 @@ public class QuestionnaireToCsvProcessor implements ResourceCSVProcessor
                 endIndex = decodedPath.length();
             }
 
-            String[] pieces = decodedPath.substring(startIndex + INCLUDE_FIELDS.length(), endIndex)
+            String[] pieces = decodedPath.substring(startIndex + name.length(), endIndex)
                 .split("=", 2);
             String left = pieces[0];
             String right = pieces.length == 2 ? pieces[1] : pieces[0];

--- a/modules/utils/pom.xml
+++ b/modules/utils/pom.xml
@@ -30,6 +30,10 @@
   <packaging>bundle</packaging>
   <name>CARDS - Utilities</name>
 
+  <properties>
+    <coverage.instructionRatio>0.04</coverage.instructionRatio>
+  </properties>
+
   <build>
     <resources>
       <resource>
@@ -101,6 +105,11 @@
       <groupId>io.uhndata.cards</groupId>
       <artifactId>cards-data-model-forms-api</artifactId>
       <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/modules/utils/src/main/java/io/uhndata/cards/serialize/internal/DefaultDataFiltersParser.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/serialize/internal/DefaultDataFiltersParser.java
@@ -19,11 +19,8 @@
 package io.uhndata.cards.serialize.internal;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -31,6 +28,7 @@ import org.osgi.service.component.annotations.Reference;
 import io.uhndata.cards.serialize.DataFiltersParser;
 import io.uhndata.cards.serialize.spi.DataFilter;
 import io.uhndata.cards.serialize.spi.DataFilterFactory;
+import io.uhndata.cards.utils.SelectorUtils;
 
 /**
  * Default implementation for {@link DataFiltersParser}.
@@ -47,30 +45,8 @@ public class DefaultDataFiltersParser implements DataFiltersParser
     @Override
     public DefaultDataFilters parseFilters(String selectorString)
     {
-        // First parse the selectors string into individual selectors.
-        // Split by unescaped dots. A backslash escapes a dot, but two backslashes are just one escaped backslash.
-        // Match by:
-        // - no preceding backslash, i.e. start counting at the first backslash (?<!\)
-        // - an even number of backslashes, i.e. any number of groups of two backslashes (?:\\)*
-        // - a literal dot \.
-        // Each backslash, except the \., is escaped twice, once as a special escape char inside a Java string, and
-        // once as a special escape char inside a RegExp. The one before the dot is escaped only once as a special
-        // char inside a Java string, since it must retain its escaping meaning in the RegExp.
-        final List<String> selectors = Arrays.asList(selectorString.split("(?<!\\\\)(?:\\\\\\\\)*\\."));
-
-        // Then, parse the dataFilter selectors into key=value pairs
-        final List<Pair<String, String>> filterStrings = selectors.stream()
-            .filter(s -> StringUtils.startsWith(s, "dataFilter:"))
-            .map(s -> StringUtils.substringAfter(s, "dataFilter:"))
-            .map(s -> Pair.of(StringUtils.substringBefore(s, "="),
-                // Also unescape inner dots, if present
-                // Escaped dot: \.
-                // As part of a regular expression, both characters need to be escaped: \\\.
-                // And as a Java string literal, each backslash must be escaped: \\\\\\.
-                StringUtils.substringAfter(s, "=").replaceAll("\\\\\\.", ".")))
-            .collect(Collectors.toList());
-
-        // Finally, pass the extracted filter pairs to all the filter factories and gather the result
+        final List<String> selectors = SelectorUtils.parseSelectors(selectorString);
+        final List<Pair<String, String>> filterStrings = SelectorUtils.parseOptions("dataFilter:", selectorString);
         final List<DataFilter> filters = new ArrayList<>();
         this.filterFactories.forEach(factory -> filters.addAll(factory.parseFilters(filterStrings, selectors)));
 

--- a/modules/utils/src/main/java/io/uhndata/cards/utils/SelectorUtils.java
+++ b/modules/utils/src/main/java/io/uhndata/cards/utils/SelectorUtils.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.uhndata.cards.utils;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * Utility class for parsing the selectors suffix from a resource into a list of selectors or a map of selector options.
+ *
+ * @version $Id$
+ * @since 0.9.33
+ */
+public final class SelectorUtils
+{
+    private SelectorUtils()
+    {
+        // Prevent instantiation of a utility class
+    }
+
+    /**
+     * Parse a selectors string into a list of selectors. This unescapes the URL-encoded string, and considers escaped
+     * dots and escaped backslashes.
+     *
+     * @param resolutionPathInfo the resolution path info, as received from Sling, may be URL-encoded
+     * @return a list of selectors, dots not included
+     */
+    public static List<String> parseSelectors(final String resolutionPathInfo)
+    {
+        if (StringUtils.isBlank(resolutionPathInfo)) {
+            return Collections.emptyList();
+        }
+        // Parse the selectors string into individual selectors.
+        // Split by unescaped dots. A backslash escapes a dot, but two backslashes are just one escaped backslash.
+        // Match by:
+        // - no preceding backslash, i.e. start counting at the first backslash, which means either any character other
+        // than \, or the start of the string: ([^\]|^)
+        // - an even number of backslashes, i.e. any number of groups of two backslashes (\\)*
+        // - due to limitations of the lookbehind implementation in Java, instead of any number, we limit to at most 10
+        // pairs: (\\){0,10}
+        // - a literal dot \.
+        // Each backslash, except the \., is escaped twice, once as a special escape char inside a Java string, and
+        // once as a special escape char inside a RegExp. The one before the dot is escaped only once as a special
+        // char inside a Java string, since it must retain its escaping meaning in the RegExp.
+        return Arrays
+            .asList(URLDecoder.decode(resolutionPathInfo, StandardCharsets.UTF_8)
+                .split("(?<=([^\\\\]|^)(\\\\\\\\){0,10})\\."))
+            .stream()
+            // Also unescape escaped dots, if present
+            // No preceding backslash, negative lookbehind for \: (?<!\)
+            // As a regexp special character, each backslash must be escaped: (?<!\\)
+            // As a Java string literal, each backslash must be escaped again: (?<!\\\\)
+            // Escaped dot: odd number of \ followed by a dot, so (\\)*+\.
+            // As a regexp special character, each backslash must be escaped: (\\\\)*+\\.
+            // As a regexp special character, the dot must be escaped: (\\\\)*+\\\.
+            // As a Java string literal, each backslash must be escaped again: (\\\\\\\\)*+\\\\\\.
+            // Since we want to keep the backslashes in its selector, capture them in a group: ((\\\\\\\\)*+)
+            .map(s -> s.replaceAll("(?<!\\\\)((\\\\\\\\)*+)\\\\\\.", "$1.")
+                // Finally, unescape escaped backslashes
+                .replace("\\\\", "\\"))
+            .filter(StringUtils::isNotBlank)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Parse the options for a given prefix, for example from {@code .dataFilter:status=SUBMITTED} extracts the pair
+     * {@code (status, SUBMITTED)}. This returns all matching pairs, with multiple instances for the same key included
+     * if it is present more than once in the path info.
+     *
+     * @param optionPrefix the option prefix to look for
+     * @param resolutionPathInfo the resolution path info, as received from Sling, may be URL-encoded
+     * @return a list of extracted pairs of key=value
+     */
+    public static List<Pair<String, String>> parseOptions(final String optionPrefix, final String resolutionPathInfo)
+    {
+        if (StringUtils.isAnyBlank(optionPrefix, resolutionPathInfo)) {
+            return Collections.emptyList();
+        }
+        final String prefix = StringUtils.appendIfMissing(optionPrefix, ":");
+        // First parse the selectors string into a list of selectors
+        // Then parse the dataFilter selectors into key=value pairs
+        return parseSelectors(resolutionPathInfo).stream()
+            .filter(s -> StringUtils.startsWith(s, prefix))
+            .map(s -> StringUtils.substringAfter(s, prefix))
+            .map(s -> {
+                String[] bits = s.split("(?<=([^\\\\]|^)(\\\\\\\\){0,10})=", 2);
+                if (bits.length == 2) {
+                    return Pair.of(bits[0].replace("\\=", "="), bits[1].replace("\\=", "=").replace("\\\\", "\\"));
+                }
+                return Pair.of(bits[0].replace("\\=", "=").replace("\\\\", "\\"), "");
+            })
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Parse the options for a given prefix, for example from {@code .dataFilter:status=SUBMITTED} extracts the pair
+     * {@code (status, SUBMITTED)}. This returns only the last value for a given key, if multiple instances for the same
+     * key are present in the path info.
+     *
+     * @param optionPrefix the option prefix to look for
+     * @param resolutionPathInfo the resolution path info, as received from Sling, may be URL-encoded
+     * @return a map of the extracted key=value
+     */
+    public static Map<String, String> parseOptionsToMap(final String optionPrefix, final String resolutionPathInfo)
+    {
+        List<Pair<String, String>> allOptions = parseOptions(optionPrefix, resolutionPathInfo);
+        Map<String, String> result = new HashMap<>();
+        allOptions.stream().forEach(pair -> result.put(pair.getKey(), pair.getValue()));
+        return result;
+    }
+}

--- a/modules/utils/src/test/java/io/uhndata/cards/utils/SelectorUtilsTest.java
+++ b/modules/utils/src/test/java/io/uhndata/cards/utils/SelectorUtilsTest.java
@@ -1,0 +1,221 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.uhndata.cards.utils;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link SelectorUtils}.
+ *
+ * @version $Id$
+ */
+public class SelectorUtilsTest
+{
+    @Test
+    public void testSimpleParsing()
+        throws Exception
+    {
+        Assert.assertEquals(List.of("a", "b", "c", "d"), SelectorUtils.parseSelectors("a.b.c.d"));
+    }
+
+    @Test
+    public void testEmptyStringParsing()
+        throws Exception
+    {
+        Assert.assertEquals(List.of(), SelectorUtils.parseSelectors(""));
+    }
+
+    @Test
+    public void testNullStringParsing()
+        throws Exception
+    {
+        Assert.assertEquals(List.of(), SelectorUtils.parseSelectors(null));
+    }
+
+    @Test
+    public void testEmptySelectorsAreIgnored()
+        throws Exception
+    {
+        Assert.assertEquals(List.of("a", "b", "c", "d"), SelectorUtils.parseSelectors("..a.b.c...d.."));
+    }
+
+    @Test
+    public void testDotEscaping()
+        throws Exception
+    {
+        Assert.assertEquals(List.of("a.b", "c.d"), SelectorUtils.parseSelectors("a\\.b...c\\.d"));
+        Assert.assertEquals(List.of("a\\.b", "c\\.d"), SelectorUtils.parseSelectors("a\\\\\\.b...c\\\\\\.d"));
+    }
+
+    @Test
+    public void testBackslashEscaping()
+        throws Exception
+    {
+        Assert.assertEquals(List.of("a\\", "b", "c\\", "d"), SelectorUtils.parseSelectors("a\\\\.b...c\\\\.d"));
+    }
+
+    @Test
+    public void testTrailingBackslash()
+        throws Exception
+    {
+        Assert.assertEquals(List.of("a", "b", "c", "d\\"), SelectorUtils.parseSelectors("a.b.c.d\\"));
+        Assert.assertEquals(List.of("a", "b", "c", "d\\"), SelectorUtils.parseSelectors("a.b.c.d\\\\"));
+        Assert.assertEquals(List.of("a", "b", "c", "d\\\\"), SelectorUtils.parseSelectors("a.b.c.d\\\\\\"));
+    }
+
+    @Test
+    public void testURLDecodingWhenParsing()
+        throws Exception
+    {
+        Assert.assertEquals(List.of("csvReplaceColumnLabels: ID=", "csvReplaceColumnLabels:@=#", "csv"),
+            SelectorUtils
+                .parseSelectors(".csvReplaceColumnLabels:%20ID%3D.csvReplaceColumnLabels:%40%3D%23.csv"));
+    }
+
+    @Test
+    public void testFullEscaping()
+        throws Exception
+    {
+        Assert.assertEquals(List.of("a\\\\", "b\\.c\\", "d\\"),
+            SelectorUtils.parseSelectors("a\\\\\\\\.b\\\\\\.c\\\\.d\\\\"));
+    }
+
+    @Test
+    public void testSimpleOptionParsing()
+        throws Exception
+    {
+        Assert.assertEquals(List.of(Pair.of("a", "1"), Pair.of("b", "2")),
+            SelectorUtils.parseOptions("dataFilter:", ".data.dataFilter:a=1.dataOption:c=3.dataFilter:b=2"));
+    }
+
+    @Test
+    public void testEmptyStringOptionParsing()
+        throws Exception
+    {
+        Assert.assertEquals(List.of(), SelectorUtils.parseOptions("a", ""));
+    }
+
+    @Test
+    public void testNullStringOptionParsing()
+        throws Exception
+    {
+        Assert.assertEquals(List.of(), SelectorUtils.parseOptions("a", null));
+    }
+
+    @Test
+    public void testNullPrefixOptionParsing()
+        throws Exception
+    {
+        Assert.assertEquals(List.of(), SelectorUtils.parseOptions(null, ":b=c"));
+    }
+
+    @Test
+    public void testEmptyPrefixOptionParsing()
+        throws Exception
+    {
+        Assert.assertEquals(List.of(), SelectorUtils.parseOptions("", ":b=c"));
+    }
+
+    @Test
+    public void testMissinColonOptionParsing()
+        throws Exception
+    {
+        Assert.assertEquals(List.of(Pair.of("a", "1"), Pair.of("b", "2")),
+            SelectorUtils.parseOptions("dataFilter", ".data.dataFilter:a=1.dataOption:c=3.dataFilter:b=2"));
+    }
+
+    @Test
+    public void testOptionParsingUsesFirstEquals()
+        throws Exception
+    {
+        Assert.assertEquals(List.of(Pair.of("a", "1=1"), Pair.of("b", "2=2")),
+            SelectorUtils.parseOptions("dataFilter", ".data.dataFilter:a=1=1.dataFilter:b=2=2"));
+    }
+
+    @Test
+    public void testEscapesInOptionParsing()
+        throws Exception
+    {
+        Assert.assertEquals(List.of(Pair.of("a.1", "1.1"), Pair.of("b=2", "2=2")),
+            SelectorUtils.parseOptions("dataFilter", ".data.dataFilter:a\\.1=1\\.1.dataFilter:b\\=2=2\\=2"));
+    }
+
+    @Test
+    public void testValuelessOptionParsing()
+        throws Exception
+    {
+        Assert.assertEquals(List.of(Pair.of("a", ""), Pair.of("b=2", "")),
+            SelectorUtils.parseOptions("dataFilter", ".data.dataFilter:a.dataFilter:b\\=2"));
+    }
+
+    @Test
+    public void testRealOptionParsing()
+        throws Exception
+    {
+        final String pathInfo = ".data"
+            + ".deep"
+            + ".dataOption:formSelectors=deep\\.-identify\\.simple"
+            + ".dataFilter:createdAfter=2025-01-01T00:00:00\\.000-05:00"
+            + ".dataFilter:status=SUBMITTED"
+            + ".json";
+        Assert.assertEquals(
+            List.of("data",
+                "deep",
+                "dataOption:formSelectors=deep.-identify.simple",
+                "dataFilter:createdAfter=2025-01-01T00:00:00.000-05:00",
+                "dataFilter:status=SUBMITTED",
+                "json"),
+            SelectorUtils.parseSelectors(pathInfo));
+        Assert.assertEquals(List.of(Pair.of("formSelectors", "deep.-identify.simple")),
+            SelectorUtils.parseOptions("dataOption:", pathInfo));
+        Assert.assertEquals(
+            List.of(
+                Pair.of("createdAfter", "2025-01-01T00:00:00.000-05:00"),
+                Pair.of("status", "SUBMITTED")),
+            SelectorUtils.parseOptions("dataFilter:", pathInfo));
+    }
+
+    @Test
+    public void testURLDecodingWhenParsingOptions()
+        throws Exception
+    {
+        Assert.assertEquals(List.of(Pair.of(" ID", ""), Pair.of("@", "#")),
+            SelectorUtils
+                .parseOptions("csvReplaceColumnLabels",
+                    ".csvReplaceColumnLabels:%20ID%3D.csvReplaceColumnLabels:%40%3D%23.csv"));
+    }
+
+    @Test
+    public void testParseToMap()
+    {
+        Assert.assertEquals(Map.of("formSelectors", "deep.-identify.simple", "descendantData", "2"),
+            SelectorUtils.parseOptionsToMap("dataOption:",
+                ".data"
+                    + ".dataOption:formSelectors=deep\\.-identify\\.simple"
+                    + ".dataOption:descendantData=true"
+                    + ".dataOption:descendantData=5"
+                    + ".dataOption:descendantData=2"));
+    }
+}


### PR DESCRIPTION
- Add -csvStripHeader option to csv exports that removes `@` symbol
- Add this option to prems labelled form export

Testing (prems runmode):
- From the admin view, export the inpatient survey with labels and identifiers checked. Test various options for the header label replacement and header id replacement fields. e.g.
    ```
    @=# ,        Identifier=ID
    Patient=User
    ```

