### PR TITLE
CARDS-2789: Patient portal - update post submission text to "You already submitted this survey"

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -689,7 +689,11 @@ function QuestionnaireSet(props) {
   let welcomeScreen = (isComplete && isSubmitted || questionnaireIds?.length == 0) ? [
     greet(username),
     appointmentAlert(),
-    displayText("noSurveysMessage", Typography, {color: "textSecondary", variant: "subtitle1", key: "survey-info"}),
+    displayText(
+      isSubmitted ? "surveySubmittedMessage" : "noSurveysMessage",
+      Typography,
+      {color: "textSecondary", variant: "subtitle1", key: "survey-info"}
+    ),
   ] : [
     greet(username),
     appointmentAlert(),

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/SurveyInstructionsConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/SurveyInstructionsConfiguration.jsx
@@ -34,6 +34,7 @@ export const SURVEY_INSTRUCTIONS_PATH = "/Survey/SurveyInstructions";
 export const DEFAULT_INSTRUCTIONS = {
   noEventsMessage: "We could not find any pending surveys to fill out.",
   noSurveysMessage: "You have no pending surveys to fill out.",
+  surveySubmittedMessage: "You already answered this survey.",
   surveyDraftInfo: "If you close your browser window before finishing the survey, your answers will be automatically saved. You can return to the survey to complete and submit it by following the link you received in your invitation email."
 };
 
@@ -54,7 +55,7 @@ function SurveyInstructionsConfiguration() {
   const labels = {
     welcomeMessage: ["welcomeMessage"],
     eventSelectionScreen: ["noEventsMessage", "eventSelectionMessage"],
-    startScreen: [ "enableStartScreen", "greeting", "eventLabel", "noSurveysMessage", "surveyIntro", "surveyDraftInfo" ],
+    startScreen: [ "enableStartScreen", "greeting", "eventLabel", "noSurveysMessage", "surveySubmittedMessage", "surveyIntro", "surveyDraftInfo" ],
     reviewScreen: ["enableReviewScreen"],
     summaryScreen: [ "disclaimer", "summaryInstructions", "interpretationInstructions" ]
   };

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/SurveyInstructions.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/Survey/SurveyInstructions.xml
@@ -52,6 +52,11 @@ Completing this survey is voluntary, and your name and contact information will 
         <type>String</type>
     </property>
     <property>
+        <name>surveySubmittedMessage</name>
+        <value></value>
+        <type>String</type>
+    </property>
+    <property>
         <name>enableStartScreen</name>
         <value>True</value>
         <type>Boolean</type>


### PR DESCRIPTION
https://phenotips.atlassian.net/browse/CARDS-2789

Replaced "submitted" with "answered" as it might be more meaningful for non-technical users.

<img width="394" height="248" alt="image" src="https://github.com/user-attachments/assets/e24e0f26-4ef1-4a42-b076-5b0787e008f3" />
