### PR TITLE
CARDS-2799: Conditions relying on numeric answers with "includes*" / "exludes*" comparators are not evaluated correctly when the condition data type is left to the default value "text"

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
@@ -23,7 +23,7 @@ import ConditionalComponentManager from "./ConditionalComponentManager";
 let transform = (values, transformerFunc) => values.map(v => Array.isArray(v) ? v.map(e => transformerFunc(e)) : transformerFunc(v));
 
 const TRANSFORMATIONS = {
-  "text": (a, b) => [a, b],
+  "text": (a, b) => transform([a, b], v => String(v)),
   "date": (a, b) => transform([a, b], v => new Date(v).getTime()),
   "long": (a, b) => transform([a, b], parseInt),
   "decimal": (a, b) => transform([a, b], parseFloat),


### PR DESCRIPTION
Steps to replicate and testing instructions: https://phenotips.atlassian.net/browse/CARDS-2799