### PR TITLE
CARDS-2875: Questionnaire editor > Edit dialog: info icon for properties is poorly aligned

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditorInput.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/EditorInput.jsx
@@ -51,13 +51,13 @@ let EditorInput = (props) => {
     <Grid>
       <Grid container alignItems="flex-start" spacing={2}>
         <Grid size={4} className={classes.labelContainer}>
-          <Typography variant="subtitle2">
+          <Typography variant="subtitle2" sx={{ display: "flex" }}>
             {camelCaseToWords(name?.concat(':')) || ''}
             { name && hint &&
             <Tooltip enterTouchDelay={200} title={
               <FormattedText variant="caption">{hint}</FormattedText>
             }>
-              <Info color="primary" />
+              <Info color="primary" fontSize="small" sx={{ pl: .25 }} />
             </Tooltip>
             }
           </Typography>


### PR DESCRIPTION
Details: https://phenotips.atlassian.net/browse/CARDS-2875

Before:

<img width="220" alt="image" src="https://github.com/user-attachments/assets/0a09b89a-9bd6-46b8-9c2b-510a258ab7cf" />


After:

<img width="153" height="59" alt="image" src="https://github.com/user-attachments/assets/c466a16f-3207-487a-a886-afa0fc8c374d" />
