### PR TITLE
[misc] Don't run install scripts for npm dependencies to avoid some malware

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1642,6 +1642,9 @@
               <goals>
                 <goal>yarn</goal>
               </goals>
+              <configuration>
+                <arguments>install --ignore-scripts</arguments>
+              </configuration>
             </execution>
             <!-- Runs webpack to compile the JS source code -->
             <execution>


### PR DESCRIPTION
None of our current dependencies should have any installation scripts, so it should be safe to generally disable install scripts. To test: build and start a fresh clone of cards.