### PR TITLE
[misc] Remove unused variants icon from the homepage module

### DIFF
--- a/modules/homepage/src/main/frontend/assets.config
+++ b/modules/homepage/src/main/frontend/assets.config
@@ -2,7 +2,6 @@
 
 ['cards-homepage.ThemeIndex']: './src/themePage/index.jsx'
 ['cards-homepage.ModelOrganismsIcon']: '@mui/icons-material/Pets'
-['cards-homepage.VariantsIcon']: '@mui/icons-material/Subtitles'
 ['cards-homepage.AdminIcon']: '@mui/icons-material/Settings'
 ['cards-homepage.AdminDashboard']: './src/adminDashboard/AdminDashboard.jsx'
 ['cards-homepage.QuickSearchResults']: { 'dependOn': ['cards-dataentry.Forms'], 'import': './src/themePage/QuickSearchResults.jsx' }


### PR DESCRIPTION
There is a variants icon declared in the variants module