### PR TITLE
[misc] Rename relocated maven-sling-plugin to sling-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1984,7 +1984,7 @@
         <plugins>
           <plugin>
             <groupId>org.apache.sling</groupId>
-            <artifactId>maven-sling-plugin</artifactId>
+            <artifactId>sling-maven-plugin</artifactId>
             <version>2.4.0</version>
             <executions>
               <execution>


### PR DESCRIPTION
Addressed maven build warning

`[WARNING] The artifact org.apache.sling:maven-sling-plugin:jar:2.4.0 has been relocated to org.apache.sling:sling-maven-plugin:jar:2.4.0`