### PR TITLE
CARDS-2785: Form pagination should hide non-satisfied conditional sections

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -92,20 +92,8 @@ function FormPagination (props) {
   let pagesArray = [];
 
   useEffect(() => {
-    let newNumberOfSteps = 0;
-    let newActiveStep = 0;
-    pages.forEach(page => {
-      if (page.canBeVisible) {
-        newNumberOfSteps++;
-      }
-    })
-    for (let i = 0; i < activePage; i++) {
-      if (pages[i].canBeVisible) {
-        newActiveStep++;
-      }
-    }
-    setNumberOfSteps(newNumberOfSteps);
-    setActiveStep(newActiveStep);
+    setNumberOfSteps(pages.filter(page => page.canBeVisible).length);
+    setActiveStep(pages.slice(0, activePage).filter(page => page.canBeVisible).length);
   }, [activePage, pages])
 
   useEffect(() => {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -79,9 +79,10 @@ function FormPagination (props) {
   let [ nextActivePage, setNextActivePage ] = useState();
   let [ progress, setProgress ] = useState(0);
   const DIRECTION_NEXT = 1, DIRECTION_PREV = -1;
-  // The amount of the progress bar that should be complete on page 1 and incomplete on an unsaved last page
-  // Expressed as a multiple of a normal page size
-  const PROGRESS_BAR_PADDING = 0.5;
+  // The amount of the progress bar that should be complete on page 1
+  // Expressed as a multiple of a normal page size.
+  // The remainder (1 - stub size) will be used as a completion buffer on the last page
+  const INITIAL_PROGRESS_STUB = 0.7;
 
   let previousEntryType;
   let questionIndex = 0;
@@ -213,14 +214,12 @@ function FormPagination (props) {
 
   useEffect(() => {
     if (activePage != null && pages != null) {
-      // The pagination should be divided into multiple sections:
-      // - lastValidPage() sections for page by page progress
-      // - 1 padding section for the initial progress on the first page
-      // - 1 padding section for when the last page has been saved
       // The MaterialUI progress bar expects progress to be out of 100
-      const pageSize = 100 / (lastValidPage() + (2 * PROGRESS_BAR_PADDING));
-      const paddingSize = pageSize * PROGRESS_BAR_PADDING;
-      setProgress(paddingSize + (pageSize * activePage) + (savedLastPage ? paddingSize : 0))
+      const pageSize = 100 / (lastValidPage() + 1);
+      // Use some of 1 "page" worth of progression for the initial stub on the first page
+      // The rest will be used for the completion buffer on the last page
+      const stubSize = pageSize * INITIAL_PROGRESS_STUB;
+      setProgress(stubSize + (pageSize * activePage) + (savedLastPage ? pageSize - stubSize : 0))
     }
   }, [activePage, pages, savedLastPage])
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -213,9 +213,10 @@ function FormPagination (props) {
   }, [saveInProgress, pendingSubmission, disableProgress, nextActivePage, direction, activePage]);
 
   useEffect(() => {
-    if (activePage != null && pages != null) {
+    let numPages = lastValidPage();
+    if (activePage != null && pages != null && numPages >= 0) {
       // The MaterialUI progress bar expects progress to be out of 100
-      const pageSize = 100 / (lastValidPage() + 1);
+      const pageSize = 100 / (numPages + 1);
       // Use some of 1 "page" worth of progression for the initial stub on the first page
       // The rest will be used for the completion buffer on the last page
       const stubSize = pageSize * INITIAL_PROGRESS_STUB;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -213,10 +213,10 @@ function FormPagination (props) {
   }, [saveInProgress, pendingSubmission, disableProgress, nextActivePage, direction, activePage]);
 
   useEffect(() => {
-    let numPages = lastValidPage();
-    if (activePage != null && pages != null && numPages >= 0) {
+    let lastPage = lastValidPage();
+    if (activePage != null && pages != null && lastPage >= 0) {
       // The MaterialUI progress bar expects progress to be out of 100
-      const pageSize = 100 / (numPages + 1);
+      const pageSize = 100 / (lastPage + 1);
       // Use some of 1 "page" worth of progression for the initial stub on the first page
       // The rest will be used for the completion buffer on the last page
       const stubSize = pageSize * INITIAL_PROGRESS_STUB;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -77,7 +77,11 @@ function FormPagination (props) {
   let [ activePage, setActivePage ] = useState(0);
   let [ direction, setDirection ] = useState(1);
   let [ nextActivePage, setNextActivePage ] = useState();
+  let [ progress, setProgress ] = useState(0);
   const DIRECTION_NEXT = 1, DIRECTION_PREV = -1;
+  // The amount of the progress bar that should be complete on page 1 and incomplete on an unsaved last page
+  // Expressed as a multiple of a normal page size
+  const PROGRESS_BAR_PADDING = 0.5;
 
   let previousEntryType;
   let questionIndex = 0;
@@ -207,6 +211,19 @@ function FormPagination (props) {
     }
   }, [saveInProgress, pendingSubmission, disableProgress, nextActivePage, direction, activePage]);
 
+  useEffect(() => {
+    if (activePage != null && pages != null) {
+      // The pagination should be divided into multiple sections:
+      // - lastValidPage() sections for page by page progress
+      // - 1 padding section for the initial progress on the first page
+      // - 1 padding section for when the last page has been saved
+      // The MaterialUI progress bar expects progress to be out of 100
+      const pageSize = 100 / (lastValidPage() + (2 * PROGRESS_BAR_PADDING));
+      const paddingSize = pageSize * PROGRESS_BAR_PADDING;
+      setProgress(paddingSize + (pageSize * activePage) + (savedLastPage ? paddingSize : 0))
+    }
+  }, [activePage, pages, savedLastPage])
+
   let saveButton =
     <Button
       startIcon={activePage === lastValidPage() ? doneIcon : undefined}
@@ -246,8 +263,6 @@ function FormPagination (props) {
   }
   stepperClasses = stepperClasses.join(' ');
 
-  let progressAdjustment = (condition) => (condition && variant == "progress" ? 1 : 0);
-
   return (
     enabled
     ?
@@ -265,23 +280,16 @@ function FormPagination (props) {
       ?
         <MobileStepper
           variant={variant}
-          // Offset back bar 1 to create a "current page" region.
-          // If the final page has been saved, progress the front bar to complete
-          activeStep={activePage + progressAdjustment(lastSaveStatus && savedLastPage)}
-          // Change the color of the back bar
+          activeStep={activePage}
           slotProps={{
             progress: {
-              classes: {
-                bar2Buffer: classes.formStepperBufferBar,
-                dashed: classes.formStepperBackgroundBar,
-              },
-              variant: "buffer",
-              valueBuffer: (activePage + 1) / (lastValidPage() + 1) * 100,
+              // Manually control the progress bar value
+              value: progress
             }
           }}
           className={stepperClasses}
-          // base 0 to base 1, plus 1 for the "current page" region when variant is "progress"
-          steps={lastValidPage() + 1 + progressAdjustment(true)}
+
+          steps={lastValidPage() + 1}
           nextButton={saveButton}
           backButton={backButton}
         />

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -77,6 +77,8 @@ function FormPagination (props) {
   let [ activePage, setActivePage ] = useState(0);
   let [ direction, setDirection ] = useState(1);
   let [ nextActivePage, setNextActivePage ] = useState();
+  let [ numberOfSteps, setNumberOfSteps ] = useState();
+  let [ activeStep, setActiveStep ] = useState();
   let [ progress, setProgress ] = useState(0);
   const DIRECTION_NEXT = 1, DIRECTION_PREV = -1;
   // The amount of the progress bar that should be complete on page 1
@@ -88,6 +90,23 @@ function FormPagination (props) {
   let questionIndex = 0;
   let pagesResults = {};
   let pagesArray = [];
+
+  useEffect(() => {
+    let newNumberOfSteps = 0;
+    let newActiveStep = 0;
+    pages.forEach(page => {
+      if (page.canBeVisible) {
+        newNumberOfSteps++;
+      }
+    })
+    for (let i = 0; i < activePage; i++) {
+      if (pages[i].canBeVisible) {
+        newActiveStep++;
+      }
+    }
+    setNumberOfSteps(newNumberOfSteps);
+    setActiveStep(newActiveStep);
+  }, [activePage, pages])
 
   useEffect(() => {
     setPagesCallback(null);
@@ -213,16 +232,15 @@ function FormPagination (props) {
   }, [saveInProgress, pendingSubmission, disableProgress, nextActivePage, direction, activePage]);
 
   useEffect(() => {
-    let lastPage = lastValidPage();
-    if (activePage != null && pages != null && lastPage >= 0) {
+    if (activeStep != null && numberOfSteps != null) {
       // The MaterialUI progress bar expects progress to be out of 100
-      const pageSize = 100 / (lastPage + 1);
+      const pageSize = 100 / (numberOfSteps);
       // Use some of 1 "page" worth of progression for the initial stub on the first page
       // The rest will be used for the completion buffer on the last page
       const stubSize = pageSize * INITIAL_PROGRESS_STUB;
-      setProgress(stubSize + (pageSize * activePage) + (savedLastPage ? pageSize - stubSize : 0))
+      setProgress(stubSize + (pageSize * activeStep) + (savedLastPage ? pageSize - stubSize : 0))
     }
-  }, [activePage, pages, savedLastPage])
+  }, [activeStep, numberOfSteps, savedLastPage])
 
   let saveButton =
     <Button
@@ -280,7 +298,7 @@ function FormPagination (props) {
       ?
         <MobileStepper
           variant={variant}
-          activeStep={activePage}
+          activeStep={activeStep}
           slotProps={{
             progress: {
               // Manually control the progress bar value
@@ -288,8 +306,7 @@ function FormPagination (props) {
             }
           }}
           className={stepperClasses}
-
-          steps={lastValidPage() + 1}
+          steps={numberOfSteps}
           nextButton={saveButton}
           backButton={backButton}
         />

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -496,16 +496,6 @@ const questionnaireStyle = theme => ({
         margin: theme.spacing(1),
         minWidth: "fit-content",
     },
-    formStepperBufferBar: {
-        backgroundColor: theme.palette.primary.main,
-        opacity: "0.3",
-    },
-    formStepperBackgroundBar: {
-        backgroundColor: theme.palette.primary.light,
-        opacity: "0.2",
-        animation: "none",
-        backgroundImage: "none",
-    },
     actionsMenu: {
         border: "1px solid " + theme.palette.divider,
         borderRadius: theme.spacing(3),


### PR DESCRIPTION
- When a fetch occurs, update the pagination to hide non-satisfied conditionals
- Update the progress bar to have no "buffer" marking the current page

This is easiest to test with the Prems Outpatient Clinic form (not included in this branch) due to it's short length and conditional sections. However, this can be tested with any paginated form that contains pages which can be hidden or visible based on conditional states