### PR TITLE
CARDS-2767: YE: Re-import patient information daily to update any death status

### DIFF
--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -996,6 +996,7 @@ if args.mssql:
     yaml_obj['services']['cardsinitial']['environment'].append('CLARITY_YVM_SQL_TABLE=PatientActivity_Outpatient_PMCC_data_for_PtExpSurvey')
     yaml_obj['services']['cardsinitial']['environment'].append('CLARITY_PMH_OO_SQL_TABLE=PatientActivity_PMCC_Outpatient_Oncology_for_PtExpSurvey')
     yaml_obj['services']['cardsinitial']['environment'].append('CLARITY_EVENT_TIME_COLUMN=HOSP_DISCHARGE_DTTM')
+    yaml_obj['services']['cardsinitial']['environment'].append('CLARITY_DEATH_STATUS_TABLE=V_PtExpYEM_Deceased_Patients')
   elif args.cards_project == 'cards4datapro':
     yaml_obj['services']['cardsinitial']['environment'].append('CLARITY_SQL_TABLE=PatientVisitActivity_for_DATA-PRO')
     yaml_obj['services']['cardsinitial']['environment'].append('CLARITY_EVENT_TIME_COLUMN=ENCOUNTER_DATE')

--- a/compose-cluster/mssql/generate_test_death_status_sql.py
+++ b/compose-cluster/mssql/generate_test_death_status_sql.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import argparse
+import random
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('file', help='Output file name', type=argparse.FileType('w'))
+argparser.add_argument('-n', help='Number of death status entries to generate [default: 3]', default=3, type=int)
+args = argparser.parse_args()
+
+# Preamble
+args.file.write(
+    '''
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Create the schema if it doesn't already exist
+-- Note about EXEC: CREATE SCHEMA must be the first statement
+-- but we can't combine that with a conditional unless we use EXEC
+IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = 'path')
+BEGIN
+    EXEC('CREATE SCHEMA path')
+END
+
+-- Remove the table if it already exists
+IF OBJECT_ID('path.V_PtExpYEM_Deceased_Patients', 'U') IS NOT NULL
+    DROP TABLE [path].[V_PtExpYEM_Deceased_Patients];
+
+CREATE TABLE [path].[V_PtExpYEM_Deceased_Patients] (
+    PAT_MRN varchar(102) NULL,
+);
+
+-- Insert test data
+'''
+)
+
+
+def convertToSqlType(insertion_values):
+    converted_values = {}
+    for key in insertion_values:
+        if type(insertion_values[key]) == str:
+            converted_values[key] = "'" + insertion_values[key] + "'"
+        elif insertion_values[key] == None:
+            converted_values[key] = "NULL"
+        else:
+            converted_values[key] = insertion_values[key]
+    return converted_values
+
+# Insert test data
+for i in range(args.n):
+    if i % 100 == 0:
+        args.file.write("INSERT INTO [path].[V_PtExpYEM_Deceased_Patients]")
+        args.file.write("\t(PAT_MRN)\n")
+        args.file.write("\tVALUES\n")
+    insertion_values = {}
+
+    #PAT_MRN
+    mrn = random.randint(0, 9999999)
+    insertion_values['PAT_MRN'] = mrn
+
+    args.file.write("\t({PAT_MRN:07d})".format(**convertToSqlType(insertion_values)))
+    if (i != args.n - 1) and (i % 100 != 99):
+        args.file.write(",")
+    args.file.write("\n")
+
+args.file.close()

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
@@ -156,6 +156,22 @@ public class ClarityImportTask implements Runnable
             this.questionnaires.add(mapping);
         }
 
+        /**
+         * Check if any of this mapping's update policies allow creating new subjects.
+         *
+         * @return {@code true} if any of the mappings enable creating subjects
+         */
+        private boolean shouldCreateSubjectIfAbsent()
+        {
+            // Check if new subjects should be created or if only existing subjects should be processed
+            for (ClarityQuestionnaireMapping questionnaireMapping : this.questionnaires) {
+                if (questionnaireMapping.updatePolicy != UpdatePolicy.onlyExisting) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         @Override
         public String toString()
         {
@@ -480,7 +496,7 @@ public class ClarityImportTask implements Runnable
     {
         for (ClaritySubjectMapping childSubjectMapping : subjectMapping.childSubjects) {
             // Get or create the subject
-            Resource newSubjectParent = shouldCreateSubjectIfAbsent(childSubjectMapping)
+            Resource newSubjectParent = childSubjectMapping.shouldCreateSubjectIfAbsent()
                 ? getOrCreateSubject(resolver, row, childSubjectMapping, subjectParent)
                 : getSubject(resolver, row, childSubjectMapping);
             if (newSubjectParent == null) {
@@ -516,23 +532,6 @@ public class ClarityImportTask implements Runnable
             }
             walkThroughLocalConfig(resolver, row, childSubjectMapping, newSubjectParent);
         }
-    }
-
-    /**
-     * Check if any of the subject mapping update policies allow creating new subjects.
-     *
-     * @param subjectMapping The mappings to search for any policies that enable creating new subjects
-     * @return {@code true} if any of the mappings enable creating subjects
-     */
-    private boolean shouldCreateSubjectIfAbsent(ClaritySubjectMapping subjectMapping)
-    {
-        // Check if new subjects should be created or if only existing subjects should be processed
-        for (ClarityQuestionnaireMapping questionnaireMapping : subjectMapping.questionnaires) {
-            if (questionnaireMapping.updatePolicy != UpdatePolicy.onlyExisting) {
-                return true;
-            }
-        }
-        return false;
     }
 
     // Methods for storing subjects

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
@@ -167,7 +167,8 @@ public class ClarityImportTask implements Runnable
     {
         createNew,
         updateExisting,
-        cancelImport
+        cancelImport,
+        onlyExisting,
     }
 
     private static final class ClarityQuestionnaireMapping
@@ -490,23 +491,25 @@ public class ClarityImportTask implements Runnable
                     newSubjectParent);
 
                 if (formNode != null) {
-                    if (updatePolicy == UpdatePolicy.updateExisting) {
+                    if (updatePolicy == UpdatePolicy.updateExisting || updatePolicy == UpdatePolicy.onlyExisting) {
                         // Update the answers to an existing Form
                         updateExistingForm(resolver, formNode, questionnaireMapping, row);
                     }
                 } else {
-                    // Create a new Form
-                    formNode = createForm(resolver, questionnaireMapping.getQuestionnaireResource(resolver),
-                        newSubjectParent);
+                    if (updatePolicy != UpdatePolicy.onlyExisting) {
+                        // Create a new Form
+                        formNode = createForm(resolver, questionnaireMapping.getQuestionnaireResource(resolver),
+                            newSubjectParent);
 
-                    // Attach all the Answer nodes to it
-                    populateEmptyForm(resolver, formNode, questionnaireMapping, row);
+                        // Attach all the Answer nodes to it
+                        populateEmptyForm(resolver, formNode, questionnaireMapping, row);
 
-                    // Commit the changes to the JCR
-                    resolver.commit();
+                        // Commit the changes to the JCR
+                        resolver.commit();
 
-                    // Perform a JCR check-in to this cards:Form node once the import is completed
-                    this.nodesToCheckin.get().add(formNode.getPath());
+                        // Perform a JCR check-in to this cards:Form node once the import is completed
+                        this.nodesToCheckin.get().add(formNode.getPath());
+                    }
                 }
             }
             walkThroughLocalConfig(resolver, row, childSubjectMapping, newSubjectParent);

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
@@ -480,7 +480,9 @@ public class ClarityImportTask implements Runnable
     {
         for (ClaritySubjectMapping childSubjectMapping : subjectMapping.childSubjects) {
             // Get or create the subject
-            Resource newSubjectParent = getOrCreateSubject(resolver, row, childSubjectMapping, subjectParent);
+            Resource newSubjectParent = shouldCreateSubjectIfAbsent(childSubjectMapping)
+                ? getOrCreateSubject(resolver, row, childSubjectMapping, subjectParent)
+                : getSubject(resolver, row, childSubjectMapping);
             if (newSubjectParent == null) {
                 return;
             }
@@ -516,25 +518,41 @@ public class ClarityImportTask implements Runnable
         }
     }
 
+    /**
+     * Check if any of the subject mapping update policies allow creating new subjects.
+     *
+     * @param subjectMapping The mappings to search for any policies that enable creating new subjects
+     * @return {@code true} if any of the mappings enable creating subjects
+     */
+    private boolean shouldCreateSubjectIfAbsent(ClaritySubjectMapping subjectMapping)
+    {
+        // Check if new subjects should be created or if only existing subjects should be processed
+        for (ClarityQuestionnaireMapping questionnaireMapping : subjectMapping.questionnaires) {
+            if (questionnaireMapping.updatePolicy != UpdatePolicy.onlyExisting) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     // Methods for storing subjects
 
     /**
-     * Grab a subject of the specified type, or create it if it doesn't exist.
+     * Grab a subject of the specified type with an identifier matching the configured ID column and row data.
      *
-     * @param resolver ResourceResolver to use for reading and writing to the JCR
+     * @param resolver ResourceResolver to use for reading the JCR
      * @param row {@code Map<String, String>} object that maps column names to values for a SQL query result row
-     * @param subjectMapping ClaritySubjectMapping object describing how a CARDS Subject is to be created from a SQL row
-     * @param parent Resource if this is a child of that resource, or null (parent JCR node to defaults to /Subjects/)
-     * @return A Subject resource
+     * @param subjectMapping ClaritySubjectMapping object describing how a CARDS Subject is to be found from a SQL row
+     * @return A Subject resource, or {@code null} if no existing subject was found
      */
-    private Resource getOrCreateSubject(ResourceResolver resolver, Map<String, String> row,
-        ClaritySubjectMapping subjectMapping, Resource parent) throws RepositoryException, PersistenceException
+    private Resource getSubject(ResourceResolver resolver, Map<String, String> row,
+        ClaritySubjectMapping subjectMapping) throws RepositoryException
     {
-
-        final String subjectTypePath = subjectMapping.subjectType;
-        final String identifier = (!"".equals(subjectMapping.subjectIdColumn))
-            ? row.get(subjectMapping.subjectIdColumn) : UUID.randomUUID().toString();
-        final String incrementMetricOnCreation = subjectMapping.incrementMetricOnCreation;
+        if ("".equals(subjectMapping.subjectIdColumn)) {
+            // No ID column to try to match an existing subject to
+            return null;
+        }
+        final String identifier = row.get(subjectMapping.subjectIdColumn);
 
         if (StringUtils.isEmpty(identifier)) {
             return null;
@@ -551,6 +569,33 @@ public class ClarityImportTask implements Runnable
             this.nodesToCheckin.get().add(subjectResource.getPath());
             return subjectResource;
         } else {
+            return null;
+        }
+    }
+
+    /**
+     * Grab a subject of the specified type, or create it if it doesn't exist.
+     *
+     * @param resolver ResourceResolver to use for reading and writing to the JCR
+     * @param row {@code Map<String, String>} object that maps column names to values for a SQL query result row
+     * @param subjectMapping ClaritySubjectMapping object describing how a CARDS Subject is to be created from a SQL row
+     * @param parent Resource if this is a child of that resource, or null (parent JCR node to defaults to /Subjects/)
+     * @return A Subject resource
+     */
+    private Resource getOrCreateSubject(ResourceResolver resolver, Map<String, String> row,
+        ClaritySubjectMapping subjectMapping, Resource parent) throws RepositoryException, PersistenceException
+    {
+        final Resource subject = getSubject(resolver, row, subjectMapping);
+
+        if (subject != null) {
+            return subject;
+        } else {
+            final String subjectTypePath = subjectMapping.subjectType;
+            final String identifier = (!"".equals(subjectMapping.subjectIdColumn))
+                ? row.get(subjectMapping.subjectIdColumn) : UUID.randomUUID().toString();
+            final String incrementMetricOnCreation = subjectMapping.incrementMetricOnCreation;
+
+
             Resource parentResource = parent;
             if (parentResource == null) {
                 parentResource = resolver.getResource("/Subjects/");

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/ClarityImportTask.java
@@ -612,6 +612,7 @@ public class ClarityImportTask implements Runnable
             }
             replaceFormAnswer(resolver, formNode,
                 generateAnswerNodeProperties(resolver, questionMapping, row));
+            LOGGER.info("{} Updated form {}", this.config.name(), formNode.getPath());
         }
         // Perform a JCR check-in to this cards:Form node once the import is completed
         this.nodesToCheckin.get().add(formNode.getPath());

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/internal/ConfiguredGenericMapper.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/internal/ConfiguredGenericMapper.java
@@ -74,6 +74,10 @@ public class ConfiguredGenericMapper extends AbstractConditionalClarityDataProce
 
         @AttributeDefinition
         String service_pid();
+
+        @AttributeDefinition(name = "Should any changes made by this mapper be logged",
+            required = false)
+        boolean enableLogging() default true;
     }
 
     private final String column;
@@ -81,6 +85,8 @@ public class ConfiguredGenericMapper extends AbstractConditionalClarityDataProce
     private final String value;
 
     private final String id;
+
+    private final Boolean enableLogging;
 
     @Activate
     public ConfiguredGenericMapper(Config configuration) throws ConfigurationException
@@ -90,6 +96,7 @@ public class ConfiguredGenericMapper extends AbstractConditionalClarityDataProce
         this.value = configuration.value();
         String pid = configuration.service_pid();
         this.id = pid.substring(pid.lastIndexOf("~") + 1);
+        this.enableLogging = configuration.enableLogging();
     }
 
     @Override
@@ -100,8 +107,10 @@ public class ConfiguredGenericMapper extends AbstractConditionalClarityDataProce
             usedValue = input.get(usedValue.substring(2, usedValue.length() - 1));
         }
         input.put(this.column, usedValue);
-        LOGGER.warn("{} Updated visit {} value for column {} set to {} due to all conditions met", this.id,
-            input.getOrDefault("/SubjectTypes/Patient/Visit", "Unknown"), this.column, usedValue);
+        if (this.enableLogging) {
+            LOGGER.warn("{} Updated visit {} value for column {} set to {} due to all conditions met", this.id,
+                input.getOrDefault("/SubjectTypes/Patient/Visit", "Unknown"), this.column, usedValue);
+        }
         return input;
     }
 

--- a/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/internal/ConfiguredGenericMapper.java
+++ b/modules/clarity-integration/src/main/java/io/uhndata/cards/clarity/importer/internal/ConfiguredGenericMapper.java
@@ -86,7 +86,7 @@ public class ConfiguredGenericMapper extends AbstractConditionalClarityDataProce
 
     private final String id;
 
-    private final Boolean enableLogging;
+    private final boolean enableLogging;
 
     @Activate
     public ConfiguredGenericMapper(Config configuration) throws ConfigurationException

--- a/prems-resources/clinical-data/pom.xml
+++ b/prems-resources/clinical-data/pom.xml
@@ -81,6 +81,7 @@
               SLING-INF/content/apps/cards/clarityImport/YourExperience.xml;path:=/apps/cards/clarityImport/YourExperience;overwrite:=true,
               SLING-INF/content/apps/cards/clarityImport/PMH-YVM.xml;path:=/apps/cards/clarityImport/PMH-YVM;overwrite:=true,
               SLING-INF/content/apps/cards/clarityImport/PMH-OO.xml;path:=/apps/cards/clarityImport/PMH-OO;overwrite:=true,
+              SLING-INF/content/apps/cards/clarityImport/DeathStatus.xml;path:=/apps/cards/clarityImport/DeathStatus;overwrite:=true,
             </Sling-Initial-Content>
           </instructions>
         </configuration>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clarityImport/DeathStatus.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clarityImport/DeathStatus.xml
@@ -71,11 +71,11 @@
             <value>/Questionnaires/Patient information/email_unsubscribed</value>
             <type>String</type>
           </property>
-            <property>
-              <name>computed</name>
-              <value>True</value>
-              <type>Boolean</type>
-            </property>
+          <property>
+            <name>computed</name>
+            <value>True</value>
+            <type>Boolean</type>
+          </property>
         </node>
       </node>
     </node>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clarityImport/DeathStatus.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clarityImport/DeathStatus.xml
@@ -1,0 +1,83 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+  <name>DeathStatus</name>
+  <primaryNodeType>sling:Folder</primaryNodeType>
+  <node>
+    <name>Patient</name>
+    <primaryNodeType>cards:ClaritySubjectMapping</primaryNodeType>
+    <property>
+      <name>subjectIDColumn</name>
+      <value>PAT_MRN</value>
+      <type>String</type>
+    </property>
+    <property>
+      <name>subjectType</name>
+      <value>/SubjectTypes/Patient</value>
+      <type>String</type>
+    </property>
+    <node>
+      <name>questionnaires</name>
+      <primaryNodeType>sling:Folder</primaryNodeType>
+      <node>
+        <name>Patient information</name>
+        <primaryNodeType>cards:ClarityQuestionnaireMapping</primaryNodeType>
+        <property>
+          <name>updatePolicy</name>
+          <value>onlyExisting</value>
+          <type>String</type>
+        </property>
+        <node>
+          <name>00000001</name>
+          <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+          <property>
+            <name>column</name>
+            <value>PAT_MRN</value>
+            <type>String</type>
+          </property>
+          <property>
+            <name>question</name>
+            <value>/Questionnaires/Patient information/mrn</value>
+            <type>String</type>
+          </property>
+        </node>
+        <node>
+          <name>00000002</name>
+          <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+          <property>
+            <name>column</name>
+            <value>UNSUBSCRIBED</value>
+            <type>String</type>
+          </property>
+          <property>
+            <name>question</name>
+            <value>/Questionnaires/Patient information/email_unsubscribed</value>
+            <type>String</type>
+          </property>
+            <property>
+              <name>computed</name>
+              <value>True</value>
+              <type>Boolean</type>
+            </property>
+        </node>
+      </node>
+    </node>
+  </node>
+</node>

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -453,6 +453,16 @@
       "dayToImport": -2
     },
 
+    // Pull the most recent patient status from the death status table
+    "io.uhndata.cards.clarity.importer.ClarityImportConfig~death-status": {
+      "name": "Death Status",
+      "type": "death-status",
+      "importSchedule": "0 0 9 * * ? *",
+      "tableName": "%ENV%CLARITY_DEATH_STATUS_TABLE",
+      "dateColumn": "",
+      "mapping": "/apps/cards/clarityImport/DeathStatus"
+    },
+
     // Clarity import filters and mappers
 
     // Discard patients with invalid or non-consented emails
@@ -790,6 +800,13 @@
       "gracePeriod": 183,
       // This is already excluded by access rights, but we can speedup queries this way
       "excludedQuestionnaires": ["/Questionnaires/Survey events"]
+    },
+    // Unsubscribe deceased patients from all emails
+    "io.uhndata.cards.clarity.importer.internal.ConfiguredGenericMapper~DeathStatusEmailUnsubscribed":{
+      "supportedTypes": ["death-status"],
+      "priority": 35,
+      "column": "UNSUBSCRIBED",
+      "value": "Yes"
     }
   }
 }

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -806,7 +806,8 @@
       "supportedTypes": ["death-status"],
       "priority": 35,
       "column": "UNSUBSCRIBED",
-      "value": "Yes"
+      "value": "Yes",
+      "enableLogging": false
     }
   }
 }


### PR DESCRIPTION
- Add new `onlyExisting` update policy to only update forms that already exist for a given import
- Add `death status` import configuration, running daily at 9 am that unsubscribes any retrieved MRNs

Testing:
- Build and launch with docker with adminer enabled
```
mvn clean install -Pdocker
cd compose-cluster
python3 generate_compose_yaml.py --mssql --cards_project  cards4prems --oak_filesystem --dev_docker_image --composum --adminer
docker-compose build && docker-compose up
```
- Generate a sample YE and Death Status sql file. In `/compose-cluster/mssql/`, run the following:
```
python3 ./generate_test_YE_sql.py -n 20 YE_sample.sql
python3 ./generate_test_death_status_sql.py -n 5 death_sample.sql
```
- Navigate to adminer and sign in: http://localhost:1435/?mssql=mssql&username=sa&db=master&ns=path&import=, password `testPassword_
- Import the generated YE_sample sql file into adminer
- Import the YE data into CARDS: http://localhost:8080/Subjects.importClarity?config=Your%20Experience%20-%20Inpatient%20and%20ED%20discharge%20events
- Edit the generated `death_sample.sql` file so a couple of the imported patient MRNs are in the data
- Import the death sample data into adminer
- Import the death sample data into CARDS: http://localhost:8080/Subjects.importClarity?config=Death%20Status
- Verify that the patients with an MRN in the death status table are unsubscribed from emails (`The patient unsubscribed from all email notifications` should be Yes)
- Verify that other patients are untouched (No unsubscribe answer) and that no new patients were generated by the death status import
- When complete, halt and clean up docker:
```
docker-compose down && docker-compose rm && docker volume prune -f && ./cleanup.sh
```