### PR TITLE
CARDS-2751: Unsubscribe links expire when the survey expires

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
@@ -69,9 +69,6 @@ function Unsubscribe (props) {
       <ErrorPage
         title="Invalid access"
         message="This page can only be accessed by opening an invitation to fill in a survey"
-        buttonLink="/content.html/Questionnaires/User"
-        buttonLabel="Go to the dashboard"
-        textAlign="left"
       />
     );
   }

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
@@ -108,6 +108,7 @@ function Unsubscribe (props) {
   let unsubscribe = (value) => {
     let request_data = new FormData();
     request_data.append("unsubscribe", value);
+    request_data.append("patient", patient);
     fetch("/Survey.unsubscribe", { method: 'POST', body: request_data })
       .then( (response) => response.ok ? response.json() : Promise.reject(response) )
       .then( json => json.status == "success" ? (setConfirmed(json.unsubscribed), setAlreadyUnsubscribed(null)) : Promise.reject(json.error))

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
@@ -61,8 +61,21 @@ function Unsubscribe (props) {
   const [ alreadyUnsubscribed, setAlreadyUnsubscribed ] = useState(false);
   const { classes } = useStyles();
 
+  let patient = new URLSearchParams(window.location.search).get("patient");
+  if (!patient) {
+    return (
+      <ErrorPage
+        title="Invalid access"
+        message="This page can only be accessed by opening an invitation to fill in a survey"
+        buttonLink="/content.html/Questionnaires/User"
+        buttonLabel="Go to the dashboard"
+        textAlign="left"
+      />
+    );
+  }
+
   useEffect(() => {
-    fetch("/Survey.unsubscribe", { method: 'GET' })
+    fetch(`/Survey.unsubscribe?patient=${patient}`, { method: 'GET' })
       .then( (response) => response.ok ? response.json() : Promise.reject(response) )
       .then( json => json.status == "success" ? setAlreadyUnsubscribed(json.unsubscribed) : Promise.reject(json.error))
       .catch((response) => {
@@ -81,18 +94,6 @@ function Unsubscribe (props) {
         let errMsg = "Unsubscribing failed";
         setError(errMsg + (response.status ? ` with error code ${response.status}: ${response.statusText}` : response));
       });
-  }
-
-  if (!("hasSessionSubject" in document.getElementById("patient-portal-unsubscribe-container").dataset)) {
-    return (
-      <ErrorPage
-        title="Invalid access"
-        message="This page can only be accessed by opening an invitation to fill in a survey"
-        buttonLink="/content.html/Questionnaires/User"
-        buttonLabel="Go to the dashboard"
-        textAlign="left"
-      />
-    );
   }
 
   let appName = document.querySelector('meta[name="title"]')?.content;

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
@@ -76,11 +76,32 @@ function Unsubscribe (props) {
 
   useEffect(() => {
     fetch(`/Survey.unsubscribe?patient=${patient}`, { method: 'GET' })
-      .then( (response) => response.ok ? response.json() : Promise.reject(response) )
-      .then( json => json.status == "success" ? setAlreadyUnsubscribed(json.unsubscribed) : Promise.reject(json.error))
-      .catch((response) => {
+      .then(async (response) => {
+        if (response.ok) {
+          return response.json();
+        } else {
+          // Try to read JSON error body
+          let errorData;
+          try {
+            errorData = await response.json();
+          } catch (e) {
+            // Fallback if body is not JSON
+            errorData = { error: response.statusText };
+          }
+          return Promise.reject(errorData);
+        }
+      })
+      .then(json => {
+        if (json.status === "success") {
+          setAlreadyUnsubscribed(json.unsubscribed);
+        } else {
+          return Promise.reject(json.error);
+        }
+      })
+      .catch(error => {
+        // error now has access to a custom backend error data
         let errMsg = "Cannot unsubscribe: ";
-        setError(errMsg + (response.status ? response.statusText : response));
+        setError(errMsg + (error.error || error));
       });
   }, []);
 

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
@@ -61,8 +61,10 @@ function Unsubscribe (props) {
   const [ alreadyUnsubscribed, setAlreadyUnsubscribed ] = useState(false);
   const { classes } = useStyles();
 
-  let patient = new URLSearchParams(window.location.search).get("patient");
-  if (!patient) {
+  const params = new URLSearchParams(window.location.search);
+  const patient = params.get("patient");
+  const authToken = params.get("auth_token");
+  if (!(patient || authToken)) {
     return (
       <ErrorPage
         title="Invalid access"
@@ -75,7 +77,7 @@ function Unsubscribe (props) {
   }
 
   useEffect(() => {
-    fetch(`/Survey.unsubscribe?patient=${patient}`, { method: 'GET' })
+    fetch("/Survey.unsubscribe" + (patient ? `?patient=${patient}` : ""), { method: 'GET' })
       .then(async (response) => {
         if (response.ok) {
           return response.json();
@@ -108,7 +110,7 @@ function Unsubscribe (props) {
   let unsubscribe = (value) => {
     let request_data = new FormData();
     request_data.append("unsubscribe", value);
-    request_data.append("patient", patient);
+    patient && request_data.append("patient", patient);
     fetch("/Survey.unsubscribe", { method: 'POST', body: request_data })
       .then( (response) => response.ok ? response.json() : Promise.reject(response) )
       .then( json => json.status == "success" ? (setConfirmed(json.unsubscribed), setAlreadyUnsubscribed(null)) : Promise.reject(json.error))

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/UnsubscribeLink.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/UnsubscribeLink.jsx
@@ -20,15 +20,20 @@ import { FooterLink } from "./Footer";
 
 function UnsubscribeLink (props) {
 
-  let patient = new URLSearchParams(window.location.search).get("patient");
+  const params = new URLSearchParams(window.location.search);
+  const patient = params.get("patient");
+  const authToken = params.get("auth_token");
 
-  return (patient ?
-    <FooterLink
-      href={`/Survey.unsubscribe.html?patient=${patient}`}
-    >
+  const value = patient || authToken;
+  const paramName = patient ? "patient" : "auth_token";
+
+  if (!value) return null;
+
+  return (
+    <FooterLink href={`/Survey.unsubscribe.html?${paramName}=${value}`}>
       Unsubscribe
     </FooterLink>
-    : null);
+  );
 }
 
 export default UnsubscribeLink;

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/UnsubscribeLink.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/UnsubscribeLink.jsx
@@ -20,11 +20,11 @@ import { FooterLink } from "./Footer";
 
 function UnsubscribeLink (props) {
 
-  let auth_token = new URLSearchParams(window.location.search).get("auth_token");
+  let patient = new URLSearchParams(window.location.search).get("patient");
 
-  return (auth_token ?
+  return (patient ?
     <FooterLink
-      href={`/Survey.unsubscribe.html?auth_token=${auth_token}`}
+      href={`/Survey.unsubscribe.html?patient=${patient}`}
     >
       Unsubscribe
     </FooterLink>

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/UnsubscribeServlet.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/UnsubscribeServlet.java
@@ -72,25 +72,22 @@ public class UnsubscribeServlet extends SlingAllMethodsServlet
     public void doGet(final SlingHttpServletRequest request, final SlingHttpServletResponse response)
         throws IOException
     {
-        // This only works for a token-authenticated session; refuse requests if this is not the case
-        final String sessionSubjectIdentifier =
-            (String) this.resolverFactory.getThreadResourceResolver().getAttribute("cards:sessionSubject");
-        if (sessionSubjectIdentifier == null) {
+        // This only works for a uuid-authenticated session; refuse requests if this is not the case
+        final String sessionPatientIdentifier = request.getParameter("patient");
+        if (sessionPatientIdentifier == null) {
             writeError(response, SlingHttpServletResponse.SC_BAD_REQUEST, "Not a valid patient session");
             return;
         }
         try (ResourceResolver rr = this.resolverFactory.getServiceResourceResolver(
             Map.of(ResourceResolverFactory.SUBSERVICE, "unsubscribe"))) {
             final Session session = rr.adaptTo(Session.class);
-            final Node visitSubject = session.getNodeByIdentifier(sessionSubjectIdentifier);
-            final Node patientInformationQuestionnaire = getPatientInformationQuestionnaire(session);
-            final Node patientInformationForm =
-                getPatientInformationForm(visitSubject, patientInformationQuestionnaire, session);
+            final Node patientInformationForm = session.getNodeByIdentifier(sessionPatientIdentifier);
             if (patientInformationForm == null) {
                 writeError(response, SlingHttpServletResponse.SC_NOT_FOUND, "Sorry, cannot find your profile");
                 return;
             }
 
+            final Node patientInformationQuestionnaire = getPatientInformationQuestionnaire(session);
             final Node unsubscribeQuestion =
                 this.questionnaireUtils.getQuestion(patientInformationQuestionnaire, UNSUBSCRIBE);
             Node unsubscribeAnswer = this.formUtils.getAnswer(patientInformationForm, unsubscribeQuestion);

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/UnsubscribeServlet.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/UnsubscribeServlet.java
@@ -73,36 +73,13 @@ public class UnsubscribeServlet extends SlingAllMethodsServlet
     public void doGet(final SlingHttpServletRequest request, final SlingHttpServletResponse response)
         throws IOException
     {
-        // This only works for a uuid-authenticated session; refuse requests if this is not the case
-        final String sessionPatientIdentifier = request.getParameter("patient");
-        String sessionSubjectIdentifier = null;
-        if (sessionPatientIdentifier == null) {
-            // fall back to the previous version of unsuscribing params
-            sessionSubjectIdentifier =
-                (String) this.resolverFactory.getThreadResourceResolver().getAttribute("cards:sessionSubject");
-            if (sessionSubjectIdentifier == null) {
-                writeError(response, SlingHttpServletResponse.SC_BAD_REQUEST, "Not a valid patient session");
-                return;
-            }
-        }
-
         try (ResourceResolver rr = this.resolverFactory.getServiceResourceResolver(
             Map.of(ResourceResolverFactory.SUBSERVICE, "unsubscribe"))) {
             final Session session = rr.adaptTo(Session.class);
-            final Node patientInformationQuestionnaire = getPatientInformationQuestionnaire(session);
-            final Node patientInformationForm;
-            if (sessionPatientIdentifier != null) {
-                patientInformationForm = session.getNodeByIdentifier(sessionPatientIdentifier);
-            } else {
-                final Node visitSubject = session.getNodeByIdentifier(sessionSubjectIdentifier);
-                patientInformationForm =
-                    getPatientInformationForm(visitSubject, patientInformationQuestionnaire, session);
-            }
 
-            if (patientInformationForm == null) {
-                writeError(response, SlingHttpServletResponse.SC_NOT_FOUND, "Sorry, cannot find your profile");
-                return;
-            }
+            final Node patientInformationQuestionnaire = getPatientInformationQuestionnaire(session);
+            final Node patientInformationForm =
+                getPatientInformationForm(request, session, patientInformationQuestionnaire);
 
             final Node unsubscribeQuestion =
                 this.questionnaireUtils.getQuestion(patientInformationQuestionnaire, UNSUBSCRIBE);
@@ -113,6 +90,8 @@ public class UnsubscribeServlet extends SlingAllMethodsServlet
             writeSuccess(response, unsubscribed);
         } catch (final LoginException e) {
             LOGGER.error("Service authorization not granted: {}", e.getMessage());
+        } catch (final IllegalAccessException e) {
+            writeError(response, SlingHttpServletResponse.SC_BAD_REQUEST, "Not a valid patient session");
         } catch (final ItemNotFoundException e) {
             writeError(response, SlingHttpServletResponse.SC_NOT_FOUND, "Sorry, cannot find your profile");
         } catch (final RepositoryException e) {
@@ -121,40 +100,16 @@ public class UnsubscribeServlet extends SlingAllMethodsServlet
     }
 
     @Override
-    @SuppressWarnings({"checkstyle:ExecutableStatementCount"})
     public void doPost(final SlingHttpServletRequest request, final SlingHttpServletResponse response)
         throws IOException
     {
-        // This only works for a uuid-authenticated session; refuse requests if this is not the case
-        final String sessionPatientIdentifier = request.getParameter("patient");
-        String sessionSubjectIdentifier = null;
-        if (sessionPatientIdentifier == null) {
-            // fall back to the previous version of unsuscribing params
-            sessionSubjectIdentifier =
-                (String) this.resolverFactory.getThreadResourceResolver().getAttribute("cards:sessionSubject");
-            if (sessionSubjectIdentifier == null) {
-                writeError(response, SlingHttpServletResponse.SC_BAD_REQUEST, "Not a valid patient session");
-                return;
-            }
-        }
-
         try (ResourceResolver rr = this.resolverFactory.getServiceResourceResolver(
             Map.of(ResourceResolverFactory.SUBSERVICE, "unsubscribe"))) {
             final Session session = rr.adaptTo(Session.class);
-            final Node patientInformationQuestionnaire = getPatientInformationQuestionnaire(session);
-            final Node patientInformationForm;
-            if (sessionPatientIdentifier != null) {
-                patientInformationForm = session.getNodeByIdentifier(sessionPatientIdentifier);
-            } else {
-                final Node visitSubject = session.getNodeByIdentifier(sessionSubjectIdentifier);
-                patientInformationForm =
-                    getPatientInformationForm(visitSubject, patientInformationQuestionnaire, session);
-            }
 
-            if (patientInformationForm == null) {
-                writeError(response, SlingHttpServletResponse.SC_CONFLICT, "Sorry, cannot record your answer");
-                return;
-            }
+            final Node patientInformationQuestionnaire = getPatientInformationQuestionnaire(session);
+            final Node patientInformationForm =
+                getPatientInformationForm(request, session, patientInformationQuestionnaire);
 
             final VersionManager versionManager = session.getWorkspace().getVersionManager();
             final boolean checkin = !versionManager.isCheckedOut(patientInformationForm.getPath());
@@ -176,6 +131,10 @@ public class UnsubscribeServlet extends SlingAllMethodsServlet
             writeSuccess(response, value == 1);
         } catch (final LoginException e) {
             LOGGER.error("Service authorization not granted: {}", e.getMessage());
+        } catch (final IllegalAccessException e) {
+            writeError(response, SlingHttpServletResponse.SC_BAD_REQUEST, "Not a valid patient session");
+        } catch (final ItemNotFoundException e) {
+            writeError(response, SlingHttpServletResponse.SC_NOT_FOUND, "Sorry, cannot find your profile");
         } catch (final RepositoryException e) {
             LOGGER.warn("Exception validating patient authentication: {}", e.getMessage(), e);
         }
@@ -186,7 +145,41 @@ public class UnsubscribeServlet extends SlingAllMethodsServlet
         return session.getNode("/Questionnaires/Patient information");
     }
 
-    private Node getPatientInformationForm(final Node visitSubject, final Node patientInformationQuestionnaire,
+    private Node getPatientInformationForm(final SlingHttpServletRequest request, final Session session,
+        final Node patientInformationQuestionnaire)
+        throws IllegalAccessException, ItemNotFoundException, RepositoryException
+    {
+        // This only works for a uuid-authenticated session; refuse requests if this is not the case
+        final String sessionPatientIdentifier = request.getParameter("patient");
+        String sessionSubjectIdentifier = null;
+        if (sessionPatientIdentifier == null) {
+            // Fall back to the previous version of unsubscribing params
+            sessionSubjectIdentifier =
+                (String) this.resolverFactory.getThreadResourceResolver().getAttribute("cards:sessionSubject");
+        } else {
+            // Check that this is indeed a patient profile
+            final Node patient = session.getNodeByIdentifier(sessionPatientIdentifier);
+            if (!patient.isNodeType("cards:Form")
+                || !this.formUtils.getQuestionnaire(patient).isSame(patientInformationQuestionnaire)) {
+                throw new IllegalAccessException();
+            }
+        }
+
+        final Node patientInformationForm;
+        if (sessionPatientIdentifier != null) {
+            patientInformationForm = session.getNodeByIdentifier(sessionPatientIdentifier);
+        } else {
+            final Node visitSubject = session.getNodeByIdentifier(sessionSubjectIdentifier);
+            patientInformationForm =
+                getPatientInformationFormFromVisit(visitSubject, patientInformationQuestionnaire, session);
+        }
+        if (patientInformationForm == null) {
+            throw new ItemNotFoundException();
+        }
+        return patientInformationForm;
+    }
+
+    private Node getPatientInformationFormFromVisit(final Node visitSubject, final Node patientInformationQuestionnaire,
         final Session session) throws RepositoryException
     {
         // Look for the patient's information in the repository

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/UnsubscribeServlet.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/UnsubscribeServlet.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
+import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
 import javax.jcr.PropertyIterator;
 import javax.jcr.RepositoryException;
@@ -97,6 +98,8 @@ public class UnsubscribeServlet extends SlingAllMethodsServlet
             writeSuccess(response, unsubscribed);
         } catch (final LoginException e) {
             LOGGER.error("Service authorization not granted: {}", e.getMessage());
+        } catch (final ItemNotFoundException e) {
+            writeError(response, SlingHttpServletResponse.SC_NOT_FOUND, "Sorry, cannot find your profile");
         } catch (final RepositoryException e) {
             LOGGER.warn("Exception validating patient authentication: {}", e.getMessage(), e);
         }

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/UnsubscribeServlet.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/UnsubscribeServlet.java
@@ -109,10 +109,9 @@ public class UnsubscribeServlet extends SlingAllMethodsServlet
     public void doPost(final SlingHttpServletRequest request, final SlingHttpServletResponse response)
         throws IOException
     {
-        // This only works for a token-authenticated session; refuse requests if this is not the case
-        final String sessionSubjectIdentifier =
-            (String) this.resolverFactory.getThreadResourceResolver().getAttribute("cards:sessionSubject");
-        if (sessionSubjectIdentifier == null) {
+        // This only works for a uuid-authenticated session; refuse requests if this is not the case
+        final String sessionPatientIdentifier = request.getParameter("patient");
+        if (sessionPatientIdentifier == null) {
             writeError(response, SlingHttpServletResponse.SC_BAD_REQUEST, "Not a valid patient session");
             return;
         }
@@ -120,10 +119,7 @@ public class UnsubscribeServlet extends SlingAllMethodsServlet
         try (ResourceResolver rr = this.resolverFactory.getServiceResourceResolver(
             Map.of(ResourceResolverFactory.SUBSERVICE, "unsubscribe"))) {
             final Session session = rr.adaptTo(Session.class);
-            final Node visitSubject = session.getNodeByIdentifier(sessionSubjectIdentifier);
-            final Node patientInformationQuestionnaire = getPatientInformationQuestionnaire(session);
-            final Node patientInformationForm =
-                getPatientInformationForm(visitSubject, patientInformationQuestionnaire, session);
+            final Node patientInformationForm = session.getNodeByIdentifier(sessionPatientIdentifier);
             if (patientInformationForm == null) {
                 writeError(response, SlingHttpServletResponse.SC_CONFLICT, "Sorry, cannot record your answer");
                 return;
@@ -133,6 +129,7 @@ public class UnsubscribeServlet extends SlingAllMethodsServlet
             final boolean checkin = !versionManager.isCheckedOut(patientInformationForm.getPath());
             versionManager.checkout(patientInformationForm.getPath());
 
+            final Node patientInformationQuestionnaire = getPatientInformationQuestionnaire(session);
             final Node unsubscribeQuestion =
                 this.questionnaireUtils.getQuestion(patientInformationQuestionnaire, UNSUBSCRIBE);
             Node unsubscribeAnswer = this.formUtils.getAnswer(patientInformationForm, unsubscribeQuestion);

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/UnsubscribeServlet.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/UnsubscribeServlet.java
@@ -75,20 +75,35 @@ public class UnsubscribeServlet extends SlingAllMethodsServlet
     {
         // This only works for a uuid-authenticated session; refuse requests if this is not the case
         final String sessionPatientIdentifier = request.getParameter("patient");
+        String sessionSubjectIdentifier = null;
         if (sessionPatientIdentifier == null) {
-            writeError(response, SlingHttpServletResponse.SC_BAD_REQUEST, "Not a valid patient session");
-            return;
+            // fall back to the previous version of unsuscribing params
+            sessionSubjectIdentifier =
+                (String) this.resolverFactory.getThreadResourceResolver().getAttribute("cards:sessionSubject");
+            if (sessionSubjectIdentifier == null) {
+                writeError(response, SlingHttpServletResponse.SC_BAD_REQUEST, "Not a valid patient session");
+                return;
+            }
         }
+
         try (ResourceResolver rr = this.resolverFactory.getServiceResourceResolver(
             Map.of(ResourceResolverFactory.SUBSERVICE, "unsubscribe"))) {
             final Session session = rr.adaptTo(Session.class);
-            final Node patientInformationForm = session.getNodeByIdentifier(sessionPatientIdentifier);
+            final Node patientInformationQuestionnaire = getPatientInformationQuestionnaire(session);
+            final Node patientInformationForm;
+            if (sessionPatientIdentifier != null) {
+                patientInformationForm = session.getNodeByIdentifier(sessionPatientIdentifier);
+            } else {
+                final Node visitSubject = session.getNodeByIdentifier(sessionSubjectIdentifier);
+                patientInformationForm =
+                    getPatientInformationForm(visitSubject, patientInformationQuestionnaire, session);
+            }
+
             if (patientInformationForm == null) {
                 writeError(response, SlingHttpServletResponse.SC_NOT_FOUND, "Sorry, cannot find your profile");
                 return;
             }
 
-            final Node patientInformationQuestionnaire = getPatientInformationQuestionnaire(session);
             final Node unsubscribeQuestion =
                 this.questionnaireUtils.getQuestion(patientInformationQuestionnaire, UNSUBSCRIBE);
             Node unsubscribeAnswer = this.formUtils.getAnswer(patientInformationForm, unsubscribeQuestion);
@@ -106,20 +121,36 @@ public class UnsubscribeServlet extends SlingAllMethodsServlet
     }
 
     @Override
+    @SuppressWarnings({"checkstyle:ExecutableStatementCount"})
     public void doPost(final SlingHttpServletRequest request, final SlingHttpServletResponse response)
         throws IOException
     {
         // This only works for a uuid-authenticated session; refuse requests if this is not the case
         final String sessionPatientIdentifier = request.getParameter("patient");
+        String sessionSubjectIdentifier = null;
         if (sessionPatientIdentifier == null) {
-            writeError(response, SlingHttpServletResponse.SC_BAD_REQUEST, "Not a valid patient session");
-            return;
+            // fall back to the previous version of unsuscribing params
+            sessionSubjectIdentifier =
+                (String) this.resolverFactory.getThreadResourceResolver().getAttribute("cards:sessionSubject");
+            if (sessionSubjectIdentifier == null) {
+                writeError(response, SlingHttpServletResponse.SC_BAD_REQUEST, "Not a valid patient session");
+                return;
+            }
         }
 
         try (ResourceResolver rr = this.resolverFactory.getServiceResourceResolver(
             Map.of(ResourceResolverFactory.SUBSERVICE, "unsubscribe"))) {
             final Session session = rr.adaptTo(Session.class);
-            final Node patientInformationForm = session.getNodeByIdentifier(sessionPatientIdentifier);
+            final Node patientInformationQuestionnaire = getPatientInformationQuestionnaire(session);
+            final Node patientInformationForm;
+            if (sessionPatientIdentifier != null) {
+                patientInformationForm = session.getNodeByIdentifier(sessionPatientIdentifier);
+            } else {
+                final Node visitSubject = session.getNodeByIdentifier(sessionSubjectIdentifier);
+                patientInformationForm =
+                    getPatientInformationForm(visitSubject, patientInformationQuestionnaire, session);
+            }
+
             if (patientInformationForm == null) {
                 writeError(response, SlingHttpServletResponse.SC_CONFLICT, "Sorry, cannot record your answer");
                 return;
@@ -129,7 +160,6 @@ public class UnsubscribeServlet extends SlingAllMethodsServlet
             final boolean checkin = !versionManager.isCheckedOut(patientInformationForm.getPath());
             versionManager.checkout(patientInformationForm.getPath());
 
-            final Node patientInformationQuestionnaire = getPatientInformationQuestionnaire(session);
             final Node unsubscribeQuestion =
                 this.questionnaireUtils.getQuestion(patientInformationQuestionnaire, UNSUBSCRIBE);
             Node unsubscribeAnswer = this.formUtils.getAnswer(patientInformationForm, unsubscribeQuestion);

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
+import javax.jcr.PropertyIterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
@@ -207,8 +208,9 @@ abstract class AbstractEmailNotification
         // Send the Notification Email
         Map<String, String> valuesMap = new HashMap<>();
         valuesMap.put("surveysLink", "https://" + CARDS_HOST_AND_PORT + CLINIC_SLING_PATH + "?auth_token=" + token);
+        final String uuid = getPatientFormUUID(patientSubject, session);
         final String unsubscribeLink =
-            "https://" + CARDS_HOST_AND_PORT + "/Survey.unsubscribe.html?auth_token=" + token;
+            "https://" + CARDS_HOST_AND_PORT + "/Survey.unsubscribe.html?patient=" + uuid;
         valuesMap.put("unsubscribeLink", unsubscribeLink);
         final DateFormat sdf = DateFormat.getDateInstance(DateFormat.LONG);
         sdf.setTimeZone(tokenExpiryDate.getTimeZone());
@@ -221,6 +223,20 @@ abstract class AbstractEmailNotification
             .withRecipient(patientEmailAddress, patientFullName)
             .withExtraHeader("List-Unsubscribe", "<" + unsubscribeLink + ">")
             .build();
+    }
+
+    private String getPatientFormUUID(final Node patientSubject, final Session session) throws RepositoryException
+    {
+        final Node patientInformationQuestionnaire = session.getNode("/Questionnaires/Patient information");
+        final PropertyIterator properties = patientSubject.getReferences("subject");
+        while (properties.hasNext()) {
+            final Node form = properties.nextProperty().getParent();
+            if (patientInformationQuestionnaire.getIdentifier()
+                .equals(this.formUtils.getQuestionnaireIdentifier(form))) {
+                return form.getProperty("jcr:uuid").getString();
+            }
+        }
+        return null;
     }
 
     private void atMidnight(final Calendar c)

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
@@ -108,7 +108,7 @@ abstract class AbstractEmailNotification
      * @param notificationType
      * @return the number of notification emails that have been sent
      */
-    @SuppressWarnings({"checkstyle:ExecutableStatementCount"})
+    @SuppressWarnings({ "checkstyle:ExecutableStatementCount" })
     public long sendNotification(final int differenceInDays, final EmailTemplate template, final String clinicId,
         String notificationType)
     {
@@ -234,7 +234,7 @@ abstract class AbstractEmailNotification
             final Node form = properties.nextProperty().getParent();
             if (patientInformationQuestionnaire.getIdentifier()
                 .equals(this.formUtils.getQuestionnaireIdentifier(form))) {
-                return form.getProperty("jcr:uuid").getString();
+                return form.getIdentifier();
             }
         }
         return null;

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
@@ -207,8 +207,9 @@ abstract class AbstractEmailNotification
             .getToken();
         // Send the Notification Email
         Map<String, String> valuesMap = new HashMap<>();
-        valuesMap.put("surveysLink", "https://" + CARDS_HOST_AND_PORT + CLINIC_SLING_PATH + "?auth_token=" + token);
         final String uuid = getPatientFormUUID(patientSubject, session);
+        valuesMap.put("surveysLink", "https://" + CARDS_HOST_AND_PORT + CLINIC_SLING_PATH + "?auth_token=" + token
+            + "&patient=" + uuid);
         final String unsubscribeLink =
             "https://" + CARDS_HOST_AND_PORT + "/Survey.unsubscribe.html?patient=" + uuid;
         valuesMap.put("unsubscribeLink", unsubscribeLink);

--- a/modules/patient-portal/src/main/resources/SLING-INF/content/libs/cards/PatientHomepage/unsubscribe.html.GET.html
+++ b/modules/patient-portal/src/main/resources/SLING-INF/content/libs/cards/PatientHomepage/unsubscribe.html.GET.html
@@ -18,7 +18,7 @@
   under the License.
 */-->
 <sly data-sly-resource="${@selectors='header'}"/>
-    <div id="patient-portal-unsubscribe-container" data-sly-use.sessionAttributes="sessionAttributes.js" data-sly-attribute.data-has-session-subject="${sessionAttributes.hasSessionSubject}" style="min-height: calc(100vh - 16px);display: flex;flex-direction: column;justify-content: space-between;"></div>
+    <div id="patient-portal-unsubscribe-container" data-sly-use.sessionAttributes="sessionAttributes.js" style="min-height: calc(100vh - 16px);display: flex;flex-direction: column;justify-content: space-between;"></div>
     <sly data-sly-use.assets="/libs/cards/resources/assets">
       <script src="/libs/cards/resources/${assets['patient-portal.Unsubscribe.js']}"></script>
     </sly>


### PR DESCRIPTION
Specs: [CARDS-2751](https://phenotips.atlassian.net/browse/CARDS-2751)

[CARDS-2751]: https://phenotips.atlassian.net/browse/CARDS-2751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Testing:

- Build with `-P docker`
- In `compose-cluster`, run `python3 generate_compose_yaml.py --mssql --dev_docker_image --oak_filesystem --cards_project cards4prems --smtps --smtps_test_container --smtps_test_mail_path ~/cardsmail --composum --adminer --server_address=localhost:8080`
- Edit the generated `docker-compose.yml` file, and at the end of the environment section of the cardsinitial service, add:
- `- NIGHTLY_NOTIFICATIONS_SCHEDULE=0 * * * * ? *`
- Start with `docker-compose build && docker-compose up`
- Create a new Patient Information form, fill out all fields other than `unsubscribed` and `FIHR`
- Careate a Visit information form for that Patient dated 1 day ago. Remember which clinic is selected.  (for example, Inpatient)
- Go to `http://localhost:8080/system/console/configMgr`, edit `UHN-IP-InitialInvitationsTask` to set the schedule to `0 * * * * ? *` and set days to visit to `-1`
- Wait one minute, then check the contents of the `~/cardsmail` folder, the file in there should not be empty
- Open it with your preferred text editor or email viewer and locate the unsubscribe link (if you open in any text editor, remember to de-code the URLs for example to remove `3D` after `=` etc)
- In a browser with no active sessions (e.g. a new incognito window), navigate to the unsubscribe URL
- Unsubscribe from all of the surveys, re-subscribe and unsubscribe again
- Verify that if you have unsubscribed by checking the `Patient Information` form
- Verify that if you have unsubscribed from the visit information form’s clinic that there are no longer emails being generated for that patient
- Test the fallback: in the emails file locate the token, decode and test the link `/Survey.unsubscribe.html?auth_token=<token>` in a browser with no active sessions


