### PR TITLE
CARDS-2790: YE: Re-import patient information daily to update inpatient status

### DIFF
--- a/compose-cluster/generate_compose_yaml.py
+++ b/compose-cluster/generate_compose_yaml.py
@@ -998,6 +998,7 @@ if args.mssql:
     yaml_obj['services']['cardsinitial']['environment'].append('CLARITY_PMH_OO_SQL_TABLE=PatientActivity_PMCC_Outpatient_Oncology_for_PtExpSurvey')
     yaml_obj['services']['cardsinitial']['environment'].append('CLARITY_EVENT_TIME_COLUMN=HOSP_DISCHARGE_DTTM')
     yaml_obj['services']['cardsinitial']['environment'].append('CLARITY_DEATH_STATUS_TABLE=V_PtExpYEM_Deceased_Patients')
+    yaml_obj['services']['cardsinitial']['environment'].append('CLARITY_INPATIENT_STATUS_TABLE=V_PtExpYEM_Inpatients_currently_in_hospital')
   elif args.cards_project == 'cards4datapro':
     yaml_obj['services']['cardsinitial']['environment'].append('CLARITY_SQL_TABLE=PatientVisitActivity_for_DATA-PRO')
     yaml_obj['services']['cardsinitial']['environment'].append('CLARITY_EVENT_TIME_COLUMN=ENCOUNTER_DATE')

--- a/compose-cluster/mssql/generate_test_inpatient_status.py
+++ b/compose-cluster/mssql/generate_test_inpatient_status.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import argparse
+import random
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('file', help='Output file name', type=argparse.FileType('w'))
+argparser.add_argument('-n', help='Number of inpatient status entries to generate [default: 3]', default=3, type=int)
+args = argparser.parse_args()
+
+# Preamble
+args.file.write(
+    '''
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Create the schema if it doesn't already exist
+-- Note about EXEC: CREATE SCHEMA must be the first statement
+-- but we can't combine that with a conditional unless we use EXEC
+IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = 'path')
+BEGIN
+    EXEC('CREATE SCHEMA path')
+END
+
+-- Remove the table if it already exists
+IF OBJECT_ID('path.V_PtExpYEM_Inpatients_currently_in_hospital', 'U') IS NOT NULL
+    DROP TABLE [path].[V_PtExpYEM_Inpatients_currently_in_hospital];
+
+CREATE TABLE [path].[V_PtExpYEM_Inpatients_currently_in_hospital] (
+    PAT_MRN varchar(102) NULL,
+);
+
+-- Insert test data
+'''
+)
+
+
+def convertToSqlType(insertion_values):
+    converted_values = {}
+    for key in insertion_values:
+        if type(insertion_values[key]) == str:
+            converted_values[key] = "'" + insertion_values[key] + "'"
+        elif insertion_values[key] == None:
+            converted_values[key] = "NULL"
+        else:
+            converted_values[key] = insertion_values[key]
+    return converted_values
+
+# Insert test data
+for i in range(args.n):
+    if i % 100 == 0:
+        args.file.write("INSERT INTO [path].[V_PtExpYEM_Inpatients_currently_in_hospital]")
+        args.file.write("\t(PAT_MRN)\n")
+        args.file.write("\tVALUES\n")
+    insertion_values = {}
+
+    #PAT_MRN
+    mrn = random.randint(0, 9999999)
+    insertion_values['PAT_MRN'] = mrn
+
+    args.file.write("\t({PAT_MRN:07d})".format(**convertToSqlType(insertion_values)))
+    if (i != args.n - 1) and (i % 100 != 99):
+        args.file.write(",")
+    args.file.write("\n")
+
+args.file.close()

--- a/modules/clarity-integration/src/main/features/feature.json
+++ b/modules/clarity-integration/src/main/features/feature.json
@@ -36,7 +36,7 @@
         "scripts": [
           // In certain environments, this script gets executed before the main forms repoinit does, so we must make sure the paths we reference are created.
           "create path (cards:QuestionnairesHomepage) /Questionnaires \n create path (cards:SubjectsHomepage) /Subjects \n create path (sling:Folder) /apps",
-          "create service user clarity-import \n set ACL for clarity-import \n   allow jcr:read on /Questionnaires,/SubjectTypes,/apps \n   allow jcr:read,rep:write,jcr:versionManagement on /Forms,/Subjects \n end"
+          "create service user clarity-import \n set ACL for clarity-import \n   allow jcr:read on /Questionnaires,/SubjectTypes,/apps,/Survey \n   allow jcr:read,rep:write,jcr:versionManagement on /Forms,/Subjects \n end"
         ]
       },
       "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~clarityIntegration":{

--- a/modules/data-model/forms/api/src/main/java/io/uhndata/cards/forms/api/FormUtils.java
+++ b/modules/data-model/forms/api/src/main/java/io/uhndata/cards/forms/api/FormUtils.java
@@ -18,6 +18,7 @@ package io.uhndata.cards.forms.api;
 
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.Set;
 
 import javax.jcr.Node;
 import javax.jcr.Property;
@@ -87,6 +88,9 @@ public interface FormUtils
 
     /** The name of the property of an Answer node that holds the actual value. */
     String VALUE_PROPERTY = "value";
+
+    /** The name of the property of a Form, Answer and AnswerSection node that holds its status flags. */
+    String STATUS_FLAGS_PROPERTY = "statusFlags";
 
     enum SearchType
     {
@@ -526,6 +530,15 @@ public interface FormUtils
      *         Boolean, Calendar, Decimal, String); {@code null} may be returned if no value is stored in the answer
      */
     Object getValue(Value value);
+
+    /**
+     * Extract the set of status flags from a form, answer section or answer node.
+     * @param node the form, answer section or answer node to pull the status flags from
+     * @return the set of status flags for a form.
+     *         If not status flags are present, an empty set will be returned.
+     *         {@code null} may be returned if the node is not a supported type
+     */
+    Set<String> getStatusFlags(Node node);
 
     /**
      * Serialize the value(s) stored in an Answer.

--- a/modules/data-model/forms/api/src/main/java/io/uhndata/cards/forms/api/FormUtils.java
+++ b/modules/data-model/forms/api/src/main/java/io/uhndata/cards/forms/api/FormUtils.java
@@ -535,7 +535,7 @@ public interface FormUtils
      * Extract the set of status flags from a form, answer section or answer node.
      * @param node the form, answer section or answer node to pull the status flags from
      * @return the set of status flags for a form.
-     *         If not status flags are present, an empty set will be returned.
+     *         If no status flags are present, an empty set will be returned.
      *         {@code null} may be returned if the node is not a supported type
      */
     Set<String> getStatusFlags(Node node);

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormUtilsImpl.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormUtilsImpl.java
@@ -751,7 +751,7 @@ public final class FormUtilsImpl extends AbstractNodeUtils implements FormUtils
     public Set<String> getStatusFlags(final Node node)
     {
         try {
-            if (this.isForm(node) || !this.isAnswerSection(node) || !this.isAnswer(node)) {
+            if (this.isForm(node) || this.isAnswerSection(node) || this.isAnswer(node)) {
                 Set<String> statusFlags = new TreeSet<>();
                 if (node.hasProperty(STATUS_FLAGS_PROPERTY)) {
                     for (Value value : node.getProperty(STATUS_FLAGS_PROPERTY).getValues()) {

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormUtilsImpl.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/FormUtilsImpl.java
@@ -27,6 +27,8 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Consumer;
 
 import javax.jcr.Node;
@@ -743,5 +745,25 @@ public final class FormUtilsImpl extends AbstractNodeUtils implements FormUtils
             // return null
         }
         return JsonValue.NULL;
+    }
+
+    @Override
+    public Set<String> getStatusFlags(final Node node)
+    {
+        try {
+            if (this.isForm(node) || !this.isAnswerSection(node) || !this.isAnswer(node)) {
+                Set<String> statusFlags = new TreeSet<>();
+                if (node.hasProperty(STATUS_FLAGS_PROPERTY)) {
+                    for (Value value : node.getProperty(STATUS_FLAGS_PROPERTY).getValues()) {
+                        statusFlags.add(value.getString());
+                    }
+                }
+                return statusFlags;
+            } else {
+                return null;
+            }
+        } catch (RepositoryException e) {
+            return null;
+        }
     }
 }

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/api/VisitInformation.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/api/VisitInformation.java
@@ -43,9 +43,16 @@ public interface VisitInformation
      * Check if all the mandatory information is present for this visit. At the moment, this just means a visit date and
      * a questionnaire set.
      *
-     * @return {@code true} if all required information is present, {@code false otherwise}
+     * @return {@code true} if all required information is present, {@code false} otherwise
      */
     boolean hasRequiredInformation();
+
+    /**
+     * Check if the visit's status is one that means it should not be processed going forwards.
+     *
+     * @return {@code true} if the visit should not be processed, {@code false} otherwise
+     */
+    boolean hasInactiveStatus();
 
     /**
      * Check if all the patient-facing forms for this visit are complete.

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentUtils.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentUtils.java
@@ -330,6 +330,7 @@ public final class AppointmentUtils
                 + "  AND vstatus.'question' = '" + statusUUID + "' "
                 + "  AND vstatus.'value' <> 'cancelled'"
                 + "  AND vstatus.'value' <> 'entered-in-error'"
+                + "  AND vstatus.'value' <> 'on-hold'"
                 + "  AND has_surveys.'question' = '" + hasSurveysUUID + "' "
                 + "  AND has_surveys.'value' = 1 "
                 + ((clinicId != null)

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
@@ -170,8 +170,8 @@ public class VisitChangeListener implements ResourceChangeListener
     {
         final VisitInformation visitInformation = this.visitAdapter.toVisitInformation(visitForm);
 
-        // Only continue with the surveys update if we have the requirements
-        if (!visitInformation.hasRequiredInformation()) {
+        // Only continue with the surveys update if we have the requirements and it has a valid status
+        if (!visitInformation.hasRequiredInformation() || visitInformation.hasInactiveStatus()) {
             return;
         }
 

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitInformationAdapterImpl.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitInformationAdapterImpl.java
@@ -16,6 +16,7 @@
  */
 package io.uhndata.cards.patients.internal;
 
+import java.util.Arrays;
 import java.util.Calendar;
 
 import javax.jcr.Node;
@@ -138,6 +139,8 @@ public class VisitInformationAdapterImpl implements VisitInformationAdapter
     {
         private final Calendar visitDate;
 
+        private final String visitStatus;
+
         private final Node questionnaire;
 
         private final Node visitInformationForm;
@@ -161,6 +164,10 @@ public class VisitInformationAdapterImpl implements VisitInformationAdapter
             final Node visitDateQuestion = this.questionnaire.getNode("time");
             this.visitDate = (Calendar) VisitInformationAdapterImpl.this.formUtils
                 .getValue(VisitInformationAdapterImpl.this.formUtils.getAnswer(visitForm, visitDateQuestion));
+
+            final Node visitStatusQuestion = this.questionnaire.getNode("status");
+            this.visitStatus = (String) VisitInformationAdapterImpl.this.formUtils
+                .getValue(VisitInformationAdapterImpl.this.formUtils.getAnswer(visitForm, visitStatusQuestion));
 
             final Node clinicQuestion =
                 VisitInformationAdapterImpl.this.questionnaireUtils.getQuestion(this.questionnaire, "clinic");
@@ -190,6 +197,12 @@ public class VisitInformationAdapterImpl implements VisitInformationAdapter
         public boolean hasRequiredInformation()
         {
             return this.visitDate != null && StringUtils.isNotBlank(this.questionnaireSet);
+        }
+
+        @Override
+        public boolean hasInactiveStatus()
+        {
+            return Arrays.asList("cancelled", "entered-in-error", "on-hold").contains(this.visitStatus);
         }
 
         @Override

--- a/prems-resources/backend/pom.xml
+++ b/prems-resources/backend/pom.xml
@@ -54,6 +54,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>cards-data-model-subjects-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>cards-clarity-integration</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/InpatientStatusProcessor.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/InpatientStatusProcessor.java
@@ -21,6 +21,7 @@ package io.uhndata.cards.prems.internal.importer;
 
 import java.util.Calendar;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -31,6 +32,7 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.version.VersionManager;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.osgi.service.component.annotations.Activate;
@@ -70,7 +72,7 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
 
     @ObjectClassDefinition(name = "Clarity import processor - Inpatient Status",
         description = "Configuration for the Clarity importer processor that puts on hold any active visits for a "
-        + "given MRN")
+            + "given MRN")
     public @interface InpatientStatusProcessorConfigDefinition
     {
         @AttributeDefinition(name = "Enabled")
@@ -95,14 +97,14 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
     {
         final String mrn = input.get("/SubjectTypes/Patient");
 
-        if (mrn == null || mrn.length() == 0) {
+        if (StringUtils.isBlank(mrn)) {
             LOGGER.warn("Unable to process row due to no mrn");
             return null;
         } else {
             // Get all patients with that MRN
             ResourceResolver resolver = this.rrp.getThreadResourceResolver();
             String subjectMatchQuery = String.format(
-                "SELECT * FROM [cards:Subject] as subject WHERE subject.'identifier'='%s' option (index tag property)",
+                "SELECT * FROM [cards:Subject] as subject WHERE subject.identifier='%s' option (index tag property)",
                 mrn);
             resolver.refresh();
             final Iterator<Resource> subjectResourceIter = resolver.findResources(subjectMatchQuery, "JCR-SQL2");
@@ -130,7 +132,7 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
         while (visitResourceIter.hasNext()) {
             Node visit = visitResourceIter.nextNode();
 
-            if (SubjectUtils.SUBJECT_NODETYPE.equals(visit.getPrimaryNodeType().getName())) {
+            if (this.subjectUtils.isSubject(visit)) {
                 processVisit(resolver, visit);
             }
         }
@@ -153,8 +155,7 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
                     if (surveyEventsForm == null) {
                         surveyEventsForm = form;
                     } else if (form.getProperty("jcr:created").getDate().after(
-                        surveyEventsForm.getProperty("jcr:created"))
-                    ) {
+                        surveyEventsForm.getProperty("jcr:created").getDate())) {
                         surveyEventsForm = form;
                     }
                 }
@@ -177,56 +178,57 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
         throws RepositoryException
     {
         // Check if visit is recent enough for the survey to be valid
-        if (isSurveyValid(session, visit)) {
+        if (isSurveyValid(session, visit, visitInformationForm, surveyEventsForm)) {
             // If initial email sent, put on-hold
-            if (this.formUtils.getValue(this.formUtils.getAnswer(surveyEventsForm,
-                session.getNode("/Questionnaires/Survey events/invitation_sent"))) != null)
-            {
+            if (emailAlreadySent(session, surveyEventsForm) || surveyPartiallySubmitted(session, visit)) {
                 setVisitOnHold(session, visitInformationForm);
             } else {
                 // No emails have been sent for this visit: delete it so that the email cooldown is reset
-                tryDeleteVisit(session, visit);
+                deleteVisit(session, visit);
             }
         }
     }
 
-    private boolean isSurveyValid(Session session, Node visit)
+    private boolean isSurveyValid(Session session, Node visit, Node visitInformationForm, Node surveyEventsForm)
         throws RepositoryException
     {
         try {
-            Node surveyEventsForm = null;
-            final PropertyIterator forms = visit.getReferences("subject");
-            while (forms.hasNext()) {
-                Node form = forms.nextProperty().getParent();
-                String questionnairePath = this.formUtils.getQuestionnaire(form).getPath();
-                if ("/Questionnaires/Survey events".equals(questionnairePath)) {
-                    if (surveyEventsForm == null) {
-                        surveyEventsForm = form;
-                    } else if (form.getProperty("jcr:created").getDate().after(
-                        surveyEventsForm.getProperty("jcr:created"))
-                    ) {
-                        surveyEventsForm = form;
-                    }
-                }
-            }
-
-            if (surveyEventsForm != null) {
-                if (this.formUtils.getValue(this.formUtils.getAnswer(
-                    surveyEventsForm, session.getNode("/Questionnaires/Survey events/responses_received"))) != null)
-                {
-                    // Don't modify submitted forms
-                    return false;
-                }
-
-                Calendar expiry = (Calendar) this.formUtils.getValue(this.formUtils.getAnswer(
-                    surveyEventsForm, session.getNode("/Questionnaires/Survey events/survey_expiry")));
-                return (expiry != null && expiry.after(Calendar.getInstance()));
-            } else {
+            if (this.formUtils.getValue(this.formUtils.getAnswer(
+                surveyEventsForm, session.getNode("/Questionnaires/Survey events/responses_received"))) != null) {
+                // Survey already submitted, don't process submitted forms
                 return false;
             }
+
+            Calendar expiry = (Calendar) this.formUtils.getValue(this.formUtils.getAnswer(
+                surveyEventsForm, session.getNode("/Questionnaires/Survey events/survey_expiry")));
+            return (expiry != null && expiry.after(Calendar.getInstance()));
         } catch (RepositoryException e) {
             // Should not happen
             LOGGER.error("Error determining if survey {} is valid", visit.getPath(), e);
+        }
+        return false;
+    }
+
+    private boolean emailAlreadySent(final Session session, final Node surveyEventsForm)
+        throws RepositoryException
+    {
+        return this.formUtils.getValue(this.formUtils.getAnswer(surveyEventsForm,
+            session.getNode("/Questionnaires/Survey events/invitation_sent"))) != null;
+    }
+
+    private boolean surveyPartiallySubmitted(final Session session, final Node visit) throws RepositoryException
+    {
+        for (final PropertyIterator forms = visit.getReferences("subject"); forms.hasNext();) {
+            final Node form = forms.nextProperty().getParent();
+            final String questionnaireName = this.formUtils.getQuestionnaire(form).getName();
+            if (this.formUtils.getStatusFlags(form).contains("SUBMITTED")) {
+                // If the form is submitted, skip it
+                return true;
+            } else if ("Survey events".equals(questionnaireName) && this.formUtils.getValue(this.formUtils
+                .getAnswer(form, session.getNode("/Questionnaires/Survey events/responses_received"))) != null) {
+                // If the form is a survey events form with responses received, skip it
+                return true;
+            }
         }
         return false;
     }
@@ -238,8 +240,8 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
             Node statusQuestion = session.getNode("/Questionnaires/Visit information/status");
             Node statusAnswer = this.formUtils.getAnswer(visitInformationForm, statusQuestion);
             String status = (String) this.formUtils.getValue(statusAnswer);
-            if ("cancelled".equals(status) || "entered-in-error".equals(status)) {
-                // Do nothing - already a status that does not recieve emails
+            if (status != null && List.of("cancelled", "entered-in-error", "on-hold").contains(status)) {
+                // Do nothing - already a status that does not receive emails
                 return;
             }
 
@@ -264,59 +266,21 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
     }
 
     /**
-     * Delete a visit if there are not already submitted forms.
-     * If there are already submitted forms:
-     * - Delete the unsubmitted patient forms
-     * - Change the visit information form to on-hold
-     * - Keep any survey event forms with responses received, delete others
+     * Delete a visit with all its forms.
      */
-    private void tryDeleteVisit(Session session, Node visit)
+    private void deleteVisit(final Session session, final Node visit)
         throws RepositoryException
     {
         try {
-            // Checkout the parent patient if required
-            final Node patient = visit.getParent();
-            boolean skippedForm = false;
-            Node visitInformationForm = null;
             // Remove any forms for this visit
             for (final PropertyIterator forms = visit.getReferences("subject"); forms.hasNext();) {
                 final Node form = forms.nextProperty().getParent();
-                final String questionnairePath = this.formUtils.getQuestionnaire(form).getPath();
-                if (this.formUtils.getStatusFlags(form).contains("SUBMITTED")) {
-                    // If the form is submitted, skip it
-                    skippedForm = true;
-                } else if (questionnairePath.endsWith("Survey events")
-                    && this.formUtils.getValue(this.formUtils.getAnswer(
-                        form, session.getNode("/Questionnaires/Survey events/responses_received"))) != null
-                ) {
-                    // If the form is a survey events form with responses recieved, skip it
-                    skippedForm = true;
-                } else if (questionnairePath.endsWith("Visit information")) {
-                    // Handle visit information forms later
-                    visitInformationForm = form;
-                } else {
-                    form.remove();
-                }
+                form.remove();
             }
-            handleDeleteVisit(session, visit, patient, skippedForm, visitInformationForm);
-        } catch (RepositoryException e) {
-            LOGGER.error("Error deleting visit {}", visit.getPath(), e);
-        }
-    }
 
-    private void handleDeleteVisit(final Session session, final Node visit, final Node patient,
-        final boolean skippedForm, final Node visitInformationForm)
-        throws RepositoryException
-    {
-        if (skippedForm) {
-            if (visitInformationForm != null) {
-                setVisitOnHold(session, visitInformationForm);
-            }
-        } else {
-            if (visitInformationForm != null) {
-                visitInformationForm.remove();
-            }
-            // Remove the visit
+            // Remove the Visit subject itself
+            // Checkout the parent patient if required
+            final Node patient = visit.getParent();
             boolean mustCheckout = false;
             VersionManager versionManager = session.getWorkspace().getVersionManager();
             if (!patient.isCheckedOut()) {
@@ -328,6 +292,8 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
             if (mustCheckout) {
                 versionManager.checkin(patient.getPath());
             }
+        } catch (RepositoryException e) {
+            LOGGER.error("Error deleting visit {}", visit.getPath(), e);
         }
     }
 }

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/InpatientStatusProcessor.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/InpatientStatusProcessor.java
@@ -87,13 +87,13 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
     }
 
     @Activate
-    public InpatientStatusProcessor(InpatientStatusProcessorConfigDefinition configuration)
+    public InpatientStatusProcessor(final InpatientStatusProcessorConfigDefinition configuration)
     {
         super(configuration.enabled(), configuration.supportedTypes(), configuration.priority());
     }
 
     @Override
-    public Map<String, String> processEntry(Map<String, String> input)
+    public Map<String, String> processEntry(final Map<String, String> input)
     {
         final String mrn = input.get("/SubjectTypes/Patient");
 
@@ -123,7 +123,7 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
         return null;
     }
 
-    private void processSubject(ResourceResolver resolver, Node subject)
+    private void processSubject(final ResourceResolver resolver, final Node subject)
         throws RepositoryException
     {
         // Iterate through the subjects visits
@@ -138,7 +138,7 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
         }
     }
 
-    private void processVisit(ResourceResolver resolver, Node visit)
+    private void processVisit(final ResourceResolver resolver, final Node visit)
         throws RepositoryException
     {
         try {
@@ -174,11 +174,12 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
         }
     }
 
-    private void processVisitDetails(Session session, Node visit, Node visitInformationForm, Node surveyEventsForm)
+    private void processVisitDetails(final Session session, final Node visit, final Node visitInformationForm,
+        final Node surveyEventsForm)
         throws RepositoryException
     {
         // Check if visit is recent enough for the survey to be valid
-        if (isSurveyValid(session, visit, visitInformationForm, surveyEventsForm)) {
+        if (isSurveyValid(session, visit, surveyEventsForm)) {
             // If initial email sent, put on-hold
             if (emailAlreadySent(session, surveyEventsForm) || surveyPartiallySubmitted(session, visit)) {
                 setVisitOnHold(session, visitInformationForm);
@@ -189,7 +190,7 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
         }
     }
 
-    private boolean isSurveyValid(Session session, Node visit, Node visitInformationForm, Node surveyEventsForm)
+    private boolean isSurveyValid(final Session session, final Node visit, final Node surveyEventsForm)
         throws RepositoryException
     {
         try {
@@ -233,14 +234,15 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
         return false;
     }
 
-    private void setVisitOnHold(Session session, Node visitInformationForm)
+    private void setVisitOnHold(final Session session, final Node visitInformationForm)
         throws RepositoryException
     {
         try {
-            Node statusQuestion = session.getNode("/Questionnaires/Visit information/status");
+            final Node statusQuestion = session.getNode("/Questionnaires/Visit information/status");
             Node statusAnswer = this.formUtils.getAnswer(visitInformationForm, statusQuestion);
-            String status = (String) this.formUtils.getValue(statusAnswer);
-            if (status != null && List.of("cancelled", "entered-in-error", "on-hold").contains(status)) {
+            final String existingStatus = (String) this.formUtils.getValue(statusAnswer);
+            if (existingStatus != null
+                && List.of("cancelled", "entered-in-error", "on-hold").contains(existingStatus)) {
                 // Do nothing - already a status that does not receive emails
                 return;
             }

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/InpatientStatusProcessor.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/InpatientStatusProcessor.java
@@ -211,6 +211,13 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
             }
 
             if (surveyEventsForm != null) {
+                if (this.formUtils.getValue(this.formUtils.getAnswer(
+                    surveyEventsForm, session.getNode("/Questionnaires/Survey events/responses_received"))) != null)
+                {
+                    // Don't modify submitted forms
+                    return false;
+                }
+
                 Calendar expiry = (Calendar) this.formUtils.getValue(this.formUtils.getAnswer(
                     surveyEventsForm, session.getNode("/Questionnaires/Survey events/survey_expiry")));
                 return (expiry != null && expiry.after(Calendar.getInstance()));
@@ -279,8 +286,8 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
                     // If the form is submitted, skip it
                     skippedForm = true;
                 } else if (questionnairePath.endsWith("Survey events")
-                    && this.formUtils.getValue(this.formUtils.getAnswer(form,
-                        session.getNode("/Questionnaires/Survey events/responses_received"))) != null
+                    && this.formUtils.getValue(this.formUtils.getAnswer(
+                        form, session.getNode("/Questionnaires/Survey events/responses_received"))) != null
                 ) {
                     // If the form is a survey events form with responses recieved, skip it
                     skippedForm = true;

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/InpatientStatusProcessor.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/InpatientStatusProcessor.java
@@ -177,7 +177,7 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
         throws RepositoryException
     {
         // Check if visit is recent enough for the survey to be valid
-        if (isSurveyValid(session, visitInformationForm)) {
+        if (isSurveyValid(session, visit)) {
             // If initial email sent, put on-hold
             if (this.formUtils.getValue(this.formUtils.getAnswer(surveyEventsForm,
                 session.getNode("/Questionnaires/Survey events/invitation_sent"))) != null)
@@ -190,44 +190,38 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
         }
     }
 
-    private boolean isSurveyValid(Session session, Node visitInformationForm)
+    private boolean isSurveyValid(Session session, Node visit)
         throws RepositoryException
     {
         try {
-            // Get the clinic's configured valid period
-            String clinicMappingPath = (String) this.formUtils.getValue(this.formUtils.getAnswer(visitInformationForm,
-                session.getNode("/Questionnaires/Visit information/clinic")));
-            Integer validDays = null;
-            if (clinicMappingPath != null && clinicMappingPath.length() > 0) {
-                Node clinicMapping = session.getNode(clinicMappingPath);
-                if (clinicMapping.hasProperty("daysRelativeToEventWhileSurveyIsValid")) {
-                    validDays = (int) clinicMapping.getProperty("daysRelativeToEventWhileSurveyIsValid").getLong();
+            Node surveyEventsForm = null;
+            final PropertyIterator forms = visit.getReferences("subject");
+            while (forms.hasNext()) {
+                Node form = forms.nextProperty().getParent();
+                String questionnairePath = this.formUtils.getQuestionnaire(form).getPath();
+                if ("/Questionnaires/Survey events".equals(questionnairePath)) {
+                    if (surveyEventsForm == null) {
+                        surveyEventsForm = form;
+                    } else if (form.getProperty("jcr:created").getDate().after(
+                        surveyEventsForm.getProperty("jcr:created"))
+                    ) {
+                        surveyEventsForm = form;
+                    }
                 }
-            }
-            // No configured valid period for that clinic: get the default
-            if (validDays == null) {
-                Node patientAccessNode = session.getNode("/Survey/PatientAccess");
-                if (patientAccessNode.hasProperty("daysRelativeToEventWhileSurveyIsValid")) {
-                    validDays = (int) patientAccessNode.getProperty("daysRelativeToEventWhileSurveyIsValid").getLong();
-                }
-            }
-            if (validDays == null) {
-                LOGGER.error("Unable to determine if survey is valid: No default range or range for clinic {}",
-                    clinicMappingPath);
-                return false;
             }
 
-            Calendar visitDate = (Calendar) this.formUtils.getValue(this.formUtils.getAnswer(visitInformationForm,
-                session.getNode("/Questionnaires/Visit information/time")));
-            if (visitDate != null) {
-                visitDate.add(Calendar.DATE, validDays);
-                return Calendar.getInstance().compareTo(visitDate) <= 0;
+            if (surveyEventsForm != null) {
+                Calendar expiry = (Calendar) this.formUtils.getValue(this.formUtils.getAnswer(
+                    surveyEventsForm, session.getNode("/Questionnaires/Survey events/survey_expiry")));
+                return (expiry != null && expiry.after(Calendar.getInstance()));
+            } else {
+                return false;
             }
         } catch (RepositoryException e) {
             // Should not happen
-            LOGGER.error("Error determining if survey {} is valid", visitInformationForm.getPath(), e);
+            LOGGER.error("Error determining if survey {} is valid", visit.getPath(), e);
         }
-        return true;
+        return false;
     }
 
     private void setVisitOnHold(Session session, Node visitInformationForm)

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/InpatientStatusProcessor.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/InpatientStatusProcessor.java
@@ -1,0 +1,292 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.prems.internal.importer;
+
+import java.util.Calendar;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.PropertyIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.version.VersionManager;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.uhndata.cards.clarity.importer.spi.AbstractClarityDataProcessor;
+import io.uhndata.cards.clarity.importer.spi.ClarityDataProcessor;
+import io.uhndata.cards.forms.api.FormUtils;
+import io.uhndata.cards.resolverProvider.ThreadResourceResolverProvider;
+import io.uhndata.cards.subjects.api.SubjectUtils;
+
+/**
+ * Clarity import processor that puts on hold or discards any active visits for a given MRN.
+ *
+ * @version $Id$
+ */
+@Component
+@Designate(ocd = InpatientStatusProcessor.InpatientStatusProcessorConfigDefinition.class)
+public class InpatientStatusProcessor extends AbstractClarityDataProcessor implements ClarityDataProcessor
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(InpatientStatusProcessor.class);
+
+    @Reference
+    private ThreadResourceResolverProvider rrp;
+
+    @Reference
+    private FormUtils formUtils;
+
+    @Reference
+    private SubjectUtils subjectUtils;
+
+    @ObjectClassDefinition(name = "Clarity import processor - Inpatient Status",
+        description = "Configuration for the Clarity importer processor that puts on hold any active visits for a "
+        + "given MRN")
+    public @interface InpatientStatusProcessorConfigDefinition
+    {
+        @AttributeDefinition(name = "Enabled")
+        boolean enabled() default false;
+
+        @AttributeDefinition(name = "Supported import types", description = "Leave empty to support all imports")
+        String[] supportedTypes();
+
+        @AttributeDefinition(name = "Priority", description = "Clarity Data Processor priority."
+            + " Processors are run in ascending priority order")
+        int priority() default 35;
+    }
+
+    @Activate
+    public InpatientStatusProcessor(InpatientStatusProcessorConfigDefinition configuration)
+    {
+        super(configuration.enabled(), configuration.supportedTypes(), configuration.priority());
+    }
+
+    @Override
+    public Map<String, String> processEntry(Map<String, String> input)
+    {
+        final String mrn = input.get("/SubjectTypes/Patient");
+
+        if (mrn == null || mrn.length() == 0) {
+            LOGGER.warn("Unable to process row due to no mrn");
+            return null;
+        } else {
+            // Get all patients with that MRN
+            ResourceResolver resolver = this.rrp.getThreadResourceResolver();
+            String subjectMatchQuery = String.format(
+                "SELECT * FROM [cards:Subject] as subject WHERE subject.'identifier'='%s' option (index tag property)",
+                mrn);
+            resolver.refresh();
+            final Iterator<Resource> subjectResourceIter = resolver.findResources(subjectMatchQuery, "JCR-SQL2");
+
+            // Should only be 0 or 1 patient with that MRN. Process it if found.
+            if (subjectResourceIter.hasNext()) {
+                try {
+                    processSubject(resolver, subjectResourceIter.next().adaptTo(Node.class));
+                } catch (RepositoryException e) {
+                    LOGGER.error("Unexpected error processing inpatient status for {}:", mrn, e);
+                }
+            }
+        }
+
+        // All processing for this row is complete: Discard
+        return null;
+    }
+
+    private void processSubject(ResourceResolver resolver, Node subject)
+        throws RepositoryException
+    {
+        // Iterate through the subjects visits
+        final NodeIterator visitResourceIter = subject.getNodes();
+
+        while (visitResourceIter.hasNext()) {
+            Node visit = visitResourceIter.nextNode();
+
+            if (SubjectUtils.SUBJECT_NODETYPE.equals(visit.getPrimaryNodeType().getName())) {
+                processVisit(resolver, visit);
+            }
+        }
+    }
+
+    private void processVisit(ResourceResolver resolver, Node visit)
+        throws RepositoryException
+    {
+        try {
+            // Get the visit information and survey events form for this visit
+            Node visitInformationForm = null;
+            Node surveyEventsForm = null;
+            final PropertyIterator forms = visit.getReferences("subject");
+            while (forms.hasNext()) {
+                Node form = forms.nextProperty().getParent();
+                String questionnairePath = this.formUtils.getQuestionnaire(form).getPath();
+                if ("/Questionnaires/Visit information".equals(questionnairePath)) {
+                    visitInformationForm = form;
+                    if (surveyEventsForm != null) {
+                        break;
+                    }
+                } else if ("/Questionnaires/Survey events".equals(questionnairePath)) {
+                    surveyEventsForm = form;
+                    if (visitInformationForm != null) {
+                        break;
+                    }
+                }
+            }
+
+            if (visitInformationForm == null || surveyEventsForm == null) {
+                LOGGER.warn("Could not process inpatient status for visit {} due to missing form",
+                    visit.getPath());
+                return;
+            }
+
+            processVisitDetails(resolver.adaptTo(Session.class), visit, visitInformationForm, surveyEventsForm);
+        } catch (RepositoryException e) {
+            // Visit cannot be processed:s
+            LOGGER.warn("Cannot process visit {}", visit.getPath(), e);
+        }
+    }
+
+    private void processVisitDetails(Session session, Node visit, Node visitInformationForm, Node surveyEventsForm)
+        throws RepositoryException
+    {
+        // Check if visit is recent enough for the survey to be valid
+        if (isSurveyValid(session, visitInformationForm)) {
+            // If initial email sent, put on-hold
+            if (this.formUtils.getValue(this.formUtils.getAnswer(surveyEventsForm,
+                session.getNode("/Questionnaires/Survey events/invitation_sent"))) != null)
+            {
+                setVisitOnHold(session, visitInformationForm);
+            } else {
+                // No emails have been sent for this visit: delete it so that the email cooldown is reset
+                deleteVisit(session, visit);
+            }
+        }
+    }
+
+    private boolean isSurveyValid(Session session, Node visitInformationForm)
+        throws RepositoryException
+    {
+        try {
+            // Get the clinic's configured valid period
+            String clinicMappingPath = (String) this.formUtils.getValue(this.formUtils.getAnswer(visitInformationForm,
+                session.getNode("/Questionnaires/Visit information/clinic")));
+            Integer validDays = null;
+            if (clinicMappingPath != null && clinicMappingPath.length() > 0) {
+                Node clinicMapping = session.getNode(clinicMappingPath);
+                if (clinicMapping.hasProperty("daysRelativeToEventWhileSurveyIsValid")) {
+                    validDays = (int) clinicMapping.getProperty("daysRelativeToEventWhileSurveyIsValid").getLong();
+                }
+            }
+            // No configured valid period for that clinic: get the default
+            if (validDays == null) {
+                Node patientAccessNode = session.getNode("/Survey/PatientAccess");
+                if (patientAccessNode.hasProperty("daysRelativeToEventWhileSurveyIsValid")) {
+                    validDays = (int) patientAccessNode.getProperty("daysRelativeToEventWhileSurveyIsValid").getLong();
+                }
+            }
+            if (validDays == null) {
+                LOGGER.error("Unable to determine if survey is valid: No default range or range for clinic {}",
+                    clinicMappingPath);
+                return false;
+            }
+
+            Calendar visitDate = (Calendar) this.formUtils.getValue(this.formUtils.getAnswer(visitInformationForm,
+                session.getNode("/Questionnaires/Visit information/time")));
+            if (visitDate != null) {
+                visitDate.add(Calendar.DATE, validDays);
+                return Calendar.getInstance().compareTo(visitDate) <= 0;
+            }
+        } catch (RepositoryException e) {
+            // Should not happen
+            LOGGER.error("Error determining if survey {} is valid", visitInformationForm.getPath(), e);
+        }
+        return true;
+    }
+
+    private void setVisitOnHold(Session session, Node visitInformationForm)
+        throws RepositoryException
+    {
+        try {
+            Node statusQuestion = session.getNode("/Questionnaires/Visit information/status");
+            Node statusAnswer = this.formUtils.getAnswer(visitInformationForm, statusQuestion);
+            String status = (String) this.formUtils.getValue(statusAnswer);
+            if ("cancelled".equals(status) || "entered-in-error".equals(status)) {
+                // Do nothing - already a status that does not recieve emails
+                return;
+            }
+
+            // Checkout visit information form
+            VersionManager versionManager = session.getWorkspace().getVersionManager();
+            boolean mustCheckout = !versionManager.isCheckedOut(visitInformationForm.getPath());
+            if (mustCheckout) {
+                versionManager.checkout(visitInformationForm.getPath());
+            }
+            if (statusAnswer == null) {
+                statusAnswer = visitInformationForm.addNode(UUID.randomUUID().toString(), "cards:TextAnswer");
+                statusAnswer.setProperty("question", statusQuestion);
+            }
+            statusAnswer.setProperty(FormUtils.VALUE_PROPERTY, "on-hold");
+            session.save();
+            if (mustCheckout) {
+                versionManager.checkin(visitInformationForm.getPath());
+            }
+        } catch (RepositoryException e) {
+            LOGGER.error("Error putting visit information form {} on hold", visitInformationForm.getPath(), e);
+        }
+    }
+
+    private void deleteVisit(Session session, Node visit)
+        throws RepositoryException
+    {
+        try {
+            // Checkout the parent patient if required
+            final Node patient = visit.getParent();
+            boolean mustCheckout = false;
+            VersionManager versionManager = session.getWorkspace().getVersionManager();
+            if (!patient.isCheckedOut()) {
+                mustCheckout = true;
+                versionManager.checkout(patient.getPath());
+            }
+            // Remove any forms for this visit
+            for (final PropertyIterator forms = visit.getReferences("subject"); forms.hasNext();) {
+                final Node form = forms.nextProperty().getParent();
+                form.remove();
+            }
+            // Remove the visit
+            visit.remove();
+            session.save();
+            if (mustCheckout) {
+                versionManager.checkin(patient.getPath());
+            }
+        } catch (RepositoryException e) {
+            LOGGER.error("Error deleting visit {}", visit.getPath(), e);
+        }
+    }
+}

--- a/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/InpatientStatusProcessor.java
+++ b/prems-resources/backend/src/main/java/io/uhndata/cards/prems/internal/importer/InpatientStatusProcessor.java
@@ -149,13 +149,13 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
                 String questionnairePath = this.formUtils.getQuestionnaire(form).getPath();
                 if ("/Questionnaires/Visit information".equals(questionnairePath)) {
                     visitInformationForm = form;
-                    if (surveyEventsForm != null) {
-                        break;
-                    }
                 } else if ("/Questionnaires/Survey events".equals(questionnairePath)) {
-                    surveyEventsForm = form;
-                    if (visitInformationForm != null) {
-                        break;
+                    if (surveyEventsForm == null) {
+                        surveyEventsForm = form;
+                    } else if (form.getProperty("jcr:created").getDate().after(
+                        surveyEventsForm.getProperty("jcr:created"))
+                    ) {
+                        surveyEventsForm = form;
                     }
                 }
             }
@@ -185,7 +185,7 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
                 setVisitOnHold(session, visitInformationForm);
             } else {
                 // No emails have been sent for this visit: delete it so that the email cooldown is reset
-                deleteVisit(session, visit);
+                tryDeleteVisit(session, visit);
             }
         }
     }
@@ -262,31 +262,71 @@ public class InpatientStatusProcessor extends AbstractClarityDataProcessor imple
         }
     }
 
-    private void deleteVisit(Session session, Node visit)
+    /**
+     * Delete a visit if there are not already submitted forms.
+     * If there are already submitted forms:
+     * - Delete the unsubmitted patient forms
+     * - Change the visit information form to on-hold
+     * - Keep any survey event forms with responses received, delete others
+     */
+    private void tryDeleteVisit(Session session, Node visit)
         throws RepositoryException
     {
         try {
             // Checkout the parent patient if required
             final Node patient = visit.getParent();
+            boolean skippedForm = false;
+            Node visitInformationForm = null;
+            // Remove any forms for this visit
+            for (final PropertyIterator forms = visit.getReferences("subject"); forms.hasNext();) {
+                final Node form = forms.nextProperty().getParent();
+                final String questionnairePath = this.formUtils.getQuestionnaire(form).getPath();
+                if (this.formUtils.getStatusFlags(form).contains("SUBMITTED")) {
+                    // If the form is submitted, skip it
+                    skippedForm = true;
+                } else if (questionnairePath.endsWith("Survey events")
+                    && this.formUtils.getValue(this.formUtils.getAnswer(form,
+                        session.getNode("/Questionnaires/Survey events/responses_received"))) != null
+                ) {
+                    // If the form is a survey events form with responses recieved, skip it
+                    skippedForm = true;
+                } else if (questionnairePath.endsWith("Visit information")) {
+                    // Handle visit information forms later
+                    visitInformationForm = form;
+                } else {
+                    form.remove();
+                }
+            }
+            handleDeleteVisit(session, visit, patient, skippedForm, visitInformationForm);
+        } catch (RepositoryException e) {
+            LOGGER.error("Error deleting visit {}", visit.getPath(), e);
+        }
+    }
+
+    private void handleDeleteVisit(final Session session, final Node visit, final Node patient,
+        final boolean skippedForm, final Node visitInformationForm)
+        throws RepositoryException
+    {
+        if (skippedForm) {
+            if (visitInformationForm != null) {
+                setVisitOnHold(session, visitInformationForm);
+            }
+        } else {
+            if (visitInformationForm != null) {
+                visitInformationForm.remove();
+            }
+            // Remove the visit
             boolean mustCheckout = false;
             VersionManager versionManager = session.getWorkspace().getVersionManager();
             if (!patient.isCheckedOut()) {
                 mustCheckout = true;
                 versionManager.checkout(patient.getPath());
             }
-            // Remove any forms for this visit
-            for (final PropertyIterator forms = visit.getReferences("subject"); forms.hasNext();) {
-                final Node form = forms.nextProperty().getParent();
-                form.remove();
-            }
-            // Remove the visit
             visit.remove();
             session.save();
             if (mustCheckout) {
                 versionManager.checkin(patient.getPath());
             }
-        } catch (RepositoryException e) {
-            LOGGER.error("Error deleting visit {}", visit.getPath(), e);
         }
     }
 }

--- a/prems-resources/clinical-data/pom.xml
+++ b/prems-resources/clinical-data/pom.xml
@@ -86,6 +86,7 @@
               SLING-INF/content/apps/cards/clarityImport/PMH-YVM.xml;path:=/apps/cards/clarityImport/PMH-YVM;overwrite:=true,
               SLING-INF/content/apps/cards/clarityImport/PMH-OO.xml;path:=/apps/cards/clarityImport/PMH-OO;overwrite:=true,
               SLING-INF/content/apps/cards/clarityImport/DeathStatus.xml;path:=/apps/cards/clarityImport/DeathStatus;overwrite:=true,
+              SLING-INF/content/apps/cards/clarityImport/InpatientStatus.xml;path:=/apps/cards/clarityImport/InpatientStatus;overwrite:=true,
             </Sling-Initial-Content>
           </instructions>
         </configuration>

--- a/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clarityImport/InpatientStatus.xml
+++ b/prems-resources/clinical-data/src/main/resources/SLING-INF/content/apps/cards/clarityImport/InpatientStatus.xml
@@ -1,0 +1,64 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+  <name>InpatientStatus</name>
+  <primaryNodeType>sling:Folder</primaryNodeType>
+  <node>
+    <name>Patient</name>
+    <primaryNodeType>cards:ClaritySubjectMapping</primaryNodeType>
+    <property>
+      <name>subjectIDColumn</name>
+      <value>PAT_MRN</value>
+      <type>String</type>
+    </property>
+    <property>
+      <name>subjectType</name>
+      <value>/SubjectTypes/Patient</value>
+      <type>String</type>
+    </property>
+    <node>
+      <name>questionnaires</name>
+      <primaryNodeType>sling:Folder</primaryNodeType>
+      <node>
+        <name>Patient information</name>
+        <primaryNodeType>cards:ClarityQuestionnaireMapping</primaryNodeType>
+        <property>
+          <name>updatePolicy</name>
+          <value>onlyExisting</value>
+          <type>String</type>
+        </property>
+        <node>
+          <name>00000001</name>
+          <primaryNodeType>cards:ClarityQuestionMapping</primaryNodeType>
+          <property>
+            <name>column</name>
+            <value>PAT_MRN</value>
+            <type>String</type>
+          </property>
+          <property>
+            <name>question</name>
+            <value>/Questionnaires/Patient information/mrn</value>
+            <type>String</type>
+          </property>
+        </node>
+      </node>
+    </node>
+  </node>
+</node>

--- a/prems-resources/feature/src/main/features/feature.json
+++ b/prems-resources/feature/src/main/features/feature.json
@@ -534,6 +534,15 @@
       "dateColumn": "",
       "mapping": "/apps/cards/clarityImport/DeathStatus"
     },
+    // Inpatient status: don't email current inpatients
+    "io.uhndata.cards.clarity.importer.ClarityImportConfig~inpatient-status": {
+      "name": "Inpatient Status",
+      "type": "inpatient-status",
+      "importSchedule": "0 5 9 * * ? *",
+      "tableName": "%ENV%CLARITY_INPATIENT_STATUS_TABLE",
+      "dateColumn": "",
+      "mapping": "/apps/cards/clarityImport/InpatientStatus"
+    },
 
     // Clarity import filters and mappers
 
@@ -932,6 +941,12 @@
       "column": "UNSUBSCRIBED",
       "value": "Yes",
       "enableLogging": false
+    },
+    // Update the visit status for any existing, non-expired visits for current inpatients:
+    "io.uhndata.cards.prems.internal.importer.InpatientStatusProcessor":{
+      "enabled": true,
+      "supportedTypes": ["inpatient-status"],
+      "priority": 35
     }
   }
 }


### PR DESCRIPTION
When an inpatient is imported which has a visit:
- Check if the visit can have active survey invites. If not, halt
- If the survey has sent out any emails, mark the visit as on hold and stop sending future emails
- If the survey has not sent out any emails, delete the visit

Important notes while testing this PR:
- Since your computer's date will be set to the past, you will not be able to connect to the internet during testing
- If a CARDS instance encounters a time in the past (eg. you have a running cards instance and set your computer's time backwards, or have a shut down cards instance, set the time backwards and start up the existing cards instance) then some parts of CARDS continue to work but many parts stop working. If this happens, you will have to delete the cards instance and start over. Some examples of breaking components are linking between subjects and forms, search results (such as the dashboards) not showing new entries, and many background tasks.

Testing
- Update the `SubjectSelector.jsx` code to make it easier to generate the correct patients:
  - Update the `createSubjects` function to generate the node name from the entered name, not a uuid
  - Change the following line 854 from:
```
    let url = (subjectParent || "/Subjects") + "/" + uuidv4();
```
to:
```
    let url = (subjectParent || "/Subjects") + "/" + subjectName;
```
- Prepare cards to run offline:
```
docker pull docker.io/library/ubuntu:24.04
mvn clean install -Pdocker
cd compose-cluster
python3 generate_compose_yaml.py --mssql --cards_project  cards4prems --oak_filesystem --dev_docker_image --composum --adminer --smtps --smtps_test_container --smtps_test_mail_path ~/cards-mail --server_address localhost:8080
```
- Edit the `docker-compose.yml` to add the following environment variable: `- NIGHTLY_NOTIFICATIONS_SCHEDULE=0 * * * * ? *`
- Set the current date to 08/28
- Launch cards `docker-compose build && docker-compose up`
- Create a new patient information form. When creating the patient subject, name the subject 111111. Fill out name, DoB, mrn, consents to being contacted by email = yes, email address
- Create a new visit information form for the new patient. Fill out clinic to Integrated Care, Time to the current computer date, provider, location and status.
- Set the date to 09/12. Create a new patient with MRN 111222 and an integrated care visit and a new patient 222111 with an inpatient visit
- Set the date to 9/19, wait a minute and verify that an initial invitation email was sent for 222111
- Set the date to 9/26, wait a minute for 222111's reminder email
- Set the date to 9/28, wait a minute for 111111's invitation email
- Set the date to 10/3, wait for 222111's second reminder
- Set the date to 10/5, wait for 111111's reminder
- Set the date to 10/12, create a new patient 111333 with an integrated care visit and 222222 with an inpatient visit. During this time, 111111 should get a second reminder
- Set the date to 10/13, wait for 111222's invitation email
- Set the date to 10/19, wait for 222222's invitation
- Set the date to 10/20, wait for 111222's reminder
- Set the date to 10/26, wait for 222222's reminder
- Set the date to 10/27, create a new patient 222333 with an inpatient visit. During this time, 111222 should get a second reminder
- Set the date to 10/30. Import a sample inpatient status table:
- In cards/compose-cluster/mssql, run `python3 ./generate_test_inpatient_status.py -n 10 inpatient_sample.sql`
- Edit the generated `inpatient_sample.sql` so it includes MRNs 111111, 111222, 111333, 222111, 222222 and 222333
- Sign into adminer http://localhost:1435/?mssql=mssql&username=sa&db=master&ns=path&import= (password testPassword_)
- Import the inpatient sample sql file (browse, select the file, execute)
- Run the inpatient status import by navigating to http://localhost:8080/Subjects.importClarity?config=Inpatient%20Status

- Verify that patients 111111 and 222111 are unaffected. Verify that patients 111222 and 222222 have their visit information form updated with status on hold. Verify that patients 111333 and 222333 have their visits deleted but patient information form unchanged.
- Set the date to 11/3. Verify that no second reminder email is sent for 222222