### PR TITLE
CARDS-2725: Remove @ from CSV export headers - Your Experience configuration

### DIFF
--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -362,7 +362,7 @@
         "questionnaire=/Questionnaires/OAIP",
         "questionnaire=/Questionnaires/OED",
         "questionnaire=/Questionnaires/Rehab",
-        "selectors=.formToSurveyLinks.dataFilter:status=SUBMITTED.csvIncludeFields:@survey=Survey.csvHeader:raw.questionnaireFilter.questionnaireFilter:exclude=/Questionnaires/CPESIC/OverallRatingofHospital/cpesic_hospital_overall.questionnaireFilter:exclude=/Questionnaires/OED/oed_module1/oed_visit_month.questionnaireFilter:exclude=/Questionnaires/OAIP/oaip_module1/oaip_visit_month.questionnaireFilter:exclude=/Questionnaires/Rehab/rs_module1/rs_visit_month"
+        "selectors=.formToSurveyLinks.dataFilter:status=SUBMITTED.csvIncludeFields:@survey=Survey.csvReplaceColumnIds:@=#.csvHeader:raw.questionnaireFilter.questionnaireFilter:exclude=/Questionnaires/CPESIC/OverallRatingofHospital/cpesic_hospital_overall.questionnaireFilter:exclude=/Questionnaires/OED/oed_module1/oed_visit_month.questionnaireFilter:exclude=/Questionnaires/OAIP/oaip_module1/oaip_visit_month.questionnaireFilter:exclude=/Questionnaires/Rehab/rs_module1/rs_visit_month"
       ],
       "formatter": "csv",
       "fileNameFormat": "{resourcePath}.csv",

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -342,7 +342,7 @@
         "questionnaire=/Questionnaires/OAIP",
         "questionnaire=/Questionnaires/OED",
         "questionnaire=/Questionnaires/Rehab",
-        "selectors=.labels.formToSurveyLinks.dataFilter:status=SUBMITTED.csvIncludeFields:@survey=Survey.csvHeader:raw.questionnaireFilter.questionnaireFilter:exclude=/Questionnaires/CPESIC/OverallRatingofHospital/cpesic_hospital_overall.questionnaireFilter:exclude=/Questionnaires/OED/oed_module1/oed_visit_month.questionnaireFilter:exclude=/Questionnaires/OAIP/oaip_module1/oaip_visit_month.questionnaireFilter:exclude=/Questionnaires/Rehab/rs_module1/rs_visit_month"
+        "selectors=.labels.formToSurveyLinks.dataFilter:status=SUBMITTED.csvIncludeFields:@survey=Survey.csvColumnReplace:/@=#.csvHeader:raw.questionnaireFilter.questionnaireFilter:exclude=/Questionnaires/CPESIC/OverallRatingofHospital/cpesic_hospital_overall.questionnaireFilter:exclude=/Questionnaires/OED/oed_module1/oed_visit_month.questionnaireFilter:exclude=/Questionnaires/OAIP/oaip_module1/oaip_visit_month.questionnaireFilter:exclude=/Questionnaires/Rehab/rs_module1/rs_visit_month"
       ],
       "formatter": "csv",
       "fileNameFormat": "{resourcePath}_labels.csv",

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -342,7 +342,7 @@
         "questionnaire=/Questionnaires/OAIP",
         "questionnaire=/Questionnaires/OED",
         "questionnaire=/Questionnaires/Rehab",
-        "selectors=.labels.formToSurveyLinks.dataFilter:status=SUBMITTED.csvIncludeFields:@survey=Survey.csvColumnReplace:/@=#.csvHeader:raw.questionnaireFilter.questionnaireFilter:exclude=/Questionnaires/CPESIC/OverallRatingofHospital/cpesic_hospital_overall.questionnaireFilter:exclude=/Questionnaires/OED/oed_module1/oed_visit_month.questionnaireFilter:exclude=/Questionnaires/OAIP/oaip_module1/oaip_visit_month.questionnaireFilter:exclude=/Questionnaires/Rehab/rs_module1/rs_visit_month"
+        "selectors=.labels.formToSurveyLinks.dataFilter:status=SUBMITTED.csvIncludeFields:@survey=Survey.csvReplaceColumnIds:@=#.csvHeader:raw.questionnaireFilter.questionnaireFilter:exclude=/Questionnaires/CPESIC/OverallRatingofHospital/cpesic_hospital_overall.questionnaireFilter:exclude=/Questionnaires/OED/oed_module1/oed_visit_month.questionnaireFilter:exclude=/Questionnaires/OAIP/oaip_module1/oaip_visit_month.questionnaireFilter:exclude=/Questionnaires/Rehab/rs_module1/rs_visit_month"
       ],
       "formatter": "csv",
       "fileNameFormat": "{resourcePath}_labels.csv",


### PR DESCRIPTION
- Test the nightly prems export:
    1. Create a Visit Information Form with `Clinic = UHN Inpatient` and `Time = Yesterday`
    2. Put some data into the generated Inpatient form and note it's path
    3. Use `/bin/browser` to add `SUBMITTED` to the status flags for the Inpatient form
    4. Go to `/system/console/configMgr` and update `io.uhndata.cards.export.ExportConfig~UHN-Labeled-Forms:`
    5. Change Data Storage parameters to `savePath=.`
    6. Go to http://localhost:8080/Subjects.export?config=UHN-Labeled-Forms
    7. Check the folder in which you launched CARDS: There should be multiple CSVs there, one for each prems patient form
    8. Open the OAIP form, verify that the name column is called `#name`