### PR TITLE
[bugfix] Fix auth token retrieval in PatientIdentification

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
@@ -200,7 +200,7 @@ function PatientIdentification(props) {
     if (Object.keys(config).length == 0) return;
 
     let auth_token = new URLSearchParams(window.location.search).get("auth_token");
-    setAuthToken(authToken);
+    setAuthToken(auth_token);
     setCanAuthenticate(!!(config?.tokenlessAuthEnabled || auth_token));
 
     // If an auth token is provided and no further identification is required,


### PR DESCRIPTION
Fixing issue [C-01: Auth Token Variable Typo Breaks Patient Authentication](https://github.com/numbata/cards/blob/7b13b283d0d6be7ab0b3871451c5d4fdc76254cb/docs/all-findings.md#c-01-auth-token-variable-typo-breaks-patient-authentication)
`setAuthToken(authToken)` references the state variable (undefined) instead of the local `auth_token` parsed from the URL.