### PR TITLE
CARDS-2824: Make statistics a feature

### DIFF
--- a/modules/statistics/pom.xml
+++ b/modules/statistics/pom.xml
@@ -33,6 +33,11 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>slingfeature-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>

--- a/modules/statistics/src/main/features/feature.json
+++ b/modules/statistics/src/main/features/feature.json
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+{
+  "bundles":[
+    {
+      "id":"${project.groupId}:${project.artifactId}:${project.version}",
+      "start-order":"25"
+    }
+  ]
+}


### PR DESCRIPTION
- Build, start with `prems`
- Check that statistics are disabled
- Start again adding `-f mvn:io.uhndata.cards/cards-statistics/0.9.36-SNAPSHOT/slingosgifeature` to the command
- Check that statistics are enabled