### PR TITLE
CARDS-2881: Stretched logo on error pages

### DIFF
--- a/modules/commons/src/main/frontend/src/components/ErrorPage.jsx
+++ b/modules/commons/src/main/frontend/src/components/ErrorPage.jsx
@@ -57,6 +57,8 @@ export default function ErrorPage(props) {
         direction="column"
         spacing={7}
         textAlign={textAlign}
+        alignItems="center"
+        alignContent="center"
       >
         <Logo maxWidth="360px" component={Grid}/>
         <Grid>


### PR DESCRIPTION
Made cards logo indiferent to the screen size change (same way as it is done on login page)
Affected pages:

- TokenExpired (/Expired.html)
- Unsubscribe
- PatientIdentification
- GenericErrorPage
- PendingView
- PageNotFound

To test start in `--test` mode, go to mentioned pages, resize the page below 700px in height and in width concequently, make sure logo looks consistent without stretching and quality loss (blurring).