### PR TITLE
CARDS-2882: Update my Answers not working on last questionnaire

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -252,9 +252,9 @@ function QuestionnaireSet(props) {
     return contentOffset || 0;
   }, [crtStep, contentOffset]);
 
-  // Reset the crtFormId when returning to the welcome screen
+  // Reset the crtFormId when on the welcome screen or review screen so that "Update my Answers" triggers page loads correctly
   useEffect(() => {
-    crtStep == -1 && setCrtFormId(null);
+    (crtStep == -1 || crtStep >= questionnaireIds?.length) && setCrtFormId(null);
   }, [crtStep]);
 
   // Find the next step : Skip questionnaires that have already been filled out


### PR DESCRIPTION
- When advancing to the review screen, clear the current form Id.
  - Previously, "Update my Answers" failed if only the last form was incomplete as the last form id was still there from before