### PR TITLE
CARDS-2797: Enforce various useful ESLint rules

### DIFF
--- a/aggregated-frontend/src/main/frontend/eslint.config.js
+++ b/aggregated-frontend/src/main/frontend/eslint.config.js
@@ -73,6 +73,7 @@ const commonRules = {
   ...js.configs.recommended.rules,
   ...jsxA11y.configs.recommended.rules,
   ...react.configs.recommended.rules,
+  ...reactHooks.configs.flat.recommended.rules,
 
   "import/order": importOrderRule,
 
@@ -81,6 +82,9 @@ const commonRules = {
   "react/react-in-jsx-scope": "off",
   "react/prop-types": "off",
   "react-hooks/rules-of-hooks": "error",
+  "react-hooks/exhaustive-deps": "off",
+  "react-hooks/set-state-in-effect": "off",
+  "react-hooks/refs": "off",
 
   // ununsed-related rules
   "no-unused-vars": ["error", { args: "none", caughtErrors: "none" }],

--- a/aggregated-frontend/src/main/frontend/eslint.config.js
+++ b/aggregated-frontend/src/main/frontend/eslint.config.js
@@ -85,6 +85,7 @@ const commonRules = {
   "react-hooks/exhaustive-deps": "off",
   "react-hooks/set-state-in-effect": "off",
   "react-hooks/refs": "off",
+  "react-hooks/preserve-manual-memoization": "off",
 
   // ununsed-related rules
   "no-unused-vars": ["error", { args: "none", caughtErrors: "none" }],

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -159,6 +159,7 @@ function LiveTable(props) {
     let url = new URL(urlBase);
     url.searchParams.set("offset", goToStart ? 0 : newPage.offset ?? paginationData.offset);
     url.searchParams.set("limit", newPage.limit || paginationData.limit);
+    // eslint-disable-next-line react-hooks/immutability
     url.searchParams.set("req", ++fetchStatus.currentRequestNumber);
     url.searchParams.set("showTotalRows", showTotalRows);
     resourceSelectors && url.searchParams.set("resourceSelectors", resourceSelectors);

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -106,36 +106,6 @@ function LiveTable(props) {
 
   const globalLoginDisplay = useContext(GlobalLoginContext);
 
-  let refresh = () => {
-    setFetchStatus(Object.assign({}, fetchStatus, {
-      "currentRequestNumber": -1,
-    }));
-  }
-
-  // When data is changed, trigger a new fetch in the table
-  useEffect(() => {
-    // subscribe event
-    window.addEventListener("LivetableRefresh",  refresh);
-    return () => {
-      // unsubscribe event
-      document.removeEventListener("LivetableRefresh",  refresh);
-    };
-  }, [entryType]);
-
-  // When new data is added, trigger a new fetch
-  useEffect(() => {
-    if (updateData){
-      refresh();
-    }
-  }, [updateData]);
-
-  // When the data path is changed, trigger a new fetch
-  useEffect(() => {
-    if (customUrl){
-      refresh();
-    }
-  }, [customUrl]);
-
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Define the component's behavior
 
@@ -212,6 +182,36 @@ function LiveTable(props) {
   useEffect(() => {
     if (fetchStatus.currentRequestNumber == -1) fetchData(paginationData, true);
   }, [fetchStatus.currentRequestNumber]);
+
+  let refresh = () => {
+    setFetchStatus(Object.assign({}, fetchStatus, {
+      "currentRequestNumber": -1,
+    }));
+  }
+
+  // When data is changed, trigger a new fetch in the table
+  useEffect(() => {
+    // subscribe event
+    window.addEventListener("LivetableRefresh",  refresh);
+    return () => {
+      // unsubscribe event
+      document.removeEventListener("LivetableRefresh",  refresh);
+    };
+  }, [entryType]);
+
+  // When new data is added, trigger a new fetch
+  useEffect(() => {
+    if (updateData){
+      refresh();
+    }
+  }, [updateData]);
+
+  // When the data path is changed, trigger a new fetch
+  useEffect(() => {
+    if (customUrl){
+      refresh();
+    }
+  }, [customUrl]);
 
   let makeRow = (entry, i) => {
     return (

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -106,6 +106,12 @@ function LiveTable(props) {
 
   const globalLoginDisplay = useContext(GlobalLoginContext);
 
+  let refresh = () => {
+    setFetchStatus(Object.assign({}, fetchStatus, {
+      "currentRequestNumber": -1,
+    }));
+  }
+
   // When data is changed, trigger a new fetch in the table
   useEffect(() => {
     // subscribe event
@@ -130,19 +136,20 @@ function LiveTable(props) {
     }
   }, [customUrl]);
 
-  // Initialize the component: if there's no data loaded yet, fetch the first page
-  useEffect(() => {
-    if (fetchStatus.currentRequestNumber == -1) fetchData(paginationData, true);
-  }, [fetchStatus.currentRequestNumber]);
-
-  let refresh = () => {
-    setFetchStatus(Object.assign({}, fetchStatus, {
-      "currentRequestNumber": -1,
-    }));
-  }
-
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Define the component's behavior
+
+  let handleError = (response) => {
+    let err = response.statusText ? response.statusText : response.toString();
+    if (response.status == 404) {
+      err = "Access to data is pending the approval of your account";
+    }
+    setFetchStatus(Object.assign({}, fetchStatus, {
+      "currentFetch": false,
+      "fetchError": err,
+    }));
+    setTableData([]);
+  };
 
   let fetchData = (newPage, goToStart) => {
     if (fetchStatus.currentFetch) {
@@ -200,17 +207,10 @@ function LiveTable(props) {
     );
   };
 
-  let handleError = (response) => {
-    let err = response.statusText ? response.statusText : response.toString();
-    if (response.status == 404) {
-      err = "Access to data is pending the approval of your account";
-    }
-    setFetchStatus(Object.assign({}, fetchStatus, {
-      "currentFetch": false,
-      "fetchError": err,
-    }));
-    setTableData([]);
-  };
+  // Initialize the component: if there's no data loaded yet, fetch the first page
+  useEffect(() => {
+    if (fetchStatus.currentRequestNumber == -1) fetchData(paginationData, true);
+  }, [fetchStatus.currentRequestNumber]);
 
   let makeRow = (entry, i) => {
     return (

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/PrintButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/PrintButton.jsx
@@ -74,6 +74,19 @@ function PrintButton(props) {
 
   const [ open, setOpen ] = useState(false);
 
+  let onOpenView = () => {
+    onOpen?.();
+    setOpen(true);
+  }
+
+  let handleOnPrintKeydown = (event) => {
+    if ((event.ctrlKey || event.metaKey) && (event.key == "p" || event.keyCode == 80)) {
+      event.stopPropagation();
+      event.preventDefault ? event.preventDefault() : (event.returnValue = false);
+      onOpenView();
+    }
+  }
+
   // Prevent browser to open print dialog on user ctrl+P keydown and force to go through the custom print preview
   useEffect(() => {
     if (disableShortcut) return;
@@ -84,19 +97,6 @@ function PrintButton(props) {
       document.removeEventListener("keydown", handleOnPrintKeydown);
     };
   }, []);
-
-  let handleOnPrintKeydown = (event) => {
-    if ((event.ctrlKey || event.metaKey) && (event.key == "p" || event.keyCode == 80)) {
-      event.stopPropagation();
-      event.preventDefault ? event.preventDefault() : (event.returnValue = false);
-      onOpenView();
-    }
-  }
-
-  let onOpenView = () => {
-    onOpen?.();
-    setOpen(true);
-  }
 
   let onCloseView = () => {
     onClose?.();

--- a/modules/data-entry/src/main/frontend/src/questionnaire/AddressQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/AddressQuestion.jsx
@@ -46,7 +46,6 @@ fetch(APIKEY_SERVLET_URL)
   .catch((error) => {
     console.error("Error fetching GoogleApiKey node: " + error);
   });
-let isValidApiKey = true;
 
 
 // Easy way to overwrite global CSS styles using theme
@@ -133,10 +132,9 @@ function AddressQuestion(props) {
   window.gm_authFailure = () => {
     console.error("Error in Google API authentication");
     setIsValidApi(false);
-    isValidApiKey = false;
   };
 
-  if (!isValidApiKey || !isValidApi) {
+  if (!isValidApi) {
     return <StyledTextQuestion {...props} />
   }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/AddressQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/AddressQuestion.jsx
@@ -129,6 +129,7 @@ function AddressQuestion(props) {
   });
 
   // If google API authentication problem emerges due to to the invalid key or key with disabled Places service
+  // eslint-disable-next-line react-hooks/immutability
   window.gm_authFailure = () => {
     console.error("Error in Google API authentication");
     setIsValidApi(false);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -74,8 +74,8 @@ function Answer (props) {
       if (idHistory.indexOf(answerPath) < 0)
       {
         idHistory.push(answerPath);
-        sectionAnswersState[questionName] = idHistory;
-        onAddedAnswerPath(sectionAnswersState);
+        const updatedState = { ...sectionAnswersState, [questionName]: idHistory };
+        onAddedAnswerPath(updatedState);
         hasRegisteredPathRef.current = true;
       }
     }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx
@@ -95,11 +95,6 @@ function DateQuestion(props) {
   const formContext = useFormReaderContext();
   const handleFormDataChange = formContext?.['/OnFormDataChanged'];
 
-  useEffect(() => {
-    validateInput(null, displayedDate, false);
-    isRange && validateInput(null, displayedEndDate, true);
-  }, []);
-
   let setDate = (value, isEnd) => {
     if (isEnd) {
       setDisplayedEndDate(value);
@@ -158,6 +153,11 @@ function DateQuestion(props) {
       }
     }
   }
+
+  useEffect(() => {
+    validateInput(null, displayedDate, false);
+    isRange && validateInput(null, displayedEndDate, true);
+  }, []);
 
   let getSlingDate = (isEnd) => {
     let date = isEnd ? displayedEndDate : displayedDate;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/DicomQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DicomQuestion.jsx
@@ -63,6 +63,7 @@ const useStyles = makeStyles()(theme => ({
 // Filepaths are placed in a series of <input type="hidden"> tags for
 // submission.
 //
+/* eslint-disable react-hooks/immutability */
 function DicomQuestion(props) {
   checkPropTypes(DicomQuestion, props);
   const { existingAnswer, questionDefinition, ...rest } = props;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -150,15 +150,6 @@ function Form (props) {
     setEndReached(!paginationEnabled);
   }, [paginationEnabled]);
 
-  // Handle autosave:
-  // When autosave options are defined, trigger a background save
-  useEffect(() => {
-    if (typeof(autosaveOptions) == "object") {
-      let { performCheckin, onSuccess } = autosaveOptions;
-      saveData(new Event("autosave"), performCheckin, onSuccess);
-    }
-  }, [autosaveOptions]);
-
   // When the save is completed (successfully or not), clear the autosave options
   useEffect(() => {
     if (saveInProgress === false) setAutosaveOptions(undefined);
@@ -294,6 +285,12 @@ function Form (props) {
     setLastSaveStatus(undefined);
   }
 
+  let openErrorDialog = () => {
+    if (!errorDialogDisplayed) {
+      setErrorDialogDisplayed(true);
+    }
+  }
+
   // Event handler for the form submission event, replacing the normal browser form submission with a background fetch request.
   let saveData = (event, performCheckin, onSuccess) => {
     // This stops the normal browser form submission
@@ -382,6 +379,15 @@ function Form (props) {
       .finally(() => formNode?.current && setSaveInProgress(false));
   }
 
+  // Handle autosave:
+  // When autosave options are defined, trigger a background save
+  useEffect(() => {
+    if (typeof(autosaveOptions) == "object") {
+      let { performCheckin, onSuccess } = autosaveOptions;
+      saveData(new Event("autosave"), performCheckin, onSuccess);
+    }
+  }, [autosaveOptions]);
+
   let saveDataWithCheckin = (event, onSuccess) => {
     return saveData(event, true, onSuccess);
   }
@@ -395,12 +401,6 @@ function Form (props) {
     })
     setChangedSubject(subject);
     setSelectorDialogOpen(false);
-  }
-
-  let openErrorDialog = () => {
-    if (!errorDialogDisplayed) {
-      setErrorDialogDisplayed(true);
-    }
   }
 
   let closeErrorDialog = () => {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionMatrix.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionMatrix.jsx
@@ -153,7 +153,7 @@ let QuestionMatrix = (props) => {
     let checked = !event?.target?.checked;
 
     let getNewSelection = (id, option, checked) => {
-      let newSelection = selection;
+      let newSelection = { ...selection };
       let answer = newSelection[id] || [];
 
       // If the element was already checked, remove it instead

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
@@ -356,6 +356,7 @@ let QuestionnaireItemSet = (props) => {
               classes={classes}
             />
           </Grid>
+        // eslint-disable-next-line react-hooks/unsupported-syntax
         )(eval(stripCardsNamespace(value['jcr:primaryType'])))
         )
       }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Section.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import { useCallback, useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import Add from "@mui/icons-material/Add";
 import UnfoldLess from '@mui/icons-material/UnfoldLess';
@@ -210,7 +210,7 @@ function Section(props) {
 
   // mountOnEnter and unmountOnExit force the inputs and children to be outside of the DOM during form submission
   // if it is not currently visible
-  return useCallback(
+  return (
     <>
       {/* if conditional is true, the collapse component is rendered and displayed.
         else, the corresponding input tag to the conditional section is deleted  */}
@@ -360,7 +360,7 @@ function Section(props) {
         )
       }
     </>
-    , [conditionIsMet, instanceLabels, labelsToHide, selectedUUID, removableAnswers[ID_STATE_KEY], pageActive, isEdit]);
+  );
 }
 
 Section.propTypes = {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -300,7 +300,10 @@ function SubjectHeader(props) {
   };
 
   useEffect(() => {
-    reloadSubject.current = fetchSubjectData;
+    if (reloadSubject) {
+      // eslint-disable-next-line react-hooks/immutability
+      reloadSubject.current = fetchSubjectData;
+    }
   }, [id]);
 
   // When the top-level subject is deleted, redirect to its parent if it has one, otherwise to the Subjects page

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -275,21 +275,6 @@ function SubjectHeader(props) {
   let globalLoginDisplay = useContext(GlobalLoginContext);
   let navigate = useNavigate();
 
-  useEffect(() => {
-    reloadSubject.current = fetchSubjectData;
-  }, [id]);
-
-  // Fetch the subject's data as JSON from the server.
-  // The data will contain the subject metadata,
-  // such as authorship and versioning information.
-  // Once the data arrives from the server, it will be stored in the `data` state variable.
-  let fetchSubjectData = () => {
-    fetchWithReLogin(globalLoginDisplay, `/Subjects/${id}.deep.json`)
-      .then((response) => response.ok ? response.json() : Promise.reject(response))
-      .then(handleSubjectResponse)
-      .catch(handleError);
-  };
-
   // Callback method for the `fetchData` method, invoked when the data successfully arrived from the server.
   let handleSubjectResponse = (json) => {
     getSubject(json);
@@ -302,6 +287,21 @@ function SubjectHeader(props) {
     setError(response);
     setSubject({});  // Prevent an infinite loop if data was not set
   };
+
+  // Fetch the subject's data as JSON from the server.
+  // The data will contain the subject metadata,
+  // such as authorship and versioning information.
+  // Once the data arrives from the server, it will be stored in the `data` state variable.
+  let fetchSubjectData = () => {
+    fetchWithReLogin(globalLoginDisplay, `/Subjects/${id}.deep.json`)
+      .then((response) => response.ok ? response.json() : Promise.reject(response))
+      .then(handleSubjectResponse)
+      .catch(handleError);
+  };
+
+  useEffect(() => {
+    reloadSubject.current = fetchSubjectData;
+  }, [id]);
 
   // When the top-level subject is deleted, redirect to its parent if it has one, otherwise to the Subjects page
   let handleDeletion = () => {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
@@ -163,6 +163,12 @@ function SubjectTimeline(props) {
   let [ dateEntries, setDateEntries ] = useState(null);
   let globalLoginDisplay = useContext(GlobalLoginContext);
 
+  // Callback method for the `fetchData` method, invoked when the request failed.
+  let handleError = (response) => {
+    setDateEntries([]);
+    console.log(response.statusText || response.message);
+  };
+
   // Fetch the forms and answers for a specific subject
   let fetchSubjectData = (subject, level, subjectNames) => {
     // Fetch a subject with it's forms (.data) and those forms' answers (.deep)
@@ -357,12 +363,6 @@ function SubjectTimeline(props) {
         .then(dateAnswers => getDateEntries(dateAnswers));
     }
   }, [subject]);
-
-  // Callback method for the `fetchData` method, invoked when the request failed.
-  let handleError = (response) => {
-    setDateEntries([]);
-    console.log(response.statusText || response.message);
-  };
 
   if (!dateEntries) {
     return <CircularProgress/>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/TimeQuestion.jsx
@@ -96,7 +96,10 @@ function TimeQuestion(props) {
   // Provide the display formatted time to the Question component so the right formatting is displayed in view mode
   let formattedAnswer = existingAnswer;
   if (selectedTime && formattedAnswer?.[1]) {
-    formattedAnswer[1].displayedValue = selectedTime.toFormat(dateFormat);
+    formattedAnswer = [
+      formattedAnswer[0],
+      { ...formattedAnswer[1], displayedValue: selectedTime.toFormat(dateFormat) }
+    ];
   }
 
   let outputAnswers = [["time", selectedTime && selectedTime.isValid ? selectedTime.toFormat(saveFormat) : null]];

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ListInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ListInput.jsx
@@ -41,6 +41,10 @@ let ListInput = (props) => {
     setSelection(Array.of(val ?? []).flat().filter(v => v?.[type.identifierProperty] != ''));
   }
 
+  let handleError = () => {
+    console.log('error');
+  }
+
   useEffect(() => {
     fetch('/query?query=' + encodeURIComponent(`select * from [${type.primaryType}] as n order by n.'${type.orderProperty}'`))
       .then((response) => response.ok ? response.json() : Promise.reject(response))
@@ -81,10 +85,6 @@ let ListInput = (props) => {
       })
       .catch(handleError);
   }, []);
-
-  let handleError = () => {
-    console.log('error');
-  }
 
   const handleChange = (event) => {
     changeValue(event.target.value);

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReferenceInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReferenceInput.jsx
@@ -58,17 +58,6 @@ let ReferenceInput = (props) => {
     setCurValue(newVal);
   }
 
-  useEffect(() => {
-    getRestrictions(allowOnlyApplicableFor);
-  },
-  [fieldsReader[allowOnlyApplicableFor]]);
-
-  useEffect(() => {
-    if (options.length > 0 && Object.keys(titleMap).length > 0 && autoselectOptions.length == 0) {
-      setAutoselectOptions(getFieldsLabelsList(options, ""));
-    }
-  }, [options, titleMap]);
-
   // Obtain information about the questions that can be used as a reference
   let grabData = (urlBase, parser) => {
     let url = new URL(urlBase, window.location.origin);
@@ -167,6 +156,12 @@ let ReferenceInput = (props) => {
     }).flat();
   }
 
+  useEffect(() => {
+    if (options.length > 0 && Object.keys(titleMap).length > 0 && autoselectOptions.length == 0) {
+      setAutoselectOptions(getFieldsLabelsList(options, ""));
+    }
+  }, [options, titleMap]);
+
   let getRestrictions = (restrictingField) => {
     let field = fieldsReader[restrictingField];
     if (Array.isArray(field)) {
@@ -245,6 +240,11 @@ let ReferenceInput = (props) => {
       })
       .catch(console.log);
   }
+
+  useEffect(() => {
+    getRestrictions(allowOnlyApplicableFor);
+  },
+  [fieldsReader[allowOnlyApplicableFor]]);
 
   useEffect(() => {
     fieldsWriter((oldContext) => ({ ...oldContext, [objectKey]: curValue }));

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReferenceInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReferenceInput.jsx
@@ -156,12 +156,6 @@ let ReferenceInput = (props) => {
     }).flat();
   }
 
-  useEffect(() => {
-    if (options.length > 0 && Object.keys(titleMap).length > 0 && autoselectOptions.length == 0) {
-      setAutoselectOptions(getFieldsLabelsList(options, ""));
-    }
-  }, [options, titleMap]);
-
   let getRestrictions = (restrictingField) => {
     let field = fieldsReader[restrictingField];
     if (Array.isArray(field)) {
@@ -257,6 +251,12 @@ let ReferenceInput = (props) => {
       grabData(FILTER_URL, parseQuestionnaireData);
     }
   }, [value["primaryType"]]);
+
+  useEffect(() => {
+    if (options.length > 0 && Object.keys(titleMap).length > 0 && autoselectOptions.length == 0) {
+      setAutoselectOptions(getFieldsLabelsList(options, ""));
+    }
+  }, [options, titleMap]);
 
   // The form of the hidden input depends on the value of curValue
   // The fallback is to just use its value as-is in a hidden input

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
@@ -127,9 +127,6 @@ function AdminConfigScreen(props) {
   const navigate = useNavigate();
   const { classes } = useStyles();
 
-  useEffect(() => {getConfig()}, []);
-  useEffect(() => {hasChanges && setConfigIsInitial(false)}, [hasChanges]);
-
   // Loading the existing configuration
   const getConfig = () => {
     fetchWithReLogin(globalContext, `${configPath}.json`)
@@ -144,6 +141,9 @@ function AdminConfigScreen(props) {
         setError("The configuration could not be loaded.");
       });
   }
+
+  useEffect(() => {getConfig()}, []);
+  useEffect(() => {hasChanges && setConfigIsInitial(false)}, [hasChanges]);
 
   // Submitting the form to save the new configuration
   const handleSubmit = (event) => {

--- a/modules/login/src/main/frontend/src/login/RegistrationForm.js
+++ b/modules/login/src/main/frontend/src/login/RegistrationForm.js
@@ -164,7 +164,7 @@ function RegistrationForm(props) {
   let [ errorOpen, setErrorOpen ] = useState(false);
   let [ errorMsg, setErrorMsg ] = useState("");
 
-  let form = useRef();
+  const formRef = useRef();
 
   let signIn = (username, password) => {
     fetch('/j_security_check',
@@ -276,7 +276,7 @@ function RegistrationForm(props) {
           validationSchema={validationSchema}
           onSubmit={submitValues}
           onReset={handleExit}
-          innerRef={el => (form = el)}
+          innerRef={formRef}
         >
           {props => <FormFieldsComponent {...props} />}
         </Formik>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
@@ -233,15 +233,15 @@ function PatientIdentification(props) {
     }
   }, [visitList, touCleared]);
 
+  let authenticate = () => {
+    onSuccess && onSuccess(Object.assign({ subject: visit }, patientDetails));
+  }
+
   // When the visit is successfully obtained and the latest version of Terms of Use accepted, pass it along with the identification data
   // to the parent component
   useEffect(() => {
     visit && patientDetails && touCleared && authenticate();
   }, [visit, touCleared, !!patientDetails]);
-
-  let authenticate = () => {
-    onSuccess && onSuccess(Object.assign({ subject: visit }, patientDetails));
-  }
 
   // -----------------------------------------------------------------------------------------------------
   // Rendering

--- a/modules/statistics/src/main/frontend/src/Statistics/Statistic.jsx
+++ b/modules/statistics/src/main/frontend/src/Statistics/Statistic.jsx
@@ -261,7 +261,7 @@ function Statistic(props) {
                 <Label value={definition["x-label"]} offset={-10} position="insideBottom" />
               </XAxis>
               <YAxis allowDecimals={false} label={{ value: definition["y-label"], angle: -90, position: 'insideLeft', offset: 10 }} />
-              <Tooltip content={<CustomTooltip />} />
+              <Tooltip content={(props) => <CustomTooltip {...props} />} />
               {isSplit && <Legend align="right" verticalAlign="top" height={legendHeight} />}
               {allFields.map((field, idx) =>
                 isBar ? (groupNullAndFalseAnswersForXVar ?

--- a/modules/ui-extension/src/main/frontend/src/uiextension/ExtensionPoint.jsx
+++ b/modules/ui-extension/src/main/frontend/src/uiextension/ExtensionPoint.jsx
@@ -84,6 +84,7 @@ function ExtensionPoint(props) {
     if (['text/javascript', 'application/javascript'].indexOf(contentType) >= 0) {
       // javascript -- evaluate as-is
       response.text().then( (text) => {
+        // eslint-disable-next-line react-hooks/unsupported-syntax
         return(eval(text));
       });
     } else if (contentType === 'application/json') {


### PR DESCRIPTION
Extend on `eslint-plugin-react-hooks` recommended rules aka `Rules of React`
Most of the PR is safe changes such as change of functions declaration order, disabling linter rules for certain lines of code and shallow copies of vars.
Actual code change have `RegistrationForm.js` where `innerRef` was incorrectly defined, and `Section.jsx` where `usecallBack()` contract was violated.