### PR TITLE
CARDS-2888: Update NodeJS from 22.13.1 to v.26.0.0

### DIFF
--- a/modules/principals/src/main/frontend/src/Userboard/Groups/GroupsManager.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/GroupsManager.jsx
@@ -32,14 +32,14 @@ import { MaterialReactTable, useMaterialReactTable } from 'material-react-table'
 import PropTypes from "prop-types";
 import { withStyles } from 'tss-react/mui'
 
-import AdminScreen from "../../adminDashboard/AdminScreen.jsx";
-import { checkPropTypes } from "../../propTypes";
-import userboardStyles from '../userboardStyles.jsx';
-import CreateGroupDialog from "./CreateGroupDialog.jsx";
-import DeletePrincipalDialog from "../DeletePrincipalDialog.jsx";
 import AddUserToGroupDialog from "./AddUserToGroupDialog.jsx";
-import NewItemButton from "../../components/NewItemButton.jsx"
+import CreateGroupDialog from "./CreateGroupDialog.jsx";
+import AdminScreen from "../../adminDashboard/AdminScreen.jsx";
+import NewItemButton from "../../components/NewItemButton.jsx";
 import { fetchWithReLogin, GlobalLoginContext } from "../../login/ReLoginDialog.js";
+import { checkPropTypes } from "../../propTypes";
+import DeletePrincipalDialog from "../DeletePrincipalDialog.jsx";
+import userboardStyles from '../userboardStyles.jsx';
 
 const GROUP_URL = "/system/userManager/group/";
 

--- a/modules/principals/src/main/frontend/src/Userboard/Users/UsersManager.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Users/UsersManager.jsx
@@ -25,13 +25,13 @@ import { MaterialReactTable } from 'material-react-table';
 import PropTypes from "prop-types";
 import { withStyles } from 'tss-react/mui';
 
-import AdminScreen from "../../adminDashboard/AdminScreen.jsx";
-import { checkPropTypes } from "../../propTypes";
-import userboardStyles from '../userboardStyles.jsx';
-import CreateUserDialog from "./CreateUserDialog.jsx";
-import DeletePrincipalDialog from "../DeletePrincipalDialog.jsx";
 import ChangeUserPasswordDialog from "./ChangeUserPasswordDialog.jsx";
+import CreateUserDialog from "./CreateUserDialog.jsx";
+import AdminScreen from "../../adminDashboard/AdminScreen.jsx";
 import NewItemButton from "../../components/NewItemButton.jsx";
+import { checkPropTypes } from "../../propTypes";
+import DeletePrincipalDialog from "../DeletePrincipalDialog.jsx";
+import userboardStyles from '../userboardStyles.jsx';
 
 
 const USER_URL = "/system/userManager/user/";

--- a/pom.xml
+++ b/pom.xml
@@ -1655,7 +1655,7 @@
             </execution>
           </executions>
           <configuration>
-            <nodeVersion>v23.11.0</nodeVersion>
+            <nodeVersion>v26.0.0</nodeVersion>
             <yarnVersion>v1.22.22</yarnVersion>
             <workingDirectory>src/main/frontend</workingDirectory>
           </configuration>


### PR DESCRIPTION
Associated Linter errors were fixed
Reason: `eslint-plugin-import`'s alphabetize check for the combined `["parent", "sibling", "index"]` group silently fails to resolve or rank `../../` (two-level) paths when `eslint.config.js` is loaded as CJS (Node v.23). It can compare `./` vs `../` fine, but the `../../` cross-comparisons produce no result and the check is skipped.
Under Node v.26, the config loads as ESM, path resolution works fully for all relative depths, and the `../../` violations surface.