### PR TITLE
CARDS-2794: Add ESLint rule to report unused imports

### DIFF
--- a/Utilities/Development/ExtensionPointResources/ExtensionPointUserTemplate.jsx
+++ b/Utilities/Development/ExtensionPointResources/ExtensionPointUserTemplate.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Grid } from '@mui/material';
 import { loadExtensions } from "../uiextension/extensionManager";
 

--- a/Utilities/Development/ExtensionPointResources/extension_boilerplate.jsx
+++ b/Utilities/Development/ExtensionPointResources/extension_boilerplate.jsx
@@ -16,5 +16,3 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-
-import React from "react";

--- a/aggregated-frontend/src/main/frontend/eslint.config.js
+++ b/aggregated-frontend/src/main/frontend/eslint.config.js
@@ -26,6 +26,7 @@ import reactHooks from "eslint-plugin-react-hooks";
 import importPlugin from "eslint-plugin-import";
 import jsxA11y from "eslint-plugin-jsx-a11y";
 import globals from "globals";
+import unusedImports from "eslint-plugin-unused-imports";
 
 // For ESLint rules specs see  https://eslint.org/docs/latest/rules/
 
@@ -47,6 +48,7 @@ const commonGlobals = {
 const commonPlugins = {
   react,
   "react-hooks": reactHooks,
+  "unused-imports": unusedImports,
   import: importPlugin,
 };
 
@@ -74,6 +76,14 @@ const whitespaceRules = {
 const commonRules = {
   "import/order": importOrderRule,
   "react/jsx-no-undef": ["error", { allowGlobals: true }],
+  "react/jsx-uses-vars": "error",
+  "no-unused-vars": "off",
+  "unused-imports/no-unused-imports": [
+  "error",
+  {
+    "varsIgnorePattern": "^React"
+  }
+],
   ...whitespaceRules,
 };
 

--- a/aggregated-frontend/src/main/frontend/eslint.config.js
+++ b/aggregated-frontend/src/main/frontend/eslint.config.js
@@ -78,12 +78,7 @@ const commonRules = {
   "react/jsx-no-undef": ["error", { allowGlobals: true }],
   "react/jsx-uses-vars": "error",
   "no-unused-vars": "off",
-  "unused-imports/no-unused-imports": [
-  "error",
-  {
-    "varsIgnorePattern": "^React"
-  }
-],
+  "unused-imports/no-unused-imports": "error",
   ...whitespaceRules,
 };
 

--- a/aggregated-frontend/src/main/frontend/package.json
+++ b/aggregated-frontend/src/main/frontend/package.json
@@ -70,6 +70,7 @@
 	"eslint-plugin-react-hooks": "7.0.0",
 	"eslint-plugin-import": "2.32.0",
 	"eslint-plugin-jsx-a11y": "6.10.2",
+	"eslint-plugin-unused-imports": "4.3.0",
     "eslint": "9.24.0",
 	"eslint-webpack-plugin": "5.0.2",
     "webpack": "5.99.5",

--- a/aggregated-frontend/src/main/frontend/package.json
+++ b/aggregated-frontend/src/main/frontend/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@babel/core": "7.27.1",
-    "@babel/plugin-transform-runtime": "7.27.1",
     "@babel/preset-env": "7.27.1",
     "@babel/preset-react": "7.27.1",
     "@babel/preset-typescript": "7.28.5", 

--- a/aggregated-frontend/src/main/frontend/package.json
+++ b/aggregated-frontend/src/main/frontend/package.json
@@ -11,7 +11,9 @@
   "babel": {
     "presets": [
       "@babel/preset-env",
-      "@babel/preset-react",
+      ["@babel/preset-react", {
+        "runtime": "automatic"
+      }],
 	  "@babel/preset-typescript"
     ]
   },

--- a/aggregated-frontend/src/main/frontend/yarn.lock
+++ b/aggregated-frontend/src/main/frontend/yarn.lock
@@ -3414,6 +3414,11 @@ eslint-plugin-react@7.37.5:
     string.prototype.matchall "^4.0.12"
     string.prototype.repeat "^1.0.0"
 
+eslint-plugin-unused-imports@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.3.0.tgz#69ff9c4f83f02f7789808bbbab77636cb742af50"
+  integrity sha512-ZFBmXMGBYfHttdRtOG9nFFpmUvMtbHSjsKrS20vdWdbfiVYsO3yA2SGYy9i9XmZJDfMGBflZGBCm70SEnFQtOA==
+
 eslint-scope@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"

--- a/aggregated-frontend/src/main/frontend/yarn.lock
+++ b/aggregated-frontend/src/main/frontend/yarn.lock
@@ -860,18 +860,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-runtime@7.27.1":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.27.1.tgz#f9fbf71949a209eb26b3e60375b1d956937b8be9"
-  integrity sha512-TqGF3desVsTcp3WrJGj4HfKokfCXCLcHpt4PJF0D8/iT6LPd9RS82Upw3KPeyr6B22Lfd3DO8MVrmp0oRkUDdw==
-  dependencies:
-    "@babel/helper-module-imports" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
-    babel-plugin-polyfill-corejs2 "^0.4.10"
-    babel-plugin-polyfill-corejs3 "^0.11.0"
-    babel-plugin-polyfill-regenerator "^0.6.1"
-    semver "^6.3.1"
-
 "@babel/plugin-transform-shorthand-properties@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz#532abdacdec87bfee1e0ef8e2fcdee543fe32b90"

--- a/modules/commons/src/main/frontend/src/SearchBar.jsx
+++ b/modules/commons/src/main/frontend/src/SearchBar.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useContext, useEffect } from "react";
+import { useRef, useState, useContext, useEffect } from "react";
 
 import DescriptionIcon from "@mui/icons-material/Description";
 import Search from "@mui/icons-material/Search";
@@ -99,9 +99,9 @@ function SearchBar(props) {
 
   const globalLoginDisplay = useContext(GlobalLoginContext);
 
-  let input = React.useRef();
-  let suggestionMenu = React.useRef();
-  let searchBar = React.useRef();
+  let input = useRef();
+  let suggestionMenu = useRef();
+  let searchBar = useRef();
 
   // Fetch saved admin config settings
   useEffect(() => {
@@ -196,7 +196,7 @@ function SearchBar(props) {
   }
 
   return(
-    <React.Fragment>
+    <>
       <Input
         type="text"
         placeholder="Search"
@@ -317,7 +317,7 @@ function SearchBar(props) {
           </Grow>
         )}
       </Popper>
-    </React.Fragment>
+    </>
   );
 }
 
@@ -333,13 +333,13 @@ let defaultQueryConstructor = (query, requestID, showTotalRows, allowedResourceT
 }
 
 let defaultResultConstructor = (props) => (
-  <React.Fragment>
+  <>
     <ListItemAvatar><Avatar className={classes.searchResultAvatar}><DescriptionIcon /></Avatar></ListItemAvatar>
     <ListItemText
       primary={(props.resultData["jcr:uuid"])}
       className={classes.dropdownItem}
     />
-  </React.Fragment>
+  </>
 );
 
 let defaultRedirect = (event, row, props) => {

--- a/modules/commons/src/main/frontend/src/components/404.js
+++ b/modules/commons/src/main/frontend/src/components/404.js
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from 'react';
-
 import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
 import { createRoot } from 'react-dom/client';
 

--- a/modules/commons/src/main/frontend/src/components/ComposedIcon.jsx
+++ b/modules/commons/src/main/frontend/src/components/ComposedIcon.jsx
@@ -23,8 +23,6 @@
 //
 // Inspired by https://github.com/rand0mC0d3r/material-ui-mix-icon/blob/master/src/components/ComposedIcon/ComposedIcon.js
 
-import React from 'react';
-
 import { useTheme } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 

--- a/modules/commons/src/main/frontend/src/components/DragAndDrop.jsx
+++ b/modules/commons/src/main/frontend/src/components/DragAndDrop.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useRef, useEffect, useState } from "react";
+import { useRef, useEffect, useState } from "react";
 
 import AttachFile from '@mui/icons-material/AttachFile';
 import { IconButton, Typography } from "@mui/material";

--- a/modules/commons/src/main/frontend/src/components/ErrorDialog.jsx
+++ b/modules/commons/src/main/frontend/src/components/ErrorDialog.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from "react";
-
 import CloseIcon from '@mui/icons-material/Close';
 import {
   Dialog,

--- a/modules/commons/src/main/frontend/src/components/ErrorPage.jsx
+++ b/modules/commons/src/main/frontend/src/components/ErrorPage.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from 'react';
-
 import NavigationIcon from '@mui/icons-material/Navigation';
 import { Fab, Grid, Paper, Typography } from '@mui/material';
 import { makeStyles } from 'tss-react/mui';

--- a/modules/commons/src/main/frontend/src/components/FormattedText.jsx
+++ b/modules/commons/src/main/frontend/src/components/FormattedText.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from 'react';
-
 import { Typography } from "@mui/material";
 import MDEditor from '@uiw/react-md-editor';
 import PropTypes from 'prop-types';

--- a/modules/commons/src/main/frontend/src/components/GenericErrorPage.js
+++ b/modules/commons/src/main/frontend/src/components/GenericErrorPage.js
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from 'react';
-
 import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
 import { createRoot } from 'react-dom/client';
 

--- a/modules/commons/src/main/frontend/src/components/Logo.jsx
+++ b/modules/commons/src/main/frontend/src/components/Logo.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from 'react';
-
 import { Box } from '@mui/material';
 import PropTypes from 'prop-types';
 import { makeStyles } from 'tss-react/mui';

--- a/modules/commons/src/main/frontend/src/components/MainActionButton.jsx
+++ b/modules/commons/src/main/frontend/src/components/MainActionButton.jsx
@@ -15,8 +15,6 @@
   under the License.
 */
 
-import React from "react";
-
 import { CircularProgress, Fab, Tooltip } from "@mui/material";
 import PropTypes from "prop-types";
 import { withStyles } from 'tss-react/mui';

--- a/modules/commons/src/main/frontend/src/components/NewItemButton.jsx
+++ b/modules/commons/src/main/frontend/src/components/NewItemButton.jsx
@@ -15,8 +15,6 @@
   under the License.
 */
 
-import React from "react";
-
 import AddIcon from "@mui/icons-material/Add";
 import PropTypes from "prop-types";
 

--- a/modules/commons/src/main/frontend/src/components/PageNotFound.js
+++ b/modules/commons/src/main/frontend/src/components/PageNotFound.js
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import ErrorPage from './ErrorPage.jsx';
 

--- a/modules/commons/src/main/frontend/src/components/ResponsiveDialog.jsx
+++ b/modules/commons/src/main/frontend/src/components/ResponsiveDialog.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { forwardRef } from "react";
+import { forwardRef } from "react";
 
 import CloseIcon from '@mui/icons-material/Close';
 import {

--- a/modules/commons/src/main/frontend/src/components/UserInputAssistant.jsx
+++ b/modules/commons/src/main/frontend/src/components/UserInputAssistant.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import EmojiObjectsIcon from "@mui/icons-material/EmojiObjects";
 import WarningIcon from "@mui/icons-material/Warning";

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteButton.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useContext } from "react";
+import { useState, useContext } from "react";
 
 import { Delete } from "@mui/icons-material";
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton } from "@mui/material";
@@ -172,7 +172,7 @@ function DeleteButton(props) {
   }
 
   return (
-    <React.Fragment>
+    <>
       {errorOpen &&
         <ErrorDialog open={errorOpen} onClose={closeError}>
           <Typography>{errorMessage}</Typography>
@@ -214,7 +214,7 @@ function DeleteButton(props) {
           {buttonText}
         </Button>
       }
-    </React.Fragment>
+    </>
   );
 }
 

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteWithRefreshButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/DeleteWithRefreshButton.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
-
 import DeleteButton from "./DeleteButton.jsx";
 
 /**

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/EditButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/EditButton.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
-
 import EditIcon from "@mui/icons-material/Edit";
 import { IconButton, Tooltip } from "@mui/material";
 import PropTypes from "prop-types";

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/ExportButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/ExportButton.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect, useContext } from 'react';
+import { useState, useEffect, useContext } from 'react';
 
 
 import DownloadIcon from '@mui/icons-material/FileDownload';
@@ -319,7 +319,7 @@ function ExportButton(props) {
   }
 
   return(
-    <React.Fragment>
+    <>
       <ResponsiveDialog
         title={`Export "${entryName}" Data`}
         open={open}
@@ -527,7 +527,7 @@ function ExportButton(props) {
           {entryLabel}
         </Button>
       }
-    </React.Fragment>
+    </>
   )
 }
 

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/BooleanFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/BooleanFilter.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { forwardRef, useState } from "react";
+import { forwardRef, useState } from "react";
 
 import { Select, MenuItem } from "@mui/material";
 import PropTypes from "prop-types";

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/DateFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/DateFilter.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, forwardRef } from "react";
+import { useState, forwardRef } from "react";
 
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterLuxon } from "@mui/x-date-pickers/AdapterLuxon";

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/ListFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/ListFilter.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { forwardRef, useState } from "react";
+import { forwardRef, useState } from "react";
 
 import { Select, MenuItem } from "@mui/material";
 import PropTypes from "prop-types";

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/NumericFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/NumericFilter.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { forwardRef } from "react";
+import { forwardRef } from "react";
 
 import { TextField } from "@mui/material";
 import PropTypes from "prop-types";

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/QuestionnaireFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/QuestionnaireFilter.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { forwardRef, useState } from "react";
+import { forwardRef, useState } from "react";
 
 import ErrorIcon from "@mui/icons-material/Error";
 import { Select, MenuItem, Card, CardHeader, CardContent, Typography } from "@mui/material";

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/ResourceFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/ResourceFilter.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { forwardRef } from "react";
+import { forwardRef } from "react";
 
 import PropTypes from "prop-types";
 import { withStyles } from 'tss-react/mui';

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/SubjectFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/SubjectFilter.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { forwardRef, useState } from "react";
+import { forwardRef, useState } from "react";
 
 import ErrorIcon from "@mui/icons-material/Error";
 import { InputAdornment, Tooltip } from "@mui/material";

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/TextFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/TextFilter.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { forwardRef, useState } from "react";
+import { forwardRef, useState } from "react";
 
 import { TextField } from "@mui/material";
 import PropTypes from "prop-types";

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/UserFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/UserFilter.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { forwardRef, useState, useEffect, useContext } from "react";
+import { forwardRef, useState, useEffect, useContext } from "react";
 
 import { TextField } from "@mui/material";
 import Autocomplete, { createFilterOptions } from "@mui/material/Autocomplete";

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/VocabularyFilter.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FilterComponents/VocabularyFilter.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { forwardRef } from "react";
+import { forwardRef } from "react";
 
 import PropTypes from "prop-types";
 import { withStyles } from 'tss-react/mui';

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
@@ -24,15 +24,16 @@ import { Chip, Typography, Button, CircularProgress, IconButton, Tooltip } from 
 import { DialogActions, DialogContent, Grid, Select, MenuItem, TextField } from "@mui/material";
 import { withStyles } from 'tss-react/mui';
 
-import BooleanFilter from "./FilterComponents/BooleanFilter.jsx";
 import LiveTableStyle from "./tableStyle.jsx";
 import VariableAutocomplete from "./VariableAutocomplete";
 import ResponsiveDialog from "../components/ResponsiveDialog";
 import FilterComponentManager from "./FilterComponents/FilterComponentManager.jsx";
 import { fetchWithReLogin, GlobalLoginContext } from "../login/ReLoginDialog.js";
-// We have to import each filter dependency here to load them properly into the FilterComponentManager
-import DateFilter from "./FilterComponents/DateFilter.jsx";
 import { UNARY_COMPARATORS, TEXT_COMPARATORS } from "./FilterComponents/FilterComparators.jsx";
+// We have to import each filter dependency here to load them properly into the FilterComponentManager
+/* eslint-disable unused-imports/no-unused-imports, import/order */
+import BooleanFilter from "./FilterComponents/BooleanFilter.jsx";
+import DateFilter from "./FilterComponents/DateFilter.jsx";
 import ListFilter from "./FilterComponents/ListFilter.jsx";
 import NumericFilter from "./FilterComponents/NumericFilter.jsx";
 import QuestionnaireFilter from "./FilterComponents/QuestionnaireFilter.jsx";
@@ -41,6 +42,7 @@ import SubjectFilter from "./FilterComponents/SubjectFilter.jsx";
 import TextFilter from "./FilterComponents/TextFilter.jsx";
 import UserFilter from "./FilterComponents/UserFilter.jsx";
 import VocabularyFilter from "./FilterComponents/VocabularyFilter.jsx";
+/* eslint-enable unused-imports/no-unused-imports, import/order */
 
 const FILTER_URL = "/Questionnaires.filters";
 

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/FormView.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import DescriptionIcon from '@mui/icons-material/Description';
 import LaunchIcon from '@mui/icons-material/Launch';

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Forms.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
-
 import { Grid } from "@mui/material";
 import { useLocation } from 'react-router';
 import { withStyles } from 'tss-react/mui';

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useEffect, useContext } from "react";
+import { useState, useEffect, useContext } from "react";
 
 import {
   Paper,

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect, useContext } from "react";
+import { useState, useEffect, useContext } from "react";
 
 import {
   Button,
@@ -412,7 +412,7 @@ function NewFormDialog(props) {
   });
 
   return (
-    <React.Fragment>
+    <>
       <ResponsiveDialog
         title={progress === PROGRESS_SELECT_QUESTIONNAIRE ? "Select a questionnaire" : "Select a subject"}
         open={withButton ? dialogOpen : open}
@@ -425,7 +425,7 @@ function NewFormDialog(props) {
         <DialogContent dividers className={classes.dialogContentWithTable}>
           {error && (!newSubjectPopperOpen) && <Alert severity="error">{error}</Alert>}
           {progress === PROGRESS_SELECT_QUESTIONNAIRE ?
-            <React.Fragment>
+            <>
               {relatedForms && <>
                 <MaterialReactTable table={table}/>
                 <TablePagination
@@ -442,9 +442,9 @@ function NewFormDialog(props) {
                 />
               </>
               }
-            </React.Fragment>
+            </>
             :
-            <React.Fragment>
+            <>
               { /* We need selectedQuestionnaire to be filled out before this renders, or it will try grabbing the wrong subjects */
                 selectedQuestionnaire && <SubjectSelectorList
                   allowedTypes={parseToArray(selectedQuestionnaire?.["requiredSubjectTypes"])}
@@ -457,7 +457,7 @@ function NewFormDialog(props) {
                   selectedQuestionnaire={selectedQuestionnaire}
                   disableProgress={setDisableProgress}
                 />}
-            </React.Fragment>}
+            </>}
         </DialogContent>
         <DialogActions>
           {progress === PROGRESS_SELECT_SUBJECT &&
@@ -513,7 +513,7 @@ function NewFormDialog(props) {
             inProgress={!dialogOpen && isFetching}
           />
       }
-    </React.Fragment>
+    </>
   )
 }
 

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/PermissionsButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/PermissionsButton.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
-
 import { Lock } from "@mui/icons-material"
 import { IconButton, Tooltip } from "@mui/material";
 import { withStyles } from 'tss-react/mui';
@@ -31,13 +29,13 @@ function PermissionsButton(props) {
   const { classes, size } = props;
 
   return (
-    <React.Fragment>
+    <>
       <Tooltip title="Set Permissions">
         <IconButton component="span" className={classes.titleButton} size="large">
           <Lock fontSize={size || "default"}/>
         </IconButton>
       </Tooltip>
-    </React.Fragment>
+    </>
   );
 }
 

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/PrintButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/PrintButton.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import PrintIcon from "@mui/icons-material/Print";
 import { Button, IconButton, Tooltip } from "@mui/material";

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Questionnaires.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState } from "react";
+import { useState } from "react";
 
 import { Box } from "@mui/material";
 import { Link } from 'react-router';

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectTypes.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState } from "react";
+import { useState } from "react";
 
 import { Box } from "@mui/material";
 import { Link } from 'react-router';

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/SubjectView.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect, useContext } from "react";
+import { useState, useEffect, useContext } from "react";
 
 import AssignmentIndIcon from '@mui/icons-material/AssignmentInd';
 import LaunchIcon from '@mui/icons-material/Launch';
@@ -50,7 +50,7 @@ function SubjectView(props) {
   const [ activeTab, setActiveTab ] = useState(0);
   const [ subjectTypes, setSubjectTypes] = useState([])
   const [ tabsLoading, setTabsLoading ] = useState(null);
-  const [ columns, setColumns ] = React.useState(props.columns || null);
+  const [ columns, setColumns ] = useState(props.columns || null);
   const [ filtersJsonString, setFiltersJsonString ] = useState(new URLSearchParams(window.location.hash.substring(1)).get("subjects:filters"));
   const hasSubjects = tabsLoading === false && subjectTypes.length > 0;
 

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Subjects.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
-
 import { Grid } from "@mui/material";
 import { withStyles } from 'tss-react/mui';
 

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import {
   Button,
@@ -86,7 +86,7 @@ function UserDashboard(props) {
   }
 
   return (
-    <React.Fragment>
+    <>
       { dashboardExtensions.length > 0 &&
       <Grid container spacing={4} className={classes.dashboardContainer}>
         {
@@ -175,7 +175,7 @@ function UserDashboard(props) {
           })
         }
       </>}
-    </React.Fragment>
+    </>
   );
 }
 

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/VariableAutocomplete.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/VariableAutocomplete.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from "react";
-
 import { ListItemButton, ListItemText, Popper, TextField } from "@mui/material";
 import Autocomplete, { createFilterOptions } from "@mui/material/Autocomplete";
 import PropTypes from 'prop-types';

--- a/modules/data-entry/src/main/frontend/src/questionnaire/AddressQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/AddressQuestion.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState } from "react";
+import { useState } from "react";
 
 import { TextField } from "@mui/material";
 import GlobalStyles from '@mui/material/GlobalStyles';

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef } from "react";
 
 import PropTypes from "prop-types";
 import { v4 as uuidv4 } from 'uuid';
@@ -118,7 +118,7 @@ function Answer (props) {
   }, [answers, questionName]);
 
   return (
-    <React.Fragment>
+    <>
       <input type="hidden" className="cards-answer-id" value={answerID}></input>
       <input type="hidden" name={`${answerPath}/jcr:primaryType`} value={answerNodeType}></input>
       <input type="hidden" name={`${answerPath}/question`} value={questionDefinition['jcr:uuid']}></input>
@@ -126,7 +126,7 @@ function Answer (props) {
 
       {/* Add the answers, if any exist, or otherwise delete them */}
       {answers?.length ?
-        (<React.Fragment>
+        (<>
           <input type="hidden" name={`${answerPath}/value@TypeHint`} value={valueType + (isMultivalued ? '[]' : '')}></input>
           {answers.map( (element, index) => {
             return (
@@ -145,7 +145,7 @@ function Answer (props) {
                 );
               })
           }
-        </React.Fragment>)
+        </>)
         :
         <>
           <input type="hidden" name={`${answerPath}/value@Delete`} value="0"></input>
@@ -170,7 +170,7 @@ function Answer (props) {
           {...noteProps}
         />
       }
-    </React.Fragment>
+    </>
   );
 }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/AnswerInstructions.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/AnswerInstructions.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import { Typography } from "@mui/material";
 import PropTypes from "prop-types";

--- a/modules/data-entry/src/main/frontend/src/questionnaire/AutocreatedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/AutocreatedQuestion.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { List, ListItem } from "@mui/material";
 import PropTypes from 'prop-types';

--- a/modules/data-entry/src/main/frontend/src/questionnaire/BooleanQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/BooleanQuestion.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from "react";
-
 import PropTypes from "prop-types";
 
 import { checkPropTypes } from "../propTypes";

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ChromosomeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ChromosomeQuestion.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from "react";
-
 import PropTypes from "prop-types";
 
 import { checkPropTypes } from "../propTypes";

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { InputAdornment, TextField, Typography } from "@mui/material";
 import PropTypes from 'prop-types';

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import { Typography } from "@mui/material";
 import { LocalizationProvider } from '@mui/x-date-pickers';
@@ -289,10 +289,10 @@ function DateQuestion(props) {
           { getDateField(false, displayedDate, formatError) }
           { /* If this is an interval, allow the user to select a second date */
             isRange &&
-          <React.Fragment>
+          <>
             <span className="separator">&mdash;</span>
             { getDateField(true, displayedEndDate, endFormatError) }
-          </React.Fragment>
+          </>
           }
         </div>
       }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionYear.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestionYear.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from "react";
-
 import { checkPropTypes } from "../propTypes";
 import AnswerComponentManager from "./AnswerComponentManager";
 import NumberQuestion from "./NumberQuestion";

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DicomQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DicomQuestion.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {
@@ -277,7 +277,7 @@ function DicomQuestion(props) {
 
   // Render a customized FileQuestion
   return (
-    <React.Fragment>
+    <>
       <ResponsiveDialog
         size="xs"
         open={Boolean(errorDialogText)}
@@ -319,7 +319,7 @@ function DicomQuestion(props) {
           value: dicomMetadataNote
         }}
       />
-    </React.Fragment>
+    </>
   );
 }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FileQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FileQuestion.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useContext, useState } from "react";
+import { useContext, useState } from "react";
 
 import { Grid, LinearProgress, Link, TextField } from "@mui/material";
 import PropTypes from "prop-types";

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect, useState, useContext } from "react";
+import { useRef, useEffect, useState, useContext } from "react";
 
 
 import CloudUploadIcon from "@mui/icons-material/CloudUpload";
@@ -167,7 +167,7 @@ function Form (props) {
     }
   }, [lastSaveStatus, endReached, incompleteQuestionEl, saveInProgress]);
 
-  let formNode = React.useRef();
+  let formNode = useRef();
   let pageNameWriter = usePageNameWriterContext();
   const formURL = `/Forms/${id}`;
   const baseURL = "/content.html" + (extensionURL ? "/" + extensionURL : "");
@@ -672,10 +672,10 @@ function Form (props) {
               </Backdrop>
             }
             {changedSubject &&
-              <React.Fragment>
+              <>
                 <input type="hidden" name={`${data["@path"]}/subject`} value={changedSubject["@path"]}></input>
                 <input type="hidden" name={`${data["@path"]}/subject@TypeHint`} value="Reference"></input>
-              </React.Fragment>
+              </>
             }
             {pages && !fetchInProgress &&
               Object.entries(data.questionnaire)

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormContext.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormContext.jsx
@@ -17,12 +17,12 @@
 //  under the License.
 //
 
-import React from "react";
+import { createContext, useContext, useState } from "react";
 
 const DEFAULT_STATE = {};
 
-const FormReaderContext = React.createContext(DEFAULT_STATE);
-const FormWriterContext = React.createContext();
+const FormReaderContext = createContext(DEFAULT_STATE);
+const FormWriterContext = createContext();
 
 /**
  * A context provider for a form, which contains answers and a way to set them
@@ -30,7 +30,7 @@ const FormWriterContext = React.createContext();
  * @returns {Object} a React component with the form provider
  */
 export function FormProvider(props) {
-  const [answers, setAnswers] = React.useState(DEFAULT_STATE);
+  const [answers, setAnswers] = useState(DEFAULT_STATE);
   const { additionalFormData, ...rest } = props
 
   return (
@@ -46,7 +46,7 @@ export function FormProvider(props) {
  * @throws an error if it is not within a FormProvider
  */
 export function useFormReaderContext() {
-  const context = React.useContext(FormReaderContext);
+  const context = useContext(FormReaderContext);
 
   if (context == undefined) {
     throw new Error("useFormReaderContext must be used within a FormProvider")
@@ -61,7 +61,7 @@ export function useFormReaderContext() {
  * @throws an error if it is not within a FormProvider
  */
 export function useFormWriterContext() {
-  const context = React.useContext(FormWriterContext);
+  const context = useContext(FormWriterContext);
 
   if (context == undefined) {
     throw new Error("useFormWriterContext must be used within a FormProvider")

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from "react";
-
 import { Grid } from "@mui/material";
 
 /* eslint-disable import/order */

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormEntry.jsx
@@ -21,9 +21,10 @@ import React from "react";
 
 import { Grid } from "@mui/material";
 
-import AddressQuestion from "./AddressQuestion";
-import AnswerComponentManager from "./AnswerComponentManager";
+/* eslint-disable import/order */
 // FIXME In order for the questions to be registered, they need to be loaded, and the only way to do that at the moment is to explicitly invoke them here. Find a way to automatically load all question types, possibly using self-declaration in a node, like the assets, or even by filtering through assets.
+/* eslint-disable unused-imports/no-unused-imports */
+import AddressQuestion from "./AddressQuestion";
 import BooleanQuestion from "./BooleanQuestion";
 import ChromosomeQuestion from "./ChromosomeQuestion";
 import ComputedQuestion from "./ComputedQuestion";
@@ -31,20 +32,23 @@ import DateQuestion from "./DateQuestion";
 import DateQuestionYear from "./DateQuestionYear";
 import DicomQuestion from "./DicomQuestion";
 import FileQuestion from "./FileQuestion";
-import { hasWarningFlags } from "./FormUtilities";
 import IdentifierQuestion from "./IdentifierQuestion";
-import Information from "./Information";
 import NumberQuestion from "./NumberQuestion";
 import PedigreeQuestion from "./PedigreeQuestion";
 import PhoneQuestion from "./PhoneQuestion";
-import QuestionMatrix from "./QuestionMatrix";
 import ReferenceQuestion from "./ReferenceQuestion";
 import ResourceQuestion from "./ResourceQuestion";
-import Section from "./Section";
 import SelectableArea from "./SelectableAreaQuestion";
 import TextQuestion from "./TextQuestion";
 import TimeQuestion from "./TimeQuestion";
 import VocabularyQuestion from "./VocabularyQuestion";
+/* eslint-enable unused-imports/no-unused-imports */
+import AnswerComponentManager from "./AnswerComponentManager";
+import { hasWarningFlags } from "./FormUtilities";
+import Information from "./Information";
+import QuestionMatrix from "./QuestionMatrix";
+import Section from "./Section";
+/* eslint-enable import/order */
 
 export const QUESTION_TYPES = ["cards:Question"];
 export const SECTION_TYPES = ["cards:Section"];

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPageNavigation.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPageNavigation.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 
 import CheckIcon from '@mui/icons-material/Check';

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import {
   Button,

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormUpdateContext.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormUpdateContext.jsx
@@ -16,13 +16,12 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-
-import React from "react";
+import { createContext, useContext, useState } from "react";
 
 const DEFAULT_STATE = {};
 
-const FormUpdateReaderContext = React.createContext(DEFAULT_STATE);
-const FormUpdateWriterContext = React.createContext();
+const FormUpdateReaderContext = createContext(DEFAULT_STATE);
+const FormUpdateWriterContext = createContext();
 
 /**
  * A context provider for a form, which contains update requests to a form
@@ -32,7 +31,7 @@ const FormUpdateWriterContext = React.createContext();
  */
 export function FormUpdateProvider(props) {
   const { extraFunctions, ...rest } = props;
-  const [answers, setAnswers] = React.useState(DEFAULT_STATE);
+  const [answers, setAnswers] = useState(DEFAULT_STATE);
 
   return (
     <FormUpdateReaderContext.Provider value={{ ...answers, ...extraFunctions }}>
@@ -47,7 +46,7 @@ export function FormUpdateProvider(props) {
  * @throws an error if it is not within a FormProvider
  */
 export function useFormUpdateReaderContext() {
-  const context = React.useContext(FormUpdateReaderContext);
+  const context = useContext(FormUpdateReaderContext);
 
   if (context == undefined) {
     throw new Error("useFormUpdateReaderContext must be used within a FormUpdateProvider")
@@ -62,7 +61,7 @@ export function useFormUpdateReaderContext() {
  * @throws an error if it is not within a FormProvider
  */
 export function useFormUpdateWriterContext() {
-  const context = React.useContext(FormUpdateWriterContext);
+  const context = useContext(FormUpdateWriterContext);
 
   if (context == undefined) {
     throw new Error("useFormUpdateWriterContext must be used within a FormUpdateProvider")

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormView.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormView.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useLocation } from "react-router";
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/IdentifierQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/IdentifierQuestion.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import { Button, Tooltip } from "@mui/material";

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Information.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Information.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from "react";
-
 import { Alert, Card, CardContent } from "@mui/material";
 import PropTypes from "prop-types";
 import { withStyles } from 'tss-react/mui';

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 
 import Close from "@mui/icons-material/Close";
 import {
@@ -483,7 +483,7 @@ function MultipleChoice(props) {
 
   if (isSelect) {
     return (
-      <React.Fragment>
+      <>
         {
           pageActive && <FormControl sx={{ width: 300 }}>
             {instructions}
@@ -526,11 +526,11 @@ function MultipleChoice(props) {
           onAddSuggestion={acceptOptionFromWidget}
           {...rest}
         />
-      </React.Fragment>
+      </>
     )
   } else if (isBare) {
     return(
-      <React.Fragment>
+      <>
         {
           pageActive && <>
             {instructions}
@@ -544,11 +544,11 @@ function MultipleChoice(props) {
           onAddSuggestion={acceptOptionFromWidget}
           {...rest}
         />
-      </React.Fragment>
+      </>
     )
   } else if (isRadio) {
     return (
-      <React.Fragment>
+      <>
         {
           pageActive && <>
             {instructions}
@@ -600,11 +600,11 @@ function MultipleChoice(props) {
           onAddSuggestion={acceptOptionFromWidget}
           {...rest}
         />
-      </React.Fragment>
+      </>
     );
   } else {
     return (
-      <React.Fragment>
+      <>
         {
           pageActive && <>
             {instructions}
@@ -622,7 +622,7 @@ function MultipleChoice(props) {
           onAddSuggestion={acceptOptionFromWidget}
           {...rest}
         />
-      </React.Fragment>
+      </>
     )
   }
 }
@@ -658,7 +658,7 @@ function ResponseChild(props) {
   const handleFormDataChange = formContext?.['/OnFormDataChanged'];
 
   return (
-    <React.Fragment>
+    <>
       <ListItem
         key={name}
         className={isDefaultOption ? classes.selectionChild : undefined}
@@ -703,7 +703,7 @@ function ResponseChild(props) {
               </FormattedText>
             </>
             ) : ((name !== "") && (
-              <React.Fragment>
+              <>
                 <IconButton
                   onClick={() => {onDelete(id, name)}}
                   className={classes.deleteButton}
@@ -723,11 +723,11 @@ function ResponseChild(props) {
                   {description}
                 </FormattedText>
                 }
-              </React.Fragment>
+              </>
             ))
         }
       </ListItem>
-    </React.Fragment>
+    </>
   );
 }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/NCRNote.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/NCRNote.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState } from "react";
+import { useState } from "react";
 
 import { CircularProgress, Chip, Tooltip, Typography } from "@mui/material";
 import { withStyles } from 'tss-react/mui';
@@ -63,10 +63,10 @@ function ParsedNoteSection (props) {
     onAddSuggestion(firstMatch[ONTOLOGY_KEY].replace(/:/g, ""), firstMatch["names"][0])
   }
 
-  return (<React.Fragment>
+  return (<>
     <Typography display="inline">{frontMatter}</Typography>
     {hasMatch &&
-      <React.Fragment>
+      <>
         <Tooltip title={`Add ${matchName} (${matchID}) to selection`}>
           <Chip
             size="small"
@@ -91,8 +91,8 @@ function ParsedNoteSection (props) {
           onAddSuggestion={onAddSuggestion}
         />
         <Typography display="inline">{endMatter}</Typography>
-      </React.Fragment>}
-  </React.Fragment>)
+      </>}
+  </>)
 }
 
 function NCRNote (props) {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Note.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Note.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect } from "react";
 
 import AddIcon from "@mui/icons-material/Add";
 import UnfoldLess from "@mui/icons-material/UnfoldLess";
@@ -65,7 +65,7 @@ function Note (props) {
     return <></>;
   }
 
-  return (<React.Fragment>
+  return (<>
     <div className = {classes.notesContainer}>
       <Tooltip
         title = {visible ? "Hide notes" : (noteIsEmpty ? "Add notes" : "Show notes")}
@@ -110,7 +110,7 @@ function Note (props) {
     {noteIsEmpty ?
       <input type="hidden" name={`${answerPath}/note@Delete`} value="0" />
       : <input type="hidden" name={`${answerPath}/note`} value={note} />}
-  </React.Fragment>);
+  </>);
 }
 
 Note.propTypes = {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { forwardRef, useState } from "react";
+import { forwardRef, useState, useEffect } from "react";
 
 import {
   InputAdornment,
@@ -234,7 +234,7 @@ function NumberQuestion(props) {
     return null;
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!isRange) return;
     // Check for invalid range limits
     setMinMaxError(
@@ -247,7 +247,7 @@ function NumberQuestion(props) {
     );
   }, [lowerLimit, upperLimit]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (isRange) return;
     setMinMaxError(
       getMinMaxValueError(sliderValue)

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Button, Dialog, DialogContent, Grid, Link, Tooltip } from "@mui/material";
 import PropTypes from "prop-types";

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PhoneQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PhoneQuestion.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState } from "react";
+import { useState } from "react";
 
 import 'react-phone-input-2/lib/style.css';
 import PropTypes from "prop-types";

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PrintPreview.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, {
+import {
   useRef,
   useState,
   useEffect,

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Question.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Question.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useRef, useEffect, useState } from "react";
+import { useRef, useEffect, useState } from "react";
 
 import { Card, CardHeader, CardContent, List, ListItem, Typography } from "@mui/material";
 import PropTypes from "prop-types";

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionMatrix.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionMatrix.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import {
   Checkbox,

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import EditIcon from '@mui/icons-material/Edit';
 import PreviewIcon from '@mui/icons-material/FindInPage';

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireAutocomplete.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireAutocomplete.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from 'react';
+import React from "react";
 
 import ClearIcon from '@mui/icons-material/Clear';
 import {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireContext.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireContext.jsx
@@ -16,13 +16,12 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-
-import React from "react";
+import { createContext, useContext, useState } from "react";
 
 const DEFAULT_STATE = [];
 
-const QuestionnaireReaderContext = React.createContext(DEFAULT_STATE);
-const QuestionnaireWriterContext = React.createContext();
+const QuestionnaireReaderContext = createContext(DEFAULT_STATE);
+const QuestionnaireWriterContext = createContext();
 
 /**
  * A context provider for a questionnaire, which contains questions data and a way to set them
@@ -30,7 +29,7 @@ const QuestionnaireWriterContext = React.createContext();
  * @returns {Object} a React component with the questionnaire provider
  */
 export function QuestionnaireProvider(props) {
-  const [questions, setQuestions] = React.useState(DEFAULT_STATE);
+  const [questions, setQuestions] = useState(DEFAULT_STATE);
 
   return (
     <QuestionnaireReaderContext.Provider value={questions}>
@@ -45,7 +44,7 @@ export function QuestionnaireProvider(props) {
  * @throws an error if it is not within a QuestionnaireProvider
  */
 export function useQuestionnaireReaderContext() {
-  const context = React.useContext(QuestionnaireReaderContext);
+  const context = useContext(QuestionnaireReaderContext);
 
   if (context == undefined) {
     throw new Error("useQuestionnaireReaderContext must be used within a QuestionnaireProvider")
@@ -60,7 +59,7 @@ export function useQuestionnaireReaderContext() {
  * @throws an error if it is not within a QuestionnaireProvider
  */
 export function useQuestionnaireWriterContext() {
-  const context = React.useContext(QuestionnaireWriterContext);
+  const context = useContext(QuestionnaireWriterContext);
 
   if (context == undefined) {
     throw new Error("useQuestionnaireWriterContext must be used within a QuestionnaireProvider")

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import CloseIcon from "@mui/icons-material/Close";
 import {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ResourceHeader.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ResourceHeader.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from "react";
-
 import {
   Breadcrumbs,
   Collapse,

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ResourceQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ResourceQuestion.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useEffect, useContext } from "react";
+import { useState, useEffect, useContext } from "react";
 
 import { CircularProgress } from '@mui/material';
 import PropTypes from "prop-types";

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -30,8 +30,10 @@ import { v4 as uuidv4 } from 'uuid';
 
 import ConditionalComponentManager from "./ConditionalComponentManager";
 // FIXME In order for the conditionals to be registered, they need to be loaded, and the only way to do that at the moment is to explicitly invoke them here. Find a way to automatically load all conditional types, possibly using self-declaration in a node, like the assets, or even by filtering through assets.
+/* eslint-disable unused-imports/no-unused-imports */
 import ConditionalGroup from "./ConditionalGroup";
 import ConditionalSingle from "./ConditionalSingle";
+/* eslint-enable unused-imports/no-unused-imports */
 import { useFormReaderContext, useFormWriterContext } from "./FormContext";
 import FormEntry, { ENTRY_TYPES } from "./FormEntry";
 import { hasWarningFlags } from "./FormUtilities";

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useCallback, useState, useEffect } from "react";
+import { useCallback, useState, useEffect } from "react";
 
 import Add from "@mui/icons-material/Add";
 import UnfoldLess from '@mui/icons-material/UnfoldLess';
@@ -195,7 +195,7 @@ function Section(props) {
   // mountOnEnter and unmountOnExit force the inputs and children to be outside of the DOM during form submission
   // if it is not currently visible
   return useCallback(
-    <React.Fragment>
+    <>
       {/* if conditional is true, the collapse component is rendered and displayed.
         else, the corresponding input tag to the conditional section is deleted  */}
       { isDisplayed
@@ -342,7 +342,7 @@ function Section(props) {
           <input type="hidden" name={`${path + "/" + uuid}@Delete`} value="0" key={uuid}></input>
         )
       }
-    </React.Fragment>
+    </>
     , [conditionIsMet, instanceLabels, labelsToHide, selectedUUID, removableAnswers[ID_STATE_KEY], pageActive, isEdit]);
 }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SelectableAreaQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SelectableAreaQuestion.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 
 import { Alert, Checkbox, FormControlLabel, Typography } from "@mui/material";
 import { useTheme, alpha } from '@mui/material/styles';

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SessionExpiryWarningModal.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SessionExpiryWarningModal.jsx
@@ -15,7 +15,7 @@
   under the License.
 */
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Backdrop, Button, DialogActions, DialogContent, Typography } from "@mui/material";
 import PropTypes from "prop-types";

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useContext, useEffect, useRef } from "react";
+import { useState, useContext, useEffect, useRef } from "react";
 
 import SubjectIcon from "@mui/icons-material/AssignmentInd";
 import CollapsedIcon from "@mui/icons-material/ChevronRight";
@@ -126,7 +126,7 @@ function Subject(props) {
   }
 
   return (
-    <React.Fragment>
+    <>
       <NewFormDialog
         currentSubject={currentSubject}
         withButton
@@ -177,7 +177,7 @@ function Subject(props) {
           </CardContent></Card>
         </Grid>
       </Grid>
-    </React.Fragment>
+    </>
   );
 }
 
@@ -243,7 +243,7 @@ function SubjectContainer(props) {
   }
 
   return (
-    subject && <React.Fragment>
+    subject && <>
       <SubjectMember
         classes={classes}
         id={id}
@@ -257,7 +257,7 @@ function SubjectContainer(props) {
         baseURL={baseURL}
         extensionURL={extensionURL}
       />
-    </React.Fragment>
+    </>
   );
 }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectActions.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectActions.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import getActions from "./actionsManager";
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectActions.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectActions.jsx
@@ -20,8 +20,6 @@
 import React, { useEffect, useState } from "react";
 
 import getActions from "./actionsManager";
-import { loadExtensions } from "../uiextension/extensionManager";
-
 
 export default function SubjectActions(props) {
   let { subject, reloadSubject, className, size, variant } = props;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectIdentifier.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectIdentifier.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from "react";
-
 import { Link } from 'react-router';
 
 function defaultCreator (node) {
@@ -47,10 +45,10 @@ export function getSubjectIdFromPath (path) {
 export function getHierarchy (node, RenderComponent, propsCreator, extensionURL="") {
   let HComponent = RenderComponent || Link;
   let props = propsCreator || extensionCreator(node, extensionURL);
-  let output = <React.Fragment>{node.type.label} <HComponent {...props}>{node.identifier}</HComponent></React.Fragment>;
+  let output = <>{node.type.label} <HComponent {...props}>{node.identifier}</HComponent></>;
   if (node["parents"]?.type) {
     let ancestors = getHierarchy(node["parents"], HComponent, propsCreator, extensionURL);
-    return <React.Fragment>{ancestors} / {output}</React.Fragment>
+    return <>{ancestors} / {output}</>
   } else {
     return output;
   }
@@ -63,7 +61,7 @@ export function getShortHierarchy (node, RenderComponent, propsCreator, extensio
   let output = <HComponent {...props}>{node.identifier}</HComponent>;
   if (node["parents"] && node["parents"].type) {
     let ancestors = getShortHierarchy(node["parents"], HComponent, propsCreator, extensionURL);
-    return <React.Fragment>{ancestors} / {output}</React.Fragment>
+    return <>{ancestors} / {output}</>
   } else {
     return output;
   }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -150,7 +150,7 @@ function UnstyledNewSubjectDialog (props) {
   ]);
 
   return(
-    <React.Fragment>
+    <>
       <ResponsiveDialog title="Create new subject" open={open} onClose={onClose}>
         <DialogContent dividers className={classes.dialogContentWithTable}>
           { error && <Alert severity="error">{error}</Alert>}
@@ -228,7 +228,7 @@ function UnstyledNewSubjectDialog (props) {
           </Button>
         </DialogActions>
       </ResponsiveDialog>
-    </React.Fragment>
+    </>
   )
 }
 
@@ -671,7 +671,7 @@ export function NewSubjectDialog (props) {
   }
 
   return (
-    <React.Fragment>
+    <>
       <NewSubjectDialogChild
         allowedTypes={newSubjectIndex == 0 ? allowedTypes : newSubjectAllowedTypes[newSubjectIndex-1]}
         continueDisabled={!(newSubjectName[newSubjectIndex] && newSubjectType[newSubjectIndex])}
@@ -707,7 +707,7 @@ export function NewSubjectDialog (props) {
         parentType={newSubjectTypeParent}
         value={newSubjectParent[newSubjectIndex]}
       /> }
-    </React.Fragment>)
+    </>)
 }
 
 /**
@@ -781,7 +781,7 @@ function UnstyledSelectorDialog (props) {
 
   let disabled_controls = isPosting || disabled;
 
-  return (<React.Fragment>
+  return (<>
     <NewSubjectDialog
       allowedTypes={allowedTypes}
       currentSubject={currentSubject}
@@ -833,7 +833,7 @@ function UnstyledSelectorDialog (props) {
         </Button>
       </DialogActions>
     </ResponsiveDialog>
-  </React.Fragment>);
+  </>);
 }
 
 export const SelectorDialog = withStyles(UnstyledSelectorDialog, QuestionnaireStyle)
@@ -1049,7 +1049,7 @@ function SubjectSelectorList(props) {
   ]);
 
   return(
-    <React.Fragment>
+    <>
       <MaterialReactTable
         enableColumnActions={false}
         enableColumnFilters={false}
@@ -1092,7 +1092,7 @@ function SubjectSelectorList(props) {
           }),
         })}
       />
-    </React.Fragment>
+    </>
   )
 };
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useContext, useEffect } from "react";
+import { useState, useContext, useEffect } from "react";
 
 import {
   Timeline,

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTypeDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTypeDialog.jsx
@@ -15,7 +15,7 @@
   under the License.
 */
 
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import {
   Button,

--- a/modules/data-entry/src/main/frontend/src/questionnaire/TextQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/TextQuestion.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from "react";
-
 import { Typography } from "@mui/material";
 import PropTypes from "prop-types";
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
@@ -19,7 +19,6 @@
 
 import React, { useState, useEffect } from "react";
 
-import { TextField, Typography } from "@mui/material";
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { TimePicker } from '@mui/x-date-pickers/TimePicker';

--- a/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';

--- a/modules/data-entry/src/main/frontend/src/questionnaire/VocabularyQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/VocabularyQuestion.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from "react";
-
 import PropTypes from "prop-types";
 
 import { checkPropTypes } from "../propTypes";

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/AnswerOptions.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/AnswerOptions.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/BooleanInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/BooleanInput.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { Switch } from "@mui/material";
 import PropTypes from 'prop-types';

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/CodeInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/CodeInput.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import TextInput from "./TextInput";

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ConditionalValueInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ConditionalValueInput.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState } from "react";
+import { useState } from "react";
 
 import {
   Autocomplete,

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/CreationMenu.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/CreationMenu.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import {
   Button,

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/DroppableAnswerOption.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/DroppableAnswerOption.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 
 import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';
@@ -205,7 +205,7 @@ function DroppableAnswerOption(props) {
   }
 
   return (
-    <React.Fragment>
+    <>
       <div className={classes.optionsList}>
         {generateOption(false)}
         {draggableState?.type === 'dragging-over' && draggableState?.closestEdge &&
@@ -216,7 +216,7 @@ function DroppableAnswerOption(props) {
           generateOption(true),
           draggableState.container
         )}
-    </React.Fragment>
+    </>
   )
 }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/DroppableAnswerOptionList.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/DroppableAnswerOptionList.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 
 import { monitorForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
 import { triggerPostMoveFlash } from '@atlaskit/pragmatic-drag-and-drop-flourish/trigger-post-move-flash';
@@ -82,7 +82,7 @@ function DroppableAnswerOptionList(props) {
   }, [options]);
 
   return (
-    <React.Fragment>
+    <>
       {options && options.map((value, index) =>
         <DroppableAnswerOption
           key={value.value}
@@ -93,7 +93,7 @@ function DroppableAnswerOptionList(props) {
           classes={classes}
         />
       )}
-    </React.Fragment>
+    </>
   );
 }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditDialog.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useContext } from "react";
+import { useState, useContext, useRef } from "react";
 
 import {
   Button,
@@ -67,7 +67,7 @@ let EditDialog = (props) => {
 
   let formattedType = camelCaseToWords(type);
 
-  let saveButtonRef = React.useRef();
+  let saveButtonRef = useRef();
   const globalLoginDisplay = useContext(GlobalLoginContext);
 
   let saveData = (event) => {

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditorInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditorInput.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from 'react';
-
 import Info from "@mui/icons-material/Info";
 import {
   Grid,

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Fields.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Fields.jsx
@@ -16,8 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-
-import React from 'react';
+import React from "react";
 
 import PropTypes from 'prop-types';
 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Fields.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Fields.jsx
@@ -21,20 +21,24 @@ import React from 'react';
 
 import PropTypes from 'prop-types';
 
+/* eslint-disable import/order */
 import { checkPropTypes } from "../propTypes";
+import { FieldsProvider } from "./FieldsContext.jsx";
+import LabeledField from "./LabeledField";
 // Unused imports required for the component manager
+/* eslint-disable unused-imports/no-unused-imports */
 import AnswerOptions from "./AnswerOptions";
 import BooleanInput from "./BooleanInput";
 import CodeInput from "./CodeInput";
 import ConditionalValueInput from "./ConditionalValueInput";
-import { FieldsProvider } from "./FieldsContext.jsx";
-import LabeledField from "./LabeledField";
 import ListInput from "./ListInput";
 import MarkdownTextField from "./MarkdownTextField";
 import NumberInput from "./NumberInput";
 import ObjectInput from "./ObjectInput";
 import ReferenceInput from "./ReferenceInput";
 import TextInput from "./TextInput";
+/* eslint-enable unused-imports/no-unused-imports */
+/* eslint-enable import/order */
 import QuestionComponentManager from "../questionnaireEditor/QuestionComponentManager";
 import ValueComponentManager from "../questionnaireEditor/ValueComponentManager";
 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/FieldsContext.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/FieldsContext.jsx
@@ -16,13 +16,12 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-
-import React from "react";
+import { createContext, useContext, useState } from "react";
 
 const DEFAULT_STATE = {};
 
-const FieldsReaderContext = React.createContext(DEFAULT_STATE);
-const FieldsWriterContext = React.createContext();
+const FieldsReaderContext = createContext(DEFAULT_STATE);
+const FieldsWriterContext = createContext();
 
 /**
  * A context provider for a set of fields, which contains answers and a way to set them
@@ -30,7 +29,7 @@ const FieldsWriterContext = React.createContext();
  * @returns {Object} a React component with the fields provider
  */
 export function FieldsProvider(props) {
-  const [answers, setAnswers] = React.useState(DEFAULT_STATE);
+  const [answers, setAnswers] = useState(DEFAULT_STATE);
   const { additionalFieldData, ...rest } = props
 
   return (
@@ -46,7 +45,7 @@ export function FieldsProvider(props) {
  * @throws an error if it is not within a FieldsProvider
  */
 export function useFieldsReaderContext() {
-  const context = React.useContext(FieldsReaderContext);
+  const context = useContext(FieldsReaderContext);
 
   if (context == undefined) {
     throw new Error("useFieldsReaderContext must be used within a FieldsProvider")
@@ -61,7 +60,7 @@ export function useFieldsReaderContext() {
  * @throws an error if it is not within a FieldsProvider
  */
 export function useFieldsWriterContext() {
-  const context = React.useContext(FieldsWriterContext);
+  const context = useContext(FieldsWriterContext);
 
   if (context == undefined) {
     throw new Error("useFieldsWriterContext must be used within a FieldsProvider")

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/LabeledField.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/LabeledField.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from 'react';
-
 import {
   Grid,
   Typography

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ListInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ListInput.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 
 import { Chip, Input, MenuItem, Select, Typography } from "@mui/material";
 import FormControl from '@mui/material/FormControl';

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/MarkdownText.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/MarkdownText.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 
 import MDEditor, { commands } from '@uiw/react-md-editor';
 import PropTypes from 'prop-types';

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/MarkdownTextField.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/MarkdownTextField.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import PropTypes from 'prop-types';
 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/NewQuestionnaireDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/NewQuestionnaireDialog.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState } from "react";
+import { useState } from "react";
 
 import {
   Button,
@@ -79,7 +79,7 @@ function NewQuestionnaireDialog(props) {
   }
 
   return (
-    <React.Fragment>
+    <>
       <Dialog open={open} onClose={onClose} autoFocus={false}>
         <DialogTitle id="new-questionnaire-title">
           Create a new questionnaire
@@ -123,7 +123,7 @@ function NewQuestionnaireDialog(props) {
           </Button>
         </DialogActions>
       </Dialog>
-    </React.Fragment>
+    </>
   )
 }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/NumberInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/NumberInput.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState } from "react";
+import { useState } from "react";
 
 import { TextField } from "@mui/material";
 import PropTypes from 'prop-types';

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ObjectInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ObjectInput.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState } from "react";
+import { useState } from "react";
 
 import {
   MenuItem,

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/QuestionnaireItemCard.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/QuestionnaireItemCard.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import EditIcon from '@mui/icons-material/Edit';
 import MoreIcon from '@mui/icons-material/MoreHoriz';

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/QuestionnaireItemCard.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/QuestionnaireItemCard.jsx
@@ -38,7 +38,7 @@ import { makeStyles } from 'tss-react/mui';
 
 import { checkPropTypes } from "../propTypes";
 import EditDialog from "./EditDialog";
-import { camelCaseToWords }  from "./LabeledField";
+import { camelCaseToWords } from "./LabeledField";
 import FormattedText from "../components/FormattedText.jsx";
 import DeleteButton from "../dataHomepage/DeleteButton.jsx";
 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReferenceInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReferenceInput.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 
 import PropTypes from 'prop-types';
 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/TextInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/TextInput.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from 'react';
-
 import { TextField } from "@mui/material";
 import PropTypes from 'prop-types';
 

--- a/modules/data-entry/src/main/frontend/src/resourceQuery/ResourceQuery.jsx
+++ b/modules/data-entry/src/main/frontend/src/resourceQuery/ResourceQuery.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useRef, useState, useContext } from "react";
+import { useRef, useState, useContext } from "react";
 
 import Info from "@mui/icons-material/Info";
 import Search from "@mui/icons-material/Search";

--- a/modules/data-entry/src/main/frontend/src/vocabQuery/InfoBox.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/InfoBox.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
-
 import CloseIcon from '@mui/icons-material/Close';
 import {
   Avatar,

--- a/modules/data-entry/src/main/frontend/src/vocabQuery/VocabularyBranch.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/VocabularyBranch.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import Info from "@mui/icons-material/Info";
 import ArrowDown from "@mui/icons-material/KeyboardArrowDown";

--- a/modules/data-entry/src/main/frontend/src/vocabQuery/VocabularyBrowser.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/VocabularyBrowser.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import { Snackbar, SnackbarContent } from "@mui/material";
 import PropTypes from "prop-types";

--- a/modules/data-entry/src/main/frontend/src/vocabQuery/VocabularyQuery.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/VocabularyQuery.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
-
 import PropTypes from "prop-types";
 
 import { checkPropTypes } from "../propTypes";

--- a/modules/data-entry/src/main/frontend/src/vocabQuery/VocabularyTree.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/VocabularyTree.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import {
   Button,

--- a/modules/demo-banner/src/main/frontend/src/DemoBanner.jsx
+++ b/modules/demo-banner/src/main/frontend/src/DemoBanner.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from "react";
-
 import {
   Alert,
   AppBar,

--- a/modules/downtime-warning-banner/src/main/frontend/src/DowntimeBanner.jsx
+++ b/modules/downtime-warning-banner/src/main/frontend/src/DowntimeBanner.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import BuildIcon from '@mui/icons-material/Build';
 import {

--- a/modules/downtime-warning-banner/src/main/frontend/src/DowntimeWarningConfiguration.jsx
+++ b/modules/downtime-warning-banner/src/main/frontend/src/DowntimeWarningConfiguration.jsx
@@ -31,7 +31,6 @@ import { DateTime } from "luxon";
 import { makeStyles } from 'tss-react/mui';
 
 import AdminConfigScreen from "./adminDashboard/AdminConfigScreen.jsx";
-import DateTimeUtilities from "./components/DateTimeUtilities";
 
 const useStyles = makeStyles()(theme => ({
   textField: {

--- a/modules/downtime-warning-banner/src/main/frontend/src/DowntimeWarningConfiguration.jsx
+++ b/modules/downtime-warning-banner/src/main/frontend/src/DowntimeWarningConfiguration.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 
 import {
   Checkbox,

--- a/modules/embedded-view/src/main/frontend/src/embeddedView/index.jsx
+++ b/modules/embedded-view/src/main/frontend/src/embeddedView/index.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
-
 import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
 import { createRoot } from 'react-dom/client';
 

--- a/modules/google-apis/src/main/frontend/src/GoogleApiKeyAdminPage.jsx
+++ b/modules/google-apis/src/main/frontend/src/GoogleApiKeyAdminPage.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useEffect, useContext } from "react";
+import { useState, useEffect, useContext } from "react";
 
 import {
   Alert,

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect, useContext } from "react";
+import { useState, useEffect, useContext } from "react";
 
 import {
   Alert,

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminDashboard.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminDashboard.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import {
   CircularProgress,

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminResourceListing.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminResourceListing.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useContext, useEffect } from "react";
+import { useState, useContext, useEffect } from "react";
 
 import { MaterialReactTable } from "material-react-table";
 

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminScreen.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminScreen.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
-
 import { Breadcrumbs, Card, CardContent, CardHeader, Typography } from "@mui/material";
 import PropTypes from "prop-types";
 import { Link } from 'react-router';

--- a/modules/homepage/src/main/frontend/src/themePage/EntityIdentifier.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/EntityIdentifier.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
-
 import { getTextHierarchy } from "../questionnaire/SubjectIdentifier.jsx";
 
 // Get the identifier of the item wrt item primaryType

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/AdminNavbarLinks.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/AdminNavbarLinks.jsx
@@ -9,7 +9,7 @@
 =========================================================
 * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 */
-import React, { useContext, useEffect, useRef, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 
 // @mui/material components
 import CloseIcon from '@mui/icons-material/Close';

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/Navbar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/Navbar.jsx
@@ -9,8 +9,6 @@
 =========================================================
 * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 */
-import React from "react";
-
 import Menu from "@mui/icons-material/Menu";
 import { AppBar, Box, Toolbar, IconButton } from "@mui/material";
 import classNames from "classnames";

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/QuickSearchIdentifier.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/QuickSearchIdentifier.jsx
@@ -20,7 +20,7 @@ import AssignmentIcon from '@mui/icons-material/Assignment';
 import AssignmentIndIcon from "@mui/icons-material/AssignmentInd";
 import DescriptionIcon from "@mui/icons-material/Description";
 import OtherIcon from '@mui/icons-material/Reorder';
-import { Avatar, ListItemButton, ListItemText, ListItemAvatar }  from "@mui/material";
+import { Avatar, ListItemButton, ListItemText, ListItemAvatar } from "@mui/material";
 import { useTheme } from '@mui/material/styles';
 import { Link } from "react-router";
 

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/QuickSearchIdentifier.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/QuickSearchIdentifier.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
-
 import AssignmentIcon from '@mui/icons-material/Assignment';
 import AssignmentIndIcon from "@mui/icons-material/AssignmentInd";
 import DescriptionIcon from "@mui/icons-material/Description";
@@ -46,13 +44,13 @@ export function QuickSearchMatch(props) {
   // Adjust the question text to reflect the notes, if the match was on the notes
   let questionText = matchData[CARDS_QUERY_QUESTION_KEY] + (matchData[CARDS_QUERY_MATCH_NOTES_KEY] ? " / Notes" : "");
   return (
-    <React.Fragment>
+    <>
       <span className={classes.queryMatchKey}>{questionText}</span>
       <span className={classes.queryMatchSeparator}>: </span>
       <span className={classes.queryMatchBefore}>{matchData[CARDS_QUERY_MATCH_BEFORE_KEY]}</span>
       <span className={classes.highlightedText}>{matchData[CARDS_QUERY_MATCH_TEXT_KEY]}</span>
       <span className={classes.queryMatchAfter}>{matchData[CARDS_QUERY_MATCH_AFTER_KEY]}</span>
-    </React.Fragment>
+    </>
   )
 }
 

--- a/modules/homepage/src/main/frontend/src/themePage/Page.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Page.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
 
 const DEFAULT_STATE = "";
 

--- a/modules/homepage/src/main/frontend/src/themePage/QuickSearchConfiguration.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/QuickSearchConfiguration.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import {
   Checkbox,

--- a/modules/homepage/src/main/frontend/src/themePage/QuickSearchResults.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/QuickSearchResults.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
-
 import { Card, CardContent, CardHeader, Typography } from "@mui/material";
 import { withStyles } from 'tss-react/mui';
 

--- a/modules/homepage/src/main/frontend/src/themePage/Sidebar/AppInfo.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Sidebar/AppInfo.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from "react";
-
 import { Tooltip, Typography } from "@mui/material";
 
 function AppInfo (props) {

--- a/modules/homepage/src/main/frontend/src/themePage/Sidebar/Sidebar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Sidebar/Sidebar.jsx
@@ -9,7 +9,7 @@
 =========================================================
 * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 */
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import { Drawer, List, ListItemButton, ListItemText } from "@mui/material";
 import classNames from "classnames";

--- a/modules/homepage/src/main/frontend/src/themePage/index.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/index.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { Suspense } from "react";
+import { Suspense } from "react";
 import { useState, useEffect } from "react";
 
 import createCache from "@emotion/cache";
@@ -99,7 +99,7 @@ function Main(props) {
   };
 
   return (
-    <React.Fragment>
+    <>
       <GlobalLoginContext.Provider
         value={{
           dialogOpen: (loginHandlerFcn, discardOnFailure) => {
@@ -158,7 +158,7 @@ function Main(props) {
           </Suspense>
         </div>
       </GlobalLoginContext.Provider>
-    </React.Fragment>
+    </>
   );
 }
 

--- a/modules/homepage/src/main/frontend/src/themePage/indexStyle.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/indexStyle.jsx
@@ -11,8 +11,7 @@
 */
 import {
   drawerWidth,
-  transition,
-  container
+  transition
 } from "../themeStyle.jsx";
 
 const appStyle = theme => ({

--- a/modules/locking/src/main/frontend/src/locking/SubjectLockAction.jsx
+++ b/modules/locking/src/main/frontend/src/locking/SubjectLockAction.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect, useContext } from "react";
+import { useState, useEffect, useContext } from "react";
 
 
 import AssignmentIcon from "@mui/icons-material/Assignment";

--- a/modules/login/src/main/frontend/src/login/MainLoginContainer.js
+++ b/modules/login/src/main/frontend/src/login/MainLoginContainer.js
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { Breadcrumbs, Button, Grid, Paper, Tooltip, Typography } from '@mui/material';
 import { withStyles } from 'tss-react/mui';

--- a/modules/login/src/main/frontend/src/login/ReLoginDialog.js
+++ b/modules/login/src/main/frontend/src/login/ReLoginDialog.js
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from 'react';
+import { createContext } from "react";
 
 import { Dialog } from '@mui/material';
 import PropTypes from 'prop-types';
@@ -24,7 +24,7 @@ import PropTypes from 'prop-types';
 import MainLoginContainer from './MainLoginContainer';
 import { checkPropTypes } from "../propTypes";
 
-export const GlobalLoginContext = React.createContext();
+export const GlobalLoginContext = createContext();
 
 export function fetchWithReLogin(displayLoginCtx, url, fetchArgs, discardOnFailure) {
   return new Promise(function(resolve, reject) {

--- a/modules/login/src/main/frontend/src/login/loginMain.js
+++ b/modules/login/src/main/frontend/src/login/loginMain.js
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from 'react';
-
 import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
 import { createRoot } from 'react-dom/client';
 

--- a/modules/page-start-header/src/main/frontend/src/PageStart.jsx
+++ b/modules/page-start-header/src/main/frontend/src/PageStart.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { loadExtensions } from "./uiextension/extensionManager";
 
@@ -89,7 +89,7 @@ export default function PageStart(props) {
   }
 
   return (
-    <React.Fragment>
+    <>
       {
         visualComponents.map((ThisComp, index) => {
           return (
@@ -112,6 +112,6 @@ export default function PageStart(props) {
           );
         })
       }
-    </React.Fragment>
+    </>
   );
 }

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/ClinicDashboard.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/ClinicDashboard.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect, useContext } from "react";
+import { useState, useEffect, useContext } from "react";
 
 import {
   CircularProgress,

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/ClinicFormList.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/ClinicFormList.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState } from "react";
+import { useState } from "react";
 
 import {
   Avatar,

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/ClinicForms.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/ClinicForms.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import {
   CircularProgress,

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/ClinicVisits.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/ClinicVisits.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
-
 import EventIcon from '@mui/icons-material/Event';
 import { Link } from 'react-router';
 import { makeStyles } from 'tss-react/mui';

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Clinics.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 
 import {
   Button,

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/DashboardSettingsConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/DashboardSettingsConfiguration.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import {
   Checkbox,

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Footer.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Footer.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import {
   Link,

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Header.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Header.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
-
 import {
   AppBar,
   Breadcrumbs,

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/LandingPage.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/LandingPage.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import {
   Breadcrumbs,

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import {
   Checkbox,

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect }  from 'react';
+import { useState, useEffect }  from 'react';
 
 import AppointmentIcon from '@mui/icons-material/Event';
 import {

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import { useState, useEffect }  from 'react';
+import { useState, useEffect } from 'react';
 
 import AppointmentIcon from '@mui/icons-material/Event';
 import {

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PrintHeader.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PrintHeader.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
-
 import {
   Typography
 } from "@mui/material";

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect, useContext }  from 'react';
+import { useState, useEffect, useContext }  from 'react';
 
 
 import SurveyIcon from '@mui/icons-material/Assignment';

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import { useState, useEffect, useContext }  from 'react';
+import { useState, useEffect, useContext } from 'react';
 
 
 import SurveyIcon from '@mui/icons-material/Assignment';

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/ToUConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/ToUConfiguration.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import {
   Checkbox,

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/ToUDialog.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/ToUDialog.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 
 import {

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/ToULink.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/ToULink.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState } from "react";
+import { useState } from "react";
 
 import { FooterLink } from "./Footer";
 import ToUDialog from "./ToUDialog.jsx";

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import {
   Alert,

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/UnsubscribeLink.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/UnsubscribeLink.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
-
 import { FooterLink } from "./Footer";
 
 function UnsubscribeLink (props) {

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/WelcomeMessageConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/WelcomeMessageConfiguration.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from 'react';
-
 import {
   Alert,
   Box,

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/index.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/index.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import createCache from "@emotion/cache";
 import { CacheProvider } from "@emotion/react";

--- a/modules/permissions-trusted/src/main/frontend/src/permissions/PendingView.jsx
+++ b/modules/permissions-trusted/src/main/frontend/src/permissions/PendingView.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from "react";
-
 import ErrorPage from "../components/ErrorPage.jsx";
 
 function PendingView() {

--- a/modules/principals/src/main/frontend/src/Userboard/DeletePrincipalDialog.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/DeletePrincipalDialog.jsx
@@ -15,7 +15,7 @@
   under the License.
 */
 
-import React, { useContext } from "react";
+import { useContext } from "react";
 
 import { Button, Dialog, DialogTitle, DialogActions, DialogContent, Typography } from "@mui/material";
 import PropTypes from "prop-types";

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/AddUserToGroupDialog.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/AddUserToGroupDialog.jsx
@@ -15,7 +15,7 @@
   under the License.
 */
 
-import React, { useState, useContext } from "react";
+import { useState, useContext } from "react";
 
 import CheckIcon from '@mui/icons-material/Check';
 import {

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/CreateGroupDialog.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/CreateGroupDialog.jsx
@@ -15,7 +15,7 @@
   under the License.
 */
 
-import React, { useState, useContext } from "react";
+import { useState, useContext } from "react";
 
 import {
   Alert,

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/GroupsContainer.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/GroupsContainer.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from 'react';
-
 import PrincipalsContainer from '../PrincipalsContainer.jsx';
 
 export default function GroupsContainer() {

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/GroupsManager.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/GroupsManager.jsx
@@ -15,7 +15,7 @@
   under the License.
 */
 
-import React, { useState, useContext, useMemo, useCallback } from "react";
+import { useState, useContext, useMemo, useCallback } from "react";
 
 import CheckIcon from '@mui/icons-material/Check';
 import DeleteIcon from '@mui/icons-material/Delete';

--- a/modules/principals/src/main/frontend/src/Userboard/PrincipalsContainer.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/PrincipalsContainer.jsx
@@ -18,7 +18,7 @@
 //
 
 
-import React, { useState, useEffect, useContext } from 'react';
+import { useState, useEffect, useContext } from 'react';
 
 import GroupsManager from './Groups/GroupsManager.jsx';
 import UsersManager from './Users/UsersManager.jsx';

--- a/modules/principals/src/main/frontend/src/Userboard/Users/ChangeUserPasswordDialog.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Users/ChangeUserPasswordDialog.jsx
@@ -15,7 +15,7 @@
   under the License.
 */
 
-import React, { useState, useContext } from "react";
+import { useState, useContext } from "react";
 
 import {
   Alert,
@@ -106,7 +106,7 @@ function FormFields(props) {
       />
       { !isValid ?
       // Render hover over and button
-        <React.Fragment>
+        <>
           <Tooltip title="You must fill in all fields.">
             <span>
               <Button
@@ -119,7 +119,7 @@ function FormFields(props) {
               </Button>
             </span>
           </Tooltip>
-        </React.Fragment> :
+        </> :
       // Else just render the button
         <Button
           type="submit"

--- a/modules/principals/src/main/frontend/src/Userboard/Users/CreateUserDialog.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Users/CreateUserDialog.jsx
@@ -15,8 +15,6 @@
   under the License.
 */
 
-import React from "react";
-
 import { Grid, Dialog, DialogTitle, DialogContent } from "@mui/material";
 import PropTypes from "prop-types";
 

--- a/modules/principals/src/main/frontend/src/Userboard/Users/UsersContainer.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Users/UsersContainer.jsx
@@ -17,8 +17,6 @@
 //  under the License.
 //
 
-import React from 'react';
-
 import PrincipalsContainer from '../PrincipalsContainer.jsx';
 
 export default function UsersContainer() {

--- a/modules/principals/src/main/frontend/src/Userboard/Users/UsersManager.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Users/UsersManager.jsx
@@ -15,7 +15,7 @@
   under the License.
 */
 
-import React, { useState } from "react";
+import { useState } from "react";
 
 import CheckIcon from '@mui/icons-material/Check';
 import DeleteIcon from '@mui/icons-material/Delete';

--- a/modules/statistics/src/main/frontend/src/Statistics/AdminStatistics.jsx
+++ b/modules/statistics/src/main/frontend/src/Statistics/AdminStatistics.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 
 import {
   Box,

--- a/modules/statistics/src/main/frontend/src/Statistics/Statistic.jsx
+++ b/modules/statistics/src/main/frontend/src/Statistics/Statistic.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
-
 import BarChartIcon from '@mui/icons-material/BarChart';
 import LineChartIcon from '@mui/icons-material/ShowChart';
 import {

--- a/modules/statistics/src/main/frontend/src/Statistics/UserStatistics.jsx
+++ b/modules/statistics/src/main/frontend/src/Statistics/UserStatistics.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useContext, useState } from "react";
+import { useContext, useState } from "react";
 
 import {
   Grid,
@@ -123,13 +123,13 @@ function UserStatistics(props) {
   }
 
   return (
-    <React.Fragment>
+    <>
       <Grid container spacing={3} className={classes.statsContainer}>
         {sortedStats.map((stat, i) => {
           return <Statistic definition={stat} key={i} />
         })}
       </Grid>
-    </React.Fragment>
+    </>
   );
 }
 

--- a/modules/token-authentication/src/main/frontend/src/tokenAuthentication/TokenExpired.jsx
+++ b/modules/token-authentication/src/main/frontend/src/tokenAuthentication/TokenExpired.jsx
@@ -16,8 +16,6 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from 'react';
-
 import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
 import { createRoot } from 'react-dom/client';
 

--- a/modules/ui-extension/src/main/frontend/src/uiextension/ExtensionPoint.jsx
+++ b/modules/ui-extension/src/main/frontend/src/uiextension/ExtensionPoint.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState } from "react";
+import { useState } from "react";
 
 import PropTypes from "prop-types";
 

--- a/modules/variants/src/main/frontend/src/VariantFilesContainer.jsx
+++ b/modules/variants/src/main/frontend/src/VariantFilesContainer.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useContext, useState } from "react";
+import { useContext, useState } from "react";
 
 import BackupIcon from '@mui/icons-material/Backup';
 import CloseIcon from '@mui/icons-material/Close';
@@ -774,7 +774,7 @@ export default function VariantFilesContainer() {
   let uploadAllComplete = !selectedFiles.some((file) => !file.sent);
 
   return (
-    <React.Fragment>
+    <>
       <Typography variant="h2">Variants Upload</Typography>
       <form method="POST"
         encType="multipart/form-data"
@@ -975,6 +975,6 @@ export default function VariantFilesContainer() {
           />
         </DialogContent>
       </Dialog>
-    </React.Fragment>
+    </>
   );
 }

--- a/modules/vocabularies/src/main/frontend/src/BioportalApiKey.jsx
+++ b/modules/vocabularies/src/main/frontend/src/BioportalApiKey.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect, useContext } from "react";
+import { useEffect, useContext, useState } from "react";
 
 import SettingsIcon from '@mui/icons-material/Settings';
 import {
@@ -73,8 +73,8 @@ export function BioPortalApiKey(props) {
   const { classes } = useStyles();
 
   /* User input api key */
-  const [customApiKey, setCustomApiKey] = React.useState('');
-  const [displayPopup, setDisplayPopup] = React.useState(false);
+  const [customApiKey, setCustomApiKey] = useState('');
+  const [displayPopup, setDisplayPopup] = useState(false);
 
   // function to create / edit node
   function addNewKey() {
@@ -122,7 +122,7 @@ export function BioPortalApiKey(props) {
   }
 
   return(
-    <React.Fragment>
+    <>
       <Grid>
         <Typography variant="h6">
           Find on <a href="https://bioportal.bioontology.org/" target="_blank">BioPortal</a>
@@ -170,6 +170,6 @@ export function BioPortalApiKey(props) {
           <Button variant="contained" className={classes.vocabularyAction} onClick={() => {addNewKey()}}>Update</Button>
         </DialogActions>
       </Dialog>
-    </React.Fragment>
+    </>
   );
 }

--- a/modules/vocabularies/src/main/frontend/src/OwlInstaller.jsx
+++ b/modules/vocabularies/src/main/frontend/src/OwlInstaller.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useContext } from "react";
+import { useState, useContext } from "react";
 
 import {
   Button,
@@ -107,7 +107,7 @@ export default function OwlInstaller(props) {
   }
 
   return(
-    <React.Fragment>
+    <>
       <Grid>
         <Typography variant="h6">
           Install from local file
@@ -220,6 +220,6 @@ export default function OwlInstaller(props) {
           </Grid>
         </form>
       </Grid>
-    </React.Fragment>
+    </>
   );
 }

--- a/modules/vocabularies/src/main/frontend/src/VocabulariesAdminPage.jsx
+++ b/modules/vocabularies/src/main/frontend/src/VocabulariesAdminPage.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import {
   Grid,
@@ -55,9 +55,9 @@ function generateRemoteLink(apiKey, linkKey) {
 
 export default function VocabulariesAdminPage() {
   /* All remote vocabularies */
-  const [remoteVocabList, setRemoteVocabList] = React.useState([]);
+  const [remoteVocabList, setRemoteVocabList] = useState([]);
   /* Installed vocabularies */
-  const [localVocabList, setLocalVocabList] = React.useState([]);
+  const [localVocabList, setLocalVocabList] = useState([]);
 
   /*
     The Phase represents the state of Vocabulary. It can be 1 of:
@@ -67,14 +67,14 @@ export default function VocabulariesAdminPage() {
       4) Latest
       5) Uninstalling
   */
-  const [acronymPhaseObject, setAcronymPhaseObject] = React.useState(null);
-  const [acronymPhaseSettersObject, setAcronymPhaseSettersObject] = React.useState({});
-  const [remoteLoaded, setRemoteLoaded] = React.useState(false);
-  const [localLoaded, setLocalLoaded] = React.useState(false);
+  const [acronymPhaseObject, setAcronymPhaseObject] = useState(null);
+  const [acronymPhaseSettersObject, setAcronymPhaseSettersObject] = useState({});
+  const [remoteLoaded, setRemoteLoaded] = useState(false);
+  const [localLoaded, setLocalLoaded] = useState(false);
   /*
     Initially the key will be fetched from a script service.
   */
-  const [bioPortalApiKey, setBioPortalApiKey] = React.useState(null);
+  const [bioPortalApiKey, setBioPortalApiKey] = useState(null);
 
   const localLink = '/query?query=' + encodeURIComponent(`select * from [cards:Vocabulary]`);
 

--- a/modules/vocabularies/src/main/frontend/src/VocabularyAction.jsx
+++ b/modules/vocabularies/src/main/frontend/src/VocabularyAction.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useState, useContext } from "react";
+import { useState, useContext } from "react";
 
 import {
   Button,
@@ -85,7 +85,7 @@ const useStyles = makeStyles()(theme => ({
 export default function VocabularyAction(props) {
   const { install, uninstall, phase, vocabulary, exit } = props;
   const { classes } = useStyles();
-  const [displayPopup, setDisplayPopup] = React.useState(false);
+  const [displayPopup, setDisplayPopup] = useState(false);
   const [linkedQuestions, setLinkedQuestions] = useState([]);
   const [questionnaires, setQuestionnaires] = useState([]);
   const handleOpen = () => {fetchQuestionnaires();}
@@ -156,7 +156,7 @@ export default function VocabularyAction(props) {
   }
 
   return(
-    <React.Fragment>
+    <>
       {exit && (
         <Tooltip title="Close">
           <Button onClick={exit} variant="outlined" className={classes.vocabularyAction}>Close</Button>
@@ -174,14 +174,14 @@ export default function VocabularyAction(props) {
         </span>
       )}
       {(phase == Phase["Update Available"]) && (
-        <React.Fragment>
+        <>
           <Tooltip title="Update this vocabulary">
             <Button onClick={install} variant="contained" className={classes.vocabularyAction + " " + classes.update}>Update</Button>
           </Tooltip>
           <Tooltip title="Remove this vocabulary">
             <Button onClick={uninstall} variant="contained" className={classes.vocabularyAction + " " + classes.uninstall}>Uninstall</Button>
           </Tooltip>
-        </React.Fragment>
+        </>
       )}
       {(phase == Phase["Uninstalling"]) && (
         <span className={classes.wrapper}>
@@ -229,6 +229,6 @@ export default function VocabularyAction(props) {
         </DialogActions>
 
       </Dialog>
-    </React.Fragment>
+    </>
   );
 }

--- a/modules/vocabularies/src/main/frontend/src/VocabularyActions.jsx
+++ b/modules/vocabularies/src/main/frontend/src/VocabularyActions.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect, useContext } from "react";
+import { useEffect, useContext, useState } from "react";
 
 import {
   Typography
@@ -39,11 +39,11 @@ const vocabLinks = require('./vocabularyLinks.json');
 export default function VocabularyActions(props) {
   const { vocabulary, updateLocalList, initPhase } = props;
   // The following facilitates the usage of the same code to report errors for both installation and uninstallation
-  const [error, setError] = React.useState(false);
-  const [action, setAction] = React.useState("");
-  const [errorMessage, setErrorMessage] = React.useState("");
+  const [error, setError] = useState(false);
+  const [action, setAction] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
 
-  const [phase, setPhase] = React.useState(initPhase);
+  const [phase, setPhase] = useState(initPhase);
 
   const globalLoginDisplay = useContext(GlobalLoginContext);
 
@@ -105,10 +105,10 @@ export default function VocabularyActions(props) {
         });
       });
   }
-  React.useEffect(() => {props.addSetter(setPhase);},[0]);
+  useEffect(() => {props.addSetter(setPhase);},[0]);
 
   return(
-    <React.Fragment>
+    <>
       <VocabularyAction
         install={install}
         uninstall={uninstall}
@@ -127,6 +127,6 @@ export default function VocabularyActions(props) {
         <Typography variant="subtitle2" gutterBottom>Version: {vocabulary.version}</Typography>
         <Typography component="p" color="error">{errorMessage}</Typography>
       </ErrorDialog>}
-    </React.Fragment>
+    </>
   );
 }

--- a/modules/vocabularies/src/main/frontend/src/VocabularyDetails.jsx
+++ b/modules/vocabularies/src/main/frontend/src/VocabularyDetails.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 import {
   Button,
@@ -61,7 +61,7 @@ const useStyles = makeStyles()(theme => ({
 export default function VocabularyDetails(props) {
   const { install, uninstall, phase, vocabulary } = props;
 
-  const [displayPopup, setDisplayPopup] = React.useState(false);
+  const [displayPopup, setDisplayPopup] = useState(false);
   const handleOpen = () => {setDisplayPopup(true);}
   const handleClose = () => {setDisplayPopup(false);}
 
@@ -77,7 +77,7 @@ export default function VocabularyDetails(props) {
   };
 
   return(
-    <React.Fragment>
+    <>
 
       <Tooltip title="About this vocabulary" slots={{ transition: Zoom }}>
         <Button onClick={handleOpen} variant="contained" className={classes.button + " " + classes.about} >About</Button>
@@ -118,6 +118,6 @@ export default function VocabularyDetails(props) {
           onCloseBrowser={closeBrowser}
         />
       }
-    </React.Fragment>
+    </>
   );
 }

--- a/modules/vocabularies/src/main/frontend/src/VocabularyDirectory.jsx
+++ b/modules/vocabularies/src/main/frontend/src/VocabularyDirectory.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { 
   Button,
@@ -52,7 +52,7 @@ function reformat(data, type) {
 
 // Requests list of Vocabularies from Bioontology API. Currently only renders a table to display items if they are form the remote source
 export default function VocabularyDirectory(props) {
-  const [curStatus, setCurStatus] = React.useState(Status["Init"]);
+  const [curStatus, setCurStatus] = useState(Status["Init"]);
 
   // Function that fetches list of existing Vocabularies from Bioontology API
   function getVocabList() {
@@ -112,14 +112,14 @@ export default function VocabularyDirectory(props) {
   }, [props.loaded, props.link])
 
   return(
-    <React.Fragment>
+    <>
       {(curStatus == Status["Loading"]) && (
         <Grid>
           <LinearProgress color={(props.type === "remote" ? "primary" : "secondary" )} />
         </Grid>
       )}
       {(curStatus == Status["Error"]) && (
-        <React.Fragment>
+        <>
           <Grid>
             <Typography color="error">
             The list of Bioportal vocabularies is currently inaccessible.
@@ -133,7 +133,7 @@ export default function VocabularyDirectory(props) {
               <Typography variant="button">Retry</Typography>
             </Button>
           </Grid>
-        </React.Fragment>
+        </>
       )}
       {(curStatus == Status["Loaded"] && props.acronymPhaseObject) && (
         <VocabularyTable
@@ -145,6 +145,6 @@ export default function VocabularyDirectory(props) {
           addSetter={props.addSetter}
         />
       )}
-    </React.Fragment>
+    </>
   );
 }

--- a/modules/vocabularies/src/main/frontend/src/VocabularySearch.jsx
+++ b/modules/vocabularies/src/main/frontend/src/VocabularySearch.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useContext } from "react";
+import { useContext, useState } from "react";
 
 import CloseIcon from "@mui/icons-material/Close";
 import SearchIcon from "@mui/icons-material/Search";
@@ -61,9 +61,9 @@ const useStyles = makeStyles()(theme => ({
 }));
 
 export default function VocabularySearch(props) {
-  const [error, setError] = React.useState(false);
-  const [keywords, setKeywords] = React.useState("");
-  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = useState(false);
+  const [keywords, setKeywords] = useState("");
+  const [loading, setLoading] = useState(false);
   const { classes } = useStyles();
 
   const globalLoginDisplay = useContext(GlobalLoginContext);
@@ -124,7 +124,7 @@ export default function VocabularySearch(props) {
   }
 
   return(
-    <React.Fragment>
+    <>
       <Grid>
         <TextField
           fullWidth
@@ -154,6 +154,6 @@ export default function VocabularySearch(props) {
           variant="outlined"
         />
       </Grid>
-    </React.Fragment>
+    </>
   );
 }

--- a/modules/vocabularies/src/main/frontend/src/VocabularyTable.jsx
+++ b/modules/vocabularies/src/main/frontend/src/VocabularyTable.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import {
   Grid,
@@ -36,7 +36,7 @@ export default function VocabularyTable(props) {
   const [filterTable, setFilterTable] = useState(false);
   const [acronymFilterList, setAcronymFilterList] = useState([]);
   const [filteredVocabs, setFilteredVocabs] = useState([]);
-  const [loading, setLoading] = React.useState(false);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (filterTable) {
@@ -49,7 +49,7 @@ export default function VocabularyTable(props) {
   }, [filterTable, acronymFilterList])
 
   return(
-    <React.Fragment>
+    <>
       {(type === "remote") &&
       <VocabularySearch
         setAcronymFilterList={setAcronymFilterList}
@@ -120,6 +120,6 @@ export default function VocabularyTable(props) {
         />
       </Grid>
       }
-    </React.Fragment>
+    </>
   );
 }


### PR DESCRIPTION
- Added ESLint rule to report unused imports
- Removed unused imports
- Removed React imports
- Removed explicit `React.Fragment` from `<React.Fragment>` and `</React.Fragment>`
- Imported React hooks instead using explicit `React.` object qualifier in `React.<hook>`
- Removed redundant `@babel/plugin-transform-runtime`
- Tuned `Babel` to use new `JSX transform` runtime