### PR TITLE
[misc] Remove wrong maxAnswers property

### DIFF
--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ResourceTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/ResourceTest.xml
@@ -310,11 +310,6 @@
 			<type>String</type>
 		</property>
 		<property>
-			<name>maxAnswers</name>
-			<value>0</value>
-			<type>Long</type>
-		</property>
-		<property>
 			<name>primaryType</name>
 			<value>cards:Question</value>
 			<type>String</type>


### PR DESCRIPTION
A `maxAnswers=0` was added to this question in commit 7da921b for CARDS-2357 . However, this question, whose text says "Pick or search for ONE question..." already had `maxAnswers=1` which is overwritten by this one. Removing `maxAnswers=0`.