### PR TITLE
CARDS-2803: Skip major backend edits on already submitted forms

### DIFF
--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/CreateMissingAnswersEditor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/CreateMissingAnswersEditor.java
@@ -17,10 +17,13 @@
 package io.uhndata.cards.forms.internal;
 
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 import javax.jcr.Node;
 import javax.jcr.Session;
 
+import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.spi.commit.DefaultEditor;
 import org.apache.jackrabbit.oak.spi.commit.Editor;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
@@ -43,6 +46,8 @@ import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
 public class CreateMissingAnswersEditor extends DefaultEditor
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(CreateMissingAnswersEditor.class);
+
+    private static final String STATUS_FLAGS = "statusFlags";
 
     // This holds the builder for the current node. The methods called for editing specific properties don't receive the
     // actual parent node of those properties, so we must manually keep track of the current node.
@@ -106,6 +111,14 @@ public class CreateMissingAnswersEditor extends DefaultEditor
     public void leave(final NodeState before, final NodeState after)
     {
         if (!this.isFormNode) {
+            return;
+        }
+
+        final Set<String> statusFlags = new TreeSet<>();
+        if (this.currentNodeBuilder.hasProperty(STATUS_FLAGS)) {
+            this.currentNodeBuilder.getProperty(STATUS_FLAGS).getValue(Type.STRINGS).forEach(statusFlags::add);
+        }
+        if (statusFlags.contains("SUBMITTED")) {
             return;
         }
 

--- a/modules/form-completion-status/src/main/java/io/uhndata/cards/formcompletionstatus/AnswerCompletionStatusEditor.java
+++ b/modules/form-completion-status/src/main/java/io/uhndata/cards/formcompletionstatus/AnswerCompletionStatusEditor.java
@@ -124,6 +124,13 @@ public class AnswerCompletionStatusEditor extends DefaultEditor
         throws CommitFailedException
     {
         if (this.isFormNode) {
+            final Set<String> statusFlags = new TreeSet<>();
+            if (this.currentNodeBuilder.hasProperty(STATUS_FLAGS)) {
+                this.currentNodeBuilder.getProperty(STATUS_FLAGS).getValue(Type.STRINGS).forEach(statusFlags::add);
+            }
+            if (statusFlags.contains("SUBMITTED")) {
+                return;
+            }
             processNode(this.currentNodeBuilder);
         }
     }


### PR DESCRIPTION
To test:
- start in prems+dev mode
- create a new visit, complete and submit it as a patient
- add new mandatory questions to the questionnaire
- from Composum, checkout the submitted form, change one of the existing answers, checkin
- make sure the form is not incomplete and the new questions don't have an empty Answer node
- repeat the test, but this time complete but don't submit the survey, making sure that the new answers are added and the form is marked as incomplete