### PR TITLE
[bugfix] Fixed window Event Listener removal

### DIFF
--- a/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/LiveTable.jsx
@@ -190,7 +190,7 @@ function LiveTable(props) {
     window.addEventListener("LivetableRefresh",  refresh);
     return () => {
       // unsubscribe event
-      document.removeEventListener("LivetableRefresh",  refresh);
+      window.removeEventListener("LivetableRefresh",  refresh);
     };
   }, [entryType]);
 

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/PrintButton.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/PrintButton.jsx
@@ -94,7 +94,7 @@ function PrintButton(props) {
     window.addEventListener("keydown", handleOnPrintKeydown);
     return () => {
       // unsubscribe event
-      document.removeEventListener("keydown", handleOnPrintKeydown);
+      window.removeEventListener("keydown", handleOnPrintKeydown);
     };
   }, []);
 

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminResourceListing.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminResourceListing.jsx
@@ -80,9 +80,9 @@ function AdminResourceListing(props) {
     window.addEventListener("MaterialTableAppend", addData);
     return () => {
       // unsubscribe event
-      document.removeEventListener("MaterialTableAppend", addData);
+      window.removeEventListener("MaterialTableAppend", addData);
     };
-  });
+  }, []);
 
   return (
     <AdminScreen


### PR DESCRIPTION
Fixed:

[H-14: window/document Event Listener Mismatch in LiveTable](https://github.com/numbata/cards/blob/7b13b283d0d6be7ab0b3871451c5d4fdc76254cb/docs/all-findings.md#h-14-windowdocument-event-listener-mismatch-in-livetable)

[H-15: window/document Event Listener Mismatch in PrintButton](https://github.com/numbata/cards/blob/7b13b283d0d6be7ab0b3871451c5d4fdc76254cb/docs/all-findings.md#h-15-windowdocument-event-listener-mismatch-in-printbutton)

[H-16: window/document Event Listener Mismatch + Missing Deps in AdminResourceListing](https://github.com/numbata/cards/blob/7b13b283d0d6be7ab0b3871451c5d4fdc76254cb/docs/all-findings.md#h-16-windowdocument-event-listener-mismatch--missing-deps-in-adminresourcelisting)