### PR TITLE
CARDS-2804: Option to enforce vertical layout for QuestionMatrix

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionMatrix.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionMatrix.jsx
@@ -63,7 +63,7 @@ const DATA_TO_NODE_TYPE = {
 
 let QuestionMatrix = (props) => {
   const { sectionDefinition, existingSectionAnswer, existingAnswers, path, isEdit, classes, pageActive, contentOffset, ...rest} = props;
-  const { maxAnswers, minAnswers } = {...sectionDefinition, ...props};
+  const { maxAnswers, minAnswers, verticalLayout } = {...sectionDefinition, ...props};
 
   // Use existing existingAnswer, Otherwise, create a new UUID
   const isRadio = maxAnswers === 1;
@@ -72,7 +72,7 @@ let QuestionMatrix = (props) => {
   const answerSectionID = existingSectionAnswer ? existingSectionAnswer[0] : uuidv4();
   const [sectionAnswerPath, setSectionAnswerPath ] = useState(path + "/" + answerSectionID);
 
-  const enableVerticalLayout = useMediaQuery('(max-width:600px)');
+  const enableVerticalLayout = verticalLayout || useMediaQuery('(max-width:600px)');
 
   useEffect(() => {
     if (existingSectionAnswer) {

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Section.json
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Section.json
@@ -38,6 +38,7 @@
         "//CHILDREN" : {"Question" : "QuestionMatrixEntry.json"},
         "minAnswers": "long",
         "maxAnswers": "long",
+        "verticalLayout" : "boolean",
         "dataType": {
           "text": {
             "answerOptions" : {


### PR DESCRIPTION
Specs: https://phenotips.atlassian.net/browse/CARDS-2804

To test:
* create a questionnaire with a question matrix
* turn the "Vertical layout" switch from the questionnaire designer on and off to check its effect