### PR TITLE
CARDS-2849: Test mode should include patient portal and locking by default

### DIFF
--- a/start_cards.sh
+++ b/start_cards.sh
@@ -306,7 +306,7 @@ do
     unset ARGS[$i]
     ARGS[$ARGS_LENGTH]=-f
     ARGS_LENGTH=${ARGS_LENGTH}+1
-    ARGS[$ARGS_LENGTH]=mvn:io.uhndata.cards/cards-modules-test-forms/${CARDS_VERSION}/slingosgifeature
+    ARGS[$ARGS_LENGTH]=mvn:io.uhndata.cards/cards-modules-test-forms/${CARDS_VERSION}/slingosgifeature,mvn:io.uhndata.cards/cards-email-notifications/${CARDS_VERSION}/slingosgifeature,mvn:io.uhndata.cards/cards-patient-portal/${CARDS_VERSION}/slingosgifeature,mvn:io.uhndata.cards/cards-locking/${CARDS_VERSION}/slingosgifeature
     ARGS_LENGTH=${ARGS_LENGTH}+1
   elif [[ ${ARGS[$i]} == '--saml' ]]
   then


### PR DESCRIPTION
To test: build and start with `start.sh --test --dev`, check that the Visit and Patient Information questionnaires are present, and that locking is present on subject pages.