### PR TITLE
CARDS-2879: Quick Search Results table does not allow seeing more than one page of results

### DIFF
--- a/modules/homepage/src/main/frontend/src/themePage/QuickSearchResults.jsx
+++ b/modules/homepage/src/main/frontend/src/themePage/QuickSearchResults.jsx
@@ -70,6 +70,7 @@ function QuickSearchResults(props) {
             customUrl={'/query?quick='+ encodeURIComponent(anchor) + allowedResourceTypes.map(i => `&allowedResourceTypes=${encodeURIComponent(i)}`).join('')}
             defaultLimit={10}
             disableTopPagination
+            showTotalRows={true}
           />
         </CardContent>
       </Card>


### PR DESCRIPTION
To test:
- start in test mode
- go to administration -> quick search
- enable searching in questionnaires, save the settings
- reload, type `a` in the quick search bar, click on the `see all 3xx results`
- check that the table shows how many results there are and allows navigating to other pages