### PR TITLE
CARDS-2906: Add a status report specifying the system startup time

### DIFF
--- a/modules/status/pom.xml
+++ b/modules/status/pom.xml
@@ -62,5 +62,9 @@
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/modules/status/src/main/java/io/uhndata/cards/status/StatusReportEndpoint.java
+++ b/modules/status/src/main/java/io/uhndata/cards/status/StatusReportEndpoint.java
@@ -19,11 +19,14 @@
 package io.uhndata.cards.status;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
 
 import jakarta.json.Json;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.servlet.Servlet;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.SlingJakartaHttpServletResponse;
 import org.apache.sling.api.servlets.SlingJakartaSafeMethodsServlet;
@@ -48,11 +51,26 @@ public class StatusReportEndpoint extends SlingJakartaSafeMethodsServlet
         throws IOException
     {
         final boolean unprivileged = !("admin".equals(request.getRemoteUser()));
-        JsonArrayBuilder results = Json.createArrayBuilder();
-        this.manager.getReports(unprivileged).stream()
-            .map(StatusReport::toJson)
-            .forEach(r -> results.add(r));
-        response.setContentType("application/json");
-        response.getWriter().print(results.build().toString());
+        final StatusReport.Status targetStatus =
+            StatusReport.Status.valueOf(StringUtils.defaultIfBlank(request.getParameter("targetStatus"), "INFO"));
+        final Set<String> tags = request.getParameterValues("tags") == null ? Collections.emptySet()
+            : Set.of(request.getParameterValues("tags"));
+        final boolean txtOutput = request.getPathInfo().endsWith(".txt");
+        if (txtOutput) {
+            final String result = StringUtils.join(
+                this.manager.getReports(unprivileged, targetStatus, tags).stream()
+                    .map(StatusReport::getText)
+                    .toList(),
+                "\n\n");
+            response.setContentType("text/plain");
+            response.getWriter().print(result);
+        } else {
+            final JsonArrayBuilder results = Json.createArrayBuilder();
+            this.manager.getReports(unprivileged, targetStatus, tags).stream()
+                .map(StatusReport::toJson)
+                .forEach(r -> results.add(r));
+            response.setContentType("application/json");
+            response.getWriter().print(results.build().toString());
+        }
     }
 }

--- a/modules/status/src/main/java/io/uhndata/cards/status/internal/UptimeStatusReporter.java
+++ b/modules/status/src/main/java/io/uhndata/cards/status/internal/UptimeStatusReporter.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.uhndata.cards.status.internal;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Set;
+
+import org.osgi.service.component.annotations.Component;
+
+import io.uhndata.cards.status.spi.StatusReport;
+import io.uhndata.cards.status.spi.StatusReporter;
+
+@Component(immediate = true)
+public class UptimeStatusReporter implements StatusReporter
+{
+    private static final String TITLE = "System Started";
+
+    private static final ZonedDateTime STARTED = ZonedDateTime.now();
+
+    @Override
+    public String getName()
+    {
+        return TITLE;
+    }
+
+    @Override
+    public StatusReport report(boolean unprivileged)
+    {
+        return new StatusReport(TITLE, StatusReport.Status.INFO,
+            STARTED.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+    }
+
+    @Override
+    public Set<String> getTags()
+    {
+        return Set.of("status", "systemStarted");
+    }
+}


### PR DESCRIPTION
To test:
- build
- start
- open `http://localhost:8080/system/status.txt?targetStatus=DEBUG&tags=status&tags=metrics` and `http://localhost:8080/system/status?tags=status` and `http://localhost:8080/system/status` and check that the startup time is reported correctly