### PR TITLE
CARDS-1761: Adapt React Date / Time pickers

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx
@@ -65,7 +65,12 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 function DateQuestion(props) {
   checkPropTypes(DateQuestion, props);
   let {existingAnswer, classes, pageActive, ...rest} = props;
-  let {dateFormat, type, lowerLimit, upperLimit} = {dateFormat: DateTimeUtilities.defaultDateFormat, type: DateTimeUtilities.TIMESTAMP_TYPE, ...props.questionDefinition, ...props};
+  let {
+    dateFormat = DateTimeUtilities.defaultDateFormat,
+    type = DateTimeUtilities.TIMESTAMP_TYPE,
+    lowerLimit,
+    upperLimit
+  } = {...props.questionDefinition, ...props};
 
   const existingValues = existingAnswer && existingAnswer[1].value || "";
   const upperLimitLuxon = DateTimeUtilities.toPrecision(DateTimeUtilities.processRelativeDate(upperLimit));
@@ -204,7 +209,7 @@ function DateQuestion(props) {
     const initialValue = Array.from(existingAnswer?.[1]?.value || []);
     let limits = initialValue.slice(0, 2);
     if (idx > 0 || limits.length == 0) return '';
-    limits[0] = label;
+    limits[0] = DateTimeUtilities.toPrecision(limits[0])?.toFormat(dateFormat);
     // In case of invalid data (only one limit of the range is available)
     if (limits.length == 1) {
       limits.push("");


### PR DESCRIPTION
- Fixed dates `rangeDisplayFormatter` for the cases when format is not specified in the question
- Better default props definition

To test: create any date range question without explicit date format and check the view mode.
Before:
<img width="242" height="104" alt="image" src="https://github.com/user-attachments/assets/44ef1bb9-5b68-44bc-8ec3-b4d704978d49" />

After:
<img width="225" height="110" alt="image" src="https://github.com/user-attachments/assets/a781056d-3dd2-4d75-a55e-473e33f4034d" />
