### PR TITLE
CARDS-2817: Add healthcheck rules ensuring that CARDS is running well

### DIFF
--- a/distribution/src/main/features/core/healthcheck-cards.json
+++ b/distribution/src/main/features/core/healthcheck-cards.json
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+{
+    "prototype":{
+        "id": "io.uhndata.cards:cards-healthcheck:slingosgifeature:${project.version}"
+    }
+}

--- a/distribution/src/main/features/healthcheck.json
+++ b/distribution/src/main/features/healthcheck.json
@@ -26,7 +26,8 @@
         "org.apache.felix.hc.generalchecks.BundlesStartedCheck":{
             "hc.tags":[
                 "bundles"
-            ]
+            ],
+            "useCriticalForInactive": true
         },
         "org.apache.felix.hc.generalchecks.CpuCheck":{
             "hc.tags":[

--- a/modules/healthcheck/pom.xml
+++ b/modules/healthcheck/pom.xml
@@ -26,35 +26,17 @@
     <version>0.9.37-SNAPSHOT</version>
   </parent>
 
-  <artifactId>cards-utils</artifactId>
+  <artifactId>cards-healthcheck</artifactId>
   <packaging>bundle</packaging>
-  <name>CARDS - Utilities</name>
-
-  <properties>
-    <coverage.instructionRatio>0.04</coverage.instructionRatio>
-  </properties>
+  <name>CARDS - Healthcheck</name>
+  <description>Extra healthchecks specific to CARDS to plug into the Apache Felix HealthCheck system.</description>
 
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Include-Resource>{maven-resources}</Include-Resource>
-            <Sling-Initial-Content>
-              SLING-INF/content/libs/cards/conf/;path:=/libs/cards/conf/;overwrite:=false,
-              SLING-INF/content/libs/cards/healthcheck/;path:=/libs/cards/healthcheck/;overwriteProperties:=true,
-            </Sling-Initial-Content>
-          </instructions>
-        </configuration>
       </plugin>
     </plugins>
   </build>
@@ -65,54 +47,62 @@
       <artifactId>org.apache.sling.api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.sling</groupId>
-      <artifactId>org.apache.sling.scripting.sightly.runtime</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.sling</groupId>
-      <artifactId>org.apache.sling.servlets.post</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.sling</groupId>
-      <artifactId>org.apache.sling.servlets.annotations</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.json</groupId>
-      <artifactId>javax.json-api</artifactId>
+      <groupId>javax.jcr</groupId>
+      <artifactId>jcr</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
+      <groupId>org.osgi</groupId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.jcr</groupId>
-      <artifactId>jcr</artifactId>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.healthcheck.api</artifactId>
+      <version>2.0.4</version>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.uhndata.cards</groupId>
-      <artifactId>cards-data-model-forms-api</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
 
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.testing.sling-mock.core</artifactId>
+      <version>3.2.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
+      <version>3.2.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.testing.sling-mock-oak</artifactId>
+      <version>3.1.2-1.40.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.testing.jcr-mock</artifactId>
+      <version>1.5.4</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/modules/healthcheck/src/main/features/feature.json
+++ b/modules/healthcheck/src/main/features/feature.json
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+{
+  "bundles":[
+    {
+      "id":"${project.groupId}:${project.artifactId}:${project.version}",
+      "start-order":"15"
+    }
+  ],
+  "configurations":{
+    "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~locking":{
+      "user.mapping":[
+        "io.uhndata.cards.healthcheck:healthcheck=[sling-readall]"
+      ]
+    }
+  }
+}

--- a/modules/healthcheck/src/main/java/io/uhndata/cards/healthcheck/internal/DuplicateJarsHealthCheck.java
+++ b/modules/healthcheck/src/main/java/io/uhndata/cards/healthcheck/internal/DuplicateJarsHealthCheck.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.healthcheck.internal;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.felix.hc.api.FormattingResultLog;
+import org.apache.felix.hc.api.HealthCheck;
+import org.apache.felix.hc.api.Result;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Check that there are no duplicate jars.
+ *
+ * @version $Id$
+ * @since 0.9.37
+ */
+@Component(service = HealthCheck.class,
+    property = { HealthCheck.TAGS + "=cards", HealthCheck.NAME + "=CARDS duplicate jars" }, immediate = true)
+public class DuplicateJarsHealthCheck implements HealthCheck
+{
+    private BundleContext context;
+
+    @Activate
+    protected void activate(BundleContext bundleContext)
+    {
+        this.context = bundleContext;
+    }
+
+    @Override
+    public Result execute()
+    {
+        final FormattingResultLog result = new FormattingResultLog();
+        final Set<String> seen = new HashSet<>();
+        int count = 0;
+        final Bundle[] allBundles = this.context.getBundles();
+        if (allBundles == null || allBundles.length == 0) {
+            return new Result(Result.Status.HEALTH_CHECK_ERROR, "No bundles found!");
+        }
+        for (Bundle bundle : allBundles) {
+            count++;
+            if (!seen.add(bundle.getSymbolicName())) {
+                result.warn("Possible duplicate jar: {}", bundle.getSymbolicName());
+            }
+        }
+        result.info("Checked {} bundles", count);
+        return new Result(result);
+    }
+}

--- a/modules/healthcheck/src/main/java/io/uhndata/cards/healthcheck/internal/PropertiesPresentHealthCheck.java
+++ b/modules/healthcheck/src/main/java/io/uhndata/cards/healthcheck/internal/PropertiesPresentHealthCheck.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.healthcheck.internal;
+
+import java.util.Map;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Value;
+
+import org.apache.felix.hc.api.FormattingResultLog;
+import org.apache.felix.hc.api.HealthCheck;
+import org.apache.felix.hc.api.Result;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Check that all the required node properties are present. The list of properties to check is defined as nodes in the
+ * repository, under {@code /libs/cards/healthcheck/requiredProperties/}, with the {@code propertyPath} property holding
+ * the full JCR path to a property, and an optional {@code requiredValue} property holding the expected value for the
+ * property. If the property value is not set, only the property's existence is checked.Other CARDS modules should
+ * provide the actual required properties to check for.
+ *
+ * @version $Id$
+ * @since 0.9.37
+ */
+@Component(service = HealthCheck.class, property = { HealthCheck.TAGS + "=cards",
+    HealthCheck.NAME + "=CARDS properties present" }, immediate = true)
+public class PropertiesPresentHealthCheck implements HealthCheck
+{
+    /** JCR node where all the configurations are stored. */
+    public static final String CONFIGURATION_PATH = "/libs/cards/healthcheck/requiredProperties";
+
+    /** The name of the configuration node property holding the path to the property to check. */
+    public static final String PATH_PROPERTY = "propertyPath";
+
+    /** The name of the configuration node property holding the required value to check. */
+    public static final String VALUE_PROPERTY = "requiredValue";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PropertiesPresentHealthCheck.class);
+
+    @Reference
+    private ResourceResolverFactory rrf;
+
+    @Override
+    public Result execute()
+    {
+        final FormattingResultLog result = new FormattingResultLog();
+        int present = 0;
+        int missing = 0;
+        try (ResourceResolver resolver =
+            this.rrf.getServiceResourceResolver(Map.of(ResourceResolverFactory.SUBSERVICE, "healthcheck"))) {
+            final Session session = resolver.adaptTo(Session.class);
+            if (!session.nodeExists(CONFIGURATION_PATH)) {
+                result.warn("No required properties configuration, please check the system integrity");
+                return new Result(result);
+            }
+            final NodeIterator configurations = session.getNode(CONFIGURATION_PATH).getNodes();
+            while (configurations.hasNext()) {
+                final Node configuration = configurations.nextNode();
+                try {
+                    final String propertyPath = configuration.getProperty(PATH_PROPERTY).getString();
+                    if (!session.propertyExists(propertyPath)) {
+                        result.critical("Required property not found: {}", propertyPath);
+                        missing++;
+                        continue;
+                    }
+                    if (!configuration.hasProperty(VALUE_PROPERTY)) {
+                        result.debug("Required property exists: {}", propertyPath);
+                        present++;
+                        continue;
+                    }
+
+                    final Value requiredValue = configuration.getProperty(VALUE_PROPERTY).getValue();
+                    final Value actualValue = session.getProperty(propertyPath).getValue();
+                    if (!requiredValue.equals(actualValue)) {
+                        result.critical("Required value for property {} is wrong {} -- {}",
+                            propertyPath, requiredValue.getString(), actualValue.getString());
+                        missing++;
+                    } else {
+                        result.debug("Required property is correct: {}={}", propertyPath, actualValue);
+                        present++;
+                    }
+                } catch (RepositoryException e) {
+                    LOGGER.error("Unexpected exception while checking required properties", e.getMessage(), e);
+                    result.healthCheckError("Cannot run status check: {}", e.getMessage(), e);
+                }
+            }
+        } catch (LoginException | RepositoryException e) {
+            result.healthCheckError("Healthcheck module not set up properly: {}", e.getMessage());
+        }
+        result.info("{} required properties present" + (missing != 0 ? " and {} wrong/missing" : ""), present, missing);
+        return new Result(result);
+    }
+}

--- a/modules/healthcheck/src/main/java/io/uhndata/cards/healthcheck/internal/ServicesPresentHealthCheck.java
+++ b/modules/healthcheck/src/main/java/io/uhndata/cards/healthcheck/internal/ServicesPresentHealthCheck.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.healthcheck.internal;
+
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.felix.hc.api.FormattingResultLog;
+import org.apache.felix.hc.api.HealthCheck;
+import org.apache.felix.hc.api.Result;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Check that all the required services are present. The list of services to check is defined as nodes in the
+ * repository, under {@code /libs/cards/healthcheck/requiredServices/}, with the {@code serviceClass} property holding
+ * the fully qualified name of a service, and an optional {@code osgiFilter} property holding a valid OSGi service
+ * filter. Other CARDS modules should provide the actual required services to check for.
+ *
+ * @version $Id$
+ * @since 0.9.37
+ */
+@Component(service = HealthCheck.class, property = { HealthCheck.TAGS + "=cards",
+    HealthCheck.NAME + "=CARDS services active" }, immediate = true)
+public class ServicesPresentHealthCheck implements HealthCheck
+{
+    /** JCR node where all the configurations are stored. */
+    public static final String CONFIGURATION_PATH = "/libs/cards/healthcheck/requiredServices";
+
+    /** The name of the configuration node property holding the path to the property to check. */
+    public static final String SERVICE_PROPERTY = "serviceClass";
+
+    /** The name of the configuration node property holding the required value to check. */
+    public static final String FILTER_PROPERTY = "osgiFilter";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServicesPresentHealthCheck.class);
+
+    private BundleContext context;
+
+    @Reference
+    private ResourceResolverFactory rrf;
+
+    @Activate
+    protected void activate(BundleContext bundleContext)
+    {
+        this.context = bundleContext;
+    }
+
+    @Override
+    public Result execute()
+    {
+        FormattingResultLog result = new FormattingResultLog();
+        int present = 0;
+        int missing = 0;
+        try (ResourceResolver resolver =
+            this.rrf.getServiceResourceResolver(Map.of(ResourceResolverFactory.SUBSERVICE, "healthcheck"))) {
+            Resource requiredServices = resolver.getResource(CONFIGURATION_PATH);
+            if (requiredServices == null || requiredServices.isResourceType(Resource.RESOURCE_TYPE_NON_EXISTING)) {
+                result.warn("No required services configuration, please check the system integrity");
+                return new Result(result);
+            }
+            for (Resource requiredService : requiredServices.getChildren()) {
+                try {
+                    final String serviceClass = requiredService.getValueMap().get(SERVICE_PROPERTY, "");
+                    final String osgiFilter = requiredService.getValueMap().get(FILTER_PROPERTY, "");
+                    ServiceReference<?>[] implementations = this.context.getAllServiceReferences(serviceClass,
+                        StringUtils.defaultIfBlank(osgiFilter, null));
+
+                    if (implementations == null || implementations.length == 0) {
+                        result.critical("Required service implementation not found: {}/{}", serviceClass, osgiFilter);
+                        missing++;
+                    } else {
+                        result.debug("Found service: {}/{}", serviceClass, osgiFilter);
+                        present++;
+                    }
+                } catch (InvalidSyntaxException e) {
+                    LOGGER.error("Invalid syntax: {}", e.getMessage(), e);
+                    result.healthCheckError("Cannot run status check: {}", e.getMessage(), e);
+                }
+            }
+        } catch (LoginException e) {
+            result.healthCheckError("Healthcheck module not set up properly: {}", e.getMessage());
+        }
+        result.info("{} required services active" + (missing != 0 ? " and {} missing" : ""), present, missing);
+        return new Result(result);
+    }
+}

--- a/modules/healthcheck/src/test/java/io/uhndata/cards/healthcheck/internal/DuplicateJarsHealthCheckTest.java
+++ b/modules/healthcheck/src/test/java/io/uhndata/cards/healthcheck/internal/DuplicateJarsHealthCheckTest.java
@@ -1,0 +1,150 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.uhndata.cards.healthcheck.internal;
+
+import java.util.Iterator;
+
+import javax.jcr.RepositoryException;
+
+import org.apache.felix.hc.api.Result;
+import org.apache.felix.hc.api.Result.Status;
+import org.apache.felix.hc.api.ResultLog.Entry;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.PersistenceException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ServicesPresentHealthCheck}.
+ *
+ * @version $Id$
+ */
+public class DuplicateJarsHealthCheckTest
+{
+    @Mock
+    private BundleContext bc;
+
+    @Mock
+    private Bundle b1;
+
+    @Mock
+    private Bundle b1a;
+
+    @Mock
+    private Bundle b2;
+
+    @Mock
+    private Bundle b2a;
+
+    @Mock
+    private Bundle b2b;
+
+    @Mock
+    private Bundle b3;
+
+    @Mock
+    private Bundle b4;
+
+    @InjectMocks
+    private DuplicateJarsHealthCheck checker;
+
+    @Before
+    public void setup() throws LoginException, RepositoryException, PersistenceException, InvalidSyntaxException
+    {
+        MockitoAnnotations.initMocks(this);
+        this.checker.activate(this.bc);
+
+        when(this.b1.getSymbolicName()).thenReturn("example.bundle1");
+        when(this.b1a.getSymbolicName()).thenReturn("example.bundle1");
+        when(this.b2.getSymbolicName()).thenReturn("example.bundle2");
+        when(this.b2a.getSymbolicName()).thenReturn("example.bundle2");
+        when(this.b2b.getSymbolicName()).thenReturn("example.bundle2");
+        when(this.b3.getSymbolicName()).thenReturn("example.bundle3");
+        when(this.b4.getSymbolicName()).thenReturn("example.bundle4");
+    }
+
+    @Test
+    public void testNoBundles() throws Exception
+    {
+        when(this.bc.getBundles()).thenReturn(null);
+        Result result = this.checker.execute();
+        Assert.assertEquals(Status.HEALTH_CHECK_ERROR, result.getStatus());
+
+        when(this.bc.getBundles()).thenReturn(new Bundle[0]);
+        result = this.checker.execute();
+        Assert.assertEquals(Status.HEALTH_CHECK_ERROR, result.getStatus());
+    }
+
+    @Test
+    public void testNoDuplicates() throws Exception
+    {
+        when(this.bc.getBundles()).thenReturn(new Bundle[] { this.b1, this.b2, this.b3, this.b4 });
+        Result result = this.checker.execute();
+        Assert.assertEquals(Status.OK, result.getStatus());
+        Assert.assertEquals("Checked 4 bundles", result.iterator().next().getMessage());
+    }
+
+    @Test
+    public void testDuplicates() throws Exception
+    {
+        when(this.bc.getBundles()).thenReturn(new Bundle[] { this.b1, this.b1a });
+        Result result = this.checker.execute();
+        Assert.assertEquals(Status.WARN, result.getStatus());
+        Iterator<Entry> log = result.iterator();
+        Assert.assertEquals("Possible duplicate jar: example.bundle1", log.next().getMessage());
+        Assert.assertEquals("Checked 2 bundles", log.next().getMessage());
+    }
+
+    @Test
+    public void testTriplicates() throws Exception
+    {
+        when(this.bc.getBundles()).thenReturn(new Bundle[] { this.b2, this.b2a, this.b2b });
+        Result result = this.checker.execute();
+        Assert.assertEquals(Status.WARN, result.getStatus());
+        Iterator<Entry> log = result.iterator();
+        Assert.assertEquals("Possible duplicate jar: example.bundle2", log.next().getMessage());
+        Assert.assertEquals("Possible duplicate jar: example.bundle2", log.next().getMessage());
+        Assert.assertEquals("Checked 3 bundles", log.next().getMessage());
+    }
+
+    @Test
+    public void testAggregation() throws Exception
+    {
+        when(this.bc.getBundles())
+            .thenReturn(new Bundle[] { this.b1, this.b1a, this.b2, this.b2a, this.b2b, this.b3, this.b4 });
+        Result result = this.checker.execute();
+        Assert.assertEquals(Status.WARN, result.getStatus());
+        Iterator<Entry> log = result.iterator();
+        Assert.assertEquals(Status.WARN, log.next().getStatus());
+        Assert.assertEquals(Status.WARN, log.next().getStatus());
+        Assert.assertEquals("Possible duplicate jar: example.bundle2", log.next().getMessage());
+        Assert.assertEquals(Status.OK, log.next().getStatus());
+        Assert.assertFalse(log.hasNext());
+    }
+}

--- a/modules/healthcheck/src/test/java/io/uhndata/cards/healthcheck/internal/PropertiesPresentHealthCheckTest.java
+++ b/modules/healthcheck/src/test/java/io/uhndata/cards/healthcheck/internal/PropertiesPresentHealthCheckTest.java
@@ -1,0 +1,199 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.uhndata.cards.healthcheck.internal;
+
+import java.util.Iterator;
+import java.util.List;
+
+import javax.jcr.Node;
+import javax.jcr.PathNotFoundException;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Value;
+
+import org.apache.felix.hc.api.Result;
+import org.apache.felix.hc.api.Result.Status;
+import org.apache.felix.hc.api.ResultLog.Entry;
+import org.apache.jackrabbit.commons.iterator.NodeIteratorAdapter;
+import org.apache.jackrabbit.value.LongValue;
+import org.apache.jackrabbit.value.StringValue;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PropertiesPresentHealthCheck}.
+ *
+ * @version $Id$
+ */
+public class PropertiesPresentHealthCheckTest
+{
+    @Mock
+    private ResourceResolverFactory rrf;
+
+    @Mock
+    private ResourceResolver rr;
+
+    @Mock
+    private Session session;
+
+    @Mock
+    private Node configurations;
+
+    @Mock
+    private Node config1;
+
+    @Mock
+    private Property path1;
+
+    @Mock
+    private Node config2;
+
+    @Mock
+    private Property path2;
+
+    @Mock
+    private Node config3;
+
+    @Mock
+    private Property path3;
+
+    @Mock
+    private Property value3;
+
+    private Value expectedValue = new StringValue("a");
+
+    @Mock
+    private Property value;
+
+    @InjectMocks
+    private PropertiesPresentHealthCheck checker;
+
+    @Before
+    public void setup() throws LoginException, RepositoryException
+    {
+        MockitoAnnotations.initMocks(this);
+
+        when(this.rrf.getServiceResourceResolver(any())).thenReturn(this.rr);
+        when(this.rr.adaptTo(Session.class)).thenReturn(this.session);
+        when(this.session.nodeExists(PropertiesPresentHealthCheck.CONFIGURATION_PATH)).thenReturn(true);
+        when(this.session.getNode(PropertiesPresentHealthCheck.CONFIGURATION_PATH)).thenReturn(this.configurations);
+
+        when(this.config1.getProperty(PropertiesPresentHealthCheck.PATH_PROPERTY)).thenReturn(this.path1);
+        when(this.path1.getString()).thenReturn("/node/property1");
+        when(this.session.propertyExists("/node/property1")).thenReturn(false);
+
+        when(this.config2.getProperty(PropertiesPresentHealthCheck.PATH_PROPERTY)).thenReturn(this.path2);
+        when(this.path2.getString()).thenReturn("/node/property2");
+        when(this.session.propertyExists("/node/property2")).thenReturn(true);
+        when(this.config2.hasProperty(PropertiesPresentHealthCheck.VALUE_PROPERTY)).thenReturn(false);
+
+        when(this.config3.getProperty(PropertiesPresentHealthCheck.PATH_PROPERTY)).thenReturn(this.path3);
+        when(this.path3.getString()).thenReturn("/node/property3");
+        when(this.session.propertyExists("/node/property3")).thenReturn(true);
+        when(this.config3.hasProperty(PropertiesPresentHealthCheck.VALUE_PROPERTY)).thenReturn(true);
+        when(this.config3.getProperty(PropertiesPresentHealthCheck.VALUE_PROPERTY)).thenReturn(this.value3);
+        when(this.value3.getValue()).thenReturn(this.expectedValue);
+        when(this.session.getProperty("/node/property3")).thenReturn(this.value);
+    }
+
+    @Test
+    public void testNoConfiguration() throws Exception
+    {
+        when(this.session.nodeExists(PropertiesPresentHealthCheck.CONFIGURATION_PATH)).thenReturn(false);
+        Result result = this.checker.execute();
+        Assert.assertEquals(Status.WARN, result.getStatus());
+    }
+
+    @Test
+    public void testMissingProperty() throws Exception
+    {
+        when(this.configurations.getNodes()).thenReturn(new NodeIteratorAdapter(List.of(this.config1)));
+        Result result = this.checker.execute();
+        Assert.assertEquals(Status.CRITICAL, result.getStatus());
+    }
+
+    @Test
+    public void testExistingProperty() throws Exception
+    {
+        when(this.configurations.getNodes()).thenReturn(new NodeIteratorAdapter(List.of(this.config2)));
+        Result result = this.checker.execute();
+        Assert.assertEquals(Status.OK, result.getStatus());
+    }
+
+    @Test
+    public void testWrongValue() throws Exception
+    {
+        when(this.configurations.getNodes()).thenReturn(new NodeIteratorAdapter(List.of(this.config3)));
+        when(this.value.getValue()).thenReturn(new LongValue(2));
+        Result result = this.checker.execute();
+        Assert.assertEquals(Status.CRITICAL, result.getStatus());
+    }
+
+    @Test
+    public void testCorrectValue() throws Exception
+    {
+        when(this.configurations.getNodes()).thenReturn(new NodeIteratorAdapter(List.of(this.config3)));
+        when(this.value.getValue()).thenReturn(new StringValue("a"));
+        Result result = this.checker.execute();
+        Assert.assertEquals(Status.OK, result.getStatus());
+    }
+
+    @Test
+    public void testJcrError() throws Exception
+    {
+        when(this.configurations.getNodes()).thenReturn(new NodeIteratorAdapter(List.of(this.config1)));
+        when(this.config1.getProperty(any())).thenThrow(new PathNotFoundException("missing property"));
+        Result result = this.checker.execute();
+        Assert.assertEquals(Status.HEALTH_CHECK_ERROR, result.getStatus());
+    }
+
+    @Test
+    public void testAggregation() throws Exception
+    {
+        when(this.configurations.getNodes()).thenReturn(new NodeIteratorAdapter(List.of(this.config1, this.config2)));
+        Result result = this.checker.execute();
+        Assert.assertEquals(Status.CRITICAL, result.getStatus());
+        Iterator<Entry> entries = result.iterator();
+        Assert.assertEquals(Status.CRITICAL, entries.next().getStatus());
+        Assert.assertEquals(Status.OK, entries.next().getStatus());
+        Assert.assertEquals(Status.OK, entries.next().getStatus());
+        Assert.assertFalse(entries.hasNext());
+    }
+
+    @Test
+    public void testInvalidLogin() throws Exception
+    {
+        when(this.rrf.getServiceResourceResolver(any())).thenThrow(new LoginException("wrong login"));
+        Result result = this.checker.execute();
+        Assert.assertEquals(Status.HEALTH_CHECK_ERROR, result.getStatus());
+        Assert.assertNotNull(result.iterator().next().getMessage());
+    }
+}

--- a/modules/healthcheck/src/test/java/io/uhndata/cards/healthcheck/internal/ServicesPresentHealthCheckTest.java
+++ b/modules/healthcheck/src/test/java/io/uhndata/cards/healthcheck/internal/ServicesPresentHealthCheckTest.java
@@ -1,0 +1,185 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.uhndata.cards.healthcheck.internal;
+
+import java.util.Iterator;
+import java.util.List;
+
+import javax.jcr.RepositoryException;
+
+import org.apache.felix.hc.api.Result;
+import org.apache.felix.hc.api.Result.Status;
+import org.apache.felix.hc.api.ResultLog.Entry;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.api.resource.ValueMap;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ServicesPresentHealthCheck}.
+ *
+ * @version $Id$
+ */
+public class ServicesPresentHealthCheckTest
+{
+    @Mock
+    private ResourceResolverFactory rrf;
+
+    @Mock
+    private ResourceResolver rr;
+
+    @Mock
+    private BundleContext bc;
+
+    @Mock
+    private Resource configurations;
+
+    @Mock
+    private Resource config1;
+
+    @Mock
+    private ValueMap props1;
+
+    @Mock
+    private Resource config2;
+
+    @Mock
+    private ValueMap props2;
+
+    @Mock
+    private Resource config3;
+
+    @Mock
+    private ValueMap props3;
+
+    @Mock
+    private ServiceReference<String> service;
+
+    @InjectMocks
+    private ServicesPresentHealthCheck checker;
+
+    @Before
+    public void setup() throws LoginException, RepositoryException, PersistenceException, InvalidSyntaxException
+    {
+        MockitoAnnotations.initMocks(this);
+        this.checker.activate(this.bc);
+
+        when(this.rrf.getServiceResourceResolver(any())).thenReturn(this.rr);
+        when(this.rr.getResource(ServicesPresentHealthCheck.CONFIGURATION_PATH)).thenReturn(this.configurations);
+        when(this.configurations.isResourceType(Resource.RESOURCE_TYPE_NON_EXISTING)).thenReturn(false);
+
+        when(this.config1.getValueMap()).thenReturn(this.props1);
+        when(this.props1.get(ServicesPresentHealthCheck.SERVICE_PROPERTY, "")).thenReturn("test.Class1");
+        when(this.props1.get(ServicesPresentHealthCheck.FILTER_PROPERTY, "")).thenReturn("");
+        when(this.bc.getAllServiceReferences("test.Class1", null)).thenReturn(null);
+
+        when(this.config2.getValueMap()).thenReturn(this.props2);
+        when(this.props2.get(ServicesPresentHealthCheck.SERVICE_PROPERTY, "")).thenReturn("test.Class2");
+        when(this.props2.get(ServicesPresentHealthCheck.FILTER_PROPERTY, "")).thenReturn("(service.pid=PID2)");
+        when(this.bc.getAllServiceReferences("test.Class2", "(service.pid=PID2)"))
+            .thenReturn(new ServiceReference<?>[] { this.service });
+
+        when(this.config3.getValueMap()).thenReturn(this.props3);
+        when(this.props3.get(ServicesPresentHealthCheck.SERVICE_PROPERTY, "")).thenReturn("test.Class3");
+        when(this.props3.get(ServicesPresentHealthCheck.FILTER_PROPERTY, "")).thenReturn("invalid");
+        when(this.bc.getAllServiceReferences("test.Class3", "invalid"))
+            .thenThrow(new InvalidSyntaxException("wrong syntax", "invalid"));
+    }
+
+    @Test
+    public void testNoConfiguration() throws Exception
+    {
+        when(this.configurations.isResourceType(Resource.RESOURCE_TYPE_NON_EXISTING)).thenReturn(true);
+        Result result = this.checker.execute();
+        Assert.assertEquals(Status.WARN, result.getStatus());
+
+        when(this.rr.getResource(ServicesPresentHealthCheck.CONFIGURATION_PATH)).thenReturn(null);
+        result = this.checker.execute();
+        Assert.assertEquals(Status.WARN, result.getStatus());
+    }
+
+    @Test
+    public void testMissingService() throws Exception
+    {
+        when(this.configurations.getChildren()).thenReturn(List.of(this.config1));
+        Result result = this.checker.execute();
+        Assert.assertEquals(Status.CRITICAL, result.getStatus());
+
+        when(this.bc.getAllServiceReferences("test.Class1", null)).thenReturn(new ServiceReference<?>[] {});
+        result = this.checker.execute();
+        Assert.assertEquals(Status.CRITICAL, result.getStatus());
+        verify(this.bc, times(2)).getAllServiceReferences("test.Class1", null);
+    }
+
+    @Test
+    public void testValidService() throws Exception
+    {
+        when(this.configurations.getChildren()).thenReturn(List.of(this.config2));
+        Result result = this.checker.execute();
+        Assert.assertEquals(Status.OK, result.getStatus());
+    }
+
+    @Test
+    public void testInvalidSyntax() throws Exception
+    {
+        when(this.configurations.getChildren()).thenReturn(List.of(this.config3));
+        Result result = this.checker.execute();
+        Assert.assertEquals(Status.HEALTH_CHECK_ERROR, result.getStatus());
+    }
+
+    @Test
+    public void testAggregation() throws Exception
+    {
+        when(this.configurations.getChildren()).thenReturn(List.of(this.config1, this.config2, this.config3));
+        Result result = this.checker.execute();
+        Assert.assertEquals(Status.HEALTH_CHECK_ERROR, result.getStatus());
+        Iterator<Entry> entries = result.iterator();
+        Assert.assertEquals(Status.CRITICAL, entries.next().getStatus());
+        Assert.assertEquals(Status.OK, entries.next().getStatus());
+        Assert.assertEquals(Status.HEALTH_CHECK_ERROR, entries.next().getStatus());
+        Assert.assertEquals(Status.OK, entries.next().getStatus());
+        Assert.assertFalse(entries.hasNext());
+    }
+
+    @Test
+    public void testInvalidLogin() throws Exception
+    {
+        when(this.rrf.getServiceResourceResolver(any())).thenThrow(new LoginException("wrong login"));
+        Result result = this.checker.execute();
+        Assert.assertEquals(Status.HEALTH_CHECK_ERROR, result.getStatus());
+        Assert.assertNotNull(result.iterator().next().getMessage());
+    }
+}

--- a/modules/patient-portal/pom.xml
+++ b/modules/patient-portal/pom.xml
@@ -50,6 +50,7 @@
               SLING-INF/content/Questionnaires/;path:=/Questionnaires/;overwriteProperties:=true;uninstall:=true;checkin:=true,
               SLING-INF/content/libs/cards/resources/media/patient-portal/;path:=/libs/cards/resources/media/patient-portal/;overwrite:=true;uninstall:=true,
               SLING-INF/content/Survey.json;path:=/Survey,
+              SLING-INF/content/libs/cards/healthcheck/requiredServices/;path:=/libs/cards/healthcheck/requiredServices/;overwriteProperties:=true,
               SLING-INF/content/libs/cards/PatientHomepage/;path:=/libs/cards/PatientHomepage/;overwrite:=true,
               SLING-INF/content/libs/cards/resources/assetDependencies.json;path:=/libs/cards/resources/assetDependencies;overwriteProperties:=true,
               SLING-INF/content/apps/cards/ExtensionPoints/;path:=/apps/cards/ExtensionPoints/;overwriteProperties:=true;uninstall:=true,

--- a/modules/patient-portal/src/main/resources/SLING-INF/content/libs/cards/healthcheck/requiredServices/patientPortal_surveyChangesTracker.json
+++ b/modules/patient-portal/src/main/resources/SLING-INF/content/libs/cards/healthcheck/requiredServices/patientPortal_surveyChangesTracker.json
@@ -1,0 +1,4 @@
+{
+  "serviceClass": "org.osgi.service.event.EventHandler",
+  "osgiFilter": "(service.pid=io.uhndata.cards.patients.surveytracker.SurveyTracker)"
+}

--- a/modules/patient-portal/src/main/resources/SLING-INF/content/libs/cards/healthcheck/requiredServices/patientPortal_surveyEmailsTracker.json
+++ b/modules/patient-portal/src/main/resources/SLING-INF/content/libs/cards/healthcheck/requiredServices/patientPortal_surveyEmailsTracker.json
@@ -1,0 +1,4 @@
+{
+  "serviceClass": "org.apache.sling.api.resource.observation.ResourceChangeListener",
+  "osgiFilter": "(service.pid=io.uhndata.cards.patients.surveytracker.SurveyTracker)"
+}

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -78,5 +78,6 @@
     <module>google-apis</module>
     <module>variants</module>
     <module>locking</module>
+    <module>healthcheck</module>
   </modules>
 </project>

--- a/modules/utils/src/main/resources/SLING-INF/content/libs/cards/healthcheck/requiredProperties/utils_PlatformName.json
+++ b/modules/utils/src/main/resources/SLING-INF/content/libs/cards/healthcheck/requiredProperties/utils_PlatformName.json
@@ -1,0 +1,4 @@
+{
+  "propertyPath": "/libs/cards/conf/PlatformName/PlatformName",
+  "requiredValue": "CARDS"
+}

--- a/modules/utils/src/main/resources/SLING-INF/content/libs/cards/healthcheck/requiredProperties/utils_PlatformPrevVersion.json
+++ b/modules/utils/src/main/resources/SLING-INF/content/libs/cards/healthcheck/requiredProperties/utils_PlatformPrevVersion.json
@@ -1,0 +1,3 @@
+{
+  "propertyPath": "/libs/cards/conf/PrevVersion/Version"
+}

--- a/modules/utils/src/main/resources/SLING-INF/content/libs/cards/healthcheck/requiredProperties/utils_PlatformVersion.json
+++ b/modules/utils/src/main/resources/SLING-INF/content/libs/cards/healthcheck/requiredProperties/utils_PlatformVersion.json
@@ -1,0 +1,3 @@
+{
+  "propertyPath": "/libs/cards/conf/Version/Version"
+}


### PR DESCRIPTION
To test:
- build and start with the yourexp project (on the `YE-24-healthcheck` branch)
- visit http://localhost:8080/system/health and make sure the status is OK
- in `/bin/browser.html`, delete the `/libs/cards/conf/AppVersion/` node, check that the healthcheck is now failing (missing properties)
- in `/system/console/components`, find `SurveyTracker` and stop it, check that the healthcheck is now failing (missing services)