### PR TITLE
CARDS-2894: Recording when emails were sent stops working after a few days

### DIFF
--- a/modules/patient-portal/pom.xml
+++ b/modules/patient-portal/pom.xml
@@ -92,6 +92,10 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
+      <artifactId>osgi.core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component</artifactId>
     </dependency>
     <dependency>

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AbstractEmailNotification.java
@@ -40,6 +40,7 @@ import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.commons.messaging.mail.MailService;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventAdmin;
+import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +68,7 @@ abstract class AbstractEmailNotification
 
     protected final ThreadResourceResolverProvider resolverProvider;
 
-    private final EventAdmin eventAdmin;
+    private final ServiceTracker<EventAdmin, EventAdmin> eventAdmin;
 
     private final TokenManager tokenManager;
 
@@ -83,7 +84,8 @@ abstract class AbstractEmailNotification
     AbstractEmailNotification(final ResourceResolverFactory resolverFactory,
         final ThreadResourceResolverProvider resolverProvider,
         final TokenManager tokenManager, final MailService mailService, final FormUtils formUtils,
-        final PatientAccessConfiguration patientAccessConfiguration, final EventAdmin eventAdmin,
+        final PatientAccessConfiguration patientAccessConfiguration,
+        final ServiceTracker<EventAdmin, EventAdmin> eventAdmin,
         final boolean includePatientName)
     {
         this.resolverFactory = resolverFactory;
@@ -162,7 +164,7 @@ abstract class AbstractEmailNotification
                     Event event = new Event(getNotificationType(), Map.of(
                         "visit", visitSubject.getPath(),
                         "patient", patientSubject.getPath()));
-                    this.eventAdmin.postEvent(event);
+                    this.eventAdmin.getService().postEvent(event);
                     emailsSent += 1;
                 } catch (MessagingException e) {
                     LOGGER.warn("Failed to send Initial Notification Email");

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentEmailNotificationsFactory.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/AppointmentEmailNotificationsFactory.java
@@ -21,6 +21,7 @@ import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.commons.messaging.mail.MailService;
 import org.apache.sling.commons.scheduler.ScheduleOptions;
 import org.apache.sling.commons.scheduler.Scheduler;
+import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -30,6 +31,7 @@ import org.osgi.service.event.EventAdmin;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,8 +56,7 @@ public final class AppointmentEmailNotificationsFactory
     @Reference
     private ThreadResourceResolverProvider resolverProvider;
 
-    @Reference
-    private EventAdmin eventAdmin;
+    private ServiceTracker<EventAdmin, EventAdmin> eventAdmin;
 
     /** The scheduler for rescheduling jobs. */
     @Reference
@@ -117,8 +118,10 @@ public final class AppointmentEmailNotificationsFactory
     }
 
     @Activate
-    private void activate(final Config config)
+    private void activate(final Config config, final BundleContext context)
     {
+        this.eventAdmin = new ServiceTracker<>(context, EventAdmin.class, null);
+        this.eventAdmin.open();
         LOGGER.info("Activating appointment email notifications: {}", config.name());
         final String nightlyNotificationsSchedule = StringUtils.defaultIfEmpty(config.schedule(),
             StringUtils.defaultIfEmpty(System.getenv("NIGHTLY_NOTIFICATIONS_SCHEDULE"), "0 0 6 * * ? *"));
@@ -152,6 +155,7 @@ public final class AppointmentEmailNotificationsFactory
     private void deactivate(final Config config)
     {
         LOGGER.info("Deactivating appointment email notifications: {}", config.name());
+        this.eventAdmin.close();
         String jobName = "NightlyNotifications-" + config.name();
         if (this.scheduler.unschedule(jobName)) {
             LOGGER.info("Sucessfully unscheduled {}", jobName);

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/GeneralNotificationsTask.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/emailnotifications/GeneralNotificationsTask.java
@@ -31,6 +31,7 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.commons.messaging.mail.MailService;
 import org.osgi.service.event.EventAdmin;
+import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,7 +74,8 @@ public class GeneralNotificationsTask extends AbstractEmailNotification implemen
      */
     @SuppressWarnings("checkstyle:ParameterNumber")
     public GeneralNotificationsTask(final ResourceResolverFactory resolverFactory,
-        final ThreadResourceResolverProvider resolverProvider, final EventAdmin eventAdmin,
+        final ThreadResourceResolverProvider resolverProvider,
+        final ServiceTracker<EventAdmin, EventAdmin> eventAdmin,
         final TokenManager tokenManager, final MailService mailService,
         final FormUtils formUtils, final PatientAccessConfiguration patientAccessConfiguration, final String taskName,
         final String notificationType, final String clinicId, final String emailTemplatePath, final int daysToVisit,


### PR DESCRIPTION
To test:
- build including a docker image
- build yourexp too
- use the cards-deploy-tool to build a compose file: `python3 generate_compose_yaml.py --cards_docker_image cards/cards4yourexp:latest --oak_filesystem --dev_docker_image --smtps --smtps_test_container --smtps_test_mail_path ~/cardsmail --composum --server_address localhost:8080`
- start it with `docker-compose build && docker-compose up`
- create a test patient (including email address and consent) and a test visit, on the right past day that should receive the invitation email (e.g. 2 days ago for Outpatient)
- edit the configuration for the initial invitation task at http://localhost:8080/system/console/configMgr to run right away
- check that the Survey Events records the initial date
- edit the visit to be on the day that a reminder would be sent
- edit the corresponding reminder schedule to be sent right away
- check that the Survey Events records the reminder date
- stop the containers and cleanup with `docker-compose rm -v -f && ./cleanup.sh`

This will just test that it still works as expected, there doesn't seem to be a reliable way to actually reproduce the production problem.