### PR TITLE
[misc] Add gitignore for generated proxy logo

### DIFF
--- a/compose-cluster/proxy/.gitignore
+++ b/compose-cluster/proxy/.gitignore
@@ -1,0 +1,2 @@
+# Don't commit the generated error logo
+/proxyerror/logo.png


### PR DESCRIPTION
When building with docker, a logo image is copied to `/proxyerror/logo.png`. As a build artifact, this should be ignored by git