### PR TITLE
CARDS-2737: Improve the UI for the patient portal page layout

### DIFF
--- a/modules/commons/src/main/frontend/src/components/ErrorPage.jsx
+++ b/modules/commons/src/main/frontend/src/components/ErrorPage.jsx
@@ -32,10 +32,6 @@ const useStyles = makeStyles()(theme => ({
     flexDirection: 'column',
     alignItems: 'center',
     padding: theme.spacing(12, 3, 3),
-    textAlign: "center",
-    "& .MuiGrid-root" : {
-      textAlign: "center",
-    },
   },
   extendedIcon: {
     marginRight: theme.spacing(1),
@@ -43,7 +39,18 @@ const useStyles = makeStyles()(theme => ({
 }));
 
 export default function ErrorPage(props) {
-  const { errorCode, errorCodeColor, title, titleColor, message, messageColor, buttonLink, buttonLabel, ...rest } = props;
+  const {
+    errorCode,
+    errorCodeColor,
+    title,
+    titleColor,
+    message,
+    messageColor,
+    buttonLink,
+    buttonLabel,
+    textAlign="center",
+    ...rest
+  } = props;
   const { classes } = useStyles();
 
   return (
@@ -52,8 +59,7 @@ export default function ErrorPage(props) {
           container
           direction="column"
           spacing={7}
-          alignItems="center"
-          alignContent="center"
+          textAlign={textAlign}
         >
           <Logo maxWidth="360px" component={Grid}/>
           <Grid>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
@@ -325,7 +325,7 @@ function PatientIdentification(props) {
             { error ?
               <Typography color="error">{error}</Typography>
               :
-              <Typography>Enter the following information for identification</Typography>
+              <Typography variant="h6">Enter the following information for identification:</Typography>
             }
             </div>
             <InputLabel htmlFor="j_dob" shrink={true} className={classes.dateLabel}>Date of birth</InputLabel>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
@@ -330,7 +330,7 @@ function PatientIdentification(props) {
             </div>
             <InputLabel htmlFor="j_dob" shrink={true} className={classes.dateLabel}>Date of birth</InputLabel>
             <DropdownsDatePicker id="j_dob" name="j_dob" formatDate onDateChange={setDob} autoFocus fullWidth/>
-            <Grid container alignItems="flex-start" wrap="nowrap" justifyContent="space-between">
+            <Grid container alignItems="flex-start" wrap="nowrap" spacing={2} justifyContent="space-between">
               <Grid>
                 <FormControl variant="standard" margin="normal" fullWidth>
                   <InputLabel htmlFor="j_mrn" shrink={true}>MRN</InputLabel>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
@@ -51,7 +51,7 @@ const useStyles = makeStyles()(theme => ({
   },
   description : {
     "& > *" : {
-      textAlign: "center",
+      textAlign: "left",
       marginBottom: "16px",
       "@media (max-width: 400px)" : {
         fontSize: "x-small",
@@ -89,6 +89,9 @@ const useStyles = makeStyles()(theme => ({
       justifyContent: "flex-start",
       textTransform: "none",
     },
+  },
+  submit : {
+    float: 'right',
   }
 }));
 
@@ -248,6 +251,7 @@ function PatientIdentification(props) {
         title=""
         message={message}
         messageColor="textPrimary"
+        textAlign="left"
       />
     )
   }
@@ -293,7 +297,7 @@ function PatientIdentification(props) {
     {/* Patient identification form */}
 
     <form className={classes.form} onSubmit={onSubmit} >
-      <Grid container direction="column" spacing={4} alignItems="center" justifyContent="center">
+      <Grid container direction="column" spacing={4} >
          <Logo component={Grid} size={12}/>
 
          { /* If we don't have the authentication token yet or we don't need the identification form,
@@ -405,8 +409,10 @@ function PatientIdentification(props) {
             </Grid>
             <Grid>
               <Button
-                variant="contained" onClick={() => window.location = "/system/sling/logout"}
-                >
+                variant="contained"
+                className={classes.submit}
+                onClick={() => window.location = "/system/sling/logout"}
+              >
                 Close
               </Button>
             </Grid>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -70,9 +70,6 @@ const useStyles = makeStyles()(theme => ({
     "& > .mainItem" : {
       paddingLeft: 0,
     },
-    "& h4, h6, .patient-portal-instructions" : {
-      textAlign: "center",
-    }
   },
   surveyPreviewComponent : {
     background: theme.palette.action.hover,
@@ -589,10 +586,14 @@ function QuestionnaireSet(props) {
 
 
   const greet = (name) => {
-    let hourOfDay = (new Date()).getHours();
-    let timeOfDay = hourOfDay < 12 ? "morning" : hourOfDay < 18 ? "afternoon" : "evening";
-    let greeting = `Good ${timeOfDay}` + (name ? `, ${name}` : '');
-    return <Typography variant="h6" key="welcome-greeting">{ greeting }</Typography>;
+    let greeting = displayText("greeting", Typography, {variant: "h6", key: "welcome-greeting"});
+    if (!greeting) {
+      let hourOfDay = (new Date()).getHours();
+      let timeOfDay = hourOfDay < 12 ? "morning" : hourOfDay < 18 ? "afternoon" : "evening";
+      let greetingMessage = `Good ${timeOfDay}` + (name ? `, ${name}` : '');
+      greeting = <Typography variant="h6" key="welcome-greeting">{ greetingMessage }</Typography>;
+    }
+    return greeting;
   }
 
   const appointmentDate = () => {
@@ -759,8 +760,8 @@ function QuestionnaireSet(props) {
   let endingMessage = ending.replaceAll(pattern, getVisitInformation(pieces?.[1]) || pieces?.[2] || "");
 
   let finalInstructions = (
-      endingMessage ? <FormattedText key="summary-instructions" className="patient-portal-instructions">{endingMessage}</FormattedText> :
-      displayText("summaryInstructions", FormattedText, {color: "textSecondary", key: "summary-instructions", className: "patient-portal-instructions"})
+      endingMessage ? <FormattedText key="summary-instructions">{endingMessage}</FormattedText> :
+      displayText("summaryInstructions", FormattedText, {color: "textSecondary", key: "summary-instructions"})
   );
 
   let disclaimer = (

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -592,7 +592,7 @@ function QuestionnaireSet(props) {
     let hourOfDay = (new Date()).getHours();
     let timeOfDay = hourOfDay < 12 ? "morning" : hourOfDay < 18 ? "afternoon" : "evening";
     let greeting = `Good ${timeOfDay}` + (name ? `, ${name}` : '');
-    return <Typography variant="h6" key="welcome-greeting" sx={{fontWeight: "600"}}>{ greeting }</Typography>;
+    return <Typography variant="h6" key="welcome-greeting">{ greeting }</Typography>;
   }
 
   const appointmentDate = () => {
@@ -674,9 +674,9 @@ function QuestionnaireSet(props) {
       ? <FormattedText key="intro-message">{introMessage}</FormattedText>
       : displayText("surveyIntro", Typography, {key: "welcome-message"})
     ),
-    <List key="welcome-surveys" sx={{p : 0}}>
+    <List key="welcome-surveys" dense>
     { (questionnaireIds || []).map((q, i) => (
-      <ListItem key={q+"Welcome"} sx={{pt : 0, pb: 0}}>
+      <ListItem key={q+"Welcome"}>
         <ListItemAvatar>{isFormComplete(q) ? doneIndicator : questionnaireIds.length == 1 ? surveyIndicator : stepIndicator(i)}</ListItemAvatar>
         <ListItemText
           primary={questionnaires[q]?.title}
@@ -869,7 +869,7 @@ function QuestionnaireSetScreen (props) {
       {Array.from(children || []).filter(c => c).map((c, i) =>
           <Grid
             key={i+"MainItem"}
-            alignSelf={["welcome-action", "expiry-message", "review-title", "summary-title"].includes(c.key) || c.key.startsWith("review-submit") ? "center" : ""}
+            alignSelf={["welcome-action", "expiry-message", "review-title"].includes(c.key) || c.key?.startsWith("review-submit") ? "center" : ""}
             className={classes.mainItem}
           >
             {c}

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -20,6 +20,8 @@ import React, { useState, useEffect, useContext }  from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
+  Alert,
+  AlertTitle,
   Avatar,
   Box,
   Button,
@@ -34,8 +36,6 @@ import {
   Typography,
 } from '@mui/material';
 import { makeStyles } from 'tss-react/mui';
-import Alert from '@mui/material/Alert';
-import AlertTitle from '@mui/material/AlertTitle';
 import NextStepIcon from '@mui/icons-material/ChevronRight';
 import DoneIcon from '@mui/icons-material/Done';
 import WarningIcon from '@mui/icons-material/Warning';
@@ -689,7 +689,7 @@ function QuestionnaireSet(props) {
       </ListItem>
     ))}
     </List>,
-    nextQuestionnaire && <Fab variant="extended" color="primary" onClick={launchNextForm} key="welcome-action" sx={{mr: 10, width: 1}}>Begin</Fab>,
+    nextQuestionnaire && <Fab variant="extended" color="primary" onClick={launchNextForm} key="welcome-action" sx={{px: 5}}>Begin</Fab>,
     <FormattedText key="expiry-message" color="textSecondary">
         {expiryDate()}
     </FormattedText>,
@@ -799,9 +799,9 @@ function QuestionnaireSet(props) {
   let loadingScreen = [ <CircularProgress key="exit-loading"/> ];
 
   let incompleteScreen = [
-        <List key="incomplete-list">
+        <List key="incomplete-list" disablePadding>
         { (questionnaireIds || []).map((q, i) => (
-          <ListItem key={q+"Exit"}>
+          <ListItem key={q+"Exit"} disablePadding>
             <ListItemAvatar>{isFormComplete(q) ? doneIndicator : incompleteIndicator}</ListItemAvatar>
             <ListItemText
               primary={questionnaires[q]?.title}
@@ -810,21 +810,17 @@ function QuestionnaireSet(props) {
           </ListItem>
         ))}
         </List>,
-        <Typography color="error" key="incomplete-message">Your answers are incomplete. Please update your answers by responding to all mandatory questions.</Typography>,
-        <>
-        { canSubmitIncomplete ?
-          <Grid container spacing={2}>
-            <Grid>
-              <Button variant="contained" onClick={() => {setCrtStep(-1)}} key="incomplete-button">Update my answers</Button>
-            </Grid>
+        <Alert severity="error" key="incomplete-message">Your answers are incomplete. Please update your answers by responding to all mandatory questions.</Alert>,
+        <Grid container spacing={2} justifyContent="flex-end" key="incomplete-actions">
+          { canSubmitIncomplete &&
             <Grid>
               <Button variant="outlined" onClick={() => setSubmittingIncomplete(true)}>Proceed anyway</Button>
             </Grid>
+          }
+          <Grid>
+            <Button variant="contained" onClick={() => {setCrtStep(-1)}} key="incomplete-button">Update my answers</Button>
           </Grid>
-          :
-          <Fab variant="extended" onClick={() => {setCrtStep(-1)}} key="incomplete-button">Update my answers</Fab>
-        }
-        </>
+        </Grid>
   ];
 
   let exitScreen = (
@@ -863,13 +859,18 @@ function QuestionnaireSetScreen (props) {
 
   const { classes } = useStyles();
 
+  const isElementCentered = key => (
+    ["welcome-action", "expiry-message", "exit-loading"].includes(key) || key?.startsWith("review-")
+  );
+
   return (
   <Paper elevation={0} className={classes.mainContainer}>
     <Grid container direction="column" spacing={4} {...rest}>
       {Array.from(children || []).filter(c => c).map((c, i) =>
           <Grid
             key={i+"MainItem"}
-            alignSelf={["welcome-action", "expiry-message", "exit-loading"].includes(c.key) || c.key?.startsWith("review-") ? "center" : ""}
+            size={!isElementCentered(c.key) && 12}
+            alignSelf={isElementCentered(c.key) && "center"}
             className={classes.mainItem}
           >
             {c}

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -742,9 +742,7 @@ function QuestionnaireSet(props) {
           </Grid>
         </Paper>
         :
-        <Box display="flex" justifyContent="center" alignItems="center" sx={{width: "780px"}}>
-          <CircularProgress />
-        </Box>
+        <CircularProgress />
       }
       </Grid>
       ))}
@@ -871,7 +869,7 @@ function QuestionnaireSetScreen (props) {
       {Array.from(children || []).filter(c => c).map((c, i) =>
           <Grid
             key={i+"MainItem"}
-            alignSelf={["welcome-action", "expiry-message", "review-title", "review-loading", "exit-loading"].includes(c.key) || c.key?.startsWith("review-submit") ? "center" : ""}
+            alignSelf={["welcome-action", "expiry-message", "exit-loading"].includes(c.key) || c.key?.startsWith("review-") ? "center" : ""}
             className={classes.mainItem}
           >
             {c}

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -21,6 +21,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import {
   Avatar,
+  Box,
   Button,
   CircularProgress,
   Fab,
@@ -741,7 +742,9 @@ function QuestionnaireSet(props) {
           </Grid>
         </Paper>
         :
-        <CircularProgress />
+        <Box display="flex" justifyContent="center" alignItems="center" sx={{width: "780px"}}>
+          <CircularProgress />
+        </Box>
       }
       </Grid>
       ))}
@@ -868,7 +871,7 @@ function QuestionnaireSetScreen (props) {
       {Array.from(children || []).filter(c => c).map((c, i) =>
           <Grid
             key={i+"MainItem"}
-            alignSelf={["welcome-action", "expiry-message", "review-title", "review-loading"].includes(c.key) || c.key?.startsWith("review-submit") ? "center" : ""}
+            alignSelf={["welcome-action", "expiry-message", "review-title", "review-loading", "exit-loading"].includes(c.key) || c.key?.startsWith("review-submit") ? "center" : ""}
             className={classes.mainItem}
           >
             {c}

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -718,9 +718,7 @@ function QuestionnaireSet(props) {
   );
 
   let reviewScreen = !enableReviewScreen ? [
-    <Grid alignItems="center" justifyContent="center">
-      <Grid key="review-loading"><CircularProgress/></Grid>
-    </Grid>
+    <CircularProgress key="review-loading"/>
   ] : [
     <Typography variant="h4" key="review-title">Review and Submit</Typography>,
     submitButton("Submit now"),
@@ -870,7 +868,7 @@ function QuestionnaireSetScreen (props) {
       {Array.from(children || []).filter(c => c).map((c, i) =>
           <Grid
             key={i+"MainItem"}
-            alignSelf={["welcome-action", "expiry-message", "review-title"].includes(c.key) || c.key?.startsWith("review-submit") ? "center" : ""}
+            alignSelf={["welcome-action", "expiry-message", "review-title", "review-loading"].includes(c.key) || c.key?.startsWith("review-submit") ? "center" : ""}
             className={classes.mainItem}
           >
             {c}

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -677,7 +677,7 @@ function QuestionnaireSet(props) {
     ),
     <List key="welcome-surveys" disablePadding>
     { (questionnaireIds || []).map((q, i) => (
-      <ListItem key={q+"Welcome"} sx={{py : 0}}>
+      <ListItem key={q+"Welcome"} disablePadding>
         <ListItemAvatar>{isFormComplete(q) ? doneIndicator : questionnaireIds.length == 1 ? surveyIndicator : stepIndicator(i)}</ListItemAvatar>
         <ListItemText
           primary={questionnaires[q]?.title}

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -63,7 +63,7 @@ const useStyles = makeStyles()(theme => ({
     },
   },
   screen : {
-    alignItems: "center",
+    alignItems: "flex-start",
     margin: "auto",
     maxWidth: "780px",
     width: "100%",
@@ -591,7 +591,8 @@ function QuestionnaireSet(props) {
   const greet = (name) => {
     let hourOfDay = (new Date()).getHours();
     let timeOfDay = hourOfDay < 12 ? "morning" : hourOfDay < 18 ? "afternoon" : "evening";
-    return `Good ${timeOfDay}` + (name ? `, ${name}` : '');
+    let greeting = `Good ${timeOfDay}` + (name ? `, ${name}` : '');
+    return <Typography variant="h6" key="welcome-greeting" sx={{fontWeight: "600"}}>{ greeting }</Typography>;
   }
 
   const appointmentDate = () => {
@@ -663,19 +664,19 @@ function QuestionnaireSet(props) {
   let introMessage = intro.replaceAll(pattern, getVisitInformation(pieces?.[1]) || pieces?.[2] || "");
 
   let welcomeScreen = (isComplete && isSubmitted || questionnaireIds?.length == 0) ? [
-    <Typography variant="h4" key="welcome-greeting">{ greet(username) }</Typography>,
+    greet(username),
     appointmentAlert(),
     displayText("noSurveysMessage", Typography, {color: "textSecondary", variant: "subtitle1", key: "survey-info"}),
   ] : [
-    <Typography variant="h4" key="welcome-greeting">{ greet(username) }</Typography>,
+    greet(username),
     appointmentAlert(),
     (introMessage
-      ? <FormattedText key="intro-message" className="patient-portal-instructions">{introMessage}</FormattedText>
-      : displayText("surveyIntro", Typography, {key: "welcome-message", className: "patient-portal-instructions"})
+      ? <FormattedText key="intro-message">{introMessage}</FormattedText>
+      : displayText("surveyIntro", Typography, {key: "welcome-message"})
     ),
-    <List key="welcome-surveys">
+    <List key="welcome-surveys" sx={{p : 0}}>
     { (questionnaireIds || []).map((q, i) => (
-      <ListItem key={q+"Welcome"}>
+      <ListItem key={q+"Welcome"} sx={{pt : 0, pb: 0}}>
         <ListItemAvatar>{isFormComplete(q) ? doneIndicator : questionnaireIds.length == 1 ? surveyIndicator : stepIndicator(i)}</ListItemAvatar>
         <ListItemText
           primary={questionnaires[q]?.title}
@@ -686,11 +687,11 @@ function QuestionnaireSet(props) {
       </ListItem>
     ))}
     </List>,
-    nextQuestionnaire && <Fab variant="extended" color="primary" onClick={launchNextForm} key="welcome-action">Begin</Fab>,
+    nextQuestionnaire && <Fab variant="extended" color="primary" onClick={launchNextForm} key="welcome-action" sx={{mr: 10, width: 1}}>Begin</Fab>,
     <Typography component="p" key="expiry-message" color="textSecondary">
         {expiryDate()}
     </Typography>,
-    displayText("surveyDraftInfo", FormattedText, {variant: "body2", key: "draft-info", className: "patient-portal-instructions"}),
+    displayText("surveyDraftInfo", FormattedText, {variant: "body2", key: "draft-info"}),
   ];
 
   let formScreen = [
@@ -865,7 +866,15 @@ function QuestionnaireSetScreen (props) {
   return (
   <Paper elevation={0} className={classes.mainContainer}>
     <Grid container direction="column" spacing={4} {...rest}>
-      {Array.from(children || []).filter(c => c).map((c, i) => <Grid key={i+"MainItem"} className={classes.mainItem}>{c}</Grid>)}
+      {Array.from(children || []).filter(c => c).map((c, i) =>
+          <Grid
+            key={i+"MainItem"}
+            alignSelf={["welcome-action", "expiry-message", "review-title", "summary-title"].includes(c.key) || c.key.startsWith("review-submit") ? "center" : ""}
+            className={classes.mainItem}
+          >
+            {c}
+          </Grid>)
+      }
     </Grid>
   </Paper>
   );

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -643,11 +643,11 @@ function QuestionnaireSet(props) {
       diffString("minutes", diffStrings, diffs);
 
       if (diffStrings.length > 0) {
-        result = " This survey link will expire in " + diffStrings[0] + ".";
+        result = "**This survey link will expire in " + diffStrings[0] + ".**";
       }
     } else {
       // Visit date could not be retrieved, this token will expire 1 hour from creation.
-      result = " This session will expire in 1 hour."
+      result = "**This session will expire in 1 hour.**"
     }
 
     return result;
@@ -690,10 +690,10 @@ function QuestionnaireSet(props) {
     ))}
     </List>,
     nextQuestionnaire && <Fab variant="extended" color="primary" onClick={launchNextForm} key="welcome-action" sx={{mr: 10, width: 1}}>Begin</Fab>,
-    <Typography component="p" key="expiry-message" color="textSecondary">
+    <FormattedText key="expiry-message" color="textSecondary">
         {expiryDate()}
-    </Typography>,
-    displayText("surveyDraftInfo", FormattedText, {variant: "body2", key: "draft-info"}),
+    </FormattedText>,
+    displayText("surveyDraftInfo", FormattedText, {key: "draft-info"}),
   ];
 
   let formScreen = [

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -675,9 +675,9 @@ function QuestionnaireSet(props) {
       ? <FormattedText key="intro-message">{introMessage}</FormattedText>
       : displayText("surveyIntro", Typography, {key: "welcome-message"})
     ),
-    <List key="welcome-surveys" dense>
+    <List key="welcome-surveys" disablePadding>
     { (questionnaireIds || []).map((q, i) => (
-      <ListItem key={q+"Welcome"}>
+      <ListItem key={q+"Welcome"} sx={{py : 0}}>
         <ListItemAvatar>{isFormComplete(q) ? doneIndicator : questionnaireIds.length == 1 ? surveyIndicator : stepIndicator(i)}</ListItemAvatar>
         <ListItemText
           primary={questionnaires[q]?.title}

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/SurveyInstructionsConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/SurveyInstructionsConfiguration.jsx
@@ -34,7 +34,7 @@ export const SURVEY_INSTRUCTIONS_PATH = "/Survey/SurveyInstructions";
 export const DEFAULT_INSTRUCTIONS = {
   noEventsMessage: "We could not find any pending surveys to fill out.",
   noSurveysMessage: "You have no pending surveys to fill out.",
-  surveyDraftInfo: "If you close your browser window before finishing the survey, your answers will be automatically saved.  \nYou can return to the survey to complete and submit it by following the link you received in your invitation email."
+  surveyDraftInfo: "If you close your browser window before finishing the survey, your answers will be automatically saved. You can return to the survey to complete and submit it by following the link you received in your invitation email."
 };
 
 const useStyles = makeStyles()(theme => ({

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/SurveyInstructionsConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/SurveyInstructionsConfiguration.jsx
@@ -54,7 +54,7 @@ function SurveyInstructionsConfiguration() {
   const labels = {
     welcomeMessage: ["welcomeMessage"],
     eventSelectionScreen: ["noEventsMessage", "eventSelectionMessage"],
-    startScreen: [ "enableStartScreen", "eventLabel", "noSurveysMessage", "surveyIntro", "surveyDraftInfo" ],
+    startScreen: [ "enableStartScreen", "greeting", "eventLabel", "noSurveysMessage", "surveyIntro", "surveyDraftInfo" ],
     reviewScreen: ["enableReviewScreen"],
     summaryScreen: [ "disclaimer", "summaryInstructions", "interpretationInstructions" ]
   };

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
@@ -33,6 +33,8 @@ const useStyles = makeStyles()(theme => ({
     flexDirection: 'column',
     alignItems: 'center',
     padding: theme.spacing(12, 3, 3),
+    maxWidth: 500,
+    margin: "0 auto",
   },
   submit : {
     marginTop: theme.spacing(5),

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
@@ -34,7 +34,11 @@ const useStyles = makeStyles()(theme => ({
     alignItems: 'center',
     padding: theme.spacing(12, 3, 3),
     maxWidth: 500,
+    width: "100%",
     margin: "0 auto",
+    "& > .MuiGrid-root" : {
+      width: "100%",
+    },
   },
   submit : {
     marginTop: theme.spacing(5),
@@ -93,7 +97,7 @@ function Unsubscribe (props) {
           spacing={7}
         >
           <Logo component={Grid} size={12} />
-          <Grid>
+          <Grid size={12}>
             { error && <Alert severity="error">
               <AlertTitle>An error occurred</AlertTitle>
                {error}
@@ -113,7 +117,7 @@ function Unsubscribe (props) {
               </>
               : confirmed !== null ?
               <>
-                <Alert icon={false} severity="info">
+                <Alert severity="success">
                   You have been {confirmed ? "unsubscribed from" : "resubscribed to"} {appName}.
                 </Alert>
                 <Button
@@ -127,7 +131,7 @@ function Unsubscribe (props) {
               </>
               :
               <>
-                <Typography>{`This will unsubscribe you from all ${appName} emails.`}</Typography>
+                <Alert icon={false} severity="info">{`This will unsubscribe you from all ${appName} emails.`}</Alert>
                 <Button
                   type="submit"
                   variant="contained"

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
@@ -33,13 +33,10 @@ const useStyles = makeStyles()(theme => ({
     flexDirection: 'column',
     alignItems: 'center',
     padding: theme.spacing(12, 3, 3),
-    textAlign: "center",
-    "& .MuiGrid-root" : {
-      textAlign: "center",
-    },
   },
   submit : {
     marginTop: theme.spacing(5),
+    float: 'right',
   }
 }));
 
@@ -79,6 +76,7 @@ function Unsubscribe (props) {
         message="This page can only be accessed by opening an invitation to fill in a survey"
         buttonLink="/content.html/Questionnaires/User"
         buttonLabel="Go to the dashboard"
+        textAlign="left"
       />
     );
   }
@@ -91,8 +89,6 @@ function Unsubscribe (props) {
           container
           direction="column"
           spacing={7}
-          alignItems="center"
-          alignContent="center"
         >
           <Logo component={Grid} size={12} />
           <Grid>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
@@ -18,10 +18,14 @@
 //
 import React, { useEffect, useState } from "react";
 import { createRoot } from 'react-dom/client';
-import { Paper, Grid, Button, Typography } from '@mui/material';
+import {
+  Alert,
+  AlertTitle,
+  Button,
+  Grid,
+  Paper
+} from '@mui/material';
 import { makeStyles } from 'tss-react/mui';
-import Alert from '@mui/material/Alert';
-import AlertTitle from '@mui/material/AlertTitle';
 import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
 import { appTheme } from "../themePalette.jsx";
 import ErrorPage from "../components/ErrorPage.jsx";

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/AIP.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/AIP.xml
@@ -28,10 +28,7 @@
     <property>
         <name>intro</name>
         <value>
-Please answer some questions about your recent stay at:
-
-**@{visit.location}**
-
+Please answer some questions about your recent stay at **@{visit.location}**.
 Please do not include any other hospital stays in your answers.
         </value>
         <type>String</type>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/CPES.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/CPES.xml
@@ -28,10 +28,7 @@
     <property>
         <name>intro</name>
         <value>
-Please answer some questions about your recent stay at:
-
-**@{visit.location}**
-
+Please answer some questions about your recent stay at **@{visit.location}**.
 Do not include any other hospital stays in your answers.
         </value>
         <type>String</type>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/ED.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/ED.xml
@@ -28,10 +28,7 @@
     <property>
         <name>intro</name>
         <value>
-Please answer some questions about your recent emergency visit at:
-
-**@{visit.location}**
-
+Please answer some questions about your recent emergency visit at **@{visit.location}**.
 Please do not include any other hospital stays in your answers.
         </value>
         <type>String</type>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/EDIP.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/EDIP.xml
@@ -28,10 +28,7 @@
     <property>
         <name>intro</name>
         <value>
-Please answer some questions about your recent emergency visit and hospital stay at:
-
-**@{visit.location}**
-
+Please answer some questions about your recent emergency visit and hospital stay at **@{visit.location}**.
 Please do not include any other hospital stays in your answers.
         </value>
         <type>String</type>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/OO.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/OO.xml
@@ -28,10 +28,7 @@
     <property>
         <name>intro</name>
         <value>
-Please answer some questions about your recent visit at:
-
-**@{visit.location}**
-
+Please answer some questions about your recent visit at **@{visit.location}**.
 Please do not include any other encounters or hospital stays in your answers.
         </value>
         <type>String</type>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/OOIP.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/OOIP.xml
@@ -28,10 +28,7 @@
     <property>
         <name>intro</name>
         <value>
-Please answer some questions about your recent outpatient oncology visit and hospital stay at:
-
-**@{visit.location}**
-
+Please answer some questions about your recent outpatient oncology visit and hospital stay at **@{visit.location}**.
 Please do not include any other encounters or hospital stays in your answers.
         </value>
         <type>String</type>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/Rehab.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/Rehab.xml
@@ -28,10 +28,7 @@
     <property>
         <name>intro</name>
         <value>
-Please answer some questions about your recent stay at:
-
-**@{visit.location}**
-
+Please answer some questions about your recent stay at **@{visit.location}**.
 Please do not include any other hospital stays in your answers.
         </value>
         <type>String</type>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/SurveyInstructions.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/SurveyInstructions.xml
@@ -57,6 +57,11 @@ Completing this survey is voluntary, and your name and contact information will 
         <type>Boolean</type>
     </property>
     <property>
+        <name>greeting</name>
+        <value>Your Experience at UHN</value>
+        <type>String</type>
+    </property>
+    <property>
         <name>surveyIntro</name>
         <value></value>
         <type>String</type>


### PR DESCRIPTION
Specs: [CARDS-2737](https://phenotips.atlassian.net/browse/CARDS-2737)

**To test the YE workflows:**
* start with `-P prems`
* before authenticating, navigate to /Survey.html to check the default patient portal screen
* as admin create a Patient subject with a Patient information form and a Visit subject with a visit information form
  * obtain the visit token from `/Subjects/<PATIENT UUID>/<VISIT UUID>.token.html`
* in a different browser or in incognito mode, navigate to `/Survey.html?auth_token=<THE TOKEN>`
  * complete the survey to test all YE screens
  * repeat the test for different YE surveys to check the welcome screen layout with different intros and numbers of questionnaires
  * click on Unsubscribe in the footer to test the unsubscribe/resubscribe screens and functionality

**To test other workflows:**
* as admin navigate to Administration > Patient Access
  * tick the checkbox "_Patients can answer surveys without a personalized link_" and save
  * in a different browser or in incognito mode, navigate to /Survey.html? and check the layout of the patient identification page
* as admin, on  the Administration > Patient Access page, enter a negative number in the box labeled "_Relatively to the associated event, patients can start submitting incomplete surveys within:_" to enable the submission of incomplete surveys and save
  * go through the YE patient workflow **without answering any of the questions**
  * check the layout of the "Incomplete surveys" screen just before the Review step


[CARDS-2737]: https://phenotips.atlassian.net/browse/CARDS-2737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ