### PR TITLE
CARDS-2797: Enforce various useful ESLint rules

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalComponentManager.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalComponentManager.jsx
@@ -53,7 +53,7 @@ export default class ConditionalComponentManager {
     return (_registeredComponents
       .map(component => (component)(conditionDefinition))
       .filter(handler => handler)
-      .reduce(([chosenDisplayer, maxPriority], [displayer, priority]) => priority > maxPriority ? [displayer, priority] : [chosenDisplayer, maxPriority]))[0]
-    (conditionDefinition, context);
+      .reduce(([chosenDisplayer, maxPriority], [displayer, priority]) =>
+        priority > maxPriority ? [displayer, priority] : [chosenDisplayer, maxPriority]))[0](conditionDefinition, context);
   }
 }


### PR DESCRIPTION
Fixed `no-unexpected-multiline` rule
No code changed, just put all expression in 1 line