### PR TITLE
CARDS-2837: Enable React Compiler (initial)

### DIFF
--- a/aggregated-frontend/src/main/frontend/package.json
+++ b/aggregated-frontend/src/main/frontend/package.json
@@ -28,7 +28,7 @@
     "@emotion/styled": "11.14.0",
     "@mui/icons-material": "7.1.0",
     "@mui/material": "7.1.0",
-    "react": "^19.0.0",
+    "react": "^19.2.0",
     "classnames": "2.5.1",
     "prop-types": "15.8.1",
     "luxon": "3.6.1",
@@ -38,7 +38,7 @@
     "cornerstone-core": "2.6.1",
     "cornerstone-wado-image-loader": "4.13.2",
     "dicom-parser": "1.8.21",
-    "react-dom": "^19.0.0",
+    "react-dom": "^19.2.0",
     "react-number-format": "5.4.3",
     "react-phone-input-2": "2.15.1",
     "react-google-autocomplete": "2.7.5",
@@ -85,10 +85,12 @@
     "@types/react": "19.1.0",
     "@types/react-dom": "19.1.0",
     "@typescript-eslint/parser": "8.46.2",
-    "@typescript-eslint/eslint-plugin": "8.46.2"
+    "@typescript-eslint/eslint-plugin": "8.46.2",
+    "react-compiler-webpack": "1.0.0",
+    "babel-plugin-react-compiler": "1.0.0"
   },
   "resolutions": {
     "@babel/runtime": "^7.27.1",
-    "react-is": "^19.0.0"
+    "react-is": "^19.2.0"
   }
 }

--- a/aggregated-frontend/src/main/frontend/webpack.config-template.js
+++ b/aggregated-frontend/src/main/frontend/webpack.config-template.js
@@ -55,7 +55,9 @@ const isProduction = process.argv.find(arg => arg.startsWith("--mode"))?.substri
  * @param {object} event - The compiler event object
  */
 function logCompilerEvent(filename, event) {
-  const shortFile = filename.replace(/^.*[\\/]/, '');
+  if (!event) return;
+  const filePath = filename ?? event.filename ?? event.file ?? event.path ?? "(unknown file)";
+  const fileName = filePath.replace(/^.*[\\/]/, '');
 
   const ANSI = {
     reset: '\x1b[0m',
@@ -79,9 +81,9 @@ function logCompilerEvent(filename, event) {
   const sep = `${ANSI.gray}${'-'.repeat(70)}${ANSI.reset}`;
   // If it's a skip/error but has no details, still log a minimal line
   console.log(sep);
-  console.log(`${ANSI.bold}${color}[React Compiler] ${kind} ${shortFile}${ANSI.reset}`);
+  console.log(`${ANSI.bold}${color}[React Compiler] ${kind} ${fileName}${ANSI.reset}`);
 
-  const options = event.detail.options;
+  const options = event.detail?.options;
   if (options) {
     const reason = options.reason;
     const category = options.category;
@@ -103,7 +105,9 @@ module.exports = (env) => {
     mode: 'development',
     devtool: 'eval-cheap-module-source-map',
     cache: {
-      type: 'filesystem'
+      type: 'filesystem',
+      // any change here invalidates the cache
+      version: String(Date.now())
     },
     infrastructureLogging: {
       level: 'error' // Mask Webpack infrastructure-level warnings to silence warning when React Compiler errors on serialisation of Webpack’s persistent cache

--- a/aggregated-frontend/src/main/frontend/webpack.config-template.js
+++ b/aggregated-frontend/src/main/frontend/webpack.config-template.js
@@ -138,7 +138,7 @@ ENTRY_CONTENT
             {
               loader: reactCompilerLoader,
               options: defineReactCompilerLoaderOption({
-                compilationMode : 'infer',
+                compilationMode : 'annotation',
                 logger: {
                   logEvent(filename, event) {
                     logCompilerEvent(filename, event);

--- a/aggregated-frontend/src/main/frontend/webpack.config-template.js
+++ b/aggregated-frontend/src/main/frontend/webpack.config-template.js
@@ -22,6 +22,7 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const { WebpackAssetsManifest } = require('webpack-assets-manifest');
 const TerserPlugin = require('terser-webpack-plugin');
 const ESLintPlugin = require('eslint-webpack-plugin');
+const { defineReactCompilerLoaderOption, reactCompilerLoader } = require('react-compiler-webpack');
 
 /*
  * Webpack 5.25.0 changed how the code is generated to no longer return the module by default when eval-ing it.
@@ -55,6 +56,9 @@ module.exports = (env) => {
     cache: {
       type: 'filesystem'
     },
+    infrastructureLogging: {
+      level: 'error' // Mask Webpack infrastructure-level warnings to silence warning when React Compiler errors on serialisation of Webpack’s persistent cache
+    },
     entry: {
 ENTRY_CONTENT
     },
@@ -76,7 +80,20 @@ ENTRY_CONTENT
           test: /\.(js|jsx|ts|tsx)$/,
           exclude: /node_modules/,
           resolve: { fullySpecified: false }, // disable ESM fully specified
-          use: ['babel-loader']
+          use: [
+            { loader: 'babel-loader' },
+            {
+              loader: reactCompilerLoader,
+              options: defineReactCompilerLoaderOption({
+                compilationMode : 'infer',
+                logger: {
+                  logEvent(filename, event) {
+                    console.log(`[Compiler] ${event.kind}: ${filename}`);
+                  }
+                }
+              })
+            }
+          ]
         },
         {
           test:/\.css$/,

--- a/aggregated-frontend/src/main/frontend/webpack.config-template.js
+++ b/aggregated-frontend/src/main/frontend/webpack.config-template.js
@@ -49,6 +49,55 @@ module_name = require("./package.json").name + ".";
 
 const isProduction = process.argv.find(arg => arg.startsWith("--mode"))?.substring(7) == 'production';
 
+/**
+ * Helper function to format and log React Compiler events
+ * @param {string} filename - The full file path
+ * @param {object} event - The compiler event object
+ */
+function logCompilerEvent(filename, event) {
+  const shortFile = filename.replace(/^.*[\\/]/, '');
+
+  const ANSI = {
+    reset: '\x1b[0m',
+    bold: '\x1b[1m',
+    red: '\x1b[31m',
+    yellow: '\x1b[33m',
+    green: '\x1b[32m',
+    cyan: '\x1b[36m',
+    gray: '\x1b[90m',
+  };
+
+  const kind = event.kind;
+
+  if (kind !== 'CompileError' && kind !== 'CompileSkip') return;
+
+  const color =
+    kind === 'CompileError' ? ANSI.red :
+    kind === 'CompileSkip'  ? ANSI.yellow :
+    ANSI.cyan;
+
+  const sep = `${ANSI.gray}${'-'.repeat(70)}${ANSI.reset}`;
+  // If it's a skip/error but has no details, still log a minimal line
+  console.log(sep);
+  console.log(`${ANSI.bold}${color}[React Compiler] ${kind} ${shortFile}${ANSI.reset}`);
+
+  const options = event.detail.options;
+  if (options) {
+    const reason = options.reason;
+    const category = options.category;
+    const desc = options.description;
+    const suggestions = options.suggestions;
+    const message = options.details?.[0]?.message;
+    const loc = options.loc ? options.loc : options.details[0].loc;
+
+    if (reason || category) console.log(`[${category || "-"}]: ${reason || "-"}`);
+    if (message) console.log(`Message: ${message}`);
+    if (desc) console.log(`Description: ${desc}`);
+    if (suggestions) console.log('Suggestions:', suggestions);
+    if (loc) console.log(`${ANSI.bold}Location: Line ${loc.start.line}, Column ${loc.start.column}, identifierName ${loc.identifierName || "-"}${ANSI.reset}`);
+  }
+}
+
 module.exports = (env) => {
   return {
     mode: 'development',
@@ -70,8 +119,8 @@ ENTRY_CONTENT
       }),
       !env.quick && new ESLintPlugin({
         extensions: ['js', 'jsx', 'ts', 'tsx'],
-        emitWarning: true,   // show warnings in console but don’t fail build
-        failOnError: false,  // set true if you want to break build on lint error
+        emitWarning: false,   // Show warnings in ESLint output, not as webpack warnings
+        failOnError: true,  // Break build on ESLint error
       }),
     ],
     module: {
@@ -88,7 +137,7 @@ ENTRY_CONTENT
                 compilationMode : 'infer',
                 logger: {
                   logEvent(filename, event) {
-                    console.log(`[Compiler] ${event.kind}: ${filename}`);
+                    logCompilerEvent(filename, event);
                   }
                 }
               })

--- a/aggregated-frontend/src/main/frontend/yarn.lock
+++ b/aggregated-frontend/src/main/frontend/yarn.lock
@@ -134,10 +134,24 @@
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
+"@babel/code-frame@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.28.6.tgz#72499312ec58b1e2245ba4a4f550c132be4982f7"
+  integrity sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.28.5"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
 "@babel/compat-data@^7.22.6", "@babel/compat-data@^7.27.1", "@babel/compat-data@^7.27.2":
   version "7.27.2"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.27.2.tgz#4183f9e642fd84e74e3eea7ffa93a412e3b102c9"
   integrity sha512-TUtMJYRPyUb/9aU8f3K0mjmjf6M9N5Woshn2CS6nqJSeJtTtQcpLUXjGt9vbF8ZGff0El99sWkLgzwW3VXnxZQ==
+
+"@babel/compat-data@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.28.6.tgz#103f466803fa0f059e82ccac271475470570d74c"
+  integrity sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==
 
 "@babel/core@7.27.1", "@babel/core@^7.7.5":
   version "7.27.1"
@@ -181,6 +195,27 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
+"@babel/core@^7.28.5":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.28.6.tgz#531bf883a1126e53501ba46eb3bb414047af507f"
+  integrity sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==
+  dependencies:
+    "@babel/code-frame" "^7.28.6"
+    "@babel/generator" "^7.28.6"
+    "@babel/helper-compilation-targets" "^7.28.6"
+    "@babel/helper-module-transforms" "^7.28.6"
+    "@babel/helpers" "^7.28.6"
+    "@babel/parser" "^7.28.6"
+    "@babel/template" "^7.28.6"
+    "@babel/traverse" "^7.28.6"
+    "@babel/types" "^7.28.6"
+    "@jridgewell/remapping" "^2.3.5"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
 "@babel/eslint-parser@^7.19.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.27.1.tgz#e146fb2facef62c6c5d1a6fd07cfd79ee9f7b0f1"
@@ -212,6 +247,17 @@
     "@jridgewell/trace-mapping" "^0.3.28"
     jsesc "^3.0.2"
 
+"@babel/generator@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.28.6.tgz#48dcc65d98fcc8626a48f72b62e263d25fc3c3f1"
+  integrity sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==
+  dependencies:
+    "@babel/parser" "^7.28.6"
+    "@babel/types" "^7.28.6"
+    "@jridgewell/gen-mapping" "^0.3.12"
+    "@jridgewell/trace-mapping" "^0.3.28"
+    jsesc "^3.0.2"
+
 "@babel/helper-annotate-as-pure@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.1.tgz#4345d81a9a46a6486e24d069469f13e60445c05d"
@@ -232,6 +278,17 @@
   integrity sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==
   dependencies:
     "@babel/compat-data" "^7.27.2"
+    "@babel/helper-validator-option" "^7.27.1"
+    browserslist "^4.24.0"
+    lru-cache "^5.1.1"
+    semver "^6.3.1"
+
+"@babel/helper-compilation-targets@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz#32c4a3f41f12ed1532179b108a4d746e105c2b25"
+  integrity sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==
+  dependencies:
+    "@babel/compat-data" "^7.28.6"
     "@babel/helper-validator-option" "^7.27.1"
     browserslist "^4.24.0"
     lru-cache "^5.1.1"
@@ -312,6 +369,14 @@
     "@babel/traverse" "^7.27.1"
     "@babel/types" "^7.27.1"
 
+"@babel/helper-module-imports@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz#60632cbd6ffb70b22823187201116762a03e2d5c"
+  integrity sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==
+  dependencies:
+    "@babel/traverse" "^7.28.6"
+    "@babel/types" "^7.28.6"
+
 "@babel/helper-module-transforms@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.27.1.tgz#e1663b8b71d2de948da5c4fb2a20ca4f3ec27a6f"
@@ -329,6 +394,15 @@
     "@babel/helper-module-imports" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
     "@babel/traverse" "^7.28.3"
+
+"@babel/helper-module-transforms@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz#9312d9d9e56edc35aeb6e95c25d4106b50b9eb1e"
+  integrity sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.28.6"
+    "@babel/helper-validator-identifier" "^7.28.5"
+    "@babel/traverse" "^7.28.6"
 
 "@babel/helper-optimise-call-expression@^7.27.1":
   version "7.27.1"
@@ -413,6 +487,14 @@
     "@babel/template" "^7.27.2"
     "@babel/types" "^7.28.4"
 
+"@babel/helpers@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.28.6.tgz#fca903a313ae675617936e8998b814c415cbf5d7"
+  integrity sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==
+  dependencies:
+    "@babel/template" "^7.28.6"
+    "@babel/types" "^7.28.6"
+
 "@babel/parser@^7.24.4", "@babel/parser@^7.28.5":
   version "7.28.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.28.5.tgz#0b0225ee90362f030efd644e8034c99468893b08"
@@ -426,6 +508,13 @@
   integrity sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==
   dependencies:
     "@babel/types" "^7.27.1"
+
+"@babel/parser@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.28.6.tgz#f01a8885b7fa1e56dd8a155130226cd698ef13fd"
+  integrity sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==
+  dependencies:
+    "@babel/types" "^7.28.6"
 
 "@babel/plugin-bugfix-firefox-class-in-computed-class-key@^7.27.1":
   version "7.27.1"
@@ -1059,6 +1148,15 @@
     "@babel/parser" "^7.27.2"
     "@babel/types" "^7.27.1"
 
+"@babel/template@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.28.6.tgz#0e7e56ecedb78aeef66ce7972b082fce76a23e57"
+  integrity sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==
+  dependencies:
+    "@babel/code-frame" "^7.28.6"
+    "@babel/parser" "^7.28.6"
+    "@babel/types" "^7.28.6"
+
 "@babel/traverse@^7.23.2", "@babel/traverse@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.27.1.tgz#4db772902b133bbddd1c4f7a7ee47761c1b9f291"
@@ -1085,6 +1183,19 @@
     "@babel/types" "^7.28.5"
     debug "^4.3.1"
 
+"@babel/traverse@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.28.6.tgz#871ddc79a80599a5030c53b1cc48cbe3a5583c2e"
+  integrity sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==
+  dependencies:
+    "@babel/code-frame" "^7.28.6"
+    "@babel/generator" "^7.28.6"
+    "@babel/helper-globals" "^7.28.0"
+    "@babel/parser" "^7.28.6"
+    "@babel/template" "^7.28.6"
+    "@babel/types" "^7.28.6"
+    debug "^4.3.1"
+
 "@babel/types@^7.20.0", "@babel/types@^7.27.1", "@babel/types@^7.4.4":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.27.1.tgz#9defc53c16fc899e46941fc6901a9eea1c9d8560"
@@ -1092,6 +1203,14 @@
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
+
+"@babel/types@^7.26.0", "@babel/types@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.28.6.tgz#c3e9377f1b155005bcc4c46020e7e394e13089df"
+  integrity sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.28.5"
 
 "@babel/types@^7.27.3", "@babel/types@^7.28.4", "@babel/types@^7.28.5":
   version "7.28.5"
@@ -2457,6 +2576,13 @@ babel-plugin-polyfill-regenerator@^0.6.1:
   integrity sha512-7gD3pRadPrbjhjLyxebmx/WrFYcuSjZ0XbdUujQMZ/fcE9oeewk2U/7PCvez84UeuK3oSjmPZ0Ch0dlupQvGzw==
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.6.4"
+
+babel-plugin-react-compiler@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz#bdf7360a23a4d5ebfca090255da3893efd07425f"
+  integrity sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==
+  dependencies:
+    "@babel/types" "^7.26.0"
 
 bail@^2.0.0:
   version "2.0.2"
@@ -5741,12 +5867,21 @@ raphael@2.3.0:
   dependencies:
     eve-raphael "0.5.0"
 
-react-dom@^19.0.0:
-  version "19.1.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.1.0.tgz#133558deca37fa1d682708df8904b25186793623"
-  integrity sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==
+react-compiler-webpack@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-compiler-webpack/-/react-compiler-webpack-1.0.0.tgz#60fac1205100a3c771aad36c695853e71ffc4184"
+  integrity sha512-psMWf+k7psntYKTo6IdiQrERADKobtCrahfJ0QAsC+ccbqANKS/3go6+dLvYauUpMBpmrMlt5AqACRJZ4bKCtg==
   dependencies:
-    scheduler "^0.26.0"
+    "@babel/core" "^7.28.5"
+    "@babel/plugin-syntax-jsx" "^7.27.1"
+    "@babel/plugin-syntax-typescript" "^7.27.1"
+
+react-dom@^19.2.0:
+  version "19.2.3"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.3.tgz#f0b61d7e5c4a86773889fcc1853af3ed5f215b17"
+  integrity sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==
+  dependencies:
+    scheduler "^0.27.0"
 
 react-fast-compare@^2.0.1:
   version "2.0.4"
@@ -5761,10 +5896,10 @@ react-google-autocomplete@2.7.5:
     lodash.debounce "^4.0.8"
     prop-types "^15.5.0"
 
-react-is@^16.13.1, react-is@^16.7.0, react-is@^18.3.1, react-is@^19.0.0, react-is@^19.1.0:
-  version "19.1.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.1.0.tgz#805bce321546b7e14c084989c77022351bbdd11b"
-  integrity sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==
+react-is@^16.13.1, react-is@^16.7.0, react-is@^18.3.1, react-is@^19.1.0, react-is@^19.2.0:
+  version "19.2.3"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.2.3.tgz#eec2feb69c7fb31f77d0b5c08c10ae1c88886b29"
+  integrity sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==
 
 react-markdown@~9.0.1:
   version "9.0.3"
@@ -5838,10 +5973,10 @@ react-uid@^2.2.0:
   dependencies:
     tslib "^2.0.0"
 
-react@^19.0.0:
-  version "19.1.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.1.0.tgz#926864b6c48da7627f004795d6cce50e90793b75"
-  integrity sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==
+react@^19.2.0:
+  version "19.2.3"
+  resolved "https://registry.yarnpkg.com/react/-/react-19.2.3.tgz#d83e5e8e7a258cf6b4fe28640515f99b87cd19b8"
+  integrity sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==
 
 recharts-scale@^0.4.4:
   version "0.4.5"
@@ -6229,10 +6364,10 @@ safe-regex-test@^1.0.3, safe-regex-test@^1.1.0:
     es-errors "^1.3.0"
     is-regex "^1.2.1"
 
-scheduler@^0.26.0:
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.26.0.tgz#4ce8a8c2a2095f13ea11bf9a445be50c555d6337"
-  integrity sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==
+scheduler@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
+  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 schema-utils@^2.7.0:
   version "2.7.1"

--- a/modules/commons/src/main/frontend/src/components/DragAndDrop.jsx
+++ b/modules/commons/src/main/frontend/src/components/DragAndDrop.jsx
@@ -140,7 +140,7 @@ export default function DragAndDrop(props) {
   return (
     <div
       style={{ display: 'inline-block', position: 'relative', opacity: disabled ? 0.5 : 1 }}
-      onClick={handleClick.bind(this)}
+      onClick={handleClick}
       onKeyDown={handleKeyDown}
       role="button"
       tabIndex={disabled ? -1 : 0}
@@ -153,7 +153,7 @@ export default function DragAndDrop(props) {
         multiple={multifile}
         ref={inputRef}
         style={{ display: 'none' }}
-        onChange={onChangeFile.bind(this)}
+        onChange={onChangeFile}
         value=""
         disabled={disabled}
       />

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -47,6 +47,7 @@ const PROGRESS_SELECT_SUBJECT = 1;
  * @param {presetPath} string The questionnaire to use automatically, if any.
  */
 function NewFormDialog(props) {
+  "use no memo";
   const {
     classes,
     presetPath,

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/NewFormDialog.jsx
@@ -107,7 +107,7 @@ function NewFormDialog(props) {
 
     // Make a POST request to create a new form, with a randomly generated UUID
     const URL = "/Forms/" + uuidv4();
-    var request_data = new FormData();
+    let request_data = new FormData();
     request_data.append('jcr:primaryType', 'cards:Form');
     request_data.append('questionnaire', selectedQuestionnaire["@path"]);
     request_data.append('questionnaire@TypeHint', 'Reference');
@@ -380,7 +380,7 @@ function NewFormDialog(props) {
     enableBottomToolbar: false,
     rowCount: rowCount,
     state: {
-      rowSelection: { [selectedQuestionnaire?.["jcr:uuid"]]: true },
+      rowSelection: selectedQuestionnaire?.["jcr:uuid"] ? { [selectedQuestionnaire["jcr:uuid"]]: true } : {},
       globalFilter,
       isLoading,
       showProgressBars: isRefetching,

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -112,7 +112,7 @@ function UserDashboard(props) {
               enableBottomToolbar={creationExtensions.length > 5}
               enablePagination={creationExtensions.length > 5}
               getRowId={ (row) => row["jcr:uuid"] }
-              state={{ rowSelection: { [selectedRow?.["jcr:uuid"]]: true } }}
+              state={{ rowSelection: selectedRow?.["jcr:uuid"] ? { [selectedRow["jcr:uuid"]]: true } : {} }}
               initialState={{ showGlobalFilter: (creationExtensions.length > 5),
                 pagination: { pageSize: 10, pageIndex: 0 }
               }}

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/VariableAutocomplete.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/VariableAutocomplete.jsx
@@ -81,11 +81,13 @@ const useStyles = makeStyles()(theme => ({
 
 let VariableAutocomplete = (props) => {
   checkPropTypes(VariableAutocomplete, props);
+  const DEFAULT_GET_OPTION_VALUE = (option) => option?.uuid;
+  const DEFAULT_GET_OPTION_LABEL = (option) => option?.label;
   const {
     className,
     options,
-    getOptionValue = (option) => option?.uuid,
-    getOptionLabel = (option) => option?.label,
+    getOptionValue = DEFAULT_GET_OPTION_VALUE,
+    getOptionLabel = DEFAULT_GET_OPTION_LABEL,
     getOptionSecondaryLabel = () => {},
     onValueChanged = () => {},
     getHelperText = () => {},

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -243,16 +243,12 @@ let ComputedQuestion = (props) => {
 
         let expressionArguments = ["form", "setError"];
         let expressionValues = [form, (errorMessage) => expressionError = errorMessage];
-        const questionsArray = Array.from(questions.values());
-        for (let i = 0; i < questionsArray.length; i++) {
-          const question = questionsArray[i];
+        for(const question of questions.values()) {
           expressionArguments.push(question["argument"]);
           expressionValues.push(question["value"]);
         }
         result = new Function(expressionArguments, parsedExpression)(...expressionValues);
-        const isUndefined = typeof(result) === "undefined";
-        const isNaNNumber = typeof(result) === "number" && isNaN(result);
-        if (isUndefined || isNaNNumber) {
+        if (typeof(result) === "undefined" || (typeof(result) === "number" && isNaN(result))) {
           result = "";
         }
       }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ComputedQuestion.jsx
@@ -115,7 +115,7 @@ let ComputedQuestion = (props) => {
       newDisplayedValue =
         DateTimeUtilities.formatDateAnswer(dateFormat, newDisplayedValue, DateTimeUtilities.slingDateFormat);
     } else if (dataType === "vocabulary") {
-      var url = new URL("." + newDisplayedValue + ".info.json", window.location.origin);
+      let url = new URL("." + newDisplayedValue + ".info.json", window.location.origin);
       let showInfo = (status, data, params) => {
         if (status === null && data) {
           console.log("Setting value to " + data["label"]);
@@ -217,7 +217,7 @@ let ComputedQuestion = (props) => {
             "value": getQuestionValue(questionName, form, defaultValue, asArray) });
       }
 
-      missingValue &&= !isValueOptional;
+      missingValue = missingValue && !isValueOptional;
       if (missingValue) {
         // Exit early as the expression cannot be evaluated without all inputs
         return null;
@@ -243,12 +243,16 @@ let ComputedQuestion = (props) => {
 
         let expressionArguments = ["form", "setError"];
         let expressionValues = [form, (errorMessage) => expressionError = errorMessage];
-        for(const question of questions.values()) {
+        const questionsArray = Array.from(questions.values());
+        for (let i = 0; i < questionsArray.length; i++) {
+          const question = questionsArray[i];
           expressionArguments.push(question["argument"]);
           expressionValues.push(question["value"]);
         }
         result = new Function(expressionArguments, parsedExpression)(...expressionValues);
-        if (typeof(result) === "undefined" || (typeof(result) === "number" && isNaN(result))) {
+        const isUndefined = typeof(result) === "undefined";
+        const isNaNNumber = typeof(result) === "number" && isNaN(result);
+        if (isUndefined || isNaNNumber) {
           result = "";
         }
       }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/ConditionalSingle.jsx
@@ -57,9 +57,9 @@ export function isConditionalSatisfied(conditional, context) {
     // Invalid operation
     throw new Error("Invalid operation specified.")
   }
-  var dataType = TRANSFORMATIONS[conditional.dataType] ? conditional.dataType : 'text';
-  var operandA = getValue(conditional.operandA, context);
-  var operandB = getValue(conditional.operandB, context);
+  let dataType = TRANSFORMATIONS[conditional.dataType] ? conditional.dataType : 'text';
+  let operandA = getValue(conditional.operandA, context);
+  let operandB = getValue(conditional.operandB, context);
 
   return compare(operandA, operandB, dataType, conditional.comparator);
 }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/FileQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/FileQuestion.jsx
@@ -66,12 +66,13 @@ function FileQuestion(props) {
 
   // Default value of knownAnswers is the name of every field we can find in namePattern
   let initialParsedAnswers = {};
+  let varNames = [];
   if (namePattern) {
-    var varNamesRegex = /@{(.+?)}/g;
-    var varNames = [...namePattern.matchAll(varNamesRegex)].map((match) => match[1]);
+    let varNamesRegex = /@{(.+?)}/g;
+    varNames = [...namePattern.matchAll(varNamesRegex)].map((match) => match[1]);
 
-    var clearedNamesRegex = namePattern.replaceAll(varNamesRegex, "(.+)");
-    var nameRegex = new RegExp(clearedNamesRegex);
+    let clearedNamesRegex = namePattern.replaceAll(varNamesRegex, "(.+)");
+    let nameRegex = new RegExp(clearedNamesRegex);
 
     // Match each of the values into our default initialParsedAnswers
     initialValues.forEach((filename) => {
@@ -187,7 +188,7 @@ function FileQuestion(props) {
     // Determine whether or not the filename matches the namePattern (if given)
     if (namePattern) {
       // Regex out variable names from the namePattern
-      var results = file['name'].match(nameRegex)?.slice(1);
+      let results = file['name'].match(nameRegex)?.slice(1);
 
       // At this point, results contains each match, which all correspond to their respective entry in varNames
       writer((oldCommands) => {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 import Close from "@mui/icons-material/Close";
 import {
@@ -152,7 +152,7 @@ function MultipleChoice(props) {
     element => {return String(element[VALUE_POS]) === String(ghostValue) || element[LABEL_POS] === ghostName}
   );
   const disabled = maxAnswers > 1 && selection.length >= maxAnswers;
-  let inputEl = null;
+  const inputElRef = useRef(null);
   const [separatorDetectionEnabled, setSeparatorDetectionEnabled] = useState(enableSeparatorDetection);
   const [separatorDetected, setSeparatorDetected] = useState(false);
   const [assistantAnchor, setAssistantAnchor] = useState(null);
@@ -314,7 +314,7 @@ function MultipleChoice(props) {
   let acceptOption = (valToAccept, labelToAccept) => {
     if (isRadio || isBare) {
       selectOption(valToAccept, labelToAccept) && setGhostName("");
-      inputEl?.blur();
+      inputElRef.current?.blur();
     } else if (maxAnswers !== 1 && !error && valToAccept !== "") {
       // If we can select multiple and are not in error, add this option (if not already available) and ensure it's selected
       addOption(valToAccept, labelToAccept);
@@ -468,7 +468,7 @@ function MultipleChoice(props) {
           value={ghostName ?? ''}
           multiline={textbox}
           minRows={textbox ? 4 : undefined}
-          inputRef={ref => {inputEl = ref}}
+          inputRef={inputElRef}
         />
       }
       { maxAnswers !== 1 && separatorDetectionEnabled &&
@@ -496,7 +496,7 @@ function MultipleChoice(props) {
   }
 
   // Remove the ["", ""] unless there are only zero or one answer items
-  var answers = selection.map(item => item[VALUE_POS] === GHOST_SENTINEL ? [item[LABEL_POS], item[LABEL_POS]] : item);
+  let answers = selection.map(item => item[VALUE_POS] === GHOST_SENTINEL ? [item[LABEL_POS], item[LABEL_POS]] : item);
   answers = ((answers.length < 2) ? answers : answers.filter(item => item[LABEL_POS] !== ''));
 
   // When counting current answers for proper highlighting of answer instructions to the user, exclude the empty one
@@ -609,7 +609,7 @@ function MultipleChoice(props) {
                             onUpdate?.(ghostSelected ? undefined : ghostName);
                             handleFormDataChange?.();
                           }}
-                          onClick={() => inputEl && inputEl.select()}
+                          onClick={() => inputElRef.current?.select()}
                           disabled={!ghostSelected && disabled}
                           className={classes.ghostRadiobox}
                         />
@@ -705,7 +705,7 @@ function generateDefaultOptions(
   });
 }
 
-var StyledResponseChild = withStyles(ResponseChild, QuestionnaireStyle);
+let StyledResponseChild = withStyles(ResponseChild, QuestionnaireStyle);
 
 // One option (either a checkbox or radiobox as appropriate)
 function ResponseChild(props) {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/NCRNote.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/NCRNote.jsx
@@ -32,31 +32,33 @@ const ONTOLOGY_KEY = "hp_id";
 function ParsedNoteSection (props) {
   let { classes, onAddSuggestion, tooltips, text, offset } = props;
   let hasMatch = tooltips.length > 0;
-  let frontMatter = text;
-  if (hasMatch) {
-    var matches = tooltips.sort( (e1, e2) => (e1.start-e2.start) );
-    var firstMatch = matches[0];
-    // The front matter is the text before the first match begins
-    frontMatter = text.substring(0, firstMatch.start-offset);
-    var matchID = firstMatch[ONTOLOGY_KEY]; // TODO: Handle more than just HPO
-    var matchName = firstMatch["names"][0];
 
-    // The contained matter is the text inside the first match
-    var containedMatches = matches.filter( (el) => (
-      el.start >= firstMatch.start && el.end <= firstMatch.end
-        && !(el.start == firstMatch.start && el.end == firstMatch.end)
-    ));
-    var containedMatter = text.substring(firstMatch.start-offset, firstMatch.end-offset);
-
-    // The uncontained matter is the text after the first match, up until the end of the last match
-    // (It still needs to be parsed for more notes)
-    var uncontainedMatches = matches.filter( (el) => (el.end > firstMatch.end));
-    var lastMatch = Math.max(...(tooltips.map((el) => (el.end))));
-    var middleMatter = text.substring(firstMatch.end-offset, lastMatch-offset);
-
-    // The end matter is the text after the last match
-    var endMatter = text.substring(lastMatch-offset);
+  if (!hasMatch) {
+    return <Typography display="inline">{text}</Typography>;
   }
+
+  let matches = tooltips.sort( (e1, e2) => (e1.start-e2.start) );
+  let firstMatch = matches[0];
+  // The front matter is the text before the first match begins
+  let frontMatter = text.substring(0, firstMatch.start-offset);
+  let matchID = firstMatch[ONTOLOGY_KEY]; // TODO: Handle more than just HPO
+  let matchName = firstMatch["names"][0];
+
+  // The contained matter is the text inside the first match
+  let containedMatches = matches.filter( (el) => (
+    el.start >= firstMatch.start && el.end <= firstMatch.end
+      && !(el.start == firstMatch.start && el.end == firstMatch.end)
+  ));
+  let containedMatter = text.substring(firstMatch.start-offset, firstMatch.end-offset);
+
+  // The uncontained matter is the text after the first match, up until the end of the last match
+  // (It still needs to be parsed for more notes)
+  let uncontainedMatches = matches.filter( (el) => (el.end > firstMatch.end));
+  let lastMatch = Math.max(...(tooltips.map((el) => (el.end))));
+  let middleMatter = text.substring(firstMatch.end-offset, lastMatch-offset);
+
+  // The end matter is the text after the last match
+  let endMatter = text.substring(lastMatch-offset);
 
   // Handle the user clicking on a chip which corresponds to a suggestion
   let addSuggestion = (event) => {
@@ -66,34 +68,31 @@ function ParsedNoteSection (props) {
 
   return (<>
     <Typography display="inline">{frontMatter}</Typography>
-    {hasMatch &&
-      <>
-        <Tooltip title={`Add ${matchName} (${matchID}) to selection`}>
-          <Chip
-            size="small"
-            onClick={addSuggestion}
-            color="info"
-            label={
-              <ParsedNoteSection
-                tooltips={containedMatches}
-                text={containedMatter}
-                offset={firstMatch.start}
-                classes={classes}
-                onAddSuggestion={onAddSuggestion}
-              />
-            }
+    <Tooltip title={`Add ${matchName} (${matchID}) to selection`}>
+      <Chip
+        size="small"
+        onClick={addSuggestion}
+        color="info"
+        label={
+          <ParsedNoteSection
+            tooltips={containedMatches}
+            text={containedMatter}
+            offset={firstMatch.start}
+            classes={classes}
+            onAddSuggestion={onAddSuggestion}
           />
-        </Tooltip>
-        <ParsedNoteSection
-          tooltips={uncontainedMatches}
-          text={middleMatter}
-          offset={firstMatch.end}
-          classes={classes}
-          onAddSuggestion={onAddSuggestion}
-        />
-        <Typography display="inline">{endMatter}</Typography>
-      </>}
-  </>)
+        }
+      />
+    </Tooltip>
+    <ParsedNoteSection
+      tooltips={uncontainedMatches}
+      text={middleMatter}
+      offset={firstMatch.end}
+      classes={classes}
+      onAddSuggestion={onAddSuggestion}
+    />
+    <Typography display="inline">{endMatter}</Typography>
+  </>);
 }
 
 function NCRNote (props) {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/PedigreeQuestion.jsx
@@ -57,16 +57,16 @@ function PedigreeQuestion(props) {
   // FIXME: hardcoded value
   const PEDIGREE_THUMBNAIL_WIDTH = 300;
 
-  var resizeSVG = function(svgText, newWidthInPixels) {
+  let resizeSVG = function(svgText, newWidthInPixels) {
     const newWidth = "$1width=\"" + newWidthInPixels + "px\"";
-    var resizedSVG = svgText?.replace(/(<svg[^>]+)height="\d+"/, "$1");
+    let resizedSVG = svgText?.replace(/(<svg[^>]+)height="\d+"/, "$1");
     resizedSVG = resizedSVG.replace(/(<svg[^>]+)width="\d+"/, newWidth);
     return resizedSVG;
   };
 
-  var pedigreeJSON = null;
-  var pedigreeSVG  = null;
-  var displayedImage = '';
+  let pedigreeJSON = null;
+  let pedigreeSVG  = null;
+  let displayedImage = '';
 
   if (pedigreeData?.image && pedigreeData.pedigreeJSON) {
     // use pedigree stored in React component state:
@@ -83,13 +83,14 @@ function PedigreeQuestion(props) {
     pedigreeJSON ? [["value", pedigreeJSON]] : []
   , [pedigreeJSON]);
 
-  var image_div = <div className={classes.thumbnail} dangerouslySetInnerHTML={{ __html: displayedImage }}/>;
+  let image_div = <div className={classes.thumbnail} dangerouslySetInnerHTML={{ __html: displayedImage }}/>;
 
-  var closeDialog = function () {
+  let closeDialog = function () {
     setExpanded(false);
   };
 
-  var openPedigree = function () {
+  let openPedigree = function () {
+    // eslint-disable-next-line react-hooks/immutability
     window.pedigreeEditor = new PedigreeEditor({
       "pedigreeJSON": pedigreeJSON,
       "pedigreeDiv": "pedigreeEditor",  // the DIV to render entire pedigree in
@@ -98,13 +99,13 @@ function PedigreeQuestion(props) {
       "readOnlyMode": false });
   };
 
-  var closePedigree = function () {
+  let closePedigree = function () {
     window.pedigreeEditor.unload();
     typeof(props.onChange) == 'function' && props.onChange();
     delete window.pedigreeEditor;
   };
 
-  var onUpdatedPedigree = function (pedigreeJSON, pedigreeSVG) {
+  let onUpdatedPedigree = function (pedigreeJSON, pedigreeSVG) {
     // state change will trigger re-render
     setPedigree({ "image": pedigreeSVG, "pedigreeJSON": pedigreeJSON });
   };

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
@@ -75,7 +75,7 @@ let Questionnaire = (props) => {
   let baseUrl = /((.*)\/Questionnaires)\/([^.]+)/.exec(location.pathname)[1];
   let id = /Questionnaires\/([^.]+)/.exec(location.pathname)[1];
   let questionnaireUrl = `${baseUrl}/${id}`;
-  let isEdit = window.location.pathname.endsWith(".edit");
+  let isEdit = location.pathname.endsWith(".edit");
   let navigate = useNavigate();
 
   let pageNameWriter = usePageNameWriterContext();

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireAutocomplete.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnaireAutocomplete.jsx
@@ -90,12 +90,13 @@ let entitySpecs = {
 // TODO: Don't actually need entity.uuid ?
 function QuestionnaireAutocomplete(props) {
   checkPropTypes(QuestionnaireAutocomplete, props);
+  const DEFAULT_GET_OPTION_VALUE = (option) => option?.path;
   const {
     multiple = false,
     entities,
     selection = [],
     onSelectionChanged = () => {},
-    getOptionValue = (option) => option?.path,
+    getOptionValue = DEFAULT_GET_OPTION_VALUE,
     placeholderText = 'Select an option',
     ...rest
   } = props;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SessionExpiryWarningModal.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SessionExpiryWarningModal.jsx
@@ -35,9 +35,11 @@ import { checkPropTypes } from "../propTypes";
  */
 function SessionExpiryWarningModal(props) {
   checkPropTypes(SessionExpiryWarningModal, props);
+  const DEFAULT_ACTIVE_LENGTH = 29 * 60 * 1000;
+  const DEFAULT_COUNTDOWN_LENGTH = 2 * 60 * 1000;
   const {
-    activeLength = 29 * 60 * 1000,
-    countdownLength = 2 * 60 * 1000,
+    activeLength = DEFAULT_ACTIVE_LENGTH,
+    countdownLength = DEFAULT_COUNTDOWN_LENGTH,
     lastActivityTimestamp,
     onStay,
     onExit,
@@ -68,7 +70,7 @@ function SessionExpiryWarningModal(props) {
     const warningTimer = setTimeout(() => {
       // Restart the countdown timer
       setCountdown(countdownLength);
-      var timeLeft = countdownLength;
+      let timeLeft = countdownLength;
       countdownTimer && clearInterval(countdownTimer);
       // display a modal alert that the session will expire soon
       setOpen(true);

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectSelector.jsx
@@ -188,7 +188,7 @@ function UnstyledNewSubjectDialog (props) {
             getRowId={ (row) => row["label"] }
             rowCount={rowCount}
             state={{
-              rowSelection: { [newSubjectType?.["label"]]: true },
+              rowSelection: newSubjectType?.["label"] ? { [newSubjectType["label"]]: true } : {},
               globalFilter,
               isLoading,
               pagination,
@@ -369,7 +369,7 @@ function UnstyledSelectParentDialog (props) {
               onPaginationChange={setPagination}
               rowCount={rowCount}
               state={{
-                rowSelection: { [value?.["jcr:uuid"]]: true },
+                rowSelection: value?.["jcr:uuid"] ? { [value["jcr:uuid"]]: true } : {},
                 globalFilter,
                 isLoading,
                 pagination,
@@ -1127,7 +1127,7 @@ function SubjectSelectorList(props) {
         getRowId={ (row) => row["jcr:uuid"] }
         rowCount={rowCount}
         state={{
-          rowSelection: { [selectedSubject?.["jcr:uuid"]]: true },
+          rowSelection: selectedSubject?.["jcr:uuid"] ? { [selectedSubject["jcr:uuid"]]: true } : {},
           globalFilter,
           isLoading,
           pagination,

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/AnswerOptions.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/AnswerOptions.jsx
@@ -243,7 +243,7 @@ let AnswerOptions = (props) => {
       newOption.label = inputs[1] ? inputs[1].trim() : "";
       newOption.isNew = true;
       setOptions(oldValue => {
-        var value = oldValue.slice();
+        let value = oldValue.slice();
         value.push(newOption);
         return value;
       });
@@ -368,7 +368,7 @@ let AnswerOptions = (props) => {
       specialOptionsInfo[descriptionIndex].setter({ ...specialOptionsInfo[descriptionIndex].data, "description": description });
     } else {
       setOptions(oldValue => {
-        var value = oldValue.slice();
+        let value = oldValue.slice();
         value[descriptionIndex].description = description;
         return value;
       });

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/DroppableAnswerOption.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/DroppableAnswerOption.jsx
@@ -174,7 +174,7 @@ function DroppableAnswerOption(props) {
               checked={value.isDefault}
               onChange={(event) => {
                 setOptions(old => {
-                  var _new = old.slice();
+                  let _new = old.slice();
                   _new[index].isDefault = !!(event?.target?.checked);
                   return _new;
                 });

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditDialog.jsx
@@ -56,6 +56,8 @@ let EditDialog = (props) => {
   let [ error, setError ] = useState('');
   let [ variableNameError, setVariableNameError ] = useState('');
 
+  // Dynamic require - webpack warning is expected for this pattern
+  // Critical dependency: the request of a dependency is an expression
   let json = model ? require(`./${model}`) : require(`./${type}.json`);
   let hints = null;
   try {
@@ -98,7 +100,7 @@ let EditDialog = (props) => {
 
     } else {
       // If the entry doesn't exist, create it
-      var request_data = new FormData(event.currentTarget);
+      let request_data = new FormData(event.currentTarget);
       request_data.append('jcr:primaryType', primaryType);
       fetchWithReLogin(globalLoginDisplay,
         `${data['@path']}/${targetId}`,

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/NewQuestionnaireDialog.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/NewQuestionnaireDialog.jsx
@@ -43,7 +43,7 @@ function NewQuestionnaireDialog(props) {
 
     // Make a POST request to create a new questionnaire, with a randomly generated UUID
     const URL = "/Questionnaires/" + uuidv4();
-    var request_data = new FormData();
+    let request_data = new FormData();
     request_data.append('jcr:primaryType', 'cards:Questionnaire');
     request_data.append('title', title);
     fetch( URL, { method: 'POST', body: request_data })

--- a/modules/data-entry/src/main/frontend/src/vocabQuery/VocabularyQuery.jsx
+++ b/modules/data-entry/src/main/frontend/src/vocabQuery/VocabularyQuery.jsx
@@ -58,18 +58,18 @@ function VocabularyQuery(props) {
   // Callback onSuccess/onFailure when all requests have responded
   let makeMultiRequest = (queue, input, statuses, prevData, onSuccess, onFailure) => {
     // Get vocabulary to search through
-    var selectedVocab = queue.pop();
+    let selectedVocab = queue.pop();
     if (selectedVocab === undefined) {
       // Finished making all the requests and received all responses
       onFetchDone(statuses, prevData, onSuccess, onFailure);
       return;
     }
-    var url = new URL(`./${selectedVocab}.search.json`, REST_URL);
+    let url = new URL(`./${selectedVocab}.search.json`, REST_URL);
     url.searchParams.set("suggest", input.replace(/[^\w\s]/g, ' '));
 
     //Are there any filters that should be associated with this request?
     if (questionDefinition?.vocabularyFilters?.[selectedVocab]) {
-      var filter = questionDefinition.vocabularyFilters[selectedVocab].map((category) => {
+      let filter = questionDefinition.vocabularyFilters[selectedVocab].map((category) => {
         return (`term_category:${category}`);
       }).join(" OR ");
       url.searchParams.set("customFilter", `(${filter})`);
@@ -83,14 +83,14 @@ function VocabularyQuery(props) {
 
   // Fetch suggestions for the given input
   let fetchSuggestions = (input, onSuccess, onFailure) => {
-    var vocabQueue = questionDefinition.sourceVocabularies.slice();
+    let vocabQueue = questionDefinition.sourceVocabularies.slice();
     makeMultiRequest(vocabQueue, input, {}, [], onSuccess, onFailure);
   }
 
   // Process the statuses from all the requests to call the appropriate handler
   let onFetchDone = (statuses, data, onSuccess, onFailure) => {
-    var allRequestsFailed = Object.keys(statuses).filter(vocab => !statuses[vocab]).length == 0;
-    var allRequestsSucceded = Object.keys(statuses).filter(vocab => statuses[vocab]).length == 0;
+    let allRequestsFailed = Object.keys(statuses).filter(vocab => !statuses[vocab]).length == 0;
+    let allRequestsSucceded = Object.keys(statuses).filter(vocab => statuses[vocab]).length == 0;
 
     if (!allRequestsFailed && !allRequestsSucceded) {
       data.splice(0, 0, {
@@ -114,9 +114,9 @@ function VocabularyQuery(props) {
       "@path" : element["@path"],
       matchedFields : []
     };
-    var name = element["label"] || element["name"] || element["identifier"];
-    var synonyms = element["synonym"] || element["has_exact_synonym"] || [];
-    var definition = Array.from(element["def"] || element["description"] || element["definition"] || [])[0] || "";
+    let name = element["label"] || element["name"] || element["identifier"];
+    let synonyms = element["synonym"] || element["has_exact_synonym"] || [];
+    let definition = Array.from(element["def"] || element["description"] || element["definition"] || [])[0] || "";
 
     suggestion.label = name;
     if (name.toLowerCase() == query.toLowerCase() || synonyms.find(s => s.toLowerCase() == query.toLowerCase())) {

--- a/modules/google-apis/src/main/frontend/src/GoogleApiKeyAdminPage.jsx
+++ b/modules/google-apis/src/main/frontend/src/GoogleApiKeyAdminPage.jsx
@@ -56,7 +56,7 @@ export default function GoogleApiKeyAdminPage() {
   // function to create / edit node
   function updateKey() {
     const URL = `/libs/cards/conf/GoogleApiKey`;
-    var request_data = new FormData();
+    let request_data = new FormData();
     request_data.append('key', googleApiKey);
     fetchWithReLogin(globalLoginDisplay, URL, { method: 'POST', body: request_data })
       .then((response) => response.ok ? response : Promise.reject(response))

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/Navbar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/Navbar.jsx
@@ -27,7 +27,7 @@ function Header({ ...props }) {
   const { classes, color } = props;
 
   return (
-    <AppBar className={classNames(classes.appbar, classes[color])}>
+    <AppBar className={classNames(classes.appBar, classes[color])}>
       <Toolbar className={classes.container}>
         <div className={classes.flex} />
         {/* While the screen is wide enough, display the navbar at the topright */}

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/Navbar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/Navbar.jsx
@@ -25,13 +25,9 @@ import { checkPropTypes } from "../../propTypes";
 function Header({ ...props }) {
   checkPropTypes(Header, props);
   const { classes, color } = props;
-  const colorClass = " " + classes[color];
-  const appBarClasses = classNames({
-    [colorClass]: color
-  });
 
   return (
-    <AppBar className={classes.appBar + appBarClasses}>
+    <AppBar className={classNames(classes.appbar, classes[color])}>
       <Toolbar className={classes.container}>
         <div className={classes.flex} />
         {/* While the screen is wide enough, display the navbar at the topright */}

--- a/modules/homepage/src/main/frontend/src/themePage/Navbars/Navbar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Navbars/Navbar.jsx
@@ -25,8 +25,9 @@ import { checkPropTypes } from "../../propTypes";
 function Header({ ...props }) {
   checkPropTypes(Header, props);
   const { classes, color } = props;
+  const colorClass = " " + classes[color];
   const appBarClasses = classNames({
-    [" " + classes[color]]: color
+    [colorClass]: color
   });
 
   return (

--- a/modules/homepage/src/main/frontend/src/themePage/QuickSearchConfiguration.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/QuickSearchConfiguration.jsx
@@ -48,7 +48,7 @@ function QuickSearchConfiguration(props) {
   let buildConfigData = (formData) => {
     formData.append('limit', limit);
     formData.append('showTotalRows', showTotalRows);
-    for (var i in allowedResourceTypes) {
+    for (let i in allowedResourceTypes) {
       formData.append('allowedResourceTypes', allowedResourceTypes[i]);
     }
   }

--- a/modules/homepage/src/main/frontend/src/themePage/Sidebar/Sidebar.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/Sidebar/Sidebar.jsx
@@ -37,6 +37,12 @@ const Sidebar = ({ ...props }) => {
   let [entries, setEntries] = useState();
   let [loading, setLoading] = useState(true);
 
+  let buildSidebar = (extensions) => {
+    let result = extensions.slice()
+      .sort((a, b) => a["cards:defaultOrder"] - b["cards:defaultOrder"]);
+    setEntries(result);
+  };
+
   useEffect(() => {
     loadExtensions("SidebarEntry")
       .then(buildSidebar)
@@ -44,20 +50,16 @@ const Sidebar = ({ ...props }) => {
       .finally(() => setLoading(false));
   }, []);
 
-  var buildSidebar = (extensions) => {
-    let result = extensions.slice()
-      .sort((a, b) => a["cards:defaultOrder"] - b["cards:defaultOrder"]);
-    setEntries(result);
-  };
-
   // Generate NavLinks and ListItems from the given entry
   // activeStyle is true for anything that should look "active" (e.g. the admin link, the current page)
   function generateListItem(entry, key, activeStyle) {
+    const colorClass = " " + classes[color];
+    const whiteFontClass = " " + classes.whiteFont;
     const listBackground = classNames({
-      [" " + classes[color]]: activeStyle
+      [colorClass]: activeStyle
     });
     const listItemFont = classNames({
-      [" " + classes.whiteFont]: activeStyle
+      [whiteFontClass]: activeStyle
     });
     const EntryIcon = entry["cards:icon"];
 
@@ -81,7 +83,7 @@ const Sidebar = ({ ...props }) => {
     );
   }
   // Links
-  var links = (
+  let links = (
     <List className={classes.list}>
       {loading ?
         /* Add some skeleton UI of varying heights */
@@ -99,7 +101,7 @@ const Sidebar = ({ ...props }) => {
     </List>
   );
 
-  var adminLinks = (
+  let adminLinks = (
     <List className={classes.adminSidebar}>
       {loading ? <></>
         : entries.filter(entry => _isAdministrativeButton(entry["cards:defaultOrder"]))
@@ -114,7 +116,7 @@ const Sidebar = ({ ...props }) => {
   );
 
   // Setup the div containing the logo at the top of the sidebar
-  var brand = (
+  let brand = (
     <div className={classes.logo}>
       <a
         href="/"

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
@@ -166,7 +166,7 @@ function PatientIdentification(props) {
   }
 
   const identify = () => {
-    if (!dob.isValid || !mrn && !hc) {
+    if (!dob?.isValid || (!mrn && !hc)) {
       return null;
     }
     let requestData = new FormData();
@@ -182,7 +182,7 @@ function PatientIdentification(props) {
   // On submitting the patient login form, make a request to identify the patient
   const onSubmit = (event) => {
     event?.preventDefault();
-    if (!dob.isValid || !mrn && !hc) {
+    if (!dob?.isValid || (!mrn && !hc)) {
       setError("Date of birth and either MRN or Health Card Number are required for patient identification");
       return;
     }

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/AddUserToGroupDialog.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/AddUserToGroupDialog.jsx
@@ -38,6 +38,7 @@ import userboardStyle from '../userboardStyle.jsx';
 const GROUP_URL="/system/userManager/group/";
 
 function AddUserToGroupDialog(props) {
+  "use no memo";
   checkPropTypes(AddUserToGroupDialog, props);
   const { classes, name, allUsers, groupUsers, reload, isOpen, handleClose } = props;
 

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/AddUserToGroupDialog.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/AddUserToGroupDialog.jsx
@@ -49,7 +49,7 @@ function AddUserToGroupDialog(props) {
     let formData = new FormData();
 
     let selectedUsers = Object.keys(table?.getState().rowSelection);
-    for (var i = 0; i < selectedUsers.length; ++i) {
+    for (let i = 0; i < selectedUsers.length; ++i) {
       formData.append(':member', freeUsers[selectedUsers[i]].name);
     }
 
@@ -71,7 +71,7 @@ function AddUserToGroupDialog(props) {
   let handleEntering = () => {
     setFreeUsers(allUsers);
     if (Array.isArray(groupUsers)) {
-      var groupUsersArray = groupUsers.map((n) => n.name);
+      let groupUsersArray = groupUsers.map((n) => n.name);
       let filtered = allUsers.filter(el => !groupUsersArray.includes( el.name ));
       setFreeUsers(filtered);
     }

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/GroupsManager.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/GroupsManager.jsx
@@ -195,7 +195,7 @@ function GroupsManager(props) {
 
     let usersToRemove = users ? users : Object.keys(table.getState().rowSelection).map(user => groupUsers[user].name);
     if (usersToRemove.length == 0) return;
-    for (var i = 0; i < usersToRemove.length; ++i) {
+    for (let i = 0; i < usersToRemove.length; ++i) {
       formData.append(':member@Delete', usersToRemove[i]);
     }
 

--- a/modules/variants/src/main/frontend/src/VariantFilesContainer.jsx
+++ b/modules/variants/src/main/frontend/src/VariantFilesContainer.jsx
@@ -277,7 +277,7 @@ export default function VariantFilesContainer() {
   //   -- or same tuples of tumor-patient subjects where parent is patient,
   //   -- or same tuples of region-tumor subjects, where parent is tumor.
   let setExistedFileSubjectData = (file, files) => {
-    for (var i in files) {
+    for (let i in files) {
       let fileEl = files[i];
       if (file.name === fileEl.name) { continue; }
 
@@ -668,7 +668,7 @@ export default function VariantFilesContainer() {
       data.append(filePath, file);
       data.append(filePath + "/@TypeHint", "nt:file");
 
-      var xhr = new XMLHttpRequest();
+      let xhr = new XMLHttpRequest();
       xhr.open('POST', '/');
 
       xhr.onload = function() {

--- a/modules/vocabularies/src/main/frontend/src/BioportalApiKey.jsx
+++ b/modules/vocabularies/src/main/frontend/src/BioportalApiKey.jsx
@@ -79,7 +79,7 @@ export function BioPortalApiKey(props) {
   // function to create / edit node
   function addNewKey() {
     const URL = `/libs/cards/conf/BioportalApiKey`;
-    var request_data = new FormData();
+    let request_data = new FormData();
     request_data.append('key', customApiKey);
     fetchWithReLogin(globalLoginDisplay, URL, { method: 'POST', body: request_data })
       .then((response) => response.ok ? response : Promise.reject(response))

--- a/modules/vocabularies/src/main/frontend/src/VocabulariesAdminPage.jsx
+++ b/modules/vocabularies/src/main/frontend/src/VocabulariesAdminPage.jsx
@@ -89,15 +89,15 @@ export default function VocabulariesAdminPage() {
   }
 
   function addSetter(acronym, setFunction, type) {
-    let copy = { ...acronymPhaseSettersObject };
-    if (Object.hasOwn(copy, acronym)) {
-      copy[acronym] = { ...copy[acronym], [type]: setFunction };
-    } else {
-      let temp = {};
-      temp[type] = setFunction;
-      copy[acronym] = temp;
-    }
-    setAcronymPhaseSettersObject(copy);
+    setAcronymPhaseSettersObject(prev => {
+      const copy = { ...prev };
+      if (Object.hasOwn(copy, acronym)) {
+        copy[acronym] = { ...copy[acronym], [type]: setFunction };
+      } else {
+        copy[acronym] = { [type]: setFunction };
+      }
+      return copy;
+    });
   }
 
   function setPhase(acronym, phase) {

--- a/modules/vocabularies/src/main/frontend/src/VocabulariesAdminPage.jsx
+++ b/modules/vocabularies/src/main/frontend/src/VocabulariesAdminPage.jsx
@@ -89,11 +89,11 @@ export default function VocabulariesAdminPage() {
   }
 
   function addSetter(acronym, setFunction, type) {
-    var copy = acronymPhaseSettersObject;
+    let copy = { ...acronymPhaseSettersObject };
     if (Object.hasOwn(copy, acronym)) {
-      copy[acronym][type] = setFunction;
+      copy[acronym] = { ...copy[acronym], [type]: setFunction };
     } else {
-      var temp = {};
+      let temp = {};
       temp[type] = setFunction;
       copy[acronym] = temp;
     }
@@ -106,7 +106,7 @@ export default function VocabulariesAdminPage() {
       setters[key]?.(phase);
     }
     // update acronyms object
-    let phases = acronymPhaseObject;
+    let phases = { ...acronymPhaseObject };
     phases[acronym] = phase;
     setAcronymPhaseObject(phases);
   }
@@ -115,7 +115,7 @@ export default function VocabulariesAdminPage() {
      All others have the default not installed phase
   */
   function setPhases() {
-    var tempAcronymPhaseObject = {};
+    let tempAcronymPhaseObject = {};
 
     localVocabList.map((vocab) => {
       tempAcronymPhaseObject[vocab.acronym] = Phase["Latest"]; // default
@@ -141,7 +141,7 @@ export default function VocabulariesAdminPage() {
     const acronym = vocab.acronym;
 
     if (action === "add") {
-      var tempLocalVocabList = localVocabList.slice();
+      let tempLocalVocabList = localVocabList.slice();
       // find out if we already have this vocab installed and update it
       // in case we are updating one
       let installedIndex = localVocabList.findIndex(item => item.acronym == vocab.acronym);
@@ -153,11 +153,19 @@ export default function VocabulariesAdminPage() {
       setLocalVocabList(tempLocalVocabList);
 
     } else if (action === "remove") {
-      var copy = acronymPhaseSettersObject;
-      delete copy[acronym]["local"];
+      let copy = { ...acronymPhaseSettersObject };
+      if (copy[acronym]) {
+        // eslint-disable-next-line no-unused-vars
+        const { local, ...rest } = copy[acronym];
+        if (Object.keys(rest).length > 0) {
+          copy[acronym] = rest;
+        } else {
+          delete copy[acronym];
+        }
+      }
       setAcronymPhaseSettersObject(copy);
 
-      let phases = acronymPhaseObject;
+      let phases = { ...acronymPhaseObject };
       delete phases[acronym];
       setAcronymPhaseObject(phases);
 

--- a/modules/vocabularies/src/main/frontend/src/VocabularyAction.jsx
+++ b/modules/vocabularies/src/main/frontend/src/VocabularyAction.jsx
@@ -131,7 +131,8 @@ export default function VocabularyAction(props) {
             aggregatedQuestions = aggregatedQuestions.concat(getVocabularyQuestions(data, questionnaire.title));
           })
           .finally(() => {
-            if (++i == questionnairesData.length) {
+            i = i + 1;
+            if (i == questionnairesData.length) {
               setLinkedQuestions(aggregatedQuestions);
               setDisplayPopup(true);
             }

--- a/modules/vocabularies/src/main/frontend/src/VocabularyDirectory.jsx
+++ b/modules/vocabularies/src/main/frontend/src/VocabularyDirectory.jsx
@@ -79,7 +79,7 @@ export default function VocabularyDirectory(props) {
   // Function that fetches list of Vocabularies with meta info from Bioontology API
   function getFullVocabList(existingVocabList) {
     setCurStatus(Status["Loading"]);
-    var badResponse = false;
+    let badResponse = false;
     fetch(props.link)
       .then((response) => response.ok ? response.json() : Promise.reject(response))
       .then(function(data) {

--- a/modules/vocabularies/src/main/frontend/src/VocabularySearch.jsx
+++ b/modules/vocabularies/src/main/frontend/src/VocabularySearch.jsx
@@ -36,7 +36,7 @@ import { fetchWithReLogin, GlobalLoginContext } from "./login/ReLoginDialog.js";
 const vocabLinks = require('./vocabularyLinks.json');
 
 function extractList(data) {
-  var acronymList = [];
+  let acronymList = [];
   if(Array.isArray(data)) {
     data.map((result) => {
       result.ontologies.map((ontology) => {


### PR DESCRIPTION
Initial PR includes some easy obvious error fixes.
To see Compiler logs build and observe errors reported at the `cards-aggregated-frontend` stage.
Note:
- not all `var` changed to `let` due to linter errors emerging after change. New linter errors require refactorings and left to be addressed in separate smaller individual PRs.
- changes in this PR fixing Compiler errors and some small easy to fix associated linter errors like in MultipleChoice.jsx. 

The [incremental adoption strategy](https://react.dev/learn/react-compiler/incremental-adoption) for React Compiler was decided for the transition safety