### PR TITLE
CARDS-2774: Dates should be correctly managed with respect to the timezones

### DIFF
--- a/modules/commons/src/main/frontend/src/components/DateTimeUtilities.jsx
+++ b/modules/commons/src/main/frontend/src/components/DateTimeUtilities.jsx
@@ -24,7 +24,6 @@ export default class DateTimeUtilities {
 
   static TIMESTAMP_TYPE = "timestamp";
   static INTERVAL_TYPE = "interval";
-  static slingDateFormat = "yyyy-MM-dd\'T\'HH:mm:ss.SSSZ";
   static defaultDateFormat = "yyyy-MM-dd";
   static VIEW_DATE_FORMAT = "yyyy/MM/dd";
 
@@ -88,16 +87,16 @@ export default class DateTimeUtilities {
     if (!date) {
       return null;
     }
-    if (!toFormat) {
-      toFormat = this.slingDateFormat;
-    }
 
     let new_date = date;
     if (typeof new_date === "string") {
-      new_date = fromFormat ? DateTime.fromFormat(new_date, fromFormat) : DateTime.fromISO(new_date);
+      new_date = fromFormat ? DateTime.fromFormat(new_date, fromFormat, { setZone: true }) : DateTime.fromISO(new_date, { setZone: true });
     }
     if (!new_date.isValid) {
       return null;
+    }
+    if (!toFormat) {
+      return new_date;
     }
 
     // Determine the coarsest measure to truncate the input to
@@ -230,7 +229,7 @@ export default class DateTimeUtilities {
     } else {
 
       // If not, is it a valid date in ISO format?
-      let isoDate = DateTime.fromISO(dateString.trim());
+      let isoDate = DateTime.fromISO(dateString.trim(), { setZone: true });
 
       if (isoDate.isValid){
         absoluteDate = isoDate;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx
@@ -34,6 +34,9 @@ import { AdapterLuxon } from "@mui/x-date-pickers/AdapterLuxon";
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { DateTime } from "luxon";
+import { Link } from "@mui/material";
+
 
 // Component that renders a date/time question
 // Selected answers are placed in a series of <input type="hidden"> tags for submission.
@@ -80,6 +83,7 @@ function DateQuestion(props) {
   const [endFormatError, setEndFormatError] = useState();
   const [minMaxError, setMinMaxError] = useState();
   const [rangeError, setRangeError] = useState();
+  const [switchedFromZone, setSwitchedFromZone] = useState();
 
   const views = DateTimeUtilities.getPickerViews(dateFormat);
 
@@ -156,16 +160,16 @@ function DateQuestion(props) {
     }
   }
 
-  let getSlingDate = (isEnd) => {
+  let getISODate = (isEnd) => {
     let date = isEnd ? displayedEndDate : displayedDate;
     if (date) {
-      date = date.toFormat(DateTimeUtilities.slingDateFormat) || "";
+      date = date.toISO() || "";
     }
     return date;
   }
 
-  let outputStart = getSlingDate(false);
-  let outputEnd = getSlingDate(true);
+  let outputStart = getISODate(false);
+  let outputEnd = getISODate(true);
   let outputAnswers = outputStart && outputStart !== "Invalid DateTime" && outputStart.length > 0 ? [["date", outputStart]] : [];
   if (isRange && outputEnd && outputEnd !== "Invalid DateTime" && outputEnd.length > 0) {
     outputAnswers.push(["endDate", outputEnd]);
@@ -173,7 +177,21 @@ function DateQuestion(props) {
 
   let errorMessage = formatError || minMaxError || rangeError;
 
+  let handleSwitch = (value, isEnd) => {
+    // if switchedFromZone is defined then user made a switch to local timezone in past and wants to switch back to original
+    let currentZone = value.zoneName;
+    let newDate = switchedFromZone ? value.setZone(switchedFromZone) : DateTime.fromISO(value.toISO());
+    if (isEnd) {
+      setDisplayedEndDate(newDate);
+    } else {
+      setDisplayedDate(newDate);
+    }
+    setSwitchedFromZone(switchedFromZone ? null : currentZone);
+  };
+
   let getDateField = (isEnd, date, formatError) => {
+    let localUTCZone = DateTime.fromISO(DateTime.local().toISO(), { setZone: true }).zoneName;
+    let isLocalTimeZone = DateTime.local().toISO().slice(-4) === date?.toISO().slice(-4);
     return (
     <LocalizationProvider dateAdapter={AdapterLuxon}>
       <PickerComponent
@@ -183,6 +201,7 @@ function DateQuestion(props) {
         minDate={lowerLimitLuxon || undefined}
         maxDate={upperLimitLuxon || undefined}
         value={date}
+        timezone={date?.zoneName}
         onChange={(value) => {
           setDate(value, isEnd);
           cleanErrorMessages(isEnd);
@@ -192,7 +211,19 @@ function DateQuestion(props) {
                        variant: 'standard',
                        error: formatError || minMaxError || rangeError,
                        className: classes.textField,
-                       helperText: formatError || minMaxError || null,
+                       helperText: formatError || minMaxError || date && (!isLocalTimeZone || switchedFromZone) &&
+                       <>
+                         Date is in {isLocalTimeZone ? localUTCZone : date.zoneName}
+                         <Link
+                           component="button"
+                           type="button"
+                           underline="hover"
+                           onClick={() => handleSwitch(date, isEnd)}
+                           sx={{ cursor: "pointer", ml: 1 }}
+                         >
+                           Switch to {switchedFromZone || localUTCZone}
+                         </Link>
+                       </>|| null,
                        onBlur: (event) => validateInput(event, date, isEnd),
                        onFocus: (event) => cleanErrorMessages(isEnd),
                      },

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -475,7 +475,7 @@ function Form (props) {
                          resourcePath={formURL}
                          resourceData={data}
                          breadcrumb={getTextHierarchy(data?.subject, true)}
-                         date={DateTime.fromISO(data['jcr:created']).toLocaleString(DateTime.DATE_MED)}
+                         date={DateTime.fromISO(data['jcr:created'], { setZone: true }).toLocaleString(DateTime.DATE_MED)}
                          onClose={() => { setActionsMenu(null); }}
                        />
                     </ListItem>
@@ -543,7 +543,7 @@ function Form (props) {
   )
 
   let getTimestampString  = (timestamp) => {
-    let time = DateTime.fromISO(timestamp);
+    let time = DateTime.fromISO(timestamp, { setZone: true });
     return time.hasSame(DateTime.local(),"day") ? "at " + time.toFormat("hh:mma") : time.toRelativeCalendar();
   }
 
@@ -599,7 +599,7 @@ function Form (props) {
             <Typography variant="overline">
               {"Entered by " + data['jcr:createdBy'] + " on "}
               <Tooltip title={data['jcr:created']}>
-                <span>{DateTime.fromISO(data['jcr:created']).toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)}</span>
+                <span>{DateTime.fromISO(data['jcr:created'], { setZone: true }).toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)}</span>
               </Tooltip>
             </Typography>
             : ""

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
@@ -209,7 +209,7 @@ let Questionnaire = (props) => {
           >
           { data?.['jcr:createdBy'] && data?.['jcr:created'] &&
             <Typography variant="overline">
-              Created by {data['jcr:createdBy']} on {DateTime.fromISO(data['jcr:created']).toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)}
+              Created by {data['jcr:createdBy']} on {DateTime.fromISO(data['jcr:created'], { setZone: true }).toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)}
             </Typography>
           }
         </ResourceHeader>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -346,7 +346,7 @@ function SubjectHeader(props) {
                 resourcePath={path}
                 resourceData={subject?.data}
                 breadcrumb={pageTitle}
-                date={DateTime.fromISO(subject?.data['jcr:created']).toLocaleString(DateTime.DATE_MED)}
+                date={DateTime.fromISO(subject?.data['jcr:created'], { setZone: true }).toLocaleString(DateTime.DATE_MED)}
               />
               <DeleteButton
                 entryPath={path}
@@ -381,7 +381,7 @@ function SubjectHeader(props) {
         <Typography variant="overline"  color="textSecondary">
           {"Entered by " + subject.data['jcr:createdBy'] + " on "}
           <Tooltip title={subject.data['jcr:created']}>
-            <span>{DateTime.fromISO(subject.data['jcr:created']).toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)}</span>
+            <span>{DateTime.fromISO(subject.data['jcr:created'], { setZone: true }).toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY)}</span>
           </Tooltip>
         </Typography>
         : ""
@@ -484,7 +484,7 @@ function SubjectMemberInternal (props) {
                   resourcePath={path}
                   resourceData={data}
                   breadcrumb={getTextHierarchy(data, true)}
-                  date={DateTime.fromISO(data['jcr:created']).toLocaleString(DateTime.DATE_MED)}
+                  date={DateTime.fromISO(data['jcr:created'], { setZone: true }).toLocaleString(DateTime.DATE_MED)}
                   className={classes.childSubjectHeaderButton}
                   disableShortcut
                 />
@@ -615,10 +615,10 @@ function SubjectMemberInternal (props) {
                                          {questionnaireTitle}
                                        </Link>
                                        <Typography variant="caption" component="div" color="textSecondary">
-                                         Created {DateTime.fromISO(row.original['jcr:created']).toFormat("yyyy-MM-dd HH:mm")}
+                                         Created {DateTime.fromISO(row.original['jcr:created'], { setZone: true }).toFormat("yyyy-MM-dd HH:mm")}
                                        </Typography>
                                        <Typography variant="caption" component="div" color="textSecondary">
-                                         Last modified {DateTime.fromISO(row.original['jcr:lastModified']).toFormat("yyyy-MM-dd HH:mm")}
+                                         Last modified {DateTime.fromISO(row.original['jcr:lastModified'], { setZone: true }).toFormat("yyyy-MM-dd HH:mm")}
                                        </Typography>
                                      </Grid>
                                    </Grid>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
@@ -59,21 +59,21 @@ function TimeQuestion(props) {
   checkPropTypes(TimeQuestion, props);
   let {existingAnswer, classes, pageActive, ...rest} = props;
   let {text, lowerLimit, upperLimit, errorText, minAnswers, dateFormat} = {dateFormat: "mm:ss", ...props.questionDefinition, ...props};
-  let currentStartValue = (existingAnswer && existingAnswer[1].value && DateTime.fromFormat(existingAnswer[1].value, dateFormat).isValid)
-    ? DateTime.fromFormat(existingAnswer[1].value, dateFormat) : null;
+  let currentStartValue = (existingAnswer && existingAnswer[1].value && DateTime.fromFormat(existingAnswer[1].value, dateFormat, { setZone: true }).isValid)
+    ? DateTime.fromFormat(existingAnswer[1].value, dateFormat, { setZone: true }) : null;
   const [selectedTime, changeTime] = useState(currentStartValue);
   const [error, setError] = useState(undefined);
   const defaultErrorMessage = errorText || "Please enter a valid time";
   const [errorMessage, setErrorMessage] = useState(defaultErrorMessage);
   const views = DateTimeUtilities.getPickerViews(dateFormat);
   const isHourMinuteSeconds = DateTimeUtilities.formatIsHourMinuteSeconds(dateFormat);
-  const maxTime = upperLimit ? DateTime.fromFormat(upperLimit, dateFormat) : null;
-  const minTime = lowerLimit ? DateTime.fromFormat(lowerLimit, dateFormat) : null;
+  const maxTime = upperLimit ? DateTime.fromFormat(upperLimit, dateFormat, { setZone: true }) : null;
+  const minTime = lowerLimit ? DateTime.fromFormat(lowerLimit, dateFormat, { setZone: true }) : null;
 
   // Error check existing answers when first loading the page
-  if (existingAnswer && existingAnswer[1].value && DateTime.fromFormat(existingAnswer[1].value, dateFormat).invalid) {
+  if (existingAnswer && existingAnswer[1].value && DateTime.fromFormat(existingAnswer[1].value, dateFormat, { setZone: true }).invalid) {
     setError(true);
-    setErrorMessage(DateTime.fromFormat(existingAnswer[1].value, dateFormat).invalidExplanation);
+    setErrorMessage(DateTime.fromFormat(existingAnswer[1].value, dateFormat, { setZone: true }).invalidExplanation);
   }
 
   let outputAnswers = [["time", selectedTime && selectedTime.isValid ? selectedTime.toFormat(dateFormat) : null]];

--- a/modules/downtime-warning-banner/src/main/frontend/src/DowntimeWarningConfiguration.jsx
+++ b/modules/downtime-warning-banner/src/main/frontend/src/DowntimeWarningConfiguration.jsx
@@ -56,8 +56,8 @@ function DowntimeWarningConfiguration() {
   // Read the settings from the saved configuration
   let readDowntimeWarningSettings = (json) => {
     setEnabled(json.enabled == 'true');
-    json.fromDate && setFromDate(DateTime.fromFormat(json.fromDate, dateFormat));
-    json.toDate && setToDate(DateTime.fromFormat(json.toDate, dateFormat));
+    json.fromDate && setFromDate(DateTime.fromFormat(json.fromDate, dateFormat, { setZone: true }));
+    json.toDate && setToDate(DateTime.fromFormat(json.toDate, dateFormat, { setZone: true }));
   }
 
   let buildConfigData = (formData) => {

--- a/modules/locking/src/main/frontend/src/locking/SubjectLockAction.jsx
+++ b/modules/locking/src/main/frontend/src/locking/SubjectLockAction.jsx
@@ -207,7 +207,7 @@ function SubjectLockAction(props) {
       <List dense>
         {rows.map((row, index) => {
           let date = row["jcr:created"];
-          let dateObj = DateTime.fromISO(date);
+          let dateObj = DateTime.fromISO(date, { setZone: true });
           if (dateObj.isValid) {
             date = dateObj.toFormat("yyyy-MM-dd");
           }

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PrintHeader.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PrintHeader.jsx
@@ -60,11 +60,11 @@ function PrintHeader (props) {
     <div className={classes.container}>
       <div>
         {(resourceData.last_name || resourceData.first_name) && <Typography variant="overline">{[resourceData.last_name || '-', resourceData.first_name || '-'].join(", ")}</Typography>}
-        {resourceData.date_of_birth && <Typography variant="overline">DOB: {DateTime.fromISO(resourceData.date_of_birth).toLocaleString(DateTime.DATE_MED)}</Typography>}
+        {resourceData.date_of_birth && <Typography variant="overline">DOB: {DateTime.fromISO(resourceData.date_of_birth, { setZone: true }).toLocaleString(DateTime.DATE_MED)}</Typography>}
       </div>
       <div>
         {resourceData.mrn && <Typography variant="overline">MRN: {resourceData.mrn}</Typography>}
-        {resourceData.time && <Typography variant="overline">Appt: {DateTime.fromISO(resourceData.time).toLocaleString(DateTime.DATETIME_MED)}</Typography>}
+        {resourceData.time && <Typography variant="overline">Appt: {DateTime.fromISO(resourceData.time, { setZone: true }).toLocaleString(DateTime.DATETIME_MED)}</Typography>}
       </div>
     </div>
     : null

--- a/modules/variants/src/main/frontend/src/VariantFilesContainer.jsx
+++ b/modules/variants/src/main/frontend/src/VariantFilesContainer.jsx
@@ -935,7 +935,7 @@ export default function VariantFilesContainer() {
                 })
               },
               Cell: ({ row }) => <Link href={row.original["@path"]} underline="hover">
-                                  {DateTime.fromISO(row.original['jcr:created']).toFormat(DateTimeUtilities.VIEW_DATE_FORMAT)}
+                                  {DateTime.fromISO(row.original['jcr:created'], { setZone: true }).toFormat(DateTimeUtilities.VIEW_DATE_FORMAT)}
                                  </Link>
             },
             { header: 'Uploaded By',


### PR DESCRIPTION
Specs: [CARDS-2774](https://phenotips.atlassian.net/browse/CARDS-2774)

Here is a [test branch](https://github.com/data-team-uhn/cards/tree/CARDS-2774-test) to play with (hardcoded the +2 zone date for DateQuestions)

Now can switch back/forth between local and original timezones if timezone differs from local
<img width="271" height="89" alt="image" src="https://github.com/user-attachments/assets/fb91e397-504a-40ce-bf94-c05787482b08" />
<img width="276" height="99" alt="image" src="https://github.com/user-attachments/assets/bd3500d3-c476-44b8-a4e5-18e2c3a1eac5" />



[CARDS-2774]: https://phenotips.atlassian.net/browse/CARDS-2774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ