### PR TITLE
CARDS-2876: Add admin form and subject views to test runmode

### DIFF
--- a/test-resources/pom.xml
+++ b/test-resources/pom.xml
@@ -51,6 +51,7 @@
               SLING-INF/content/Survey/PatientAccess.xml;path:=/Survey/PatientAccess;overwrite:=true,
               SLING-INF/content/Survey/TermsOfUse.xml;path:=/Survey/TermsOfUse;overwrite:=true,
               SLING-INF/content/Survey/SurveyInstructions.xml;path:=/Survey/SurveyInstructions;overwrite:=true,
+              SLING-INF/content/Extensions/;path:=/Extensions/;overwriteProperties:=true,
             </Sling-Initial-Content>
           </instructions>
         </configuration>

--- a/test-resources/src/main/resources/SLING-INF/content/Extensions/AdminDashboard/Forms.json
+++ b/test-resources/src/main/resources/SLING-INF/content/Extensions/AdminDashboard/Forms.json
@@ -1,0 +1,9 @@
+{
+  "jcr:primaryType": "cards:Extension",
+  "cards:extensionPointId": "cards/coreUI/admindashboard/entry",
+  "cards:extensionName": "Forms",
+  "cards:targetURL": "/content.html/admin/Forms",
+  "cards:extensionURL": "admin",
+  "cards:icon": "asset:cards-dataentry.formsIcon.js",
+  "cards:hint": "All created forms"
+}

--- a/test-resources/src/main/resources/SLING-INF/content/Extensions/AdminDashboard/Subjects.json
+++ b/test-resources/src/main/resources/SLING-INF/content/Extensions/AdminDashboard/Subjects.json
@@ -1,0 +1,9 @@
+{
+  "jcr:primaryType": "cards:Extension",
+  "cards:extensionPointId": "cards/coreUI/admindashboard/entry",
+  "cards:extensionName": "Subjects",
+  "cards:targetURL": "/content.html/admin/Subjects",
+  "cards:extensionURL": "admin",
+  "cards:icon": "asset:cards-dataentry.subjectsIcon.js",
+  "cards:hint": "All created subjects"
+}

--- a/test-resources/src/main/resources/SLING-INF/content/Extensions/Views/AdminFormView.json
+++ b/test-resources/src/main/resources/SLING-INF/content/Extensions/Views/AdminFormView.json
@@ -1,0 +1,8 @@
+{
+  "jcr:primaryType": "cards:Extension",
+  "cards:extensionPointId": "cards/coreUI/view",
+  "cards:extensionName": "Admin Form View",
+  "cards:targetURL": "/content.html/admin/Forms/*",
+  "cards:extensionURL": "admin",
+  "cards:extensionRenderURL": "asset:cards-dataentry.FormView.js"
+}

--- a/test-resources/src/main/resources/SLING-INF/content/Extensions/Views/AdminForms.json
+++ b/test-resources/src/main/resources/SLING-INF/content/Extensions/Views/AdminForms.json
@@ -1,0 +1,8 @@
+{
+  "jcr:primaryType": "cards:Extension",
+  "cards:extensionPointId": "cards/coreUI/view",
+  "cards:extensionName": "Admin Forms",
+  "cards:targetURL": "/content.html/admin/Forms",
+  "cards:extensionURL": "admin",
+  "cards:extensionRenderURL": "asset:cards-dataentry.Forms.js"
+}

--- a/test-resources/src/main/resources/SLING-INF/content/Extensions/Views/AdminSubject.json
+++ b/test-resources/src/main/resources/SLING-INF/content/Extensions/Views/AdminSubject.json
@@ -1,0 +1,8 @@
+{
+  "jcr:primaryType": "cards:Extension",
+  "cards:extensionPointId": "cards/coreUI/view",
+  "cards:extensionName": "Admin Subject",
+  "cards:targetURL": "/content.html/admin/Subjects/*",
+  "cards:extensionURL": "admin",
+  "cards:extensionRenderURL": "asset:cards-dataentry.Subject.js"
+}

--- a/test-resources/src/main/resources/SLING-INF/content/Extensions/Views/AdminSubjects.json
+++ b/test-resources/src/main/resources/SLING-INF/content/Extensions/Views/AdminSubjects.json
@@ -1,0 +1,8 @@
+{
+  "jcr:primaryType": "cards:Extension",
+  "cards:extensionPointId": "cards/coreUI/view",
+  "cards:extensionName": "Admin Subjects",
+  "cards:targetURL": "/content.html/admin/Subjects",
+  "cards:extensionURL": "admin",
+  "cards:extensionRenderURL": "asset:cards-dataentry.Subjects.js"
+}


### PR DESCRIPTION
Adds the Form and Subject entries to the admin dashboard for the test runmode. In particular, this allows the non-clinician dashboard version of subjects to be tested easily while also allowing navigation between this admin subject view and other subject/form views to remain in the admin extension space.