### PR TITLE
CARDS-2766: The answers entered in a conditional section are not removed from the form context when the condition becomes false

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -28,7 +28,7 @@ import UnfoldMore from '@mui/icons-material/UnfoldMore';
 import ConditionalComponentManager from "./ConditionalComponentManager";
 import DeleteButton from "../dataHomepage/DeleteButton";
 import FormEntry, { ENTRY_TYPES } from "./FormEntry";
-import { useFormReaderContext } from "./FormContext";
+import { useFormReaderContext, useFormWriterContext } from "./FormContext";
 import QuestionnaireStyle, { FORM_ENTRY_CONTAINER_PROPS } from "./QuestionnaireStyle";
 import { hasWarningFlags } from "./FormUtilities";
 
@@ -95,6 +95,7 @@ function Section(props) {
   // Keep a list of UUIDs whose contents we should hide
   const [ labelsToHide, setLabelsToHide ] = useState({});
   const formContext = useFormReaderContext();
+  const changeFormContext = useFormWriterContext();
   const [ selectedUUID, setSelectedUUID ] = useState();
   const [ removableAnswers, setRemovableAnswers ] = useState({[ID_STATE_KEY]: 1});
   const [ answersToDelete, setAnswersToDelete ] = useState([]);
@@ -119,6 +120,13 @@ function Section(props) {
       setAnswersToDelete((oldValue) => oldValue.concat(delList));
       // Reset the list of existing answers
       setRemovableAnswers({[ID_STATE_KEY]: 1});
+
+      changeFormContext((oldContext) => {
+        // Remove the section answers from the context
+        let newData = {...oldContext};
+        keySet.forEach(key => { delete newData[key] });
+        return newData;
+      });
     }
   }, [conditionIsMet])
 


### PR DESCRIPTION
Specs: [CARDS-2766](https://phenotips.atlassian.net/browse/CARDS-2766)

[CARDS-2766]: https://phenotips.atlassian.net/browse/CARDS-2766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ