### PR TITLE
[bugfix] Remove ineffectual line from MultipleChoice

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -137,7 +137,6 @@ function MultipleChoice(props) {
   // No user input (aka. an empty input) takes the place of an empty string
   if (maxAnswers !== 1) {
     initialSelection = initialSelection || ["", ""];
-    all_options.concat(["", ""]);
   }
   const [selection, setSelection] = useState(initialSelection);
   const [options, setOptions] = useState(all_options);


### PR DESCRIPTION
Fixing: [H-12: .concat() Result Discarded in MultipleChoice](https://github.com/numbata/cards/blob/7b13b283d0d6be7ab0b3871451c5d4fdc76254cb/docs/all-findings.md#h-12-concat-result-discarded-in-multiplechoice)

Remove ineffectual concatenation of empty strings to options when maxAnswers is not 1.