### PR TITLE
CARDS-2904: Re-style TriStateChip

### DIFF
--- a/modules/commons/src/main/frontend/src/components/TriStateChip.jsx
+++ b/modules/commons/src/main/frontend/src/components/TriStateChip.jsx
@@ -52,9 +52,9 @@ function TriStateChip(props) {
 
   useEffect(() => {
     setStates ([
-      new ChipState(new ChipProps(label, "outlined", "primary", <RadioButtonUncheckedIcon/>), 0, defaultTooltip),
-      new ChipState(new ChipProps(label, "outlined", "success", <CheckCircleIcon/>), 1, positiveTooltip),
-      new ChipState(new ChipProps(label, "outlined", "error",  <CancelIcon/>), -1, negativeTooltip)
+      new ChipState(new ChipProps(label, "outlined", "", <RadioButtonUncheckedIcon color="disabled"/>), 0, defaultTooltip),
+      new ChipState(new ChipProps(label, "filled", "success", <CheckCircleIcon/>), 1, positiveTooltip),
+      new ChipState(new ChipProps(label, "filled", "error",  <CancelIcon/>), -1, negativeTooltip)
     ])
   }, [label, defaultTooltip, positiveTooltip, negativeTooltip]);
 


### PR DESCRIPTION
- Make the default un-selected appearance lower contrast
- Make the positive/negative state filled
<img width="261" height="46" alt="image" src="https://github.com/user-attachments/assets/20d54cb6-3c50-41fa-8250-9b6b863f347b" />
