### PR TITLE
CARDS-2728: [YE] Add a statement at the top of the YVM and PMOO surveys and in the emails to clarify that everyone visiting the Centre receives it regardless of their diagnosis

### DIFF
--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/OO.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/OO.xml
@@ -30,11 +30,6 @@
         <value>
 Please answer some questions about your recent visit at **@{visit.location}**.
 Please do not include any other encounters or hospital stays in your answers.
-
-**This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.**
-Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
-This survey is to evaluate your experience being at the Cancer Centre.
-**If you feel this survey does not pertain to you, please disregard.**
         </value>
         <type>String</type>
     </property>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/OO.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/OO.xml
@@ -30,6 +30,11 @@
         <value>
 Please answer some questions about your recent visit at **@{visit.location}**.
 Please do not include any other encounters or hospital stays in your answers.
+
+**This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.**
+Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
+This survey is to evaluate your experience being at the Cancer Centre.
+**If you feel this survey does not pertain to you, please disregard.**
         </value>
         <type>String</type>
     </property>
@@ -48,7 +53,7 @@ Please do not include any other encounters or hospital stays in your answers.
         </property>
         <property>
             <name>estimate</name>
-            <value>5</value>
+            <value>10</value>
             <type>Long</type>
         </property>
         <property>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/OOIP.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/OOIP.xml
@@ -30,11 +30,6 @@
         <value>
 Please answer some questions about your recent outpatient oncology visit and hospital stay at **@{visit.location}**.
 Please do not include any other encounters or hospital stays in your answers.
-
-**This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.**
-Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
-This survey is to evaluate your experience being at the Cancer Centre.
-**If you feel this survey does not pertain to you, please disregard.**
         </value>
         <type>String</type>
     </property>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/OOIP.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/OOIP.xml
@@ -30,6 +30,11 @@
         <value>
 Please answer some questions about your recent outpatient oncology visit and hospital stay at **@{visit.location}**.
 Please do not include any other encounters or hospital stays in your answers.
+
+**This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.**
+Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
+This survey is to evaluate your experience being at the Cancer Centre.
+**If you feel this survey does not pertain to you, please disregard.**
         </value>
         <type>String</type>
     </property>
@@ -48,7 +53,7 @@ Please do not include any other encounters or hospital stays in your answers.
         </property>
         <property>
             <name>estimate</name>
-            <value>5</value>
+            <value>15</value>
             <type>Long</type>
         </property>
         <property>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/YVM.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/YVM.xml
@@ -39,7 +39,7 @@ answers are combined with other people’s responses to help Ontario Health (Can
 understand how to best support patients.
 
 **This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.**
-Your appointment may have been for an assessment, for cancer treatment, or for follow-up after your treatment.
+Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
 This survey is to evaluate your experience being at the Cancer Centre.
 **If you feel this survey does not pertain to you, please disregard.**
         </value>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/YVM.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/YVM.xml
@@ -28,20 +28,18 @@
     <property>
         <name>intro</name>
         <value>
-**Your Voice Matters** is a set of questions that gives you the chance to share your cancer care
-experience. Your answers will help us know how to improve the experience for patients and care
-partners at your hospital and across Ontario.
-
-Tell us about your most recent in-person (at the cancer clinic) or virtual (by telephone or video)
-cancer care visit. It will take **about 5 minutes** to complete this survey. This survey is
-**confidential** (private). Your cancer care team will not see your responses to the questions. Your
-answers are combined with other people’s responses to help Ontario Health (Cancer Care Ontario)
-understand how to best support patients.
+**Your Voice Matters** is a short survey that gives you the chance to share your experience at
+Princess Margaret Cancer Centre. Your feedback helps improve care for patients and their care
+partners – both here and across Ontario. Ontario Health (Cancer Care Ontario) uses your responses
+combined with others, to better understand what patients need and how to support them.
 
 **This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.**
 Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
 This survey is to evaluate your experience being at the Cancer Centre.
 **If you feel this survey does not pertain to you, please disregard.**
+
+Tell us about your most recent visit, whether it was in person, by phone, or by video. Your answers are
+confidential and will not affect your care. The survey takes about 5 minutes to complete.
         </value>
         <type>String</type>
     </property>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/YVM.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/YVM.xml
@@ -35,7 +35,7 @@ combined with others, to better understand what patients need and how to support
 
 **This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.**
 Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
-This survey is to evaluate your experience being at the Cancer Centre.
+This survey is to evaluate your experience at the Cancer Centre.
 **If you feel this survey does not pertain to you, please disregard.**
 
 Tell us about your most recent visit, whether it was in person, by phone, or by video. Your answers are

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO-IP/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO-IP/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -5,7 +5,13 @@
     <p>
       We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
       Our records show that you had a recent visit to ${unit} followed by an inpatient stay at Princess Margaret.
-      We would like to learn more about your experience in an optional survey. It should take approximately 10 minutes to complete.
+      We would like to learn more about your experience in an optional survey. It should take approximately 10-15 minutes to complete.
+    </p>
+    <p>
+      This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
+      Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
+      This survey is to evaluate your experience being at the Cancer Centre.
+      <strong>If you feel this survey does not pertain to you, please disregard.</strong>
     </p>
     <p class="surveylink">
       <a href="${surveysLink}">Complete the survey</a>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO-IP/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO-IP/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -7,12 +7,6 @@
       Our records show that you had a recent visit to ${unit} followed by an inpatient stay at Princess Margaret.
       We would like to learn more about your experience in an optional survey. It should take approximately 10-15 minutes to complete.
     </p>
-    <p>
-      This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
-      Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
-      This survey is to evaluate your experience being at the Cancer Centre.
-      <strong>If you feel this survey does not pertain to you, please disregard.</strong>
-    </p>
     <p class="surveylink">
       <a href="${surveysLink}">Complete the survey</a>
     </p>
@@ -47,10 +41,10 @@
       and Health Care Leaders to improve quality.
     </p>
     <p>
-      We have done everything we can to make sure that this survey does not go to families
-      who have lost a loved one. If you received this survey after your loved one has passed away,
-      please accept our heartfelt condolences and our sincere apology.
-      You may respond to this survey on behalf of your loved one if you would like.
+      We have done our best to ensure this survey does not reach families
+      who have lost a loved one. If you received it after a loss,
+      please accept our sincere condolences and apologies.
+      You are welcome to complete the survey on their behalf if you wish.
     </p>
     <p>
       For all additional patient experience feedback, please email us at <a href="mailto:PMExperience">PMExperience@uhn.ca</a>.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO-IP/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO-IP/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -5,11 +5,6 @@ Our records show that you had a recent visit to ${unit} followed by an inpatient
 We would like to learn more about your experience in an optional survey. It should take
 approximately 10-15 minutes to complete.
 
-This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
-Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
-This survey is to evaluate your experience being at the Cancer Centre.
-If you feel this survey does not pertain to you, please disregard.
-
 To begin the survey, click the following link:
 ${surveysLink}
 
@@ -29,11 +24,11 @@ personal information, and will be stored separately from your personal health in
 Your answers will be shared only with the Patient and Family Experience Committee and Health Care
 Leaders to improve quality.
 
-We have done everything we can to make sure that this survey does not go to families who have
-lost a loved one. If you received this survey after your loved one has passed away, please accept
-our heartfelt condolences and our sincere apology. You may respond to this survey on behalf of
-your loved one if you would like. For all additional patient experience feedback, please email us
-at PMExperience@uhn.ca.
+We have done our best to ensure this survey does not reach families who have lost a loved one.
+If you received it after a loss, please accept our sincere condolences and apologies.
+You are welcome to complete the survey on their behalf if you wish.
+
+For all additional patient experience feedback, please email us at PMExperience@uhn.ca.
 
 Thank you for your time and participation!
 

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO-IP/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO-IP/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -3,7 +3,12 @@ Good morning,
 We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
 Our records show that you had a recent visit to ${unit} followed by an inpatient stay at Princess Margaret.
 We would like to learn more about your experience in an optional survey. It should take
-approximately 10 minutes to complete.
+approximately 10-15 minutes to complete.
+
+This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
+Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
+This survey is to evaluate your experience being at the Cancer Centre.
+If you feel this survey does not pertain to you, please disregard.
 
 To begin the survey, click the following link:
 ${surveysLink}

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO-IP/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO-IP/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -7,7 +7,13 @@
       We would like to learn more about your most recent visit to ${unit} and inpatient stay at Princess Margaret.
       Our records indicate that we sent you an optional survey asking about your experience.
       However, we have not heard back from you.
-      The survey should take approximately 10 minutes to complete.
+      The survey should take approximately 10-15 minutes to complete.
+    </p>
+    <p>
+      This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
+      Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
+      This survey is to evaluate your experience being at the Cancer Centre.
+      <strong>If you feel this survey does not pertain to you, please disregard.</strong>
     </p>
     <p class="surveylink">
       <a href="${surveysLink}">Complete the survey</a>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO-IP/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO-IP/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -9,12 +9,6 @@
       However, we have not heard back from you.
       The survey should take approximately 10-15 minutes to complete.
     </p>
-    <p>
-      This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
-      Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
-      This survey is to evaluate your experience being at the Cancer Centre.
-      <strong>If you feel this survey does not pertain to you, please disregard.</strong>
-    </p>
     <p class="surveylink">
       <a href="${surveysLink}">Complete the survey</a>
     </p>
@@ -49,10 +43,10 @@
       and Health Care Leaders to improve quality.
     </p>
     <p>
-      We have done everything we can to make sure that this survey does not go to families
-      who have lost a loved one. If you received this survey after your loved one has passed away,
-      please accept our heartfelt condolences and our sincere apology.
-      You may respond to this survey on behalf of your loved one if you would like.
+      We have done our best to ensure this survey does not reach families
+      who have lost a loved one. If you received it after a loss,
+      please accept our sincere condolences and apologies.
+      You are welcome to complete the survey on their behalf if you wish.
     </p>
     <p>
       For all additional patient experience feedback, please email us at <a href="mailto:PMExperience">PMExperience@uhn.ca</a>.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO-IP/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO-IP/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -5,11 +5,6 @@ We would like to learn more about your most recent visit to ${unit} and inpatien
 Margaret. Our records indicate that we sent you an optional survey asking about your experience.
 However, we have not heard back from you. The survey should take approximately 10-15 minutes to complete.
 
-This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
-Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
-This survey is to evaluate your experience being at the Cancer Centre.
-If you feel this survey does not pertain to you, please disregard.
-
 To begin the survey, click the following link:
 ${surveysLink}
 
@@ -29,11 +24,11 @@ personal information, and will be stored separately from your personal health in
 Your answers will be shared only with the Patient and Family Experience Committee and Health Care
 Leaders to improve quality.
 
-We have done everything we can to make sure that this survey does not go to families who have
-lost a loved one. If you received this survey after your loved one has passed away, please accept
-our heartfelt condolences and our sincere apology. You may respond to this survey on behalf of
-your loved one if you would like. For all additional patient experience feedback, please email us
-at PMExperience@uhn.ca.
+We have done our best to ensure this survey does not reach families who have lost a loved one.
+If you received it after a loss, please accept our sincere condolences and apologies.
+You are welcome to complete the survey on their behalf if you wish.
+
+For all additional patient experience feedback, please email us at PMExperience@uhn.ca.
 
 Thank you for your time and participation!
 

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO-IP/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO-IP/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -3,7 +3,12 @@ Good morning,
 We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
 We would like to learn more about your most recent visit to ${unit} and inpatient stay at Princess
 Margaret. Our records indicate that we sent you an optional survey asking about your experience.
-However, we have not heard back from you. The survey should take approximately 10 minutes to complete.
+However, we have not heard back from you. The survey should take approximately 10-15 minutes to complete.
+
+This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
+Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
+This survey is to evaluate your experience being at the Cancer Centre.
+If you feel this survey does not pertain to you, please disregard.
 
 To begin the survey, click the following link:
 ${surveysLink}

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -7,12 +7,6 @@
       Our records show that you had a recent visit at ${unit}.
       We would like to learn more about your experience in an optional survey. It should take approximately 5-10 minutes to complete.
     </p>
-    <p>
-      This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
-      Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
-      This survey is to evaluate your experience being at the Cancer Centre.
-      <strong>If you feel this survey does not pertain to you, please disregard.</strong>
-    </p>
     <p class="surveylink">
       <a href="${surveysLink}">Complete the survey</a>
     </p>
@@ -47,10 +41,10 @@
       and Health Care Leaders to improve quality.
     </p>
     <p>
-      We have done everything we can to make sure that this survey does not go to families
-      who have lost a loved one. If you received this survey after your loved one has passed away,
-      please accept our heartfelt condolences and our sincere apology.
-      You may respond to this survey on behalf of your loved one if you would like.
+      We have done our best to ensure this survey does not reach families
+      who have lost a loved one. If you received it after a loss,
+      please accept our sincere condolences and apologies.
+      You are welcome to complete the survey on their behalf if you wish.
     </p>
     <p>
       For all additional patient experience feedback, please email us at <a href="mailto:PMExperience">PMExperience@uhn.ca</a>.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -5,7 +5,13 @@
     <p>
       We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
       Our records show that you had a recent visit at ${unit}.
-      We would like to learn more about your experience in an optional survey. It should take approximately 5 minutes to complete.
+      We would like to learn more about your experience in an optional survey. It should take approximately 5-10 minutes to complete.
+    </p>
+    <p>
+      This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
+      Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
+      This survey is to evaluate your experience being at the Cancer Centre.
+      <strong>If you feel this survey does not pertain to you, please disregard.</strong>
     </p>
     <p class="surveylink">
       <a href="${surveysLink}">Complete the survey</a>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -5,11 +5,6 @@ Our records show that you had a recent visit at ${unit}.
 We would like to learn more about your experience in an optional survey. It should take
 approximately 5-10 minutes to complete.
 
-This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
-Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
-This survey is to evaluate your experience being at the Cancer Centre.
-If you feel this survey does not pertain to you, please disregard.
-
 To begin the survey, click the following link:
 ${surveysLink}
 
@@ -29,11 +24,11 @@ personal information, and will be stored separately from your personal health in
 Your answers will be shared only with the Patient and Family Experience Committee and Health Care
 Leaders to improve quality.
 
-We have done everything we can to make sure that this survey does not go to families who have
-lost a loved one. If you received this survey after your loved one has passed away, please accept
-our heartfelt condolences and our sincere apology. You may respond to this survey on behalf of
-your loved one if you would like. For all additional patient experience feedback, please email us
-at PMExperience@uhn.ca.
+We have done our best to ensure this survey does not reach families who have lost a loved one.
+If you received it after a loss, please accept our sincere condolences and apologies.
+You are welcome to complete the survey on their behalf if you wish.
+
+For all additional patient experience feedback, please email us at PMExperience@uhn.ca.
 
 Thank you for your time and participation!
 

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -3,7 +3,12 @@ Good morning,
 We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
 Our records show that you had a recent visit at ${unit}.
 We would like to learn more about your experience in an optional survey. It should take
-approximately 5 minutes to complete.
+approximately 5-10 minutes to complete.
+
+This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
+Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
+This survey is to evaluate your experience being at the Cancer Centre.
+If you feel this survey does not pertain to you, please disregard.
 
 To begin the survey, click the following link:
 ${surveysLink}

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -9,12 +9,6 @@
       However, we have not heard back from you.
       The survey should take approximately 5-10 minutes to complete.
     </p>
-    <p>
-      This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
-      Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
-      This survey is to evaluate your experience being at the Cancer Centre.
-      <strong>If you feel this survey does not pertain to you, please disregard.</strong>
-    </p>
     <p class="surveylink">
       <a href="${surveysLink}">Complete the survey</a>
     </p>
@@ -49,10 +43,10 @@
       and Health Care Leaders to improve quality.
     </p>
     <p>
-      We have done everything we can to make sure that this survey does not go to families
-      who have lost a loved one. If you received this survey after your loved one has passed away,
-      please accept our heartfelt condolences and our sincere apology.
-      You may respond to this survey on behalf of your loved one if you would like.
+      We have done our best to ensure this survey does not reach families
+      who have lost a loved one. If you received it after a loss,
+      please accept our sincere condolences and apologies.
+      You are welcome to complete the survey on their behalf if you wish.
     </p>
     <p>
       For all additional patient experience feedback, please email us at <a href="mailto:PMExperience">PMExperience@uhn.ca</a>.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -7,7 +7,13 @@
       We would like to learn more about your most recent visit at ${unit}.
       Our records indicate that we sent you an optional survey asking about your experience.
       However, we have not heard back from you.
-      The survey should take approximately 5 minutes to complete.
+      The survey should take approximately 5-10 minutes to complete.
+    </p>
+    <p>
+      This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
+      Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
+      This survey is to evaluate your experience being at the Cancer Centre.
+      <strong>If you feel this survey does not pertain to you, please disregard.</strong>
     </p>
     <p class="surveylink">
       <a href="${surveysLink}">Complete the survey</a>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -3,7 +3,12 @@ Good morning,
 We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
 We would like to learn more about your most recent visit at ${unit}.
 Our records indicate that we sent you an optional survey asking about your experience.
-However, we have not heard back from you. The survey should take approximately 5 minutes to complete.
+However, we have not heard back from you. The survey should take approximately 5-10 minutes to complete.
+
+This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
+Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
+This survey is to evaluate your experience being at the Cancer Centre.
+If you feel this survey does not pertain to you, please disregard.
 
 To begin the survey, click the following link:
 ${surveysLink}

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PM-OO/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -5,11 +5,6 @@ We would like to learn more about your most recent visit at ${unit}.
 Our records indicate that we sent you an optional survey asking about your experience.
 However, we have not heard back from you. The survey should take approximately 5-10 minutes to complete.
 
-This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
-Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
-This survey is to evaluate your experience being at the Cancer Centre.
-If you feel this survey does not pertain to you, please disregard.
-
 To begin the survey, click the following link:
 ${surveysLink}
 
@@ -29,11 +24,11 @@ personal information, and will be stored separately from your personal health in
 Your answers will be shared only with the Patient and Family Experience Committee and Health Care
 Leaders to improve quality.
 
-We have done everything we can to make sure that this survey does not go to families who have
-lost a loved one. If you received this survey after your loved one has passed away, please accept
-our heartfelt condolences and our sincere apology. You may respond to this survey on behalf of
-your loved one if you would like. For all additional patient experience feedback, please email us
-at PMExperience@uhn.ca.
+We have done our best to ensure this survey does not reach families who have lost a loved one.
+If you received it after a loss, please accept our sincere condolences and apologies.
+You are welcome to complete the survey on their behalf if you wish.
+
+For all additional patient experience feedback, please email us at PMExperience@uhn.ca.
 
 Thank you for your time and participation!
 

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -7,6 +7,12 @@
       Our records show that you had a recent outpatient clinic visit with your nurse and/or doctor.
       We would like to learn more about your experience in an optional survey. It should take approximately 5 minutes to complete.
     </p>
+    <p>
+      This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
+      Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
+      This survey is to evaluate your experience being at the Cancer Centre.
+      <strong>If you feel this survey does not pertain to you, please disregard.</strong>
+    </p>
     <p class="surveylink">
       <a href="${surveysLink}">Complete the survey</a>
     </p>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -4,14 +4,16 @@
     <p>Good morning,</p>
     <p>
       We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
-      Our records show that you had a recent outpatient clinic visit with your nurse and/or doctor.
-      We would like to learn more about your experience in an optional survey. It should take approximately 5 minutes to complete.
+      We would like to learn more about your experience in an optional survey.
     </p>
     <p>
-      This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
+      This survey is sent to all patients who have recently had an appointment at Princess Margaret Cancer Centre.
       Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
       This survey is to evaluate your experience being at the Cancer Centre.
       <strong>If you feel this survey does not pertain to you, please disregard.</strong>
+    </p>
+    <p>
+      The survey should take approximately 5 minutes to complete.
     </p>
     <p class="surveylink">
       <a href="${surveysLink}">Complete the survey</a>
@@ -47,10 +49,9 @@
       and Health Care Leaders to improve quality.
     </p>
     <p>
-      We have done everything we can to make sure that this survey does not go to families
-      who have lost a loved one. If you received this survey after your loved one has passed away,
-      please accept our heartfelt condolences and our sincere apology.
-      You may respond to this survey on behalf of your loved one if you would like.
+      We have done our best to ensure this survey does not reach families who have lost a loved one.
+      If you received it after a loss, please accept our sincere condolences and apologies.
+      You are welcome to complete the survey on their behalf if you wish.
     </p>
     <p>
       For all additional patient experience feedback, please email us at <a href="mailto:PMExperience">PMExperience@uhn.ca</a>.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/bodyTemplate.html
@@ -9,7 +9,7 @@
     <p>
       This survey is sent to all patients who have recently had an appointment at Princess Margaret Cancer Centre.
       Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
-      This survey is to evaluate your experience being at the Cancer Centre.
+      This survey is to evaluate your experience at the Cancer Centre.
       <strong>If you feel this survey does not pertain to you, please disregard.</strong>
     </p>
     <p>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -1,14 +1,14 @@
 Good morning,
 
 We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
-Our records show that you had a recent outpatient clinic visit with your nurse and/or doctor.
-We would like to learn more about your experience in an optional survey. It should take
-approximately 5 minutes to complete.
+We would like to learn more about your experience in an optional survey.
 
-This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
+This survey is sent to all patients who have recently had an appointment at Princess Margaret Cancer Centre.
 Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
 This survey is to evaluate your experience being at the Cancer Centre.
 If you feel this survey does not pertain to you, please disregard.
+
+The survey should take approximately 5 minutes to complete.
 
 To begin the survey, click the following link:
 ${surveysLink}
@@ -29,11 +29,11 @@ personal information, and will be stored separately from your personal health in
 Your answers will be shared only with the Patient and Family Experience Committee and Health Care
 Leaders to improve quality.
 
-We have done everything we can to make sure that this survey does not go to families who have
-lost a loved one. If you received this survey after your loved one has passed away, please accept
-our heartfelt condolences and our sincere apology. You may respond to this survey on behalf of
-your loved one if you would like. For all additional patient experience feedback, please email us
-at PMExperience@uhn.ca.
+We have done our best to ensure this survey does not reach families who have lost a loved one.
+If you received it after a loss, please accept our sincere condolences and apologies.
+You are welcome to complete the survey on their behalf if you wish.
+
+For all additional patient experience feedback, please email us at PMExperience@uhn.ca.
 
 Thank you for your time and participation!
 

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -5,7 +5,7 @@ We would like to learn more about your experience in an optional survey.
 
 This survey is sent to all patients who have recently had an appointment at Princess Margaret Cancer Centre.
 Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
-This survey is to evaluate your experience being at the Cancer Centre.
+This survey is to evaluate your experience at the Cancer Centre.
 If you feel this survey does not pertain to you, please disregard.
 
 The survey should take approximately 5 minutes to complete.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/InitialInvitation/bodyTemplate.txt
@@ -5,6 +5,11 @@ Our records show that you had a recent outpatient clinic visit with your nurse a
 We would like to learn more about your experience in an optional survey. It should take
 approximately 5 minutes to complete.
 
+This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
+Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
+This survey is to evaluate your experience being at the Cancer Centre.
+If you feel this survey does not pertain to you, please disregard.
+
 To begin the survey, click the following link:
 ${surveysLink}
 

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -4,16 +4,18 @@
     <p>Good morning,</p>
     <p>
       We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
-      We would like to learn more about your most recent outpatient clinic visit with nurse and/or doctor.
+      We would like to learn more about your most recent outpatient clinic visit.
       Our records indicate that we sent you an optional survey asking about your experience.
-      However, we have not heard back from you. This is the last reminder.
-      The survey should take approximately 5 minutes to complete.
+      However, we have not heard back from you.
     </p>
     <p>
       This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
       Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
       This survey is to evaluate your experience being at the Cancer Centre.
       <strong>If you feel this survey does not pertain to you, please disregard.</strong>
+    </p>
+    <p>
+      This is the last reminder. The survey should take approximately 5 minutes to complete.
     </p>
     <p class="surveylink">
       <a href="${surveysLink}">Complete the survey</a>
@@ -49,10 +51,10 @@
       and Health Care Leaders to improve quality.
     </p>
     <p>
-      We have done everything we can to make sure that this survey does not go to families
-      who have lost a loved one. If you received this survey after your loved one has passed away,
-      please accept our heartfelt condolences and our sincere apology.
-      You may respond to this survey on behalf of your loved one if you would like.
+      We have done our best to ensure this survey does not reach families
+      who have lost a loved one. If you received it after a loss,
+      please accept our sincere condolences and apologies.
+      You are welcome to complete the survey on their behalf if you wish.
     </p>
     <p>
       For all additional patient experience feedback, please email us at <a href="mailto:PMExperience">PMExperience@uhn.ca</a>.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -11,7 +11,7 @@
     <p>
       This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
       Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
-      This survey is to evaluate your experience being at the Cancer Centre.
+      This survey is to evaluate your experience at the Cancer Centre.
       <strong>If you feel this survey does not pertain to you, please disregard.</strong>
     </p>
     <p>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/bodyTemplate.html
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/bodyTemplate.html
@@ -9,6 +9,12 @@
       However, we have not heard back from you. This is the last reminder.
       The survey should take approximately 5 minutes to complete.
     </p>
+    <p>
+      This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
+      Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
+      This survey is to evaluate your experience being at the Cancer Centre.
+      <strong>If you feel this survey does not pertain to you, please disregard.</strong>
+    </p>
     <p class="surveylink">
       <a href="${surveysLink}">Complete the survey</a>
     </p>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -7,7 +7,7 @@ However, we have not heard back from you.
 
 This survey is sent to all patients who have recently had an appointment at Princess Margaret Cancer Centre.
 Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
-This survey is to evaluate your experience being at the Cancer Centre.
+This survey is to evaluate your experience at the Cancer Centre.
 If you feel this survey does not pertain to you, please disregard.
 
 This is the last reminder. The survey should take approximately 5 minutes to complete.

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -6,6 +6,12 @@ doctor. Our records indicate that we sent you an optional survey asking about yo
 However, we have not heard back from you. This is the last reminder. The survey should take
 approximately 5 minutes to complete.
 
+
+This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
+Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
+This survey is to evaluate your experience being at the Cancer Centre.
+If you feel this survey does not pertain to you, please disregard.
+
 To begin the survey, click the following link:
 ${surveysLink}
 

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/bodyTemplate.txt
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clinics/PMH-YVM/mailTemplates/ReminderNotification/bodyTemplate.txt
@@ -1,16 +1,16 @@
 Good morning,
 
 We are always striving to improve the experience of care at Princess Margaret Cancer Centre.
-We would like to learn more about your most recent outpatient clinic visit with nurse and/or
-doctor. Our records indicate that we sent you an optional survey asking about your experience.
-However, we have not heard back from you. This is the last reminder. The survey should take
-approximately 5 minutes to complete.
+We would like to learn more about your most recent outpatient clinic visit.
+Our records indicate that we sent you an optional survey asking about your experience.
+However, we have not heard back from you.
 
-
-This survey is sent to all patients who have had an appointment at Princess Margaret Cancer Centre.
+This survey is sent to all patients who have recently had an appointment at Princess Margaret Cancer Centre.
 Your appointment may have been for an assessment, for treatment, or for follow-up after your treatment.
 This survey is to evaluate your experience being at the Cancer Centre.
 If you feel this survey does not pertain to you, please disregard.
+
+This is the last reminder. The survey should take approximately 5 minutes to complete.
 
 To begin the survey, click the following link:
 ${surveysLink}
@@ -31,11 +31,11 @@ personal information, and will be stored separately from your personal health in
 Your answers will be shared only with the Patient and Family Experience Committee and Health Care
 Leaders to improve quality.
 
-We have done everything we can to make sure that this survey does not go to families who have
-lost a loved one. If you received this survey after your loved one has passed away, please accept
-our heartfelt condolences and our sincere apology. You may respond to this survey on behalf of
-your loved one if you would like. For all additional patient experience feedback, please email us
-at PMExperience@uhn.ca.
+We have done our best to ensure this survey does not reach families who have lost a loved one.
+If you received it after a loss, please accept our sincere condolences and apologies.
+You are welcome to complete the survey on their behalf if you wish.
+
+For all additional patient experience feedback, please email us at PMExperience@uhn.ca.
 
 Thank you for your time and participation!
 


### PR DESCRIPTION
- Removed the word "cancer" before "treatment" from the statement added previously to the YVM welcome screen
- Added statement to:
  - PMOO and PMOO-IP welcome screens
  - YVM, PMOO, and PMOO-IP emails
- Updated the estimated completion time for PMOO and PMOO-IP on the welcome screens and in the emails
