### PR TITLE
CARDS-2768: On the patient portal, the survey questions should be vertically aligned to the top

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -833,7 +833,8 @@ function QuestionnaireSet(props) {
 
   const progress = 100.0 * (crtStep + 1) / ((questionnaireIds?.length || 0) + 1);
 
-  return (<>
+  const screenContent = (
+    <>
       <Header
         key="title"
         title={title}
@@ -850,7 +851,21 @@ function QuestionnaireSet(props) {
           exitScreen
         }
       </QuestionnaireSetScreen>
-  </>)
+    </>
+  )
+
+  // If we're on a screen displaying survey questions,
+  // wrap the Header and the content in a Paper component,
+  // to keep them from being spaced evenly across the screen.
+  // The survey content will appear vertically aligned to the
+  // top, while the information screens (welcome message,
+  // review screen, final "Thank you" message will appear
+  // vertically aligned to the middle.
+  return (
+    crtStep >= 0 && crtStep < questionnaireIds.length
+    ? <Paper elevation={0}>{ screenContent }</Paper>
+    : screenContent
+  )
 }
 
 function QuestionnaireSetScreen (props) {


### PR DESCRIPTION
https://phenotips.atlassian.net/browse/CARDS-2768

To test:
* start in `prems`
* go through the usual process to generate patient surveys - ALL SURVEYS SHOULD BE TESTED
* on a large screen (not phone), go through the patient workflow from start to finish for each survey
  * test that the welcome and exit screens are vertically centered, while question screens are aligned to the top

* in the Administration, allow patients to submit incomplete surveys
* create one more patient survey
* as patient, start answering the survey but leave some mandatory questions unanswered
  * as you attempt to submit the incomplete survey, test that the "proceed anyway" screen is still vertically centered.