### PR TITLE
Update Maven version from 3.8+ to 3.9+ in README.md / Prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Prerequisites:
 * Java 21
-* Maven 3.8+
+* Maven 3.9+
 * Python 2.5+ or Python 3.0+
 * psutil Python module (recommended)
 


### PR DESCRIPTION
Maven 3.9+ is needed since merging https://github.com/data-team-uhn/cards/pull/2244 (dev commit 3e7dc643b0bb8bd3f3449fd726fff401107ee3f8).