### PR TITLE
CARDS-2813: Improve progress bar progression

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -77,9 +77,10 @@ function FormPagination (props) {
   let [ nextActivePage, setNextActivePage ] = useState();
   let [ progress, setProgress ] = useState(0);
   const DIRECTION_NEXT = 1, DIRECTION_PREV = -1;
-  // The amount of the progress bar that should be complete on page 1 and incomplete on an unsaved last page
-  // Expressed as a multiple of a normal page size
-  const PROGRESS_BAR_PADDING = 0.5;
+  // The amount of the progress bar that should be complete on page 1
+  // Expressed as a multiple of a normal page size.
+  // The remainder (1 - stub size) will be used as a completion buffer on the last page
+  const INITIAL_PROGRESS_STUB = 0.7;
 
   let previousEntryType;
   let questionIndex = 0;
@@ -211,14 +212,12 @@ function FormPagination (props) {
 
   useEffect(() => {
     if (activePage != null && pages != null) {
-      // The pagination should be divided into multiple sections:
-      // - lastValidPage() sections for page by page progress
-      // - 1 padding section for the initial progress on the first page
-      // - 1 padding section for when the last page has been saved
       // The MaterialUI progress bar expects progress to be out of 100
-      const pageSize = 100 / (lastValidPage() + (2 * PROGRESS_BAR_PADDING));
-      const paddingSize = pageSize * PROGRESS_BAR_PADDING;
-      setProgress(paddingSize + (pageSize * activePage) + (savedLastPage ? paddingSize : 0))
+      const pageSize = 100 / (lastValidPage() + 1);
+      // Use some of 1 "page" worth of progression for the initial stub on the first page
+      // The rest will be used for the completion buffer on the last page
+      const stubSize = pageSize * INITIAL_PROGRESS_STUB;
+      setProgress(stubSize + (pageSize * activePage) + (savedLastPage ? pageSize - stubSize : 0))
     }
   }, [activePage, pages, savedLastPage])
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -211,9 +211,10 @@ function FormPagination (props) {
   }, [saveInProgress, pendingSubmission, disableProgress, nextActivePage, direction, activePage]);
 
   useEffect(() => {
-    if (activePage != null && pages != null) {
+    let numPages = lastValidPage();
+    if (activePage != null && pages != null && numPages >= 0) {
       // The MaterialUI progress bar expects progress to be out of 100
-      const pageSize = 100 / (lastValidPage() + 1);
+      const pageSize = 100 / (numPages + 1);
       // Use some of 1 "page" worth of progression for the initial stub on the first page
       // The rest will be used for the completion buffer on the last page
       const stubSize = pageSize * INITIAL_PROGRESS_STUB;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -75,7 +75,11 @@ function FormPagination (props) {
   let [ activePage, setActivePage ] = useState(0);
   let [ direction, setDirection ] = useState(1);
   let [ nextActivePage, setNextActivePage ] = useState();
+  let [ progress, setProgress ] = useState(0);
   const DIRECTION_NEXT = 1, DIRECTION_PREV = -1;
+  // The amount of the progress bar that should be complete on page 1 and incomplete on an unsaved last page
+  // Expressed as a multiple of a normal page size
+  const PROGRESS_BAR_PADDING = 0.5;
 
   let previousEntryType;
   let questionIndex = 0;
@@ -205,6 +209,19 @@ function FormPagination (props) {
     }
   }, [saveInProgress, pendingSubmission, disableProgress, nextActivePage, direction, activePage]);
 
+  useEffect(() => {
+    if (activePage != null && pages != null) {
+      // The pagination should be divided into multiple sections:
+      // - lastValidPage() sections for page by page progress
+      // - 1 padding section for the initial progress on the first page
+      // - 1 padding section for when the last page has been saved
+      // The MaterialUI progress bar expects progress to be out of 100
+      const pageSize = 100 / (lastValidPage() + (2 * PROGRESS_BAR_PADDING));
+      const paddingSize = pageSize * PROGRESS_BAR_PADDING;
+      setProgress(paddingSize + (pageSize * activePage) + (savedLastPage ? paddingSize : 0))
+    }
+  }, [activePage, pages, savedLastPage])
+
   let saveButton =
     <Button
       startIcon={activePage === lastValidPage() ? doneIcon : undefined}
@@ -244,8 +261,6 @@ function FormPagination (props) {
   }
   stepperClasses = stepperClasses.join(' ');
 
-  let progressAdjustment = (condition) => (condition && variant == "progress" ? 1 : 0);
-
   return (
     enabled
       ?
@@ -263,23 +278,16 @@ function FormPagination (props) {
           ?
           <MobileStepper
             variant={variant}
-            // Offset back bar 1 to create a "current page" region.
-            // If the final page has been saved, progress the front bar to complete
-            activeStep={activePage + progressAdjustment(lastSaveStatus && savedLastPage)}
-            // Change the color of the back bar
+            activeStep={activePage}
             slotProps={{
               progress: {
-                classes: {
-                  bar2Buffer: classes.formStepperBufferBar,
-                  dashed: classes.formStepperBackgroundBar,
-                },
-                variant: "buffer",
-                valueBuffer: (activePage + 1) / (lastValidPage() + 1) * 100,
+                // Manually control the progress bar value
+                value: progress
               }
             }}
             className={stepperClasses}
-            // base 0 to base 1, plus 1 for the "current page" region when variant is "progress"
-            steps={lastValidPage() + 1 + progressAdjustment(true)}
+
+            steps={lastValidPage() + 1}
             nextButton={saveButton}
             backButton={backButton}
           />

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FormPagination.jsx
@@ -211,10 +211,10 @@ function FormPagination (props) {
   }, [saveInProgress, pendingSubmission, disableProgress, nextActivePage, direction, activePage]);
 
   useEffect(() => {
-    let numPages = lastValidPage();
-    if (activePage != null && pages != null && numPages >= 0) {
+    let lastPage = lastValidPage();
+    if (activePage != null && pages != null && lastPage >= 0) {
       // The MaterialUI progress bar expects progress to be out of 100
-      const pageSize = 100 / (numPages + 1);
+      const pageSize = 100 / (lastPage + 1);
       // Use some of 1 "page" worth of progression for the initial stub on the first page
       // The rest will be used for the completion buffer on the last page
       const stubSize = pageSize * INITIAL_PROGRESS_STUB;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireStyle.jsx
@@ -496,16 +496,6 @@ const questionnaireStyle = theme => ({
     margin: theme.spacing(1),
     minWidth: "fit-content",
   },
-  formStepperBufferBar: {
-    backgroundColor: theme.palette.primary.main,
-    opacity: "0.3",
-  },
-  formStepperBackgroundBar: {
-    backgroundColor: theme.palette.primary.light,
-    opacity: "0.2",
-    animation: "none",
-    backgroundImage: "none",
-  },
   actionsMenu: {
     border: "1px solid " + theme.palette.divider,
     borderRadius: theme.spacing(3),


### PR DESCRIPTION
- Remove buffer for current page
- Add a 0.7 page padding to the start and 0.3 page padding end to show some progress on the first page and when saving

Page 1/4:
<img width="647" height="66" alt="image" src="https://github.com/user-attachments/assets/512da740-7d10-4093-9a32-e2e3f21aae4c" />
Page 2/4:
<img width="640" height="58" alt="image" src="https://github.com/user-attachments/assets/5ad48c13-5765-4c78-82f5-d2db8e8d1d01" />
Page 4/4, unsaved:
<img width="639" height="54" alt="image" src="https://github.com/user-attachments/assets/0edacb2d-0725-4b2a-99ce-3bb160bf37a6" />
Page 4/4, saved:
<img width="649" height="60" alt="image" src="https://github.com/user-attachments/assets/160df044-bd24-4150-b58b-db4b8907af9b" />

