### PR TITLE
[misc] Large sample SQLs should be split into batches

### DIFF
--- a/compose-cluster/mssql/generate_test_YE_sql.py
+++ b/compose-cluster/mssql/generate_test_YE_sql.py
@@ -154,10 +154,11 @@ def convertToSqlType(insertion_values):
     return converted_values
 
 # Insert test data
-args.file.write("INSERT INTO [path].[PatientActivity_data_for_PtExpSurveyApp]")
-args.file.write("\t(PAT_ENC_CSN_ID, PAT_MRN, PAT_FIRST_NAME, PAT_LAST_NAME, EMAIL_ADDRESS, HOSP_DISCHARGE_DTTM, DISCH_DEPT_NAME, DISCH_LOC_NAME, EMAIL_CONSENT_YN, [MYCHART_STATUS], DEATH_DATE, PRIMARY_DX_NAME, DISCH_DISPOSITION, ED_VISIT_YN, LEVEL_OF_CARE, ED_IP_TRANSFER_YN, OP_IP_TRANSFER_YN, LENGTH_OF_STAY_DAYS, UHN_ICC_STATUS, UHN_ICC_PATIENT_ELIGIBILITY, PATIENT_CLASS)\n")
-args.file.write("\tVALUES\n")
 for i in range(args.n):
+    if i % 100 == 0:
+        args.file.write("INSERT INTO [path].[PatientActivity_data_for_PtExpSurveyApp]")
+        args.file.write("\t(PAT_ENC_CSN_ID, PAT_MRN, PAT_FIRST_NAME, PAT_LAST_NAME, EMAIL_ADDRESS, HOSP_DISCHARGE_DTTM, DISCH_DEPT_NAME, DISCH_LOC_NAME, EMAIL_CONSENT_YN, [MYCHART_STATUS], DEATH_DATE, PRIMARY_DX_NAME, DISCH_DISPOSITION, ED_VISIT_YN, LEVEL_OF_CARE, ED_IP_TRANSFER_YN, OP_IP_TRANSFER_YN, LENGTH_OF_STAY_DAYS, UHN_ICC_STATUS, UHN_ICC_PATIENT_ELIGIBILITY, PATIENT_CLASS)\n")
+        args.file.write("\tVALUES\n")
     insertion_values = {}
 
     #PAT_MRN
@@ -227,7 +228,7 @@ for i in range(args.n):
     insertion_values['PAT_ENC_CSN_ID'] = i
 
     args.file.write("\t({PAT_ENC_CSN_ID:07d}, {PAT_MRN:07d}, {PAT_FIRST_NAME}, {PAT_LAST_NAME}, {EMAIL_ADDRESS}, {HOSP_DISCHARGE_DTTM}, {DISCH_DEPT_NAME}, {DISCH_LOC_NAME}, {EMAIL_CONSENT_YN}, {MYCHART_STATUS}, {DEATH_DATE}, {PRIMARY_DX_NAME}, {DISCH_DISPOSITION}, {ED_VISIT_YN}, {LEVEL_OF_CARE}, {ED_IP_TRANSFER_YN}, {OP_IP_TRANSFER_YN}, {LENGTH_OF_STAY_DAYS}, {UHN_ICC_STATUS}, {UHN_ICC_PATIENT_ELIGIBILITY}, 'Inpatient')".format(**convertToSqlType(insertion_values)))
-    if i < args.n - 1:
+    if (i != args.n - 1) and (i % 100 != 99):
         args.file.write(",")
     args.file.write("\n")
 


### PR DESCRIPTION
Adminer does not allow too many rows to be inserted in one command, so split the generated SQLs into batches of 100.