### PR TITLE
Update README.md with current prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Prerequisites:
 * Java 11
-* Maven 3.3+
+* Maven 3.8+
 * Python 2.5+ or Python 3.0+
 * psutil Python module (recommended)
 


### PR DESCRIPTION
The build fails with maven 3.6.x, while 3.8.x works. Likely introduced by https://github.com/data-team-uhn/cards/pull/2136 .