### PR TITLE
CARDS-2897: Visit type nodes are left checked out after initial content import

### DIFF
--- a/modules/data-model/subjects/types/patient/pom.xml
+++ b/modules/data-model/subjects/types/patient/pom.xml
@@ -41,7 +41,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Sling-Initial-Content>SLING-INF/content/SubjectTypes/;path:=/SubjectTypes/;overwriteProperties:=true;uninstall:=true</Sling-Initial-Content>
+            <Sling-Initial-Content>SLING-INF/content/SubjectTypes/;path:=/SubjectTypes/;overwriteProperties:=true;uninstall:=true;checkin:=true</Sling-Initial-Content>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/data-model/subjects/types/tumor-region/pom.xml
+++ b/modules/data-model/subjects/types/tumor-region/pom.xml
@@ -41,7 +41,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Sling-Initial-Content>SLING-INF/content/SubjectTypes/Patient/Tumor/;path:=/SubjectTypes/Patient/Tumor/;overwriteProperties:=true;uninstall:=true</Sling-Initial-Content>
+            <Sling-Initial-Content>SLING-INF/content/SubjectTypes/Patient/Tumor/;path:=/SubjectTypes/Patient/Tumor/;overwriteProperties:=true;uninstall:=true;checkin:=true</Sling-Initial-Content>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/data-model/subjects/types/tumor/pom.xml
+++ b/modules/data-model/subjects/types/tumor/pom.xml
@@ -41,7 +41,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Sling-Initial-Content>SLING-INF/content/SubjectTypes/Patient/;path:=/SubjectTypes/Patient/;overwriteProperties:=true;uninstall:=true</Sling-Initial-Content>
+            <Sling-Initial-Content>SLING-INF/content/SubjectTypes/Patient/;path:=/SubjectTypes/Patient/;overwriteProperties:=true;uninstall:=true;checkin:=true</Sling-Initial-Content>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/data-model/subjects/types/visit/pom.xml
+++ b/modules/data-model/subjects/types/visit/pom.xml
@@ -41,7 +41,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Sling-Initial-Content>SLING-INF/content/SubjectTypes/Patient/;path:=/SubjectTypes/Patient/;overwriteProperties:=true;uninstall:=true</Sling-Initial-Content>
+            <Sling-Initial-Content>SLING-INF/content/SubjectTypes/Patient/;path:=/SubjectTypes/Patient/;overwriteProperties:=true;uninstall:=true;checkin:=true</Sling-Initial-Content>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
To test: build cards, start in test mode, open bin/browser and see check that all nodes under /SubjectTypes/ are checked in.