### PR TITLE
CARDS-2857: Token lifespan configuration

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
@@ -37,7 +37,8 @@ export const DEFAULT_PATIENT_ACCESS_CONFIG = {
   tokenlessAuthEnabled: false,
   PIIAuthRequired: false,
   daysRelativeToEventWhileSurveyIsValid: "0",
-  draftLifetime: "-1"
+  draftLifetime: "-1",
+  manualTokenLifespanDays: "0",
 };
 
 const useStyles = makeStyles()(theme => ({
@@ -76,11 +77,16 @@ function PatientAccessConfiguration() {
       "Patients can edit unsubmitted responses for:",
       "-1 means that drafts are kept until the patient is no longer able to access their surveys, 0 means drafts are deleted daily at midnight, 1 means they are kept until the next day at midnight, etc.",
       "Please use a value of at least 0, or -1 to disable periodic draft deletion."
-    ]
+    ],
+    manualTokenLifespanDays: [
+      "When a token is created manually, the number of days that the token should be valid for by default.",
+      "This should be a positive integer for a number of days, or 0 for a 10 minute token lifespan"
+    ],
   };
 
   const LIMITS = {
-    draftLifetime: { min: -1 }
+    draftLifetime: { min: -1 },
+    manualTokenLifespanDays: { min: 0 },
   }
 
   let buildConfigData = (formData) => {
@@ -152,6 +158,7 @@ function PatientAccessConfiguration() {
         { renderConfigInput("daysRelativeToEventWhileSurveyIsValid", "days") }
         { renderConfigInput("daysRelativeToEventWhenIncompleteSurveysCanBeSubmitted", "days") }
         { renderConfigInput("draftLifetime", "days") }
+        { renderConfigInput("manualTokenLifespanDays", "days") }
       </List>
     </AdminConfigScreen>
   );

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientAccessConfiguration.jsx
@@ -80,7 +80,7 @@ function PatientAccessConfiguration() {
     ],
     manualTokenLifespanDays: [
       "When a token is created manually, the number of days that the token should be valid for by default.",
-      "This should be a positive integer for a number of days, or 0 for a 10 minute token lifespan"
+      "This should be a positive integer for a number of days, or 0 for a 1 hour token lifespan"
     ],
   };
 

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/api/PatientAccessConfiguration.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/api/PatientAccessConfiguration.java
@@ -80,4 +80,31 @@ public interface PatientAccessConfiguration
      * @return A number of days
      */
     int getClinicDaysRelativeToEventWhileSurveyIsValid(Node clinicNode);
+
+    /**
+     * Get the configured amount of time, in days, that a manually created token should be valid for.
+     * If this value is {@code 0}, then a created token should only be valid for 10 minutes.
+     *
+     * @return A number of days
+     */
+    int getManualTokenLifespanDays();
+
+    /**
+     * Get the configured manual token lifespan for the clinic linked to the Subject related to the
+     * visitInformationNode Resource or default if it cannot be found.
+     *
+     * @param visitInformationForm the JCR Visit Information Node
+     *
+     * @return A number of days
+     */
+    int getManualTokenLifespanDays(Node visitInformationForm);
+
+    /**
+     * Returns the manually created token lifetime associated with the clinic or default if it cannot be found.
+     *
+     * @param clinicNode the clinic Node
+     *
+     * @return A number of days
+     */
+    int getClinicManualTokenLifespanDays(Node clinicNode);
 }

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/api/PatientAccessConfiguration.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/api/PatientAccessConfiguration.java
@@ -83,7 +83,7 @@ public interface PatientAccessConfiguration
 
     /**
      * Get the configured amount of time, in days, that a manually created token should be valid for.
-     * If this value is {@code 0}, then a created token should only be valid for 10 minutes.
+     * If this value is {@code 0}, then a created token should only be valid for 1 hour.
      *
      * @return A number of days
      */

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/PatientAccessConfigurationImpl.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/PatientAccessConfigurationImpl.java
@@ -62,6 +62,9 @@ public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements
     /** Property on config node for the number of days draft responses from patients are kept. */
     private static final String DRAFT_LIFETIME_PROP = "draftLifetime";
 
+    /** Default property on config node for the number of days a manually created token is valid for. */
+    private static final String MANUAL_TOKEN_LIFETIME_PROP = "manualTokenLifespanDays";
+
     /** Whether or not tokenless auth is enabled by default (used in case of errors). */
     private static final Boolean TOKENLESS_AUTH_ENABLED_DEFAULT = false;
 
@@ -73,6 +76,9 @@ public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements
 
     /** The number of days a patient's draft response is kept for by default (used in case of errors). */
     private static final int DRAFT_LIFETIME_DEFAULT = -1;
+
+    /** The number of days a manually created token is valid for by default (used in case of errors). */
+    private static final int MANUAL_TOKEN_LIFETIME_DEFAULT = 0;
 
     @Reference
     private FormUtils formUtils;
@@ -131,21 +137,30 @@ public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements
     @Override
     public int getDaysRelativeToEventWhileSurveyIsValid()
     {
+        return getTokenLifespan(DEFAULT_TOKEN_LIFETIME_PROP, TOKEN_LIFETIME_DEFAULT);
+    }
+
+    private int getTokenLifespan(String prop, int defaultValue)
+    {
         try
         {
-            Property lifetime = getConfig(DEFAULT_TOKEN_LIFETIME_PROP);
-            return lifetime == null ? TOKEN_LIFETIME_DEFAULT : (int) lifetime.getLong();
+            Property lifetime = getConfig(prop);
+            return lifetime == null ? defaultValue : (int) lifetime.getLong();
         } catch (RepositoryException e) {
-            return TOKEN_LIFETIME_DEFAULT;
+            return defaultValue;
         }
     }
 
     @Override
     public int getDaysRelativeToEventWhileSurveyIsValid(Node visitInformationNode)
     {
+        return getClinicDaysRelativeToEventWhileSurveyIsValid(getClinicNode(visitInformationNode));
+    }
+
+    private Node getClinicNode(Node visitInformationNode)
+    {
         Node visitSubject = this.formUtils.getSubject(visitInformationNode, "/SubjectTypes/Patient/Visit");
-        Node clinicNode = AppointmentUtils.getValidClinicNode(this.formUtils, visitSubject);
-        return getClinicDaysRelativeToEventWhileSurveyIsValid(clinicNode);
+        return AppointmentUtils.getValidClinicNode(this.formUtils, visitSubject);
     }
 
     @Override
@@ -157,7 +172,7 @@ public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements
                 return (int) clinicNode.getProperty(TOKEN_LIFETIME_PROP).getLong();
             }
         } catch (RepositoryException e) {
-            // TODO Auto-generated catch block
+            // Fallback to default
         }
         return getDaysRelativeToEventWhileSurveyIsValid();
     }
@@ -173,5 +188,30 @@ public class PatientAccessConfigurationImpl extends AbstractNodeUtils implements
         } catch (RepositoryException e) {
             return DRAFT_LIFETIME_DEFAULT;
         }
+    }
+
+    @Override
+    public int getManualTokenLifespanDays()
+    {
+        return getTokenLifespan(MANUAL_TOKEN_LIFETIME_PROP, MANUAL_TOKEN_LIFETIME_DEFAULT);
+    }
+
+    @Override
+    public int getManualTokenLifespanDays(Node visitInformationNode)
+    {
+        return getClinicManualTokenLifespanDays(getClinicNode(visitInformationNode));
+    }
+
+    @Override
+    public int getClinicManualTokenLifespanDays(Node clinicNode)
+    {
+        try {
+            if (clinicNode != null && clinicNode.hasProperty(MANUAL_TOKEN_LIFETIME_PROP)) {
+                return (int) clinicNode.getProperty(MANUAL_TOKEN_LIFETIME_PROP).getLong();
+            }
+        } catch (RepositoryException e) {
+            // Fallback to default
+        }
+        return getManualTokenLifespanDays();
     }
 }

--- a/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
+++ b/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
@@ -15,15 +15,15 @@
 
 response.setContentType('text/plain');
 
-var get10MinExpiry = function() {
+var getOneHourExpiry = function() {
     var result = java.util.Calendar.getInstance();
-    result.setTimeInMillis(result.getTimeInMillis() + 600000);
+    result.setTimeInMillis(result.getTimeInMillis() + (1000*60*60));
     return result;
 }
 
 var getExpiryByDays = function(days) {
     if (days < 1) {
-        return get10MinExpiry();
+        return getOneHourExpiry();
     } else {
         var result = java.util.Calendar.getInstance();
         result.add(java.util.Calendar.DATE, days);

--- a/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
+++ b/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
@@ -15,8 +15,10 @@
 
 response.setContentType('text/plain');
 
+var Calendar = java.util.Calendar;
+
 var getOneHourExpiry = function() {
-    var result = java.util.Calendar.getInstance();
+    var result = Calendar.getInstance();
     result.setTimeInMillis(result.getTimeInMillis() + (1000*60*60));
     return result;
 }
@@ -25,8 +27,13 @@ var getExpiryByDays = function(days) {
     if (days < 1) {
         return getOneHourExpiry();
     } else {
-        var result = java.util.Calendar.getInstance();
-        result.add(java.util.Calendar.DATE, days);
+        var result = Calendar.getInstance();
+        // Generate a new date at midnight
+        result.add(Calendar.DATE, days + 1);
+        result.set(Calendar.HOUR_OF_DAY, 0);
+        result.set(Calendar.MINUTE, 0);
+        result.set(Calendar.SECOND, 0);
+        result.set(Calendar.MILLISECOND, 0);
         return result;
     }
 }
@@ -63,16 +70,17 @@ if (daysParam !== null) {
         var visitInformationForm = time.getParent();
         if (time.hasProperty("value")) {
             // Calculate when a standard token for this visit would expire for a standard survey
-            result = time.getProperty("value").getDate();
-            var days = config.getDaysRelativeToEventWhileSurveyIsValid(visitInformationForm);
-            result.add(java.util.Calendar.DATE, days + 1);
-            result.set(java.util.Calendar.HOUR_OF_DAY, 0);
-            result.set(java.util.Calendar.MINUTE, 0);
-            result.set(java.util.Calendar.SECOND, 0);
-            result.set(java.util.Calendar.MILLISECOND, 0);
-            var now = java.util.Calendar.getInstance();
-            if (now.compareTo(result) >= 0) {
-                // The standard survey expiry time is in the past: Use the default manual expiry time instead of a survey based expiry time
+            var visitTime = time.getProperty("value").getDate();
+            var validDays = config.getDaysRelativeToEventWhileSurveyIsValid(visitInformationForm);
+            visitTime.add(Calendar.DATE, validDays + 1);
+            var diff = java.time.temporal.ChronoUnit.DAYS.between(Calendar.getInstance().toInstant(), visitTime.toInstant());
+            // Check if we are still within the standard visit expiry period
+            if (diff >= 1) {
+                // There is at least one day left in the standard visit expiry period:
+                // Generate a token with the standard visit expiry period
+                result = getExpiryByDays(diff);
+            } else {
+                // Generate a token with the non-visit based expiry period
                 result = getDefaultExpiryForVisit(config, visitInformationForm);
             }
         } else {

--- a/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
+++ b/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
@@ -21,25 +21,51 @@ var get10MinExpiry = function() {
     return result;
 }
 
+var getExpiryByDays = function(days) {
+    if (days < 1) {
+        return get10MinExpiry();
+    } else {
+        var result = java.util.Calendar.getInstance();
+        result.add(java.util.Calendar.DATE, days);
+        return result;
+    }
+}
+
+var getDefaultExpiry = function(config) {
+    var days = config.getManualTokenLifespanDays();
+    return getExpiryByDays(days);
+}
+
+var getDefaultExpiryForVisit = function(config, visitInformationForm) {
+    var days = config.getManualTokenLifespanDays(visitInformationForm);
+    return getExpiryByDays(days);
+}
+
 var visitTimeQuestionUuid = currentSession.getNode("/Questionnaires/Visit information/time").getIdentifier();
 var time = currentSession.getWorkspace().getQueryManager().createQuery("select t.* from [cards:Form] as f inner join [cards:DateAnswer] as t on t.form = f.[jcr:uuid] where f.subject = '" + currentNode.getIdentifier() + "' and t.question = '" + visitTimeQuestionUuid + "' OPTION (index tag cards)", "JCR-SQL2").execute().getNodes();
+var config = sling.getService(Packages.io.uhndata.cards.patients.api.PatientAccessConfiguration);
 if (time.hasNext()) {
     time = time.next();
+    var visitInformationForm = time.getParent();
     if (time.hasProperty("value")) {
-        var visitInformationForm = time.getParent();
+        // Calculate when a standard token for this visit would expire for a standard survey
         time = time.getProperty("value").getDate();
-        var config = sling.getService(Packages.io.uhndata.cards.patients.api.PatientAccessConfiguration);
         var days = config.getDaysRelativeToEventWhileSurveyIsValid(visitInformationForm);
         time.add(java.util.Calendar.DATE, days + 1);
         time.set(java.util.Calendar.HOUR_OF_DAY, 0);
         time.set(java.util.Calendar.MINUTE, 0);
         time.set(java.util.Calendar.SECOND, 0);
         time.set(java.util.Calendar.MILLISECOND, 0);
+        var now = java.util.Calendar.getInstance();
+        if (now.compareTo(time) >= 0) {
+            // The standard survey expiry time is in the past: Use the default manual expiry time instead of a survey based expiry time
+            time = getDefaultExpiryForVisit(config, visitInformationForm);
+        }
     } else {
-        time = get10MinExpiry();
+        time = getDefaultExpiryForVisit(config, visitInformationForm);
     }
 } else {
-        time = get10MinExpiry();
+    time = getDefaultExpiry(config);
 }
 var token = sling.getService(Packages.io.uhndata.cards.auth.token.TokenManager).create("patient", time, {"cards:sessionSubject": currentNode.getPath()});
 out.println(token.getToken());

--- a/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
+++ b/modules/token-authentication/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
@@ -41,32 +41,51 @@ var getDefaultExpiryForVisit = function(config, visitInformationForm) {
     return getExpiryByDays(days);
 }
 
+var result = null;
+var error = null;
 var visitTimeQuestionUuid = currentSession.getNode("/Questionnaires/Visit information/time").getIdentifier();
-var time = currentSession.getWorkspace().getQueryManager().createQuery("select t.* from [cards:Form] as f inner join [cards:DateAnswer] as t on t.form = f.[jcr:uuid] where f.subject = '" + currentNode.getIdentifier() + "' and t.question = '" + visitTimeQuestionUuid + "' OPTION (index tag cards)", "JCR-SQL2").execute().getNodes();
 var config = sling.getService(Packages.io.uhndata.cards.patients.api.PatientAccessConfiguration);
-if (time.hasNext()) {
-    time = time.next();
-    var visitInformationForm = time.getParent();
-    if (time.hasProperty("value")) {
-        // Calculate when a standard token for this visit would expire for a standard survey
-        time = time.getProperty("value").getDate();
-        var days = config.getDaysRelativeToEventWhileSurveyIsValid(visitInformationForm);
-        time.add(java.util.Calendar.DATE, days + 1);
-        time.set(java.util.Calendar.HOUR_OF_DAY, 0);
-        time.set(java.util.Calendar.MINUTE, 0);
-        time.set(java.util.Calendar.SECOND, 0);
-        time.set(java.util.Calendar.MILLISECOND, 0);
-        var now = java.util.Calendar.getInstance();
-        if (now.compareTo(time) >= 0) {
-            // The standard survey expiry time is in the past: Use the default manual expiry time instead of a survey based expiry time
-            time = getDefaultExpiryForVisit(config, visitInformationForm);
-        }
+var daysParam = request.getParameter("validForDays");
+if (daysParam !== null) {
+    var days = parseInt(daysParam);
+    if (!isNaN(days) && days >= 0) {
+        result = getExpiryByDays(days);
     } else {
-        time = getDefaultExpiryForVisit(config, visitInformationForm);
+        error = "Invalid input: " + daysParam;
     }
 } else {
-    time = getDefaultExpiry(config);
+    var time = currentSession.getWorkspace().getQueryManager().createQuery(
+        "select t.* from [cards:Form] as f inner join [cards:DateAnswer] as t on t.form = f.[jcr:uuid] where f.subject = '"
+            + currentNode.getIdentifier() + "' and t.question = '" + visitTimeQuestionUuid + "' OPTION (index tag cards)"
+        , "JCR-SQL2").execute().getNodes();
+    if (time.hasNext()) {
+        time = time.next();
+        var visitInformationForm = time.getParent();
+        if (time.hasProperty("value")) {
+            // Calculate when a standard token for this visit would expire for a standard survey
+            result = time.getProperty("value").getDate();
+            var days = config.getDaysRelativeToEventWhileSurveyIsValid(visitInformationForm);
+            result.add(java.util.Calendar.DATE, days + 1);
+            result.set(java.util.Calendar.HOUR_OF_DAY, 0);
+            result.set(java.util.Calendar.MINUTE, 0);
+            result.set(java.util.Calendar.SECOND, 0);
+            result.set(java.util.Calendar.MILLISECOND, 0);
+            var now = java.util.Calendar.getInstance();
+            if (now.compareTo(result) >= 0) {
+                // The standard survey expiry time is in the past: Use the default manual expiry time instead of a survey based expiry time
+                result = getDefaultExpiryForVisit(config, visitInformationForm);
+            }
+        } else {
+            result = getDefaultExpiryForVisit(config, visitInformationForm);
+        }
+    } else {
+        result = getDefaultExpiry(config);
+    }
 }
-var token = sling.getService(Packages.io.uhndata.cards.auth.token.TokenManager).create("patient", time, {"cards:sessionSubject": currentNode.getPath()});
-out.println(token.getToken());
+if (!error) {
+    var token = sling.getService(Packages.io.uhndata.cards.auth.token.TokenManager).create("patient", result, {"cards:sessionSubject": currentNode.getPath()});
+    out.println(token.getToken());
+} else {
+    out.println(error);
+}
 %>

--- a/test-resources/src/main/resources/SLING-INF/content/Survey/ClinicMapping.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Survey/ClinicMapping.xml
@@ -96,5 +96,10 @@
             <value>Date Test</value>
             <type>String</type>
         </property>
+        <property>
+            <name>manualTokenLifespanDays</name>
+            <value>14</value>
+            <type>Long</type>
+        </property>
     </node>
 </node>

--- a/test-resources/src/main/resources/SLING-INF/content/Survey/PatientAccess.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Survey/PatientAccess.xml
@@ -34,4 +34,9 @@
         <value>30</value>
         <type>Long</type>
     </property>
+    <property>
+        <name>manualTokenLifespanDays</name>
+        <value>7</value>
+        <type>Long</type>
+    </property>
 </node>


### PR DESCRIPTION
- Add `manualTokenLifespanDays` configuration option to `PatientAccessConfiguration`
  - This supports a global configuration and a per-clinic configuration
- Update `token.html.esp` to use configured expiry when available instead of the 10-minute default
  - If the token is being created for a visit and the standard survey lifespan is still valid, that will be used instead
- Update test mode surveys to include this configuration
- Add validForDays URL parameter for token.html
  - If present and it's an int >=0, create a new token valid for that many days
  - If present and invalid, return an error message
  - If not present, use previous behaviour
- Clean  up `token.html.esp` by splitting `time` parameter into separete `time` and `result` parameters