### PR TITLE
CARDS-2794: Add ESLint rule to report unused imports

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/Filters.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useCallback, useRef, useState, useContext, useEffect } from "react";
+import { Fragment, useCallback, useRef, useState, useContext, useEffect } from "react";
 
 import Add from "@mui/icons-material/Add";
 import CloseIcon from '@mui/icons-material/Close';
@@ -396,7 +396,7 @@ function Filters(props) {
               let isNotesContain = filterDatum.comparator && (filterDatum.comparator === notesComparator);
               let isContain = filterDatum.comparator && (filterDatum.comparator.includes(TEXT_COMPARATORS));
               return(
-                <React.Fragment key={index}>
+                <Fragment key={index}>
                   {/* Select the field to filter */}
                   <Grid size={{ xs:12, sm:6 }}>
                     <VariableAutocomplete
@@ -453,7 +453,7 @@ function Filters(props) {
                       <CloseIcon />
                     </IconButton>
                   </Grid>
-                </React.Fragment>
+                </Fragment>
               );
             })}
           </Grid>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireAutocomplete.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireAutocomplete.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
+import { Fragment } from "react";
 
 import ClearIcon from '@mui/icons-material/Clear';
 import {
@@ -192,7 +192,7 @@ function QuestionnaireAutocomplete(props) {
     {/* List the entered values */}
     <List dense className={classes.selectionList}>
       { entities?.filter(v => selection.includes(getOptionValue(v))).map((value, index) =>
-        <React.Fragment key={`selection-list-item-${index}`}>
+        <Fragment key={`selection-list-item-${index}`}>
           { !!index && <Divider key={`divider-${index}`} variant="inset" component="li" /> }
           <ListItem
             key={`${value.name}-${index}`}
@@ -207,7 +207,7 @@ function QuestionnaireAutocomplete(props) {
             { getAvatar(value.type) }
             { getQuestionnaireEntryText(value, multiple) }
           </ListItem>
-        </React.Fragment>
+        </Fragment>
       )}
     </List>
   </>);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import React, { useEffect, useState, useContext } from "react";
+import { Fragment, useEffect, useState, useContext } from "react";
 
 import {
   Alert,
@@ -302,7 +302,7 @@ function UnstyledSelectParentDialog (props) {
       const json = await response.json();
 
       setData(json["rows"].map((row) => ({
-        hierarchy: getHierarchy(row, React.Fragment, ()=>({})),
+        hierarchy: getHierarchy(row, Fragment, ()=>({})),
         ...row })));
       setRowCount(json.totalrows);
 
@@ -1034,7 +1034,7 @@ function SubjectSelectorList(props) {
       }
 
       setData(filteredData.map((row) => ({
-        hierarchy: getHierarchy(row, React.Fragment, () => ({})),
+        hierarchy: getHierarchy(row, Fragment, () => ({})),
         ...row })));
       setRowCount(json.totalrows);
 

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/Fields.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/Fields.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React from "react";
+import { Fragment } from "react";
 
 import PropTypes from 'prop-types';
 
@@ -80,7 +80,7 @@ let Fields = (props) => {
 
     if (!hasValueToDisplay(key, value)) return '';
 
-    return (<React.Fragment key={key}>
+    return (<Fragment key={key}>
       <LabeledField condensed={condensed} name={key}>
         <ValueDisplay key={key} objectKey={key} value={value} data={data} />
       </LabeledField>
@@ -90,7 +90,7 @@ let Fields = (props) => {
             .map(([k, v]) => displayStaticField(k, v))
           : ""
       }
-    </React.Fragment>);
+    </Fragment>);
   };
 
   // Note that we remove the meta fields, starting with `//`, such as `//REQUIRED which indicates which fields are mandatory

--- a/modules/login/src/main/frontend/src/login/LoginForm.js
+++ b/modules/login/src/main/frontend/src/login/LoginForm.js
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useEffect } from 'react';
+import { Fragment, useState, useEffect } from 'react';
 
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
@@ -158,7 +158,7 @@ function LoginForm(props) {
         }}
       >
         { (phase == "USERNAME_ENTRY" || singleStepEntry) &&
-            <React.Fragment>
+            <Fragment>
               <FormControl variant="standard" margin="normal" required fullWidth>
                 <InputLabel htmlFor="j_username">Username{singleStepEntry ? "" : " or email address"}</InputLabel>
                 <Input
@@ -180,11 +180,11 @@ function LoginForm(props) {
                   Next
                 </Button>
               }
-            </React.Fragment>
+            </Fragment>
         }
 
         { (phase == "PASSWORD_ENTRY" || singleStepEntry) &&
-            <React.Fragment>
+            <Fragment>
               <FormControl variant="standard" margin="normal" required fullWidth>
                 <InputLabel htmlFor="j_password">Password{singleStepEntry ? "" : (" for " + username)}</InputLabel>
                 <Input
@@ -239,7 +239,7 @@ function LoginForm(props) {
                   </Button>
                 </Grid>
               </Grid>
-            </React.Fragment>
+            </Fragment>
         }
       </form>
     </div>

--- a/modules/login/src/main/frontend/src/login/RegistrationForm.js
+++ b/modules/login/src/main/frontend/src/login/RegistrationForm.js
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState, useRef } from 'react';
+import { Fragment, useState, useRef } from 'react';
 
 import {
   Button,
@@ -266,7 +266,7 @@ function RegistrationForm(props) {
   });
 
   return (
-    <React.Fragment>
+    <Fragment>
       <ErrorDialog open={errorOpen} onClose={() => setErrorOpen(false)}>
         <Typography>{errorMsg}</Typography>
       </ErrorDialog>
@@ -281,7 +281,7 @@ function RegistrationForm(props) {
           {props => <FormFieldsComponent {...props} />}
         </Formik>
       </div>
-    </React.Fragment>
+    </Fragment>
   );
 }
 

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/SurveyInstructionsConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/SurveyInstructionsConfiguration.jsx
@@ -16,7 +16,7 @@
 //  specific language governing permissions and limitations
 //  under the License.
 //
-import React, { useState } from 'react';
+import { Fragment, useState } from 'react';
 
 import {
   Checkbox,
@@ -81,7 +81,7 @@ function SurveyInstructionsConfiguration() {
       onConfigSaved={() => setHasChanges(false)}
     >
       <List className={classes.formEntries}>
-        { Object.keys(labels).map(category => { return (<React.Fragment key={category + "Wrapper"}>
+        { Object.keys(labels).map(category => { return (<Fragment key={category + "Wrapper"}>
           <ListItem key={category}>
             <Typography variant="h6">{camelCaseToWords(category)}</Typography>
           </ListItem>
@@ -132,7 +132,7 @@ function SurveyInstructionsConfiguration() {
               }
             </ListItem>)
           })}
-        </React.Fragment>)
+        </Fragment>)
         })}
       </List>
     </AdminConfigScreen>


### PR DESCRIPTION
Import `Fragment` from `React` to avoid explicit `React` import for `<React.Fragment>` use.