### PR TITLE
CARDS-2873: Subject timeline interval comparison error

### DIFF
--- a/modules/commons/src/main/frontend/src/components/DateTimeUtilities.jsx
+++ b/modules/commons/src/main/frontend/src/components/DateTimeUtilities.jsx
@@ -133,7 +133,7 @@ export default class DateTimeUtilities {
       return "";
     }
     if (Array.isArray(value)) {
-      return `${this.formatDateAnswer(dateFormat, value[0])} to ${this.formatDateAnswer(dateFormat, value[1])}`;
+      return `${this.formatDateAnswer(dateFormat, value[0], fromFormat)} to ${this.formatDateAnswer(dateFormat, value[1], fromFormat)}`;
     }
     dateFormat = dateFormat || this.defaultDateFormat;
     let dateType = this.getDateType(dateFormat);

--- a/modules/commons/src/main/frontend/src/components/DateTimeUtilities.jsx
+++ b/modules/commons/src/main/frontend/src/components/DateTimeUtilities.jsx
@@ -94,10 +94,6 @@ export default class DateTimeUtilities {
     }
 
     let new_date = date;
-    if (typeof new_date === "number") {
-      // Year date answers are saved as numbers: convert to a string for parsing
-      new_date = new_date.toString();
-    }
     if (typeof new_date === "string") {
       new_date = fromFormat ? DateTime.fromFormat(new_date, fromFormat) : DateTime.fromISO(new_date);
     }
@@ -149,12 +145,22 @@ export default class DateTimeUtilities {
     return date.toFormat(dateFormat);
   }
 
+  static dateFromAnswerValue = (dateInput) => {
+    // If the answer was an interval, it will have two dates in an array. Compare to the first date only
+    let date = Array.isArray(dateInput) ? dateInput[0] : dateInput;
+    // Year date answers are saved as numbers: convert to a string for parsing
+    if (typeof date === "number") {
+      date = date.toString();
+    }
+    return this.toPrecision(date, this.defaultDateFormat);
+  }
+
   static dateDifference = (startDateInput, endDateInput) => {
     // Compute the displayed difference
     let result = { long:"" }
     if (startDateInput && endDateInput) {
-      let startDate = this.toPrecision(startDateInput, this.defaultDateFormat);
-      let endDate = this.toPrecision(endDateInput, this.defaultDateFormat);
+      let startDate = this.dateFromAnswerValue(startDateInput);
+      let endDate = this.dateFromAnswerValue(endDateInput);
 
       let diff = [];
       let longDiff = [];

--- a/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/SubjectTimeline.jsx
@@ -99,7 +99,8 @@ function CustomTimelineConnector(props) {
 }
 
 function TimelineEntry(classes, dateEntry, index, length, nextEntry) {
-  let displayFormat = typeof dateEntry.date === "number"
+  let displayFormat = (typeof dateEntry.date === "number"
+    || (Array.isArray(dateEntry.date) && dateEntry.date.length > 0 && typeof dateEntry.date[0] === "number"))
     ? DateTimeUtilities.YEAR_DATE_FORMAT
     : DateTimeUtilities.VIEW_DATE_FORMAT;
   let dateText = DateTimeUtilities.formatDateAnswer(displayFormat, dateEntry.date);


### PR DESCRIPTION
- Fixes an error that occurs when a date interval is compared with another date on the subject timeline
  - Now compares the first date in the interval
  
  For testing:
  - Edit `start_cards.sh` to skip the clinician dashboard module in test runmode:
  - Remove `mvn:io.uhndata.cards/cards-clinician-dashboard/${CARDS_VERSION}/slingosgifeature` from line 309 so it should look like this:
```
    ARGS[$ARGS_LENGTH]=mvn:io.uhndata.cards/cards-modules-test-forms/${CARDS_VERSION}/slingosgifeature,mvn:io.uhndata.cards/cards-email-notifications/${CARDS_VERSION}/slingosgifeature,mvn:io.uhndata.cards/cards-patient-portal/${CARDS_VERSION}/slingosgifeature,mvn:io.uhndata.cards/cards-locking/${CARDS_VERSION}/slingosgifeature
```
- Launch in runmode test
- Fill out various dates in pagination test (for answers in sections) and date format test (for answers on the root) for the sample patient. Make sure to test year questions and date intervals.