### PR TITLE
CARDS-2826: The googleApiKey servlet should be accessible to unauthenticated users

### DIFF
--- a/modules/google-apis/src/main/java/io/uhndata/cards/googleapis/GoogleApiKeyServlet.java
+++ b/modules/google-apis/src/main/java/io/uhndata/cards/googleapis/GoogleApiKeyServlet.java
@@ -37,7 +37,8 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @version $Id$
  */
-@Component(service = { Servlet.class })
+@Component(service = { Servlet.class },
+    property = { "sling.auth.requirements=-/content.googleApiKey", "sling.auth.requirements=-/.googleApiKey" })
 @SlingServletResourceTypes(
     resourceTypes = { "cards/Homepage" },
     methods = { "GET" },


### PR DESCRIPTION
To test:
- build, start
- unauthenticated, access `http://localhost:8080/content.googleApiKey` and `http://localhost:8080/.googleApiKey`, expect to see a JSON instead of the login page
- login as admin, change the Google API Key from the administration
- logout, access the two pages above, make sure the right key is present in the JSON