### PR TITLE
[misc] Fix console warning regarding prop type mismatch in MultipleChoice

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
@@ -518,7 +518,7 @@ function NumberQuestion(props) {
               onUpdate={text => setMinMaxError(getMinMaxValueError(text))}
               additionalInputProps={textFieldProps}
               muiInputProps={muiInputProps}
-              error={!disableMinMaxValueEnforcement && minMaxError}
+              error={!disableMinMaxValueEnforcement && !!minMaxError}
               existingAnswer={existingAnswer}
               pageActive={pageActive}
               validate={disableMinMaxValueEnforcement ? value => !getMinMaxValueError(value) : undefined}


### PR DESCRIPTION
NumberQuestion sends a string value to the `error` prop of MultipleChoice when the entered value is out of the established range, when that prop expects a boolean.

To test:
* create a questionnaire with a year-only DateQuestion or a NumberQuestion with a minValue and maxValue
* create a form
* open dev tools
* enter an out of range value as the answer to that question
* before the fix, there will be a console warning:

```
Warning: Failed prop type: Invalid prop `error` of type `string` supplied to `MultipleChoice`, expected `boolean`
```

* after the fix there should be no more warning.