### PR TITLE
CARDS-2878: Clearing saved fields in number intervals fails

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
@@ -171,8 +171,9 @@ function NumberQuestion(props) {
   const sliderValues = [typeof(lowerLimit) === "undefined" ? minValue : Number(lowerLimit), typeof(upperLimit) === "undefined" ? minValue : Number(upperLimit)];
 
   const isSlider = displayMode === "slider" && typeof minValue !== 'undefined' && typeof maxValue !== 'undefined';
-  const isRangeSelected = isRange && typeof(lowerLimit) != 'undefined' && !isNaN(+lowerLimit) && typeof(upperLimit) != 'undefined' && !isNaN(+upperLimit);
-  const isSingleSliderSelected = isSlider && typeof(sliderValue) != 'undefined' && !isNaN(+sliderValue);
+  const isValidNumber = (input) => typeof(input) != 'undefined' && input !== "" && !isNaN(input);
+  const isRangeSelected = isRange && isValidNumber(lowerLimit) && isValidNumber(upperLimit);
+  const isSingleSliderSelected = isSlider && isValidNumber(sliderValue);
 
   const formContext = useFormReaderContext();
   const handleFormDataChange = formContext?.['/OnFormDataChanged'];


### PR DESCRIPTION
Fix number question to recognize empty inputs as not a number, leading to incomplete intervals being cleared instead of trying to save empty strings as numbers

Testing: Fill in and save a number interval question such as the year range on the Date Format test form. Then clear one or both inputs and try saving.