### PR TITLE
CARDS-2853 - Patient portal: the patient ui should display branding info similar to the default ui

### DIFF
--- a/modules/patient-portal/src/main/frontend/assets.config
+++ b/modules/patient-portal/src/main/frontend/assets.config
@@ -3,6 +3,7 @@
 ['patient-portal.LandingPage']: './src/patient-portal/LandingPage.jsx'
 ['patient-portal.PatientPortalIndex']: './src/patient-portal/index.jsx'
 ['patient-portal.Unsubscribe']: './src/patient-portal/Unsubscribe.jsx'
+['patient-portal.BrandInfo']: './src/patient-portal/BrandInfo.jsx'
 ['patient-portal.ToULink']: './src/patient-portal/ToULink.jsx'
 ['patient-portal.UnsubscribeLink']: './src/patient-portal/UnsubscribeLink.jsx'
 ['patient-portal.ClinicForms']: { 'dependOn': ['cards-dataentry.LiveTable'], 'import': './src/patient-portal/ClinicForms.jsx' }

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/BrandInfo.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/BrandInfo.jsx
@@ -1,0 +1,53 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import {
+  Link,
+  Typography
+} from "@mui/material";
+
+function BrandInfo () {
+
+  return (
+    <Typography component="span" variant="body2">
+      Built with <Link
+        href="https://cards.uhndata.io"
+        title="Clinical Archive for Data Science"
+        target="_blank"
+        rel="noreferrer"
+        underline="hover"
+      >
+        CARDS
+      </Link> by <Link
+        href="https://uhndata.io"
+        title="DATA Team @ UHN"
+        target="_blank"
+        rel="noreferrer"
+      >
+        <img
+          src="/libs/cards/resources/media/default/data-logo_light_bg.png"
+          alt="DATA"
+          style={{ height: "0.8em" }}
+        />
+      </Link>
+    </Typography>
+  );
+}
+
+export default BrandInfo;

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/BrandInfo.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/BrandInfo.jsx
@@ -27,7 +27,7 @@ function BrandInfo () {
   return (
     <Typography component="span" variant="body2">
       Built with <Link
-        href="https://cards.uhndata.io"
+        href="https://github.com/data-team-uhn/cards/"
         title="Clinical Archive for Data Science"
         target="_blank"
         rel="noreferrer"

--- a/modules/patient-portal/src/main/resources/SLING-INF/content/Extensions/Footer/Brand.json
+++ b/modules/patient-portal/src/main/resources/SLING-INF/content/Extensions/Footer/Brand.json
@@ -1,0 +1,7 @@
+{
+  "jcr:primaryType": "cards:Extension",
+  "cards:extensionPointId": "patient-portal/footer",
+  "cards:extensionName": "Brand",
+  "cards:extensionRenderURL": "asset:patient-portal.BrandInfo.js",
+  "cards:defaultOrder": 30
+}


### PR DESCRIPTION
https://phenotips.atlassian.net/browse/CARDS-2853

This branch also includes changes for [CARDS-2851](https://phenotips.atlassian.net/browse/CARDS-2851) (hide the footer on survey screens) and [CARDS-2852](https://phenotips.atlassian.net/browse/CARDS-2852) (responsive footer).

To test, go through the usual patient survey workflow and check the appearance of the footer on all screens, using different screen widths.

Preview:

<img width="1116" height="1244" alt="image" src="https://github.com/user-attachments/assets/e24c60b2-f5fe-4205-98eb-d156ffe56886" />

<img width="576" height="1272" alt="image" src="https://github.com/user-attachments/assets/81e7f598-fff9-48d6-98ce-8725b498cdd1" />


[CARDS-2851]: https://phenotips.atlassian.net/browse/CARDS-2851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CARDS-2852]: https://phenotips.atlassian.net/browse/CARDS-2852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ