### PR TITLE
CARDS-2839: NPE logged when configuring and unconfiguring the Google API key

### DIFF
--- a/modules/google-apis/src/main/java/io/uhndata/cards/googleapis/DefaultGoogleApiKeyManager.java
+++ b/modules/google-apis/src/main/java/io/uhndata/cards/googleapis/DefaultGoogleApiKeyManager.java
@@ -75,8 +75,10 @@ public class DefaultGoogleApiKeyManager implements GoogleApiKeyManager
             Resource res = this.rrp.getThreadResourceResolver().resolve(resourcePath);
             if (!res.isResourceType(Resource.RESOURCE_TYPE_NON_EXISTING)) {
                 Node keyNode = res.adaptTo(Node.class);
-                apiKey = keyNode.getProperty("key").getString();
-                LOGGER.debug("Google API key as set in the GoogleApiKey node: [{}]", apiKey);
+                if (keyNode.hasProperty("key")) {
+                    apiKey = keyNode.getProperty("key").getString();
+                    LOGGER.debug("Google API key as set in the GoogleApiKey node: [{}]", apiKey);
+                }
             }
         } catch (Exception e) {
             LOGGER.error("Failed to load Google API key from node: {}", e.getMessage(), e);


### PR DESCRIPTION
To test:
- build, start, login
- configure a non-empty Google API Key in the administration, save (doesn't have to be a working key, any string will do)
- clear the key, save
- reload the page, check that there are no errors related to the key in the java error log