### PR TITLE
CARDS-2855: Increase the allowed runtime of scheduled jobs

### DIFF
--- a/distribution/src/main/features/healthcheck.json
+++ b/distribution/src/main/features/healthcheck.json
@@ -97,6 +97,9 @@
             "user.mapping":[
                 "org.apache.sling.hc.support=[sling-readall]"
             ]
+        },
+        "org.apache.sling.commons.scheduler.impl.SchedulerHealthCheck":{
+            "max.quartzJob.duration.acceptable":600000
         }
     }
 }


### PR DESCRIPTION
Set to 10 minutes.