### PR TITLE
CARDS-2850: Add sample clinics to test runmode

### DIFF
--- a/test-resources/pom.xml
+++ b/test-resources/pom.xml
@@ -44,6 +44,13 @@
             <Sling-Initial-Content>
               SLING-INF/content/Questionnaires/;path:=/Questionnaires/;overwriteProperties:=true;uninstall:=true;checkin:=true,
               SLING-INF/content/Subjects/;path:=/Subjects/;uninstall:=true;checkin:=true,
+              SLING-INF/content/Survey/Dates.xml;path:=/Survey/Dates;overwrite:=true,
+              SLING-INF/content/Survey/Pagination.xml;path:=/Survey/Pagination;overwrite:=true,
+              SLING-INF/content/Survey/Sections.xml;path:=/Survey/Sections;overwrite:=true,
+              SLING-INF/content/Survey/ClinicMapping.xml;path:=/Survey/ClinicMapping;overwrite:=true,
+              SLING-INF/content/Survey/PatientAccess.xml;path:=/Survey/PatientAccess;overwrite:=true,
+              SLING-INF/content/Survey/TermsOfUse.xml;path:=/Survey/TermsOfUse;overwrite:=true,
+              SLING-INF/content/Survey/SurveyInstructions.xml;path:=/Survey/SurveyInstructions;overwrite:=true,
             </Sling-Initial-Content>
           </instructions>
         </configuration>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/DateConditionalTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/DateConditionalTest.xml
@@ -34,6 +34,7 @@
 		<name>requiredSubjectTypes</name>
 		<values>
 			<value>/SubjectTypes/Patient</value>
+			<value>/SubjectTypes/Patient/Visit</value>
 		</values>
 		<type>Reference</type>
 	</property>
@@ -49,6 +50,11 @@
 			<name>dataType</name>
 			<value>date</value>
 			<type>String</type>
+		</property>
+		<property>
+			<name>minAnswers</name>
+			<value>1</value>
+			<type>Long</type>
 		</property>
 	</node>
 	<node>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/DateFormatsTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/DateFormatsTest.xml
@@ -34,6 +34,7 @@
 		<name>requiredSubjectTypes</name>
 		<values>
 			<value>/SubjectTypes/Patient</value>
+			<value>/SubjectTypes/Patient/Visit</value>
 		</values>
 		<type>Reference</type>
 	</property>
@@ -57,6 +58,11 @@
 		</property>
 		<property>
 			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>minAnswers</name>
 			<value>1</value>
 			<type>Long</type>
 		</property>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/LabeledConditionalSections.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/LabeledConditionalSections.xml
@@ -34,6 +34,7 @@
 		<name>requiredSubjectTypes</name>
 		<values>
 			<value>/SubjectTypes/Patient</value>
+			<value>/SubjectTypes/Patient/Visit</value>
 		</values>
 		<type>Reference</type>
 	</property>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/PaginationTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/PaginationTest.xml
@@ -44,6 +44,7 @@ Page 4: **Follow-up and surveillance**, displayed when *Vital status* is *Alive 
 		<name>requiredSubjectTypes</name>
 		<values>
 			<value>/SubjectTypes/Patient</value>
+			<value>/SubjectTypes/Patient/Visit</value>
 		</values>
 		<type>Reference</type>
 	</property>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/RecurringSectionTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/RecurringSectionTest.xml
@@ -34,6 +34,7 @@
 		<name>requiredSubjectTypes</name>
 		<values>
 			<value>/SubjectTypes/Patient</value>
+			<value>/SubjectTypes/Patient/Visit</value>
 		</values>
 		<type>Reference</type>
 	</property>

--- a/test-resources/src/main/resources/SLING-INF/content/Survey/ClinicMapping.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Survey/ClinicMapping.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2022-2026 DATA @ UHN. See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<node>
+    <name>ClinicMapping</name>
+    <primaryNodeType>cards:ClinicMappingFolder</primaryNodeType>
+    <property>
+        <name>childNodeType</name>
+        <value>cards:ClinicMapping</value>
+        <type>String</type>
+    </property>
+    <node>
+        <name>111111</name>
+        <primaryNodeType>cards:ClinicMapping</primaryNodeType>
+        <property>
+            <name>clinicName</name>
+            <value>SectionTests</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>survey</name>
+            <value>Sections</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>displayName</name>
+            <value>Section Testing Forms</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>sidebarLabel</name>
+            <value>Section Test</value>
+            <type>String</type>
+        </property>
+    </node>
+    <node>
+        <name>222222</name>
+        <primaryNodeType>cards:ClinicMapping</primaryNodeType>
+        <property>
+            <name>clinicName</name>
+            <value>Pagination</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>survey</name>
+            <value>Pagination</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>displayName</name>
+            <value>Pagination Testing Form</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>sidebarLabel</name>
+            <value>Pagination Test</value>
+            <type>String</type>
+        </property>
+    </node>
+    <node>
+        <name>333333</name>
+        <primaryNodeType>cards:ClinicMapping</primaryNodeType>
+        <property>
+            <name>clinicName</name>
+            <value>Dates</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>survey</name>
+            <value>Dates</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>displayName</name>
+            <value>Date Testing Forms</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>sidebarLabel</name>
+            <value>Date Test</value>
+            <type>String</type>
+        </property>
+    </node>
+</node>

--- a/test-resources/src/main/resources/SLING-INF/content/Survey/Dates.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Survey/Dates.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2022-2026 DATA @ UHN. See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<node>
+    <name>Dates</name>
+    <primaryNodeType>cards:QuestionnaireSet</primaryNodeType>
+    <property>
+        <name>name</name>
+        <value></value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>intro</name>
+        <value>
+Test forms for dates
+        </value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>frequencyIgnoreClinic</name>
+        <value>True</value>
+        <type>Boolean</type>
+    </property>
+    <node>
+        <name>Date Format Test</name>
+        <primaryNodeType>cards:QuestionnaireRef</primaryNodeType>
+        <property>
+            <name>questionnaire</name>
+            <value>/Questionnaires/DateFormatsTest</value>
+            <type>Reference</type>
+        </property>
+        <property>
+            <name>estimate</name>
+            <value>5</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>frequency</name>
+            <value>26</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>order</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
+    </node>
+    <node>
+        <name>Date Conditional Test</name>
+        <primaryNodeType>cards:QuestionnaireRef</primaryNodeType>
+        <property>
+            <name>questionnaire</name>
+            <value>/Questionnaires/DateConditionalTest</value>
+            <type>Reference</type>
+        </property>
+        <property>
+            <name>estimate</name>
+            <value>5</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>frequency</name>
+            <value>26</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>order</name>
+            <value>2</value>
+            <type>Long</type>
+        </property>
+    </node>
+</node>

--- a/test-resources/src/main/resources/SLING-INF/content/Survey/Pagination.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Survey/Pagination.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2022-2026 DATA @ UHN. See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<node>
+    <name>Pagination</name>
+    <primaryNodeType>cards:QuestionnaireSet</primaryNodeType>
+    <property>
+        <name>name</name>
+        <value></value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>intro</name>
+        <value>
+Test forms for pagination
+        </value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>frequencyIgnoreClinic</name>
+        <value>True</value>
+        <type>Boolean</type>
+    </property>
+    <node>
+        <name>Pagination Test</name>
+        <primaryNodeType>cards:QuestionnaireRef</primaryNodeType>
+        <property>
+            <name>questionnaire</name>
+            <value>/Questionnaires/PaginationTest</value>
+            <type>Reference</type>
+        </property>
+        <property>
+            <name>estimate</name>
+            <value>5</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>frequency</name>
+            <value>26</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>order</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
+    </node>
+</node>

--- a/test-resources/src/main/resources/SLING-INF/content/Survey/PatientAccess.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Survey/PatientAccess.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2022-2026 DATA @ UHN. See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<node>
+    <name>PatientAccess</name>
+    <property>
+        <name>tokenlessAuthEnabled</name>
+        <value>False</value>
+        <type>Boolean</type>
+    </property>
+    <property>
+        <name>PIIAuthRequired</name>
+        <value>False</value>
+        <type>Boolean</type>
+    </property>
+    <property>
+        <name>daysRelativeToEventWhileSurveyIsValid</name>
+        <value>30</value>
+        <type>Long</type>
+    </property>
+</node>

--- a/test-resources/src/main/resources/SLING-INF/content/Survey/Sections.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Survey/Sections.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2022-2026 DATA @ UHN. See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<node>
+    <name>Sections</name>
+    <primaryNodeType>cards:QuestionnaireSet</primaryNodeType>
+    <property>
+        <name>name</name>
+        <value></value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>intro</name>
+        <value>
+Test forms for various section types
+        </value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>frequencyIgnoreClinic</name>
+        <value>True</value>
+        <type>Boolean</type>
+    </property>
+    <node>
+        <name>Compact Sections Test</name>
+        <primaryNodeType>cards:QuestionnaireRef</primaryNodeType>
+        <property>
+            <name>questionnaire</name>
+            <value>/Questionnaires/CompactSectionsTest</value>
+            <type>Reference</type>
+        </property>
+        <property>
+            <name>estimate</name>
+            <value>5</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>frequency</name>
+            <value>26</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>order</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
+    </node>
+    <node>
+        <name>Recurring Sections Test</name>
+        <primaryNodeType>cards:QuestionnaireRef</primaryNodeType>
+        <property>
+            <name>questionnaire</name>
+            <value>/Questionnaires/RecurringSectionTest</value>
+            <type>Reference</type>
+        </property>
+        <property>
+            <name>estimate</name>
+            <value>5</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>frequency</name>
+            <value>26</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>order</name>
+            <value>2</value>
+            <type>Long</type>
+        </property>
+    </node>
+    <node>
+        <name>Labeled Conditional Section Test</name>
+        <primaryNodeType>cards:QuestionnaireRef</primaryNodeType>
+        <property>
+            <name>questionnaire</name>
+            <value>/Questionnaires/LabeledConditionalSections</value>
+            <type>Reference</type>
+        </property>
+        <property>
+            <name>estimate</name>
+            <value>5</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>frequency</name>
+            <value>26</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>order</name>
+            <value>2</value>
+            <type>Long</type>
+        </property>
+    </node>
+</node>

--- a/test-resources/src/main/resources/SLING-INF/content/Survey/SurveyInstructions.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Survey/SurveyInstructions.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2022-2026 DATA @ UHN. See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<node>
+    <name>SurveyInstructions</name>
+    <property>
+        <name>welcomeMessage</name>
+        <value>
+Sample welcome message
+        </value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>noEventsMessage</name>
+        <value></value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>eventSelectionMessage</name>
+        <value></value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>eventLabel</name>
+        <value></value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>noSurveysMessage</name>
+        <value></value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>surveySubmittedMessage</name>
+        <value></value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>enableStartScreen</name>
+        <value>True</value>
+        <type>Boolean</type>
+    </property>
+    <property>
+        <name>greeting</name>
+        <value>Sample Greeting</value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>surveyIntro</name>
+        <value></value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>surveyDraftInfo</name>
+        <value></value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>enableReviewScreen</name>
+        <value>True</value>
+        <type>Boolean</type>
+    </property>
+    <property>
+        <name>disclaimer</name>
+        <value></value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>summaryInstructions</name>
+        <value>
+Thank you for filling out these test forms
+        </value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>interpretationInstructions</name>
+        <value></value>
+        <type>String</type>
+    </property>
+</node>

--- a/test-resources/src/main/resources/SLING-INF/content/Survey/TermsOfUse.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Survey/TermsOfUse.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2022-2026 DATA @ UHN. See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<node>
+    <name>TermsOfUse</name>
+    <property>
+        <name>title</name>
+        <value>Sample Terms of Use</value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>version</name>
+        <value>2026-02-11</value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>acceptanceRequired</name>
+        <value>False</value>
+        <type>Boolean</type>
+    </property>
+    <property>
+        <name>text</name>
+        <value>
+## Example Terms of Use
+
+In an actual project, this would contain a lot more text, so here is some lorum ipsum
+
+### 1. Purpose
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur volutpat dolor quis felis gravida, cursus porttitor ligula viverra. Phasellus sodales ipsum a ante porttitor, sit amet varius mauris vulputate. Phasellus vel mauris metus. Quisque euismod dui magna, sit amet pretium risus porta in. Integer ac fermentum tellus. Donec sed sem gravida, molestie velit vel, tincidunt massa. Proin imperdiet mauris a mi sagittis, vitae lacinia nisi ornare. Duis accumsan lorem sed iaculis pretium. Fusce hendrerit neque odio, at vulputate libero ullamcorper ut. Proin et auctor dui. Morbi molestie tortor ut ligula accumsan, eu dapibus metus vehicula.
+
+Sed dictum ex elit, placerat luctus nunc molestie sit amet. Sed ipsum magna, porttitor id ipsum eget, ultrices vestibulum diam. In hac habitasse platea dictumst. Nullam condimentum pulvinar justo, venenatis vulputate elit blandit id. In hac habitasse platea dictumst. Aliquam consequat non arcu sit amet ornare. Suspendisse potenti. Pellentesque et eros molestie justo mollis tincidunt nec sit amet tortor. Aliquam a maximus ligula.
+
+### 2. Data Collection
+
+Phasellus ante neque, maximus ac commodo quis, aliquet id nulla. Sed et nibh vel felis interdum gravida in nec nunc. Pellentesque feugiat eu ipsum quis imperdiet. Morbi feugiat pharetra nisi, ut condimentum nulla finibus ut. Vestibulum ut tristique tortor, et tempus justo. Curabitur efficitur sapien massa, vitae tempus elit consequat vitae. Vestibulum aliquet libero odio, eu euismod tortor dapibus sed. Maecenas mi est, consequat vitae sem ac, accumsan vehicula metus. Sed eros lacus, rhoncus ac libero vel, varius molestie turpis. Ut luctus mauris ut ullamcorper dignissim. Vestibulum dictum lobortis turpis ut blandit. Proin auctor metus ut cursus sollicitudin. Maecenas ut turpis diam. Pellentesque sollicitudin velit ligula, sed fringilla arcu rutrum non. In hac habitasse platea dictumst.
+
+Nullam ac libero sem. Cras facilisis ultrices est eget molestie. Aliquam nec magna et erat blandit pretium sagittis in mauris. Mauris sed diam consequat, venenatis enim non, bibendum turpis. Pellentesque semper fermentum cursus. Integer malesuada auctor justo, a ornare purus condimentum ut. Ut et eleifend velit.
+
+### 3. Limitations
+
+Fusce dapibus eros quis faucibus consequat. In porttitor tincidunt porta. Suspendisse ut nulla eu nibh fermentum tristique sit amet vel neque. Vivamus vitae lorem id dui ultricies tempor a vel est. Curabitur leo sapien, laoreet vitae turpis ultricies, iaculis elementum ante. Ut sit amet ultrices dui. Proin et urna at felis tristique tempor vel vitae orci.
+        </value>
+        <type>String</type>
+    </property>
+
+</node>


### PR DESCRIPTION
- Adds 3 sample clinics, with 1 - 3 questionnaires each
  - Date test clinic with 2 questionnaires
  - Section test clinic with 3 questionnaires
  - Pagination test clinic with 1 questionnaire
- Adds configuration for patient portal: Sample survey instructions, Patient access configuration, example ToS
- Update date test questionnaires to include a mandatory question so patient portal works with them
- Update a few other test questionnaires to support visit subject types