### PR TITLE
CARDS-2872: Subject timeline fails to display some dates

### DIFF
--- a/modules/commons/src/main/frontend/src/components/DateTimeUtilities.jsx
+++ b/modules/commons/src/main/frontend/src/components/DateTimeUtilities.jsx
@@ -27,6 +27,7 @@ export default class DateTimeUtilities {
   static slingDateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
   static defaultDateFormat = "yyyy-MM-dd";
   static VIEW_DATE_FORMAT = "yyyy/MM/dd";
+  static YEAR_DATE_FORMAT = "yyyy";
 
   static YEAR_DATE_TYPE = "year";
   static MONTH_DATE_TYPE = "month";
@@ -93,6 +94,10 @@ export default class DateTimeUtilities {
     }
 
     let new_date = date;
+    if (typeof new_date === "number") {
+      // Year date answers are saved as numbers: convert to a string for parsing
+      new_date = new_date.toString();
+    }
     if (typeof new_date === "string") {
       new_date = fromFormat ? DateTime.fromFormat(new_date, fromFormat) : DateTime.fromISO(new_date);
     }

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
@@ -100,7 +100,10 @@ function CustomTimelineConnector(props) {
 }
 
 function TimelineEntry(classes, dateEntry, index, length, nextEntry) {
-  let dateText = DateTimeUtilities.formatDateAnswer(DateTimeUtilities.VIEW_DATE_FORMAT, dateEntry.date);
+  let displayFormat = typeof dateEntry.date === "number"
+    ? DateTimeUtilities.YEAR_DATE_FORMAT
+    : DateTimeUtilities.VIEW_DATE_FORMAT;
+  let dateText = DateTimeUtilities.formatDateAnswer(displayFormat, dateEntry.date);
   let diff = DateTimeUtilities.dateDifference(dateEntry.date, nextEntry && nextEntry.date);
 
   let paperClasses = [classes.timelinePaper];
@@ -312,7 +315,10 @@ function SubjectTimeline(props) {
         ))
     });
     return dateAnswerData.sort((a, b) => {
-      return a.date.value > b.date.value ? 1 : (a.date.value === b.date.value ? 0 : -1)
+      // Year answers are stored as longs: convert to strings for proper comparison
+      let aVal = a.date.value.toString();
+      let bVal = b.date.value.toString();
+      return aVal > bVal ? 1 : (aVal === bVal ? 0 : -1)
     });
   }
 
@@ -335,11 +341,14 @@ function SubjectTimeline(props) {
     let previousDate = null;
 
     for (const dateAnswer of dateAnswers) {
-      let diff = DateTimeUtilities.dateDifference(previousDate, dateAnswer.date.value);
-      if (newDateEntries.length === 0 || diff.short) {
+      let newDate = dateAnswer.date.value;
+      let diff = DateTimeUtilities.dateDifference(previousDate, newDate);
+      // Do not group year answers with fully specified answers that are January first:
+      // years are stored as long which gets parsed to type number, other dates are stored as strings
+      if (newDateEntries.length === 0 || diff.short || typeof previousDate !== typeof newDate) {
         // Create a new paper
         newDateEntries.push({
-          date: dateAnswer.date.value,
+          date: newDate,
           level: dateAnswer.level,
           questions: []
         })

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
@@ -279,7 +279,7 @@ function SubjectTimeline(props) {
           currentSection = currentSection ? currentSection[1] : "";
         }
 
-        let currentAnswers = Object.entries(data.form ? data.form : data)
+        let currentAnswers = Object.entries(data)
           .filter(([key, value]) => value["sling:resourceType"] == "cards/AnswerSection"
                                   && value["section"]["@name"] == entryDefinition["@name"])[0];
         currentAnswers = currentAnswers ? currentAnswers[1] : "";
@@ -301,7 +301,7 @@ function SubjectTimeline(props) {
       dateAnswerData = dateAnswerData.concat(
         handleDisplayNodes(
           Object.entries(formEntry.form.questionnaire).filter(([key, value]) => ENTRY_TYPES.includes(value['jcr:primaryType'])),
-          formEntry,
+          formEntry.form,
           {
             level: formEntry.level,
             names: formEntry.names,


### PR DESCRIPTION
Fixes:
- Dates answers that are on the root of the form (not in a section) were skipped in the subject timeline
- Trying to process year date answers lead to subject timeline erroring out

Year answers are now shown in the timeline with only the year as their displayed date. They are ordered as if they are January 1st of that year but are not grouped with other fully qualified January 1st dates.
<img width="634" height="899" alt="image" src="https://github.com/user-attachments/assets/6ea033fa-d254-45c0-a3e3-dec82ce12544" />

To test:
- Edit `start_cards.sh` to skip the clinician dashboard module in test runmode:
  - Remove `mvn:io.uhndata.cards/cards-clinician-dashboard/${CARDS_VERSION}/slingosgifeature` from line 309 so it should look like this:
```
    ARGS[$ARGS_LENGTH]=mvn:io.uhndata.cards/cards-modules-test-forms/${CARDS_VERSION}/slingosgifeature,mvn:io.uhndata.cards/cards-email-notifications/${CARDS_VERSION}/slingosgifeature,mvn:io.uhndata.cards/cards-patient-portal/${CARDS_VERSION}/slingosgifeature,mvn:io.uhndata.cards/cards-locking/${CARDS_VERSION}/slingosgifeature
```
- Launch in runmode test
- Fill out various dates in pagination test (for answers in sections) and date format test (for answers on the root) for the sample patient. Make sure to test year questions as well as other date questions
  - Date intervals are known to break timeline, will address intervals in a separate PR
- Navigate to the sample patient timeline and make sure the timeline loads and is ordered/displayed properly