### PR TITLE
CARDS-2843: NPE at startup and when running healtcheck due to duplicate jasypt library

### DIFF
--- a/modules/email-notifications/src/main/features/feature.json
+++ b/modules/email-notifications/src/main/features/feature.json
@@ -45,10 +45,6 @@
       "start-order":"25"
     },
     {
-      "id":"org.jasypt:jasypt:1.9.3",
-      "start-order":"25"
-    },
-    {
       "id":"org.apache.servicemix.bundles:org.apache.servicemix.bundles.jasypt:1.9.3_1",
       "start-order":"25"
     },


### PR DESCRIPTION
To test:
- build docker images for this and YourExp
- use cards-deplo-tool to configure yourexp with the test smtps proxy: `python3 generate_compose_yaml.py --mssql --cards_docker_image cards/cards4yourexperience:latest --oak_filesystem --dev_docker_image --smtps --smtps_test_container --smtps_test_mail_path ~/cardsmail --composum`
- start it, create a sample patient (with email address and consent) and a sample OCPE visit two days ago
- change the email schedule to send emails right away
- check that the invitation email is stored in the mail dump file
- visit `http://localhost:8080/system/health` and check that the `Bundles Started` check is successful
