### PR TITLE
CARDS-2794: Organize imports of numerous components inside {} as each per line

### DIFF
--- a/aggregated-frontend/src/main/frontend/eslint.config.js
+++ b/aggregated-frontend/src/main/frontend/eslint.config.js
@@ -73,6 +73,7 @@ const whitespaceRules = {
 
 const commonRules = {
   "import/order": importOrderRule,
+  "react/jsx-no-undef": ["error", { allowGlobals: true }],
   ...whitespaceRules,
 };
 
@@ -91,6 +92,7 @@ const commonConfigs = {
   rules: commonRules,
   linterOptions: commonLinterOptions,
 };
+
 
 // --- Main config ---
 export default defineConfig([

--- a/modules/commons/src/main/frontend/src/SearchBar.jsx
+++ b/modules/commons/src/main/frontend/src/SearchBar.jsx
@@ -21,7 +21,17 @@ import React, { useState, useContext, useEffect } from "react";
 import DescriptionIcon from "@mui/icons-material/Description";
 import Search from "@mui/icons-material/Search";
 import { MenuList, Paper, Popper } from "@mui/material";
-import { ClickAwayListener, Grow, IconButton, Input, InputAdornment, ListItemText, MenuItem, ListItemAvatar, Avatar }  from "@mui/material";
+import {
+  ClickAwayListener,
+  Grow,
+  IconButton,
+  Input,
+  InputAdornment,
+  ListItemText,
+  MenuItem,
+  ListItemAvatar,
+  Avatar
+} from "@mui/material";
 import PropTypes from "prop-types";
 import { Link, useNavigate } from "react-router";
 import { withStyles } from 'tss-react/mui';

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/ExportButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/ExportButton.jsx
@@ -20,8 +20,23 @@ import React, { useState, useEffect, useContext } from 'react';
 
 
 import DownloadIcon from '@mui/icons-material/FileDownload';
-import { Checkbox, DialogActions, DialogContent, Divider, Stack, FormControl, Grid, Radio, RadioGroup,
-  FormControlLabel, TextField, Typography, Button, IconButton, Tooltip } from "@mui/material";
+import {
+  Checkbox,
+  DialogActions,
+  DialogContent,
+  Divider,
+  Stack,
+  FormControl,
+  Grid,
+  Radio,
+  RadioGroup,
+  FormControlLabel,
+  TextField,
+  Typography,
+  Button,
+  IconButton,
+  Tooltip
+} from "@mui/material";
 import Autocomplete, { createFilterOptions } from "@mui/material/Autocomplete";
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterLuxon } from "@mui/x-date-pickers/AdapterLuxon";

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -19,8 +19,25 @@
 
 import React, { useState, useEffect, useContext } from "react";
 
-import { Paper, Table, TableHead, TableBody, TableRow, TableCell, TablePagination } from "@mui/material";
-import { Card, CardHeader, CardContent, CardActions, Typography, Button, LinearProgress, Stack } from "@mui/material";
+import {
+  Paper,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  TablePagination
+} from "@mui/material";
+import {
+  Card,
+  CardHeader,
+  CardContent,
+  CardActions,
+  Typography,
+  Button,
+  LinearProgress,
+  Stack
+} from "@mui/material";
 import { Link } from 'react-router';
 import { withStyles } from 'tss-react/mui';
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
@@ -33,7 +33,15 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
-import { blue, blueGrey, cyan, deepPurple, indigo, orange, purple } from '@mui/material/colors';
+import {
+  blue,
+  blueGrey,
+  cyan,
+  deepPurple,
+  indigo,
+  orange,
+  purple
+} from '@mui/material/colors';
 import { DateTime } from "luxon";
 import PropTypes from "prop-types";
 import { Link, useNavigate, useLocation } from 'react-router';

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -19,7 +19,15 @@
 
 import React, { useEffect, useState, useContext } from "react";
 
-import { Alert, Button, CircularProgress, DialogActions, DialogContent, TextField, Typography } from "@mui/material";
+import {
+  Alert,
+  Button,
+  CircularProgress,
+  DialogActions,
+  DialogContent,
+  TextField,
+  Typography
+} from "@mui/material";
 import { MaterialReactTable } from "material-react-table";
 import { useNavigate } from 'react-router';
 import { withStyles } from 'tss-react/mui';

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTypeDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTypeDialog.jsx
@@ -17,7 +17,19 @@
 
 import React, { useState, useEffect } from "react";
 
-import { Button, Grid, Dialog, DialogTitle, DialogActions, DialogContent, MenuItem, TextField, Typography, Select, FormHelperText } from "@mui/material";
+import {
+  Button,
+  Grid,
+  Dialog,
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  MenuItem,
+  TextField,
+  Typography,
+  Select,
+  FormHelperText
+} from "@mui/material";
 import { withStyles } from 'tss-react/mui';
 
 import QuestionnaireStyle from "./QuestionnaireStyle.jsx";

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/NewQuestionnaireDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/NewQuestionnaireDialog.jsx
@@ -18,7 +18,15 @@
 //
 import React, { useState } from "react";
 
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField, Typography } from "@mui/material";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography
+} from "@mui/material";
 import { useNavigate } from "react-router";
 import { v4 as uuidv4 } from 'uuid';
 

--- a/modules/data-entry/src/main/frontend/src/resourceQuery/ResourceQuery.jsx
+++ b/modules/data-entry/src/main/frontend/src/resourceQuery/ResourceQuery.jsx
@@ -20,7 +20,16 @@ import React, { useRef, useState, useContext } from "react";
 
 import Info from "@mui/icons-material/Info";
 import Search from "@mui/icons-material/Search";
-import { ClickAwayListener, Grow, IconButton, Input, InputAdornment, InputLabel, FormControl, Typography } from "@mui/material";
+import {
+  ClickAwayListener,
+  Grow,
+  IconButton,
+  Input,
+  InputAdornment,
+  InputLabel,
+  FormControl,
+  Typography
+} from "@mui/material";
 import { Divider, LinearProgress, MenuItem, MenuList, Paper, Popper } from "@mui/material";
 import classNames from "classnames";
 import PropTypes from "prop-types";

--- a/modules/data-entry/src/main/frontend/src/vocabQuery/InfoBox.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/InfoBox.jsx
@@ -19,7 +19,21 @@
 import React from "react";
 
 import CloseIcon from '@mui/icons-material/Close';
-import { Avatar, Button, Card, CardActions, CardContent, CardHeader, ClickAwayListener, Grow, IconButton, Link, Popper, Tooltip, Typography } from "@mui/material";
+import {
+  Avatar,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  CardHeader,
+  ClickAwayListener,
+  Grow,
+  IconButton,
+  Link,
+  Popper,
+  Tooltip,
+  Typography
+} from "@mui/material";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import { withStyles } from 'tss-react/mui';

--- a/modules/data-entry/src/main/frontend/src/vocabQuery/VocabularyTree.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/VocabularyTree.jsx
@@ -18,7 +18,15 @@
 //
 import React, { useState, useEffect } from "react";
 
-import { Button, Checkbox, DialogContent, DialogActions, Chip, Radio, Typography } from '@mui/material';
+import {
+  Button,
+  Checkbox,
+  DialogContent,
+  DialogActions,
+  Chip,
+  Radio,
+  Typography
+} from '@mui/material';
 import PropTypes from "prop-types";
 import { withStyles } from 'tss-react/mui';
 

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
@@ -18,7 +18,16 @@
 //
 import React, { useState, useEffect, useContext } from "react";
 
-import { Alert, Button, CardActions, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material";
+import {
+  Alert,
+  Button,
+  CardActions,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle
+} from "@mui/material";
 import PropTypes from "prop-types";
 import { useNavigate } from 'react-router';
 import { makeStyles } from 'tss-react/mui';

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/AddUserToGroupDialog.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/AddUserToGroupDialog.jsx
@@ -18,7 +18,15 @@
 import React, { useState, useContext } from "react";
 
 import CheckIcon from '@mui/icons-material/Check';
-import { Avatar, Button, Dialog, DialogTitle, DialogActions, DialogContent, Grid } from "@mui/material";
+import {
+  Avatar,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  Grid
+} from "@mui/material";
 import { MaterialReactTable, useMaterialReactTable } from 'material-react-table';
 import PropTypes from "prop-types";
 import { withStyles } from 'tss-react/mui';

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/CreateGroupDialog.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/CreateGroupDialog.jsx
@@ -17,7 +17,16 @@
 
 import React, { useState, useContext } from "react";
 
-import { Alert, Button, Grid, Dialog, DialogTitle, DialogActions, DialogContent, TextField } from "@mui/material";
+import {
+  Alert,
+  Button,
+  Grid,
+  Dialog,
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  TextField
+} from "@mui/material";
 import PropTypes from "prop-types";
 import { withStyles } from 'tss-react/mui';
 

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/GroupsManager.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/GroupsManager.jsx
@@ -19,7 +19,15 @@ import React, { useState, useContext, useMemo, useCallback } from "react";
 
 import CheckIcon from '@mui/icons-material/Check';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { Alert, Avatar, Box, Button, Grid, IconButton, Tooltip } from "@mui/material";
+import {
+  Alert,
+  Avatar,
+  Box,
+  Button,
+  Grid,
+  IconButton,
+  Tooltip
+} from "@mui/material";
 import { MaterialReactTable, useMaterialReactTable } from 'material-react-table';
 import PropTypes from "prop-types";
 import { withStyles } from 'tss-react/mui'

--- a/modules/principals/src/main/frontend/src/Userboard/Users/ChangeUserPasswordDialog.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Users/ChangeUserPasswordDialog.jsx
@@ -17,7 +17,15 @@
 
 import React, { useState, useContext } from "react";
 
-import { Alert, Button, Dialog, DialogTitle, DialogContent, TextField, Tooltip } from "@mui/material";
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  TextField,
+  Tooltip
+} from "@mui/material";
 import { Formik } from "formik";
 import PropTypes from "prop-types";
 import { withStyles } from 'tss-react/mui';

--- a/modules/statistics/src/main/frontend/src/Statistics/Statistic.jsx
+++ b/modules/statistics/src/main/frontend/src/Statistics/Statistic.jsx
@@ -32,7 +32,17 @@ import { deepPurple, indigo } from '@mui/material/colors';
 import palette from "google-palette";
 import { useNavigate } from 'react-router';
 import {
-  BarChart, Bar, CartesianGrid, Line, LineChart, Label, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis
+  BarChart,
+  Bar,
+  CartesianGrid,
+  Line,
+  LineChart,
+  Label,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
 } from "recharts";
 import { withStyles } from 'tss-react/mui';
 


### PR DESCRIPTION
Imports are organised by manual file change.
New ESLint `"react/jsx-no-undef"` rule checks for any missed JSX imports, was added for general use and to support this PR as a check for any missed imports.
Any duplicated imports will be also reported by linter an error.