### PR TITLE
CARDS-2811: Markdown export of forms: question texts should have normal font weight while answers should be bold

### DIFF
--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/FormToMarkdownProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/internal/serialize/FormToMarkdownProcessor.java
@@ -91,7 +91,7 @@ public class FormToMarkdownProcessor extends AbstractFormToStringSerializer impl
     @Override
     void formatQuestion(final String question, final StringBuilder result)
     {
-        result.append("\n**").append(question).append("**  ");
+        result.append("\n").append(question).append("  ");
     }
 
     @Override
@@ -103,7 +103,7 @@ public class FormToMarkdownProcessor extends AbstractFormToStringSerializer impl
     @Override
     void formatAnswer(final String answer, final StringBuilder result)
     {
-        result.append('\n').append(answer).append('\n');
+        result.append("\n**").append(answer).append("**\n");
     }
 
     @Override


### PR DESCRIPTION
Specs: [CARDS-2811](https://phenotips.atlassian.net/browse/CARDS-2811)

[CARDS-2811]: https://phenotips.atlassian.net/browse/CARDS-2811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ