### PR TITLE
[bugfix] Fix logical operator in Answer component props

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/SelectableAreaQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SelectableAreaQuestion.jsx
@@ -393,7 +393,7 @@ function SelectableAreaQuestion(props) {
       }
       { isEdit && <Answer
         answers={notApplicableChecked ?
-          [[notApplicableOption.label | notApplicableOption.value, notApplicableOption.value]] : selection}
+          [[notApplicableOption.label || notApplicableOption.value, notApplicableOption.value]] : selection}
         existingAnswer={existingAnswer}
         questionName={questionName}
         questionDefinition={props.questionDefinition}


### PR DESCRIPTION
Fixing issue [C-02: Bitwise OR Corrupts Medical Answer Data](https://github.com/numbata/cards/blob/7b13b283d0d6be7ab0b3871451c5d4fdc76254cb/docs/all-findings.md#c-02-bitwise-or-corrupts-medical-answer-data)
The expression `notApplicableOption.label | notApplicableOption.value` uses the bitwise OR operator `|`. When applied to strings (which label and value are), JavaScript coerces both operands to integers via `Number()`, producing `0 | 0 = 0` or `NaN`. The intended behavior is a fallback: use `label` if truthy, otherwise `value`. Instead, the stored answer value for "not applicable" selections on medical questionnaires is always `0`, corrupting patient data.