### PR TITLE
CARDS-2883 and CARDS-2884 (status + slack notifications refactoring)

### DIFF
--- a/distribution/src/main/features/core/cards.json
+++ b/distribution/src/main/features/core/cards.json
@@ -26,6 +26,10 @@
             "start-order":"15"
         },
         {
+            "id":"io.uhndata.cards:cards-status:${project.version}",
+            "start-order":"15"
+        },
+        {
             "id":"${project.groupId}:cards-data-model-items-api:${project.version}",
             "start-order":"21"
         },

--- a/modules/error-tracking/pom.xml
+++ b/modules/error-tracking/pom.xml
@@ -42,6 +42,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.uhndata.cards</groupId>
+      <artifactId>cards-status</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.api</artifactId>
     </dependency>

--- a/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/internal/LoggedErrorsStatusReporter.java
+++ b/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/internal/LoggedErrorsStatusReporter.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.errortracking.internal;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.uhndata.cards.status.spi.StatusReport;
+import io.uhndata.cards.status.spi.StatusReporter;
+
+@Component(immediate = true)
+public class LoggedErrorsStatusReporter implements StatusReporter
+{
+    /** Default log. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoggedErrorsStatusReporter.class);
+
+    /** Provides access to the repository. */
+    @Reference
+    private volatile ResourceResolverFactory resolverFactory;
+
+    @Override
+    public String getName()
+    {
+        return "Logged errors";
+    }
+
+    @Override
+    public StatusReport report(boolean unprivileged)
+    {
+        LOGGER.debug("Gathering errors for the status report");
+        try (ResourceResolver resolver = this.resolverFactory.getServiceResourceResolver(null)) {
+            // Get all the error stack traces under /LoggedEvents/
+            List<String> errorStackTraces = getLoggedEvents(resolver);
+            LOGGER.debug("Found {} logged errors", errorStackTraces.size());
+
+            if (errorStackTraces.size() > 0 && unprivileged) {
+                return new StatusReport("There are " + errorStackTraces.size() + " errors logged",
+                    StatusReport.Status.ERROR, "Error content is hidden while not logged in");
+            }
+            String statusBody = generateStackTraceMessagePart(errorStackTraces);
+
+            if (statusBody.length() > 0) {
+                return new StatusReport("The following errors are logged:", StatusReport.Status.ERROR, statusBody);
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Failed to report logged errors: {}", e.getMessage(), e);
+            return new StatusReport("*ERROR*: Could not report logged errors", StatusReport.Status.ERROR,
+                e.getMessage());
+        }
+        return new StatusReport("No errors are logged", StatusReport.Status.DEBUG, "");
+    }
+
+    private List<String> getLoggedEvents(ResourceResolver resolver)
+    {
+        // Get all the nt:file nodes under /LoggedEvents/
+        Iterator<Resource> loggedEventsIter;
+        loggedEventsIter = resolver.findResources(
+            "SELECT n.* FROM [nt:file] AS n WHERE isdescendantnode(n, '/LoggedEvents')",
+            "JCR-SQL2");
+
+        List<String> errorStackTraces = new ArrayList<>();
+        while (loggedEventsIter.hasNext()) {
+            Resource thisResource = loggedEventsIter.next();
+            Resource jcrContentResource = thisResource.getChild("jcr:content");
+            if (jcrContentResource == null) {
+                continue;
+            }
+            String thisStackTrace = jcrContentResource.getValueMap().get("jcr:data", "");
+            errorStackTraces.add(thisStackTrace);
+        }
+        return errorStackTraces;
+    }
+
+    private String generateStackTraceMessagePart(List<String> errorStackTraces)
+    {
+        StringBuilder result = new StringBuilder();
+
+        for (String element : errorStackTraces) {
+            result.append("```\n" + element + "\n```\n\n");
+        }
+        return result.toString();
+    }
+
+    @Override
+    public Set<String> getTags()
+    {
+        return Set.of("problems", "errors");
+    }
+}

--- a/modules/healthcheck/pom.xml
+++ b/modules/healthcheck/pom.xml
@@ -41,6 +41,10 @@
     </plugins>
   </build>
 
+  <properties>
+    <coverage.instructionRatio>0.83</coverage.instructionRatio>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.uhndata.cards</groupId>

--- a/modules/healthcheck/pom.xml
+++ b/modules/healthcheck/pom.xml
@@ -43,6 +43,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.uhndata.cards</groupId>
+      <artifactId>cards-status</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.api</artifactId>
     </dependency>

--- a/modules/healthcheck/src/main/java/io/uhndata/cards/healthcheck/internal/HealthCheckStatusReporter.java
+++ b/modules/healthcheck/src/main/java/io/uhndata/cards/healthcheck/internal/HealthCheckStatusReporter.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.healthcheck.internal;
+
+import java.util.List;
+import java.util.Set;
+
+import org.apache.felix.hc.api.execution.HealthCheckExecutionResult;
+import org.apache.felix.hc.api.execution.HealthCheckExecutor;
+import org.apache.felix.hc.api.execution.HealthCheckSelector;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.uhndata.cards.status.spi.StatusReport;
+import io.uhndata.cards.status.spi.StatusReporter;
+
+@Component(immediate = true)
+public class HealthCheckStatusReporter implements StatusReporter
+{
+    /** Default log. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(HealthCheckStatusReporter.class);
+
+    private static final String TITLE = "Health Check";
+
+    /** Provides access to the repository. */
+    @Reference
+    private HealthCheckExecutor hc;
+
+    @Override
+    public String getName()
+    {
+        return "Health Check";
+    }
+
+    @Override
+    public StatusReport report(boolean unprivileged)
+    {
+        LOGGER.debug("Gathering errors for the Slack notification");
+        List<HealthCheckExecutionResult> failedChecks = this.hc.execute(HealthCheckSelector.empty().withTags("*"))
+            .stream()
+            .filter(r -> !r.getHealthCheckResult().isOk())
+            .toList();
+        LOGGER.error("{}", failedChecks);
+        if (failedChecks.isEmpty()) {
+            return new StatusReport(TITLE, StatusReport.Status.SUCCESS, "All is good!");
+        }
+        StringBuilder text = new StringBuilder("There are " + failedChecks.size() + " failed checks");
+        if (!unprivileged) {
+            text.append("\n\n");
+            failedChecks.forEach(error -> text.append(error.getHealthCheckMetadata().getName()).append("\n"));
+        }
+        return new StatusReport(TITLE, StatusReport.Status.ERROR, text.toString());
+    }
+
+    @Override
+    public Set<String> getTags()
+    {
+        return Set.of("problems", "healthcheck");
+    }
+}

--- a/modules/metrics/pom.xml
+++ b/modules/metrics/pom.xml
@@ -48,6 +48,15 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.uhndata.cards</groupId>
+      <artifactId>cards-status</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.api</artifactId>
     </dependency>

--- a/modules/metrics/src/main/features/feature.json
+++ b/modules/metrics/src/main/features/feature.json
@@ -28,5 +28,12 @@
       "start-order":"25"
     }
   ],
+  "configurations":{
+    "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~metrics":{
+      "user.mapping":[
+        "io.uhndata.cards.metrics=[cards-metrics]"
+      ]
+    }
+  },
   "repoinit:TEXT|true": "@file"
 }

--- a/modules/metrics/src/main/java/io/uhndata/cards/metrics/internal/MetricsStatusReporter.java
+++ b/modules/metrics/src/main/java/io/uhndata/cards/metrics/internal/MetricsStatusReporter.java
@@ -103,7 +103,7 @@ public class MetricsStatusReporter implements StatusReporter
                 gatheredStatistics.merge(thisHumanName, thisMetricValue, this::mergeStats);
             }
         } catch (LoginException e) {
-            LOGGER.warn("Failed to create service session: {}", e, e.getMessage());
+            LOGGER.warn("Failed to create service session: {}", e.getMessage(), e);
         }
         return gatheredStatistics;
     }

--- a/modules/metrics/src/main/java/io/uhndata/cards/metrics/internal/MetricsStatusReporter.java
+++ b/modules/metrics/src/main/java/io/uhndata/cards/metrics/internal/MetricsStatusReporter.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.metrics.internal;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.uhndata.cards.metrics.Metrics;
+import io.uhndata.cards.status.spi.StatusReport;
+import io.uhndata.cards.status.spi.StatusReporter;
+
+@Component(immediate = true)
+public class MetricsStatusReporter implements StatusReporter
+{
+    /** Default log. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetricsStatusReporter.class);
+
+    private static final String TITLE = "Metrics";
+
+    private static final String LABEL_TODAY = "today";
+
+    private static final String LABEL_TOTAL = "total";
+
+    /** Provides access to resources. */
+    @Reference
+    private volatile ResourceResolverFactory resolverFactory;
+
+    @Override
+    public String getName()
+    {
+        return "Metrics";
+    }
+
+    @Override
+    public StatusReport report(boolean unprivileged)
+    {
+        Map<String, Map<String, Long>> gatheredStatistics = getMetrics();
+
+        // Build the notification update string to be sent to Slack
+        StringBuilder slackNotificationString = new StringBuilder();
+        gatheredStatistics.keySet().forEach(key -> buildNotificationLine(
+            slackNotificationString,
+            key.replaceAll("^\\{\\d+\\}", ""),
+            gatheredStatistics.get(key)));
+        if (slackNotificationString.length() == 0) {
+            return new StatusReport(TITLE, StatusReport.Status.WARNING, "*WARNING*: Could not gather any metrics");
+        }
+        return new StatusReport(TITLE, StatusReport.Status.INFO, slackNotificationString.toString());
+    }
+
+    private Map<String, Map<String, Long>> getMetrics()
+    {
+        LOGGER.debug("Gathering metrics for the Slack notification");
+        Map<String, Map<String, Long>> gatheredStatistics = new TreeMap<>();
+        final Map<String, Object> params = Map.of(ResourceResolverFactory.SUBSERVICE, "MetricLogger");
+        try (ResourceResolver resolver = this.resolverFactory.getServiceResourceResolver(params)) {
+
+            // Get all the sling:Folder nodes under /Metrics/
+            Iterator<Resource> metricsIter = resolver.findResources(
+                "SELECT n.* FROM [sling:Folder] AS n WHERE isdescendantnode(n, '/Metrics')",
+                "JCR-SQL2");
+
+            while (metricsIter.hasNext()) {
+                Resource thisResource = metricsIter.next();
+                String thisJcrName = thisResource.getName();
+                String thisHumanName = Metrics.getHumanName(resolver, thisJcrName);
+                if (thisHumanName == null) {
+                    continue;
+                }
+                Map<String, Long> thisMetricValue = Metrics.getAndReset(resolver, thisJcrName);
+                if (thisMetricValue == null) {
+                    continue;
+                }
+                gatheredStatistics.merge(thisHumanName, thisMetricValue, this::mergeStats);
+            }
+        } catch (LoginException e) {
+            LOGGER.warn("Failed to create service session: {}", e, e.getMessage());
+        }
+        return gatheredStatistics;
+    }
+
+    private Map<String, Long> mergeStats(Map<String, Long> oldStats, Map<String, Long> newStats)
+    {
+        Map<String, Long> result = new HashMap<>();
+        for (Map.Entry<String, Long> newValue : newStats.entrySet()) {
+            result.put(newValue.getKey(), oldStats.get(newValue.getKey()) + newValue.getValue());
+        }
+        return result;
+    }
+
+    private void buildNotificationLine(final StringBuilder result, final String name, final Map<String, Long> statMap)
+    {
+        if (result.length() > 0) {
+            result.append("\n");
+        }
+        result
+            .append("*")
+            .append(name)
+            .append("*")
+            .append(" -- _Today_: ")
+            .append(statMap.get(LABEL_TODAY))
+            .append(", _Total_: ")
+            .append(statMap.get(LABEL_TOTAL));
+    }
+
+    @Override
+    public Set<String> getTags()
+    {
+        return Set.of("activity", "metrics");
+    }
+}

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -35,6 +35,7 @@
     <module>resolver-provider</module>
     <module>form-completion-status</module>
     <module>commons</module>
+    <module>status</module>
     <module>ui-extension</module>
     <module>login</module>
     <module>homepage</module>

--- a/modules/slack-notifications/pom.xml
+++ b/modules/slack-notifications/pom.xml
@@ -53,10 +53,6 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.service.component</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>

--- a/modules/slack-notifications/pom.xml
+++ b/modules/slack-notifications/pom.xml
@@ -49,10 +49,6 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.sling</groupId>
-      <artifactId>org.apache.sling.api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.commons.scheduler</artifactId>
     </dependency>
     <dependency>
@@ -62,6 +58,10 @@
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.metatype.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.json</groupId>
@@ -85,7 +85,7 @@
     </dependency>
     <dependency>
       <groupId>io.uhndata.cards</groupId>
-      <artifactId>cards-metrics</artifactId>
+      <artifactId>cards-status</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/Configuration.java
+++ b/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/Configuration.java
@@ -53,6 +53,6 @@ public @interface Configuration
 
     @AttributeDefinition(name = "Don't post empty messages",
         description = "If the message ends up containing nothing at all, don't post anything."
-            + "If this setting is false, then a 'Nothing to report' message will be sent in this case.")
+            + " If this setting is false, then a 'Nothing to report' message will be sent in this case.")
     boolean skipEmpty() default true;
 }

--- a/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/Configuration.java
+++ b/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/Configuration.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.slacknotifications;
+
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+@ObjectClassDefinition(name = "Scheduled Slack Notifications",
+    description = "Configuration for sending regular slack notifications.")
+public @interface Configuration
+{
+    @AttributeDefinition(name = "Name")
+    String name();
+
+    @AttributeDefinition(name = "Schedule",
+        description = "A Quartz-readable schedule expression determining when the notification job runs, for example "
+            + "'0 0 0 * * ? *' for a nightly notification, or '0 0 9 ? * MON *' for a weekly Monday morning message.")
+    String schedule() default "%ENV%SLACK_NOTIFICATIONS_SCHEDULE";
+
+    @AttributeDefinition(name = "Endpoint",
+        description = "A webhook endpoint that will receive the message.")
+    String endpoint() default "%ENV%SLACK_NOTIFICATIONS_ENDPOINT";
+
+    @AttributeDefinition(name = "Message title",
+        description = "An optional title to include in the message.")
+    String title() default "";
+
+    @AttributeDefinition(name = "Include notifications",
+        description = "Customize which notifications to include in the message. Leave empty to include all.")
+    String[] include();
+
+    @AttributeDefinition(name = "Extra parameters",
+        description = "Optional extra parameters to pass to the notification producers."
+            + " The expected values depend on each notification producer, but they must be in the key=value format.")
+    String[] notificationParameters();
+
+    @AttributeDefinition(name = "Don't post empty messages",
+        description = "If the message ends up containing nothing at all, don't post anything."
+            + "If this setting is false, then a 'Nothing to report' message will be sent in this case.")
+    boolean skipEmpty() default true;
+}

--- a/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/ScheduledSlackNotification.java
+++ b/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/ScheduledSlackNotification.java
@@ -19,43 +19,54 @@
 
 package io.uhndata.cards.slacknotifications;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.commons.scheduler.ScheduleOptions;
 import org.apache.sling.commons.scheduler.Scheduler;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.metatype.annotations.Designate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.uhndata.cards.slacknotifications.spi.SlackNotificationProducer;
+
 @Component(immediate = true)
-public class ScheduledSlackNotifications
+@Designate(ocd = Configuration.class, factory = true)
+public class ScheduledSlackNotification
 {
     /** Default log. */
-    private static final Logger LOGGER = LoggerFactory.getLogger(ScheduledSlackNotifications.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScheduledSlackNotification.class);
 
-    /** Provides access to resources. */
-    @Reference
-    private ResourceResolverFactory resolverFactory;
+    private static final String SCHEDULER_JOB_PREFIX = "ScheduledSlackNotification-";
 
-    /** The scheduler for rescheduling jobs. */
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, fieldOption = FieldOption.UPDATE,
+        policy = ReferencePolicy.DYNAMIC)
+    private volatile List<SlackNotificationProducer> notifications = new ArrayList<>();
+
     @Reference
     private Scheduler scheduler;
 
     @Activate
-    protected void activate(ComponentContext componentContext) throws Exception
+    protected void activate(Configuration config, ComponentContext componentContext) throws Exception
     {
         LOGGER.info("ScheduledSlackNotifications activating");
-        final String nightlyNotificationsSchedule =
-            StringUtils.defaultIfEmpty(System.getenv("NIGHTLY_SLACK_NOTIFICATIONS_SCHEDULE"), "0 0 7 * * ? *");
+        final String nightlyNotificationsSchedule = getSchedule(config.schedule());
 
         ScheduleOptions slackNotificationsOptions = this.scheduler.EXPR(nightlyNotificationsSchedule);
-        slackNotificationsOptions.name("slackNightlyNotifications");
+        slackNotificationsOptions.name(SCHEDULER_JOB_PREFIX + config.name());
         slackNotificationsOptions.canRunConcurrently(true);
 
-        final Runnable slackNotificationsJob = new SlackNotificationsTask(this.resolverFactory);
+        final Runnable slackNotificationsJob =
+            new SlackNotificationsTask(config, this.notifications);
 
         try {
             this.scheduler.schedule(slackNotificationsJob, slackNotificationsOptions);
@@ -63,5 +74,21 @@ public class ScheduledSlackNotifications
         } catch (Exception e) {
             LOGGER.error("SlackNotificationsTask Failed to schedule: {}", e.getMessage(), e);
         }
+    }
+
+    @Deactivate
+    public void configRemoved(final Configuration removedConfig)
+    {
+        LOGGER.debug("Removed slack notification configuration {}", removedConfig.name());
+        this.scheduler.unschedule(SCHEDULER_JOB_PREFIX + removedConfig.name());
+    }
+
+    private String getSchedule(final String config)
+    {
+        String result = config;
+        if (result != null && result.startsWith("%ENV%")) {
+            result = System.getenv(config.substring("%ENV%".length()));
+        }
+        return StringUtils.defaultIfEmpty(result, "0 0 0 * * ? *");
     }
 }

--- a/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/ScheduledSlackNotification.java
+++ b/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/ScheduledSlackNotification.java
@@ -25,7 +25,6 @@ import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.commons.scheduler.ScheduleOptions;
 import org.apache.sling.commons.scheduler.Scheduler;
-import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
@@ -56,7 +55,7 @@ public class ScheduledSlackNotification
     private Scheduler scheduler;
 
     @Activate
-    protected void activate(Configuration config, ComponentContext componentContext) throws Exception
+    protected void activate(Configuration config) throws Exception
     {
         LOGGER.info("ScheduledSlackNotifications activating");
         final String nightlyNotificationsSchedule = getSchedule(config.schedule());

--- a/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/SlackNotificationsTask.java
+++ b/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/SlackNotificationsTask.java
@@ -20,185 +20,100 @@
 package io.uhndata.cards.slacknotifications;
 
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
 
-import org.apache.sling.api.resource.LoginException;
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.uhndata.cards.httprequests.HttpRequests;
-import io.uhndata.cards.metrics.Metrics;
+import io.uhndata.cards.slacknotifications.spi.SlackNotificationProducer;
 
 public class SlackNotificationsTask implements Runnable
 {
-    private static final String SLACK_PERFORMANCE_URL = System.getenv("SLACK_PERFORMANCE_URL");
-
     /** Default log. */
     private static final Logger LOGGER = LoggerFactory.getLogger(SlackNotificationsTask.class);
-    private static final String LABEL_TODAY = "today";
-    private static final String LABEL_TOTAL = "total";
 
-    /** Provides access to resources. */
-    private final ResourceResolverFactory resolverFactory;
+    private final String endpoint;
 
-    SlackNotificationsTask(final ResourceResolverFactory resolverFactory)
+    private final List<String> include;
+
+    private final String title;
+
+    private final boolean skipEmpty;
+
+    private Map<String, String> extraParameters;
+
+    /** A list of all available notification producers. */
+    private final List<SlackNotificationProducer> notifications;
+
+    public SlackNotificationsTask(final Configuration config, final List<SlackNotificationProducer> notifications)
     {
-        this.resolverFactory = resolverFactory;
-    }
-
-    private String buildNotificationLine(String prevValue, Map<String, Long> statMap, String name)
-    {
-        String notificationLine = prevValue;
-        if (notificationLine.length() > 0) {
-            notificationLine += "\n";
-        }
-        notificationLine += "*";
-        notificationLine += name;
-        notificationLine += "*";
-        notificationLine += " -- _Today_: ";
-        notificationLine += statMap.get(LABEL_TODAY);
-        notificationLine += ", _Total_: ";
-        notificationLine += statMap.get(LABEL_TOTAL);
-        return notificationLine;
-    }
-
-    private void postToSlack(String slackUrl, String msg, String color)
-    {
-        try {
-            JsonObject slackApiReq = Json.createObjectBuilder()
-                .add("attachments", Json.createArrayBuilder()
-                    .add(Json.createObjectBuilder()
-                        .add("text", msg)
-                        .add("fallback", "Failed to generate a report :(")
-                        .add("color", color)
-                    )
-                )
-                .build();
-            HttpRequests.getPostResponse(slackUrl, slackApiReq.toString(), "application/json");
-        } catch (IOException e) {
-            LOGGER.warn("Failed to send performance update to Slack");
-        }
-    }
-
-    private List<String> getLoggedEvents(ResourceResolver resolver)
-    {
-        // Get all the nt:file nodes under /LoggedEvents/
-        Iterator<Resource> loggedEventsIter;
-        loggedEventsIter = resolver.findResources(
-            "SELECT n.* FROM [nt:file] AS n WHERE isdescendantnode(n, '/LoggedEvents')",
-            "JCR-SQL2"
-        );
-
-        List<String> errorStackTraces = new ArrayList<>();
-        while (loggedEventsIter.hasNext()) {
-            Resource thisResource = loggedEventsIter.next();
-            Resource jcrContentResource = thisResource.getChild("jcr:content");
-            if (jcrContentResource == null) {
-                continue;
+        this.notifications = notifications;
+        this.title = config.title();
+        this.endpoint = config.endpoint();
+        this.include = (config.include() == null ? Collections.emptyList() : List.of(config.include()));
+        this.extraParameters = new HashMap<>();
+        if (config.notificationParameters() != null) {
+            for (var param : config.notificationParameters()) {
+                String[] keyval = param.split("=", 2);
+                if (keyval.length == 2) {
+                    this.extraParameters.put(keyval[0], keyval[1]);
+                }
             }
-            String thisStackTrace = jcrContentResource.getValueMap().get("jcr:data", "");
-            errorStackTraces.add(thisStackTrace);
         }
-        return errorStackTraces;
-    }
-
-    private String generateStackTraceMessagePart(List<String> errorStackTraces)
-    {
-        String slackNotificationString = "";
-        Iterator<String> stackTracesIter = errorStackTraces.iterator();
-
-        // Include a separator message if there are any stack traces to be printed
-        if (stackTracesIter.hasNext()) {
-            slackNotificationString += "\n\n" + "The following errors were logged:";
-        }
-
-        // Include the stack traces text
-        while (stackTracesIter.hasNext()) {
-            slackNotificationString += "\n" + "```" + "\n" + stackTracesIter.next() + "\n" + "```";
-        }
-        return slackNotificationString;
-    }
-
-    private Map<String, Long> mergeStats(Map<String, Long> oldStats, Map<String, Long> newStats)
-    {
-        Map<String, Long> result = new HashMap<>();
-        for (Map.Entry<String, Long> newValue : newStats.entrySet()) {
-            result.put(newValue.getKey(), oldStats.get(newValue.getKey()) + newValue.getValue());
-        }
-        return result;
+        this.skipEmpty = config.skipEmpty();
     }
 
     @Override
     public void run()
     {
         LOGGER.debug("Running SlackNotificationsTask");
+        List<List<JsonObject>> result = this.notifications.stream()
+            .filter(n -> this.include.isEmpty() || this.include.contains(n.getName()))
+            .map(n -> n.prepareMessages(this.extraParameters))
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+        LOGGER.debug("Got these results: {}", result);
+        postToSlack(result);
+        LOGGER.debug("Done SlackNotificationsTask");
+    }
+
+    private void postToSlack(List<List<JsonObject>> messages)
+    {
+        if (messages.isEmpty() && this.skipEmpty) {
+            return;
+        }
         try {
-            Map<String, Object> params = new HashMap<>();
-            params.put(ResourceResolverFactory.SUBSERVICE, "SlackNotifications");
-            ResourceResolver resolver = this.resolverFactory.getServiceResourceResolver(params);
-
-            Map<String, Map<String, Long>> gatheredStatistics = new TreeMap<>();
-
-            // Get all the sling:Folder nodes under /Metrics/
-            Iterator<Resource> metricsIter;
-            metricsIter = resolver.findResources(
-                "SELECT n.* FROM [sling:Folder] AS n WHERE isdescendantnode(n, '/Metrics')",
-                "JCR-SQL2"
-            );
-
-            while (metricsIter.hasNext()) {
-                Resource thisResource = metricsIter.next();
-                String thisJcrName = thisResource.getName();
-                String thisHumanName = Metrics.getHumanName(resolver, thisJcrName);
-                if (thisHumanName == null) {
-                    continue;
-                }
-                Map<String, Long> thisMetricValue = Metrics.getAndReset(resolver, thisJcrName);
-                if (thisMetricValue == null) {
-                    continue;
-                }
-                gatheredStatistics.merge(thisHumanName, thisMetricValue, this::mergeStats);
+            JsonObjectBuilder slackApiReq = Json.createObjectBuilder();
+            JsonArrayBuilder attachments = Json.createArrayBuilder();
+            if (messages.isEmpty()) {
+                JsonObjectBuilder nothing = Json.createObjectBuilder();
+                nothing.add(SlackNotificationProducer.TEXT, "Nothing to report")
+                    .add(SlackNotificationProducer.TITLE, "All is good")
+                    .add(SlackNotificationProducer.COLOR, SlackNotificationProducer.INFO);
+                attachments.add(nothing);
+            } else {
+                messages.forEach(innerList -> innerList.forEach(attachments::add));
             }
 
-            // Get all the error stack traces under /LoggedEvents/
-            List<String> errorStackTraces = getLoggedEvents(resolver);
-
-            resolver.close();
-
-            // Build the notification update string to be sent to Slack
-            String slackNotificationString = "";
-            for (String key : gatheredStatistics.keySet())
-            {
-                slackNotificationString = buildNotificationLine(
-                    slackNotificationString,
-                    gatheredStatistics.get(key),
-                    key.replaceAll("^\\{\\d+\\}", "")
-                );
+            if (StringUtils.isNotBlank(this.title)) {
+                slackApiReq.add("text", this.title);
             }
-
-            // Include any relevant stack traces
-            slackNotificationString += generateStackTraceMessagePart(errorStackTraces);
-
-            postToSlack(SLACK_PERFORMANCE_URL,
-                (slackNotificationString.length() == 0)
-                    ? "*ERROR*: Could not gather any performance statistics" : slackNotificationString,
-                (slackNotificationString.length() == 0 || errorStackTraces.size() > 0)
-                    ? "#f3db0e" : "#2eb886"
-            );
-
-        } catch (LoginException e) {
-            LOGGER.warn("Failed to results.next().getPath()");
+            slackApiReq.add("attachments", attachments);
+            HttpRequests.getPostResponse(this.endpoint, slackApiReq.build().toString(), "application/json");
+        } catch (IOException e) {
+            LOGGER.warn("Failed to send performance update to Slack");
         }
     }
 }

--- a/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/internal/notifications/StatusReportNotification.java
+++ b/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/internal/notifications/StatusReportNotification.java
@@ -64,7 +64,7 @@ public class StatusReportNotification implements SlackNotificationProducer
     @Override
     public String getName()
     {
-        return "Health Check";
+        return "status";
     }
 
     @Override

--- a/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/internal/notifications/StatusReportNotification.java
+++ b/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/internal/notifications/StatusReportNotification.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.slacknotifications.internal.notifications;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import io.uhndata.cards.slacknotifications.spi.SlackNotificationProducer;
+import io.uhndata.cards.status.api.StatusReportManager;
+import io.uhndata.cards.status.spi.StatusReport;
+
+/**
+ * Sends a status report to Slack. See the {@code cards-status-report} module for more details about status reports.
+ * Each status message will be sent as a Slack attachment. The following parameters are supported:
+ * <ul>
+ * <li>{@code statusReport.targetStatusLevel}, the target {@link StatusReport.Status} to pass to
+ * {@link StatusReportManager#getReports(boolean, io.uhndata.cards.status.spi.StatusReport.Status, Set)}, must be one of
+ * the known levels; defaults to {@code INFO}</li>
+ * <li>{@code statusReport.includeTags}, which status tags to include, passed to
+ * {@link StatusReportManager#getReports(boolean, io.uhndata.cards.status.spi.StatusReport.Status, Set)}; defaults to
+ * all tags</li>
+ * <li>{@code statusReport.unprivileged}, whether the report should be generated for an unprivileged audience, passed to
+ * {@link StatusReportManager#getReports(boolean, io.uhndata.cards.status.spi.StatusReport.Status, Set)}; defaults to
+ * {@code false}, use {@code true} to switch to unprivileged mode</li>
+ * </ul>
+ *
+ * @version $Id$
+ * @since 0.9.38
+ */
+@Component(immediate = true)
+public class StatusReportNotification implements SlackNotificationProducer
+{
+    @Reference
+    private StatusReportManager statusReportManager;
+
+    @Override
+    public String getName()
+    {
+        return "Health Check";
+    }
+
+    @Override
+    public List<JsonObject> prepareMessages(final Map<String, String> extraParameters)
+    {
+        StatusReport.Status targetStatus = StatusReport.Status.INFO;
+        String customTargetStatus = extraParameters.get("statusReport.targetStatusLevel");
+        if (customTargetStatus != null) {
+            targetStatus = StatusReport.Status.valueOf(customTargetStatus);
+        }
+        Set<String> tags = new HashSet<>();
+        String customTags = extraParameters.get("statusReport.includeTags");
+        if (customTags != null) {
+            Collections.addAll(tags, customTags.split(","));
+        }
+        boolean unprivileged = Boolean.valueOf(extraParameters.get("statusReport.unprivileged"));
+        final List<StatusReport> reports = this.statusReportManager.getReports(unprivileged, targetStatus, tags);
+        final List<JsonObject> result = new ArrayList<>();
+        for (StatusReport report : reports) {
+            final JsonObjectBuilder json = Json.createObjectBuilder();
+            json.add(TITLE, report.getName())
+                .add(TEXT, report.getText());
+            switch (report.getStatus()) {
+                case SUCCESS:
+                    json.add(COLOR, SUCCESS);
+                    break;
+                case WARNING:
+                    json.add(COLOR, WARNING);
+                    break;
+                case ERROR:
+                    json.add(COLOR, ERROR);
+                    break;
+                default:
+                    json.add(COLOR, INFO);
+                    break;
+            }
+            result.add(json.build());
+        }
+        return result.isEmpty() ? null : result;
+    }
+}

--- a/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/spi/SlackNotificationProducer.java
+++ b/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/spi/SlackNotificationProducer.java
@@ -43,7 +43,7 @@ public interface SlackNotificationProducer
     String COLOR = "color";
 
     /** The color used for neutral/informational messages. */
-    String INFO = "996";
+    String INFO = "999";
 
     /** The color used for success messages. */
     String SUCCESS = "393";

--- a/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/spi/SlackNotificationProducer.java
+++ b/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/spi/SlackNotificationProducer.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.slacknotifications.spi;
+
+import java.util.List;
+import java.util.Map;
+
+import jakarta.json.JsonObject;
+
+/**
+ * Service interface for producing messages to post to Slack. When it's time to send a status message, each
+ * implementation's {@link #prepareMessages} will be invoked, and the results will be aggregated in a single Slack post.
+ *
+ * @version $Id$
+ * @since 0.9.38
+ */
+public interface SlackNotificationProducer
+{
+    /** The name of the JSON property holding the title of the message. */
+    String TITLE = "title";
+
+    /** The name of the JSON property holding the text part of a message. */
+    String TEXT = "text";
+
+    /** The name of the JSON property defining the side color of an attachment. */
+    String COLOR = "color";
+
+    /** The color used for neutral/informational messages. */
+    String INFO = "996";
+
+    /** The color used for success messages. */
+    String SUCCESS = "393";
+
+    /** The color used for warning messages. */
+    String WARNING = "BA0";
+
+    /** The color used for error messages. */
+    String ERROR = "900";
+
+    /**
+     * The name of this producer, used to identify it, and to enable/disable it for specific jobs.
+     *
+     * @return a simple string
+     */
+    String getName();
+
+    /**
+     * Prepare a message, as a valid Slack "attachment" object.
+     *
+     * @param extraParameters optional extra parameters configured for the Slack notification, which may influence how
+     *            the message is prepared
+     * @return a list of JSON objects respecting the attachment API, that will be added to the attachments list of the
+     *         message
+     */
+    List<JsonObject> prepareMessages(Map<String, String> extraParameters);
+}

--- a/modules/status/pom.xml
+++ b/modules/status/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.uhndata.cards</groupId>
+    <artifactId>cards-modules</artifactId>
+    <version>0.9.38-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>cards-status</artifactId>
+  <packaging>bundle</packaging>
+  <name>CARDS - Status Reporting</name>
+  <description>Support for reporting the status of the application</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.servlets.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.api</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/modules/status/src/main/features/feature.json
+++ b/modules/status/src/main/features/feature.json
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+{
+  "bundles":[
+    {
+      "id":"${project.groupId}:${project.artifactId}:${project.version}",
+      "start-order":"26"
+    },
+    {
+      "id":"${project.groupId}:cards-http-requests:${project.version}",
+      "start-order":"25"
+    }
+  ],
+  "configurations":{
+    "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~slackNotifications":{
+      "user.mapping":[
+        "io.uhndata.cards.slack-notifications:SlackNotifications=[cards-metrics]"
+      ]
+    }
+  }
+}

--- a/modules/status/src/main/java/io/uhndata/cards/status/StatusReportEndpoint.java
+++ b/modules/status/src/main/java/io/uhndata/cards/status/StatusReportEndpoint.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.uhndata.cards.status;
+
+import java.io.IOException;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.servlet.Servlet;
+
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletResponse;
+import org.apache.sling.api.servlets.SlingJakartaSafeMethodsServlet;
+import org.apache.sling.servlets.annotations.SlingServletPaths;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import io.uhndata.cards.status.api.StatusReportManager;
+import io.uhndata.cards.status.spi.StatusReport;
+
+@Component(service = { Servlet.class }, property = { "sling.auth.requirements=-/system/status" })
+@SlingServletPaths(value = "/system/status")
+public class StatusReportEndpoint extends SlingJakartaSafeMethodsServlet
+{
+    private static final long serialVersionUID = -120234215527291L;
+
+    @Reference
+    private StatusReportManager manager;
+
+    @Override
+    public void doGet(final SlingJakartaHttpServletRequest request, final SlingJakartaHttpServletResponse response)
+        throws IOException
+    {
+        final boolean unprivileged = !("admin".equals(request.getRemoteUser()));
+        JsonArrayBuilder results = Json.createArrayBuilder();
+        this.manager.getReports(unprivileged).stream()
+            .map(StatusReport::toJson)
+            .forEach(r -> results.add(r));
+        response.setContentType("application/json");
+        response.getWriter().print(results.build().toString());
+    }
+}

--- a/modules/status/src/main/java/io/uhndata/cards/status/api/StatusReportManager.java
+++ b/modules/status/src/main/java/io/uhndata/cards/status/api/StatusReportManager.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.status.api;
+
+import java.util.List;
+import java.util.Set;
+
+import io.uhndata.cards.status.spi.StatusReport;
+
+/**
+ * Service for computing status reports.
+ *
+ * @version $Id$
+ * @since 0.9.38
+ */
+public interface StatusReportManager
+{
+    /**
+     * Get all the non-debug status reports.
+     *
+     * @param unprivileged Whether the body of the report should not include sensitive information, since the report
+     *            will be posted into an unprivileged/unsecure location. {@code false} means that the report may include
+     *            confidential information, {@code true} means it should not.
+     * @return a list of status reports
+     */
+    default List<StatusReport> getReports(boolean unprivileged)
+    {
+        return getReports(unprivileged, StatusReport.Status.INFO, null);
+    }
+
+    /**
+     * Compute and get status reports.
+     *
+     * @param unprivileged Whether the body of the report should not include sensitive information, since the report
+     *            will be posted into an unprivileged/unsecure location. {@code false} means that the report may include
+     *            confidential information, {@code true} means it should not.
+     * @param level the target level, only include reports that are at this or a higher level of importance
+     * @param tags an optional set of tags of reporters to include, for example only {@code problems} or only
+     *            {@code activity}; {@code null} or an empty set includes all reporters
+     * @return a list of status reports
+     */
+    List<StatusReport> getReports(boolean unprivileged, StatusReport.Status level, Set<String> tags);
+}

--- a/modules/status/src/main/java/io/uhndata/cards/status/internal/StatusReportManagerImpl.java
+++ b/modules/status/src/main/java/io/uhndata/cards/status/internal/StatusReportManagerImpl.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.status.internal;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.FieldOption;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+
+import io.uhndata.cards.status.api.StatusReportManager;
+import io.uhndata.cards.status.spi.StatusReport;
+import io.uhndata.cards.status.spi.StatusReporter;
+
+@Component
+public class StatusReportManagerImpl implements StatusReportManager
+{
+    /** A list of all available reporters. */
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, fieldOption = FieldOption.REPLACE,
+        policy = ReferencePolicy.DYNAMIC)
+    private volatile List<StatusReporter> reporters;
+
+    @Override
+    public List<StatusReport> getReports(final boolean unprivileged, final StatusReport.Status level,
+        final Set<String> tags)
+    {
+        return this.reporters.stream()
+            .filter(r -> tags == null || tags.isEmpty() || !Collections.disjoint(r.getTags(), tags))
+            .map(r -> r.report(unprivileged))
+            .filter(Objects::nonNull)
+            .filter(r -> r.getStatus().compareTo(level) >= 0)
+            .toList();
+    }
+}

--- a/modules/status/src/main/java/io/uhndata/cards/status/spi/StatusReport.java
+++ b/modules/status/src/main/java/io/uhndata/cards/status/spi/StatusReport.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.status.spi;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+
+/**
+ * A bit of information about the status of the system.
+ *
+ * @version $Id$
+ * @since 0.9.38
+ */
+public class StatusReport
+{
+    /** A category for this status. */
+    public enum Status
+    {
+        /** A debug report, excluded unless explicitly requested. */
+        DEBUG,
+        /** An information report. */
+        INFO,
+        /** A report about a successful status. */
+        SUCCESS,
+        /** A report containing a warning message that should be looked at. */
+        WARNING,
+        /** A report containing an error message that signals a critical problem that must be investigated. */
+        ERROR
+    }
+
+    private final String name;
+
+    private final Status status;
+
+    private final String text;
+
+    public StatusReport(final String name, final Status status, final String text)
+    {
+        this.name = name;
+        this.status = status;
+        this.text = text;
+    }
+
+    /**
+     * The name of this report.
+     *
+     * @return a simple string
+     */
+    public String getName()
+    {
+        return this.name;
+    }
+
+    /**
+     * The status of this report.
+     *
+     * @return one of the {@link Status} values
+     */
+    public Status getStatus()
+    {
+        return this.status;
+    }
+
+    /**
+     * The body of the report.
+     *
+     * @return a piece of text
+     */
+    public String getText()
+    {
+        return this.text;
+    }
+
+    /**
+     * String serialization mostly for debug purposes.
+     *
+     * @return a short summary about this report, containing just the name of the report and the status level
+     */
+    @Override
+    public String toString()
+    {
+        return getName() + ": " + getStatus();
+    }
+
+    /**
+     * Serialize this report as a JSON object.
+     *
+     * @return a JSON object with the following keys: {@code name}, {@code status}, {@code text}
+     */
+    public JsonObject toJson()
+    {
+        return Json.createObjectBuilder()
+            .add("name", getName())
+            .add("status", getStatus().toString())
+            .add("text", getText())
+            .build();
+    }
+}

--- a/modules/status/src/main/java/io/uhndata/cards/status/spi/StatusReporter.java
+++ b/modules/status/src/main/java/io/uhndata/cards/status/spi/StatusReporter.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.status.spi;
+
+import java.util.Set;
+
+/**
+ * Service interface for producing status reports. When it's time to produce a status report, each implementation's
+ * {@link #report} will be invoked.
+ *
+ * @version $Id$
+ * @since 0.9.38
+ */
+public interface StatusReporter
+{
+    /**
+     * The name of this reporter, used to identify it.
+     *
+     * @return a simple string
+     */
+    String getName();
+
+    /**
+     * The tags used to categorize this reporter, used to enable/disable it for specific jobs.
+     *
+     * @return a simple string
+     */
+    Set<String> getTags();
+
+    /**
+     * Prepare and return a status report.
+     *
+     * @param unprivileged Whether the body of the report should not include sensitive information, since the report
+     *            will be posted into an unprivileged/unsecure location. {@code false} means that the report may include
+     *            confidential information, {@code true} means it should not.
+     * @return a status report, or {@code null} if there is nothing to report
+     */
+    StatusReport report(boolean unprivileged);
+}


### PR DESCRIPTION
To test:
- start with `SLACK_NOTIFICATIONS_SCHEDULE='0 * * * * ? *' ./start_cards.sh --test --dev -f mvn:io.uhndata.cards/cards-slack-notifications/VERSION/slingosgifeature`
- go to `http://localhost:8080/system/console/configMgr` and add a new `Scheduled Slack Notifications` configuration, give it a simple name like `test1`, use the testing endpoint shared on Slack, leave everything else as default
- wait one minute, check that a message is sent to the #cards-alerts-dev channel
- go to `http://localhost:8080/bin/browser.html/libs/cards/healthcheck/requiredServices/` and delete the two nodes, make sure the next status does not have a healthcheck error
- edit the configuration again, try different settings like selecting a different schedule, only some statuses, selecting a higher target level, skipping and not skipping empty messages...
- add another instance of the configuration with different settings, make sure both are firing properly; `0 1/2 * 1/1 * ? *` runs every odd minute, `0 0/2 * 1/1 * ? *` runs every even minute
- remove the first instance, make sure it's no longer firing
- also try running with yourexp, which should already have the slack module enabled