### PR TITLE
CARDS-2784: Error loading old HH:mm times in hh:mm a time questions

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 import { TextField, Typography } from "@mui/material";
 
@@ -58,9 +58,23 @@ import DateTimeUtilities from "../components/DateTimeUtilities";
 function TimeQuestion(props) {
   checkPropTypes(TimeQuestion, props);
   let {existingAnswer, classes, pageActive, ...rest} = props;
-  let {text, lowerLimit, upperLimit, errorText, minAnswers, dateFormat} = {dateFormat: "HH:mm", ...props.questionDefinition, ...props};
-  let currentStartValue = (existingAnswer && existingAnswer[1].value && DateTime.fromFormat(existingAnswer[1].value, dateFormat).isValid)
-    ? DateTime.fromFormat(existingAnswer[1].value, dateFormat) : null;
+  let {
+    text,
+    lowerLimit,
+    upperLimit,
+    errorText,
+    minAnswers,
+    dateFormat,
+    saveFormat
+  } = {
+    dateFormat: "HH:mm",
+    saveFormat: "HH:mm:ss.SSS",
+    ...props.questionDefinition,
+    ...props
+  };
+  let currentStartValue = (existingAnswer && existingAnswer[1].value && DateTime.fromFormat(existingAnswer[1].value, saveFormat).isValid)
+    ? DateTime.fromFormat(existingAnswer[1].value, saveFormat) : null;
+
   const [selectedTime, changeTime] = useState(currentStartValue);
   const [error, setError] = useState(undefined);
   const defaultErrorMessage = errorText || "Please enter a valid time";
@@ -71,16 +85,25 @@ function TimeQuestion(props) {
   const minTime = lowerLimit ? DateTime.fromFormat(lowerLimit, dateFormat) : null;
 
   // Error check existing answers when first loading the page
-  if (existingAnswer && existingAnswer[1].value && DateTime.fromFormat(existingAnswer[1].value, dateFormat).invalid) {
-    setError(true);
-    setErrorMessage(DateTime.fromFormat(existingAnswer[1].value, dateFormat).invalidExplanation);
+  useEffect(() => {
+    if (existingAnswer && existingAnswer[1].value && DateTime.fromFormat(existingAnswer[1].value, saveFormat).invalid) {
+      setError(true);
+      setErrorMessage(DateTime.fromFormat(existingAnswer[1].value, saveFormat).invalidExplanation);
+    }
+  }, []);
+
+  // Provide the display formatted time to the Question component so the right formatting is displayed in view mode
+  let formattedAnswer = existingAnswer;
+  if (selectedTime && formattedAnswer?.[1]) {
+    formattedAnswer[1].displayedValue = selectedTime.toFormat(dateFormat);
   }
 
-  let outputAnswers = [["time", selectedTime && selectedTime.isValid ? selectedTime.toFormat(dateFormat) : null]];
+  let outputAnswers = [["time", selectedTime && selectedTime.isValid ? selectedTime.toFormat(saveFormat) : null]];
   return (
     <Question
       currentAnswers={!!selectedTime?.toFormat(dateFormat) ? 1 : 0}
       {...props}
+      existingAnswer={formattedAnswer}
       >
       {
         pageActive && <>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
@@ -67,12 +67,15 @@ function TimeQuestion(props) {
     dateFormat,
     saveFormat
   } = {
-    dateFormat: "HH:mm",
-    saveFormat: "HH:mm:ss.SSS",
     ...props.questionDefinition,
     ...props
   };
-  let currentStartValue = (existingAnswer && existingAnswer[1].value && DateTime.fromFormat(existingAnswer[1].value, saveFormat).isValid)
+  // Set to defaults:
+  // Need to set saveFormat first so that it can fall back to it's default format
+  // if neither save nor date format is specified
+  saveFormat = saveFormat || dateFormat || "HH:mm:ss.SSS";
+  dateFormat = dateFormat || "HH:mm";
+  let currentStartValue = (existingAnswer?.[1]?.value && DateTime.fromFormat(existingAnswer[1].value, saveFormat).isValid)
     ? DateTime.fromFormat(existingAnswer[1].value, saveFormat) : null;
 
   const [selectedTime, changeTime] = useState(currentStartValue);
@@ -86,7 +89,7 @@ function TimeQuestion(props) {
 
   // Error check existing answers when first loading the page
   useEffect(() => {
-    if (existingAnswer && existingAnswer[1].value && DateTime.fromFormat(existingAnswer[1].value, saveFormat).invalid) {
+    if (existingAnswer?.[1]?.value && DateTime.fromFormat(existingAnswer[1].value, saveFormat).invalid) {
       setError(true);
       setErrorMessage(DateTime.fromFormat(existingAnswer[1].value, saveFormat).invalidExplanation);
     }

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Question.json
@@ -436,6 +436,7 @@
       "time": {
         "minAnswers": {"0":{}, "1":{}},
         "dateFormat": {"HH:mm": {}, "hh:mm a": {}, "HH:mm:ss":{}, "hh:mm:ss a": {}, "mm:ss": {}},
+        "saveFormat": {"HH:mm:ss.SSS": {}, "HH:mm:ss": {}, "HH:mm": {}, "hh:mm:ss a": {}, "hh:mm a": {}, "mm:ss": {}},
         "entryMode": {
           "user": {
             "lowerLimit": "string",

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/CompactSectionsTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/CompactSectionsTest.xml
@@ -1012,6 +1012,16 @@
 				<value>1</value>
 				<type>Long</type>
 			</property>
+			<property>
+				<name>dateFormat</name>
+				<value>hh:mm a</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>saveFormat</name>
+				<value>HH:mm</value>
+				<type>String</type>
+			</property>
 		</node>
 		<node>
 			<name>q14</name>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ComputedTest.xml
@@ -1540,6 +1540,16 @@ return result;
 				<type>String</type>
 			</property>
 			<property>
+				<name>dateFormat</name>
+				<value>hh:mm a</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>saveFormat</name>
+				<value>HH:mm</value>
+				<type>String</type>
+			</property>
+			<property>
 				<name>maxAnswers</name>
 				<value>1</value>
 				<type>Long</type>
@@ -1633,6 +1643,11 @@ return result;
 			</property>
 			<property>
 				<name>dateFormat</name>
+				<value>HH:mm:ss</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>saveFormat</name>
 				<value>HH:mm:ss</value>
 				<type>String</type>
 			</property>
@@ -1730,6 +1745,11 @@ return result;
 			</property>
 			<property>
 				<name>dateFormat</name>
+				<value>mm:ss</value>
+				<type>String</type>
+			</property>
+			<property>
+				<name>saveFormat</name>
 				<value>mm:ss</value>
 				<type>String</type>
 			</property>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/DateFormatsTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/DateFormatsTest.xml
@@ -984,4 +984,28 @@
 			<type>Long</type>
 		</property>
 	</node>
+	<node>
+		<name>timesavecopiesdateformats</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Default save format. Enter in hour minute seconds 24 hour, save should copy entered</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>time</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>HH:mm:ss</value>
+			<type>String</type>
+		</property>
+	</node>
 </node>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/DateFormatsTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/DateFormatsTest.xml
@@ -810,6 +810,11 @@
 			<type>String</type>
 		</property>
 		<property>
+			<name>saveFormat</name>
+			<value>mm:ss</value>
+			<type>String</type>
+		</property>
+		<property>
 			<name>maxAnswers</name>
 			<value>1</value>
 			<type>Long</type>
@@ -820,7 +825,7 @@
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>
 			<name>text</name>
-			<value>Hour Minute</value>
+			<value>Hour Minute, AM/PM</value>
 			<type>String</type>
 		</property>
 		<property>
@@ -830,6 +835,40 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
+			<value>hh:mm a</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>saveFormat</name>
+			<value>hh:mm a</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+	</node>
+	<node>
+		<name>timehoursminutes24</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Hour Minute, 24 hour</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>time</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>HH:mm</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>saveFormat</name>
 			<value>HH:mm</value>
 			<type>String</type>
 		</property>
@@ -855,6 +894,88 @@
 		<property>
 			<name>dateFormat</name>
 			<value>HH:mm:ss</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>saveFormat</name>
+			<value>HH:mm:ss</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+	</node>
+	<node>
+		<name>timehoursminutes12to24hour</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Hour Minute. Entered with AM/PM, saved 24 hour</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>time</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>hh:mm a</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>saveFormat</name>
+			<value>HH:mm</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+	</node>
+	<node>
+		<name>timehoursminutestofull</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Enter Hour Minute in 24 hour, save down to milliseconds</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>time</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>HH:mm</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>saveFormat</name>
+			<value>HH:mm:ss.SSS</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+	</node>
+	<node>
+		<name>timedefaultformats</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Default time formats. Enter in Hour minute, 24 hour, save down to milliseconds</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>time</value>
 			<type>String</type>
 		</property>
 		<property>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ServersideComputedTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ServersideComputedTest.xml
@@ -303,7 +303,12 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
-			<value>HH:MM (AM/PM)</value>
+			<value>hh:mm a</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>saveFormat</name>
+			<value>HH:mm</value>
 			<type>String</type>
 		</property>
 	</node>
@@ -330,6 +335,11 @@
 			<value>HH:mm:ss</value>
 			<type>String</type>
 		</property>
+		<property>
+			<name>saveFormat</name>
+			<value>HH:mm:ss</value>
+			<type>String</type>
+		</property>
 	</node>
 	<node>
 		<name>timeQuestionMinutes</name>
@@ -351,6 +361,11 @@
 		</property>
 		<property>
 			<name>dateFormat</name>
+			<value>mm:ss</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>saveFormat</name>
 			<value>mm:ss</value>
 			<type>String</type>
 		</property>


### PR DESCRIPTION
- Add new `saveFormat` property to time questions, allowing answers to be displayed in a different format than they are saved.
  - Allows old HH:mm questions to be displayed as `hh:mm a` but still saved and loaded from `HH:mm` to match previous behaviour
- Fix infinite render loop if there is an error loading TimeAnswers into TimeQuestions