### PR TITLE
CARDS-2908: Support "optional" questionnaires in patient portal questionnaire sets

### DIFF
--- a/modules/clinician-dashboard/src/main/frontend/src/clinician-dashboard/Visit.jsx
+++ b/modules/clinician-dashboard/src/main/frontend/src/clinician-dashboard/Visit.jsx
@@ -297,6 +297,19 @@ function Visit(props) {
     return surveyData?.[questionnaireId]?.statusFlags?.includes("LOCKED");
   }
 
+  // Whether a form is for a questionnaire that was marked optional in the questionnaire set.
+  // This is recorded on the form itself via the OPTIONAL status flag when the form is created.
+  const isFormOptional = (questionnaireId) => {
+    return surveyData?.[questionnaireId]?.statusFlags?.includes("OPTIONAL");
+  }
+
+  // Whether a form has been dealt with for display purposes. Optional forms have no mandatory questions, so
+  // they are never INCOMPLETE; like in the patient portal, they count as done only once submitted, rather than
+  // appearing complete from the moment they are created.
+  const isFormDone = (questionnaireId) => {
+    return isFormOptional(questionnaireId) ? isFormSubmitted(questionnaireId) : isFormComplete(questionnaireId);
+  }
+
   const isFormNavigable = (questionnaireId) => {
     return (surveyData?.[questionnaireId]?.questionnaire?.paginationVariant == "navigable");
   }
@@ -320,7 +333,7 @@ function Visit(props) {
 
   const displayFlags = q => (
     (surveyData?.[q]?.statusFlags ?? [])
-      .filter(f => ["INCOMPLETE", "SUBMITTED", "LOCKED"].includes(f))
+      .filter(f => ["INCOMPLETE", "SUBMITTED", "LOCKED", "OPTIONAL"].includes(f))
       .map(displayFlag)
   );
 
@@ -344,7 +357,7 @@ function Visit(props) {
             <ListItemButton onClick={() => navigate(`/content.html${surveyData?.[q]?.["@path"]}`)}>
               <ListItemAvatar sx={{ alignSelf: "baseline", zoom: 1.2 }}>
                 { isFormLocked(q) ? lockedIndicator : (
-                  isFormComplete(q) ? doneIndicator : (
+                  isFormDone(q) ? doneIndicator : (
                     isFormSubmitted(q) ? incompleteIndicator : surveyIndicator
                   )
                 )}

--- a/modules/data-model/qsets/api/src/main/java/io/uhndata/cards/qsets/api/QuestionnaireRef.java
+++ b/modules/data-model/qsets/api/src/main/java/io/uhndata/cards/qsets/api/QuestionnaireRef.java
@@ -50,6 +50,9 @@ public interface QuestionnaireRef
     /** The name of the property of a QuestionnaireRef node that specifies the target user type. */
     String TARGET_USER_TYPE_PROPERTY = "targetUserType";
 
+    /** The name of the property of a QuestionnaireRef node that marks the questionnaire as optional. */
+    String OPTIONAL_PROPERTY = "optional";
+
     /**
      * Which type of user should fill in this questionnaire.
      */
@@ -131,4 +134,13 @@ public interface QuestionnaireRef
      * @return a number of weeks
      */
     long getFrequency();
+
+    /**
+     * Whether this questionnaire is optional, i.e. the patient may legitimately leave it blank. Such a questionnaire is
+     * always offered to the patient and is only considered handled once the survey is submitted, rather than being
+     * auto-skipped for lacking mandatory answers.
+     *
+     * @return {@code true} if the questionnaire is optional, {@code false} otherwise
+     */
+    boolean isOptional();
 }

--- a/modules/data-model/qsets/api/src/main/java/io/uhndata/cards/qsets/api/QuestionnaireSetUtils.java
+++ b/modules/data-model/qsets/api/src/main/java/io/uhndata/cards/qsets/api/QuestionnaireSetUtils.java
@@ -51,6 +51,9 @@ public interface QuestionnaireSetUtils
 
     /**
      * Return a {@link QuestionnaireRef} object explicitly referencing a target {@code cards:Questionnaire} node.
+     * Since this overload takes the questionnaire node directly rather than a {@code cards:QuestionnaireRef} definition
+     * node, properties that live on the definition (such as {@code optional}) are not available and will return their
+     * default values. Use {@link #toQuestionnaireRef(Node)} when a definition node is available.
      *
      * @param questionnaire a JCR node of type {@code cards:Questionnaire}
      * @param targetUserType the target user type to use

--- a/modules/data-model/qsets/api/src/main/resources/SLING-INF/nodetypes/qsets.cnd
+++ b/modules/data-model/qsets/api/src/main/resources/SLING-INF/nodetypes/qsets.cnd
@@ -76,6 +76,11 @@
   // An optional frequency for re-taking the questionnaire, in weeks
   - frequency (long)
 
+  // An optional flag marking a questionnaire that the patient may legitimately leave blank (it has no
+  // mandatory questions). Such a questionnaire is always offered to the patient and is only considered
+  // handled once the survey is submitted, rather than being auto-skipped for lacking mandatory answers.
+  - optional (boolean)
+
   //  An optional configuration describing the columns of the livetable that lists the forms corresponding to this questionnaire
   - view (string)
 

--- a/modules/data-model/qsets/impl/src/main/java/io/uhndata/cards/qsets/internal/QuestionnaireSetUtilsImpl.java
+++ b/modules/data-model/qsets/impl/src/main/java/io/uhndata/cards/qsets/internal/QuestionnaireSetUtilsImpl.java
@@ -114,14 +114,7 @@ public class QuestionnaireSetUtilsImpl implements QuestionnaireSetUtils
                 final Node node = childNodes.nextNode();
                 if (node.isNodeType(QuestionnaireRef.NODETYPE)
                     && node.hasProperty(QuestionnaireRef.QUESTIONNAIRE_PROPERTY)) {
-                    final Node questionnaire = node.getProperty(QuestionnaireRef.QUESTIONNAIRE_PROPERTY).getNode();
-                    final QuestionnaireRef.TargetUserType targetUserType =
-                        QuestionnaireRef.TargetUserType.valueOf(node);
-                    long frequency = 0;
-                    if (node.hasProperty(QuestionnaireRef.FREQUENCY_PROPERTY)) {
-                        frequency = node.getProperty(QuestionnaireRef.FREQUENCY_PROPERTY).getLong();
-                    }
-                    addQuestionnaire(new QuestionnaireRefImpl(questionnaire, targetUserType, frequency));
+                    addQuestionnaire(new QuestionnaireRefImpl(node));
                 } else if (node.isNodeType(QuestionnaireConflict.NODETYPE)
                     && node.hasProperty(QuestionnaireConflict.QUESTIONNAIRE_PROPERTY)) {
                     addConflict(new QuestionnaireConflictImpl(node));
@@ -297,18 +290,28 @@ public class QuestionnaireSetUtilsImpl implements QuestionnaireSetUtils
 
         private final long frequency;
 
+        private final boolean optional;
+
         QuestionnaireRefImpl(final Node questionnaire, final TargetUserType targetUserType, final long frequency)
+        {
+            this(questionnaire, targetUserType, frequency, false);
+        }
+
+        QuestionnaireRefImpl(final Node questionnaire, final TargetUserType targetUserType, final long frequency,
+            final boolean optional)
         {
             this.questionnaire = questionnaire;
             this.targetUserType = targetUserType;
             this.frequency = frequency;
+            this.optional = optional;
         }
 
         QuestionnaireRefImpl(final Node definition)
             throws ItemNotFoundException, ValueFormatException, PathNotFoundException, RepositoryException
         {
             this(definition.getProperty(QUESTIONNAIRE_PROPERTY).getNode(), TargetUserType.valueOf(definition),
-                definition.hasProperty(FREQUENCY_PROPERTY) ? definition.getProperty(FREQUENCY_PROPERTY).getLong() : 0);
+                definition.hasProperty(FREQUENCY_PROPERTY) ? definition.getProperty(FREQUENCY_PROPERTY).getLong() : 0,
+                definition.hasProperty(OPTIONAL_PROPERTY) && definition.getProperty(OPTIONAL_PROPERTY).getBoolean());
         }
 
         @Override
@@ -327,6 +330,12 @@ public class QuestionnaireSetUtilsImpl implements QuestionnaireSetUtils
         public long getFrequency()
         {
             return this.frequency;
+        }
+
+        @Override
+        public boolean isOptional()
+        {
+            return this.optional;
         }
 
         @Override

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -309,7 +309,7 @@ function QuestionnaireSet(props) {
   // the patient can skip straight to the exit/review screen without going through the surveys.
   const allFormsDone = useMemo(() => (
     !!questionnaireIds?.length && questionnaireIds.every(q => isFormDone(q))
-  ), [questionnaireIds, questionnaires, formDataLoadCount]);
+  ), [questionnaireIds, formDataLoadCount]);
 
   const launchNextForm = () => {
     if (formData?.[nextQuestionnaire['@name']]) {

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -22,6 +22,7 @@ import { useState, useEffect, useContext, useMemo } from 'react';
 import SurveyIcon from '@mui/icons-material/Assignment';
 import NextStepIcon from '@mui/icons-material/ChevronRight';
 import DoneIcon from '@mui/icons-material/Done';
+import OptionalIcon from '@mui/icons-material/Remove';
 import WarningIcon from '@mui/icons-material/Warning';
 import {
   Alert,
@@ -645,6 +646,8 @@ function QuestionnaireSet(props) {
 
   const incompleteIndicator = <Avatar className={classes.incompleteIndicator}><WarningIcon /></Avatar>;
 
+  const optionalIndicator = <Avatar className={classes.stepIndicator}><OptionalIcon /></Avatar>;
+
   const greet = (name) => {
     let greeting = displayText("greeting", Typography, { variant: "h6", key: "welcome-greeting" });
     if (!greeting) {
@@ -874,10 +877,12 @@ function QuestionnaireSet(props) {
     <List key="incomplete-list" disablePadding>
       { (questionnaireIds || []).map((q, i) => (
         <ListItem key={q+"Exit"} disablePadding>
-          <ListItemAvatar>{isFormComplete(q) ? doneIndicator : incompleteIndicator}</ListItemAvatar>
+          <ListItemAvatar>
+            {isFormDone(q) ? doneIndicator : isFormOptional(q) ? optionalIndicator : incompleteIndicator}
+          </ListItemAvatar>
           <ListItemText
             primary={getDisplayTitle(q)}
-            secondary={!isFormComplete(q) && "Incomplete" || isFormSubmitted(q) && "Submitted"}
+            secondary={!isFormDone(q) && !isFormOptional(q) && "Incomplete" || isFormSubmitted(q) && "Submitted"}
           />
         </ListItem>
       ))}

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -811,7 +811,7 @@ function QuestionnaireSet(props) {
                 <Grid alignSelf="center" key="change-button">
                   <Button
                     variant="outlined"
-                    onClick={() => {setReviewMode(true); setCrtFormId(formData?.[q]?.["@name"]); setCrtStep(i)}}>
+                    onClick={() => {setReviewMode(true); setCrtFormId(formData?.[q]?.["@name"]); setCrtStep(questionnaireIds.indexOf(q))}}>
                     Change
                   </Button>
                 </Grid>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -193,6 +193,16 @@ function QuestionnaireSet(props) {
     return formData?.[questionnaireId]?.statusFlags?.includes("SUBMITTED");
   }
 
+  // Whether a form has been handled for flow purposes (offered to the patient and dealt with).
+  // Regular forms are done once they are no longer INCOMPLETE. "Optional" forms have no mandatory
+  // questions, so they are never INCOMPLETE and would otherwise be auto-skipped from creation; instead
+  // they are considered handled only once submitted, ensuring the patient is offered them at least once.
+  const isFormDone = (questionnaireId) => {
+    return questionnaires?.[questionnaireId]?.optional
+      ? isFormSubmitted(questionnaireId)
+      : isFormComplete(questionnaireId);
+  }
+
   const getVisitInformation = (questionName, formatted) => {
     let question = visitInformation?.questionnaire?.[questionName];
     if (!question) return null;
@@ -263,8 +273,8 @@ function QuestionnaireSet(props) {
   // Find the next step : Skip questionnaires that have already been filled out
   const findNextStep = (step) => {
     let next = step + 1;
-    // Skip if the corresponding questionnaire has already been filled out:
-    while (next < questionnaireIds.length && isFormComplete(questionnaireIds[next])) ++next;
+    // Skip if the corresponding questionnaire has already been handled:
+    while (next < questionnaireIds.length && isFormDone(questionnaireIds[next])) ++next;
     return next;
   }
 
@@ -278,6 +288,12 @@ function QuestionnaireSet(props) {
     let nextStep = findNextStep(crtStep);
     return nextStep < questionnaireIds?.length ? questionnaires[questionnaireIds?.[nextStep]] : null;
   }, [crtStep, questionnaires, formData, questionnaireIds]);
+
+  // Whether every questionnaire in the set has been handled (see isFormDone). Used to decide whether
+  // the patient can skip straight to the exit/review screen without going through the surveys.
+  const allFormsDone = useMemo(() => (
+    !!questionnaireIds?.length && questionnaireIds.every(q => isFormDone(q))
+  ), [questionnaireIds, questionnaires, formDataLoadCount]);
 
   const launchNextForm = () => {
     if (formData?.[nextQuestionnaire['@name']]) {
@@ -427,12 +443,16 @@ function QuestionnaireSet(props) {
       .forEach(([key, value]) => {
         let addons = Object.values(value).filter(filterValue => ENTRY_TYPES.includes(filterValue['jcr:primaryType']));
         data[value.questionnaire['@name']] = {
+          // Raw questionnaire title; also used as a key to look up form data in the subject JSON
           'title': value.questionnaire?.title || key,
+          // Title shown to the patient: optional questionnaires are flagged as such in the UI
+          'displayTitle': (value.questionnaire?.title || key) + (value.optional ? " (Optional)" : ""),
           'alias': key,
           '@path': value.questionnaire?.['@path'],
           '@name': value.questionnaire?.['@name'],
           'hasInterpretation': hasInterpretation(value.questionnaire) || addons.some(hasInterpretation),
           'estimate': value.estimate,
+          'optional': !!value.optional,
           'questionnaireAddons': addons
         }
       });
@@ -531,12 +551,14 @@ function QuestionnaireSet(props) {
     }
   }, [formDataLoadCount]);
 
-  // When the user lands on a completed visit that has not been submitted, proceed to the last step
+  // When the user lands on a fully handled visit that has not been submitted, proceed to the last step.
+  // Uses allFormsDone rather than isComplete so that optional surveys the patient has not yet gone
+  // through (which are not INCOMPLETE, but not submitted either) are still offered instead of skipped.
   useEffect(() => {
-    if(isComplete && !isSubmitted && questionnaireIds?.length > 0 && crtStep == -1) {
+    if(allFormsDone && !isSubmitted && questionnaireIds?.length > 0 && crtStep == -1) {
       setCrtStep(questionnaireIds.length);
     }
-  }, [isComplete, isSubmitted]);
+  }, [allFormsDone, isSubmitted]);
 
   // At the last step, if the configuration specifies to skip the review, automatically submit
   useEffect(() => {
@@ -711,12 +733,12 @@ function QuestionnaireSet(props) {
       { (questionnaireIds || []).map((q, i) => (
         <ListItem key={q+"Welcome"} disablePadding>
           <ListItemAvatar>
-            {isFormComplete(q) ? doneIndicator : questionnaireIds.length == 1 ? surveyIndicator : stepIndicator(i)}
+            {isFormDone(q) ? doneIndicator : questionnaireIds.length == 1 ? surveyIndicator : stepIndicator(i)}
           </ListItemAvatar>
           <ListItemText
-            primary={questionnaires[q]?.title}
+            primary={questionnaires[q]?.displayTitle}
             secondary={isFormSubmitted(q) ? "Submitted" :
-              !isFormComplete(q) && (displayEstimate(q)
+              !isFormDone(q) && (displayEstimate(q)
             + (["patient", "guest-patient"].includes(formData?.[q]?.["jcr:lastModifiedBy"]) ? " (in progress)" : ""))}
           />
         </ListItem>
@@ -842,7 +864,7 @@ function QuestionnaireSet(props) {
         <ListItem key={q+"Exit"} disablePadding>
           <ListItemAvatar>{isFormComplete(q) ? doneIndicator : incompleteIndicator}</ListItemAvatar>
           <ListItemText
-            primary={questionnaires[q]?.title}
+            primary={questionnaires[q]?.displayTitle}
             secondary={!isFormComplete(q) && "Incomplete" || isFormSubmitted(q) && "Submitted"}
           />
         </ListItem>
@@ -882,7 +904,7 @@ function QuestionnaireSet(props) {
         greeting={username}
         withSignout={!!(config?.PIIAuthRequired)}
         progress={progress}
-        subtitle={questionnaires[questionnaireIds[crtStep]]?.title}
+        subtitle={questionnaires[questionnaireIds[crtStep]]?.displayTitle}
         step={stepIndicator(crtStep, true)}
       />
       <QuestionnaireSetScreen

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -193,12 +193,27 @@ function QuestionnaireSet(props) {
     return formData?.[questionnaireId]?.statusFlags?.includes("SUBMITTED");
   }
 
+  // Whether a form is for a questionnaire that was marked optional in the questionnaire set.
+  // This is recorded on the form itself via the OPTIONAL status flag when the form is created,
+  // so we don't need to cross-reference the questionnaire set definition here.
+  const isFormOptional = (questionnaireId) => {
+    return formData?.[questionnaireId]?.statusFlags?.includes("OPTIONAL");
+  }
+
+  // Title shown to the patient: optional questionnaires are flagged as such in the UI.
+  const getDisplayTitle = (questionnaireId) => {
+    const title = questionnaires?.[questionnaireId]?.title || questionnaireId;
+    return title
+      ? title + (isFormOptional(questionnaireId) ? " (Optional)" : "")
+      : title;
+  }
+
   // Whether a form has been handled for flow purposes (offered to the patient and dealt with).
   // Regular forms are done once they are no longer INCOMPLETE. "Optional" forms have no mandatory
   // questions, so they are never INCOMPLETE and would otherwise be auto-skipped from creation; instead
   // they are considered handled only once submitted, ensuring the patient is offered them at least once.
   const isFormDone = (questionnaireId) => {
-    return questionnaires?.[questionnaireId]?.optional
+    return isFormOptional(questionnaireId)
       ? isFormSubmitted(questionnaireId)
       : isFormComplete(questionnaireId);
   }
@@ -445,14 +460,11 @@ function QuestionnaireSet(props) {
         data[value.questionnaire['@name']] = {
           // Raw questionnaire title; also used as a key to look up form data in the subject JSON
           'title': value.questionnaire?.title || key,
-          // Title shown to the patient: optional questionnaires are flagged as such in the UI
-          'displayTitle': (value.questionnaire?.title || key) + (value.optional ? " (Optional)" : ""),
           'alias': key,
           '@path': value.questionnaire?.['@path'],
           '@name': value.questionnaire?.['@name'],
           'hasInterpretation': hasInterpretation(value.questionnaire) || addons.some(hasInterpretation),
           'estimate': value.estimate,
-          'optional': !!value.optional,
           'questionnaireAddons': addons
         }
       });
@@ -736,7 +748,7 @@ function QuestionnaireSet(props) {
             {isFormDone(q) ? doneIndicator : questionnaireIds.length == 1 ? surveyIndicator : stepIndicator(i)}
           </ListItemAvatar>
           <ListItemText
-            primary={questionnaires[q]?.displayTitle}
+            primary={getDisplayTitle(q)}
             secondary={isFormSubmitted(q) ? "Submitted" :
               !isFormDone(q) && (displayEstimate(q)
             + (["patient", "guest-patient"].includes(formData?.[q]?.["jcr:lastModifiedBy"]) ? " (in progress)" : ""))}
@@ -864,7 +876,7 @@ function QuestionnaireSet(props) {
         <ListItem key={q+"Exit"} disablePadding>
           <ListItemAvatar>{isFormComplete(q) ? doneIndicator : incompleteIndicator}</ListItemAvatar>
           <ListItemText
-            primary={questionnaires[q]?.displayTitle}
+            primary={getDisplayTitle(q)}
             secondary={!isFormComplete(q) && "Incomplete" || isFormSubmitted(q) && "Submitted"}
           />
         </ListItem>
@@ -904,7 +916,7 @@ function QuestionnaireSet(props) {
         greeting={username}
         withSignout={!!(config?.PIIAuthRequired)}
         progress={progress}
-        subtitle={questionnaires[questionnaireIds[crtStep]]?.displayTitle}
+        subtitle={getDisplayTitle(questionnaireIds[crtStep])}
         step={stepIndicator(crtStep, true)}
       />
       <QuestionnaireSetScreen

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -204,9 +204,8 @@ function QuestionnaireSet(props) {
   // Title shown to the patient: optional questionnaires are flagged as such in the UI.
   const getDisplayTitle = (questionnaireId) => {
     const title = questionnaires?.[questionnaireId]?.title || questionnaireId;
-    return title
-      ? title + (isFormOptional(questionnaireId) ? " (Optional)" : "")
-      : title;
+    if (!title) return null;
+    return title + (isFormOptional(questionnaireId) ? " (Optional)" : "");
   }
 
   // Whether a form has been handled for flow purposes (offered to the patient and dealt with).

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -575,10 +575,10 @@ function QuestionnaireSet(props) {
 
   // At the last step, if the configuration specifies to skip the review, automatically submit
   useEffect(() => {
-    if (isComplete && !isSubmitted && endReached && !enableReviewScreen) {
+    if ((isComplete || submittingIncomplete) && !isSubmitted && endReached && !enableReviewScreen) {
       onSubmit();
     }
-  }, [isComplete, isSubmitted, endReached, enableReviewScreen]);
+  }, [isComplete, submittingIncomplete, isSubmitted, endReached, enableReviewScreen]);
 
   // At first, load the existing subject data to determine which questionnaire set is bound to the visit
   useEffect(loadExistingData, []);
@@ -729,7 +729,7 @@ function QuestionnaireSet(props) {
   // Replace all occurrences of the visit information pattern with the value from the Visit information form
   const introMessage = fillInVisitData(intro);
 
-  const welcomeScreen = (isComplete && isSubmitted || questionnaireIds?.length == 0) ? [
+  const welcomeScreen = (isSubmitted || questionnaireIds?.length == 0) ? [
     greet(username),
     appointmentAlert(),
     displayText(

--- a/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
+++ b/modules/patient-portal/src/main/java/io/uhndata/cards/patients/internal/VisitChangeListener.java
@@ -250,8 +250,18 @@ public class VisitChangeListener implements ResourceChangeListener
             final String uuid = UUID.randomUUID().toString();
             final Node form = visitSubject.getSession().getNode("/Forms").addNode(uuid, FormUtils.FORM_NODETYPE);
             form.setProperty(FormUtils.QUESTIONNAIRE_PROPERTY, questionnaire.getQuestionnaire());
+            final List<String> flags = new LinkedList<>();
             if (questionnaire.isPatientFacing()) {
-                form.setProperty(STATUS_FLAGS, new String[] { "PATIENT SURVEY" });
+                flags.add("PATIENT SURVEY");
+            }
+            // Mark optional questionnaires on the form itself, so that the dashboards can tell them apart
+            // (and require them to be submitted rather than auto-skipping them) without having to cross-reference
+            // the questionnaire set definition.
+            if (questionnaire.isOptional()) {
+                flags.add("OPTIONAL");
+            }
+            if (!flags.isEmpty()) {
+                form.setProperty(STATUS_FLAGS, flags.toArray(EMPTY_ARRAY_OF_STRINGS));
             }
             form.setProperty(FormUtils.SUBJECT_PROPERTY, visitSubject);
             results.add(form.getPath());

--- a/test-resources/pom.xml
+++ b/test-resources/pom.xml
@@ -49,6 +49,8 @@
               SLING-INF/content/Survey/Sections.xml;path:=/Survey/Sections;overwrite:=true,
               SLING-INF/content/Survey/ClinicMapping.xml;path:=/Survey/ClinicMapping;overwrite:=true,
               SLING-INF/content/Survey/PatientAccess.xml;path:=/Survey/PatientAccess;overwrite:=true,
+              SLING-INF/content/Survey/InitialSurvey.xml;path:=/Survey/InitialSurvey;overwrite:=true,
+              SLING-INF/content/Survey/FollowUpSurvey.xml;path:=/Survey/FollowUpSurvey;overwrite:=true,
               SLING-INF/content/Survey/TermsOfUse.xml;path:=/Survey/TermsOfUse;overwrite:=true,
               SLING-INF/content/Survey/SurveyInstructions.xml;path:=/Survey/SurveyInstructions;overwrite:=true,
             </Sling-Initial-Content>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/SmallTest1.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/SmallTest1.xml
@@ -1,0 +1,52 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>SmallTest1</name>
+	<primaryNodeType>cards:Questionnaire</primaryNodeType>
+	<property>
+		<name>description</name>
+		<value>A small questionnaire to be tested with the patient portal clinics.</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>title</name>
+		<value>Small Form Test 1</value>
+		<type>String</type>
+	</property>
+	<node>
+		<name>question</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Write something</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>text</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+	</node>
+</node>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/SmallTest2.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/SmallTest2.xml
@@ -1,0 +1,57 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>SmallTest2</name>
+	<primaryNodeType>cards:Questionnaire</primaryNodeType>
+	<property>
+		<name>description</name>
+		<value>A small questionnaire to be tested with the patient portal clinics.</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>title</name>
+		<value>Small Form Test 2</value>
+		<type>String</type>
+	</property>
+	<node>
+		<name>question</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Write something</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>text</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>minAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+	</node>
+</node>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/SmallTest3.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/SmallTest3.xml
@@ -1,0 +1,57 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>SmallTest3</name>
+	<primaryNodeType>cards:Questionnaire</primaryNodeType>
+	<property>
+		<name>description</name>
+		<value>A small questionnaire to be tested with the patient portal clinics.</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>title</name>
+		<value>Small Form Test 3</value>
+		<type>String</type>
+	</property>
+	<node>
+		<name>question</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Write something</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>text</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>minAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+	</node>
+</node>

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/SmallTest4.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/SmallTest4.xml
@@ -1,0 +1,52 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<node>
+	<name>SmallTest4</name>
+	<primaryNodeType>cards:Questionnaire</primaryNodeType>
+	<property>
+		<name>description</name>
+		<value>A small questionnaire to be tested with the patient portal clinics.</value>
+		<type>String</type>
+	</property>
+	<property>
+		<name>title</name>
+		<value>Small Form Test 4</value>
+		<type>String</type>
+	</property>
+	<node>
+		<name>question</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Write something</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>text</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+	</node>
+</node>

--- a/test-resources/src/main/resources/SLING-INF/content/Survey/ClinicMapping.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Survey/ClinicMapping.xml
@@ -102,4 +102,62 @@
             <type>Long</type>
         </property>
     </node>
+    <node>
+        <name>InitialSurvey</name>
+        <primaryNodeType>cards:ClinicMapping</primaryNodeType>
+        <property>
+            <name>clinicName</name>
+            <value>Initial 2 part survey</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>survey</name>
+            <value>InitialSurvey</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>displayName</name>
+            <value>Small 2-part survey with optional forms (initial)</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>sidebarLabel</name>
+            <value>Initial</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>manualTokenLifespanDays</name>
+            <value>14</value>
+            <type>Long</type>
+        </property>
+    </node>
+    <node>
+        <name>FollowUpSurvey</name>
+        <primaryNodeType>cards:ClinicMapping</primaryNodeType>
+        <property>
+            <name>clinicName</name>
+            <value>Follow-up 2 part survey</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>survey</name>
+            <value>FollowUpSurvey</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>displayName</name>
+            <value>Small 2-part survey with optional forms (follow-up)</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>sidebarLabel</name>
+            <value>Initial</value>
+            <type>String</type>
+        </property>
+        <property>
+            <name>manualTokenLifespanDays</name>
+            <value>14</value>
+            <type>Long</type>
+        </property>
+    </node>
 </node>

--- a/test-resources/src/main/resources/SLING-INF/content/Survey/FollowUpSurvey.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Survey/FollowUpSurvey.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2022-2026 DATA @ UHN. See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<node>
+    <name>FollowUpSurvey</name>
+    <primaryNodeType>cards:QuestionnaireSet</primaryNodeType>
+    <property>
+        <name>name</name>
+        <value>Follow Up Survey</value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>intro</name>
+        <value>Test 2 part survey with optional forms</value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>frequencyIgnoreClinic</name>
+        <value>True</value>
+        <type>Boolean</type>
+    </property>
+    <node>
+        <name>Form1</name>
+        <primaryNodeType>cards:QuestionnaireRef</primaryNodeType>
+        <property>
+            <name>questionnaire</name>
+            <value>/Questionnaires/SmallTest1</value>
+            <type>Reference</type>
+        </property>
+        <property>
+            <name>estimate</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>frequency</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>optional</name>
+            <value>True</value>
+            <type>Boolean</type>
+        </property>
+        <property>
+            <name>order</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
+    </node>
+    <node>
+        <name>Form2</name>
+        <primaryNodeType>cards:QuestionnaireRef</primaryNodeType>
+        <property>
+            <name>questionnaire</name>
+            <value>/Questionnaires/SmallTest2</value>
+            <type>Reference</type>
+        </property>
+        <property>
+            <name>estimate</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>frequency</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>order</name>
+            <value>2</value>
+            <type>Long</type>
+        </property>
+    </node>
+    <node>
+        <name>Form3</name>
+        <primaryNodeType>cards:QuestionnaireRef</primaryNodeType>
+        <property>
+            <name>questionnaire</name>
+            <value>/Questionnaires/SmallTest3</value>
+            <type>Reference</type>
+        </property>
+        <property>
+            <name>estimate</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>frequency</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>order</name>
+            <value>3</value>
+            <type>Long</type>
+        </property>
+    </node>
+    <node>
+        <name>Form4</name>
+        <primaryNodeType>cards:QuestionnaireRef</primaryNodeType>
+        <property>
+            <name>questionnaire</name>
+            <value>/Questionnaires/SmallTest4</value>
+            <type>Reference</type>
+        </property>
+        <property>
+            <name>estimate</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>frequency</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>optional</name>
+            <value>True</value>
+            <type>Boolean</type>
+        </property>
+        <property>
+            <name>order</name>
+            <value>4</value>
+            <type>Long</type>
+        </property>
+    </node>
+</node>

--- a/test-resources/src/main/resources/SLING-INF/content/Survey/InitialSurvey.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Survey/InitialSurvey.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2022-2026 DATA @ UHN. See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<node>
+    <name>InitialSurvey</name>
+    <primaryNodeType>cards:QuestionnaireSet</primaryNodeType>
+    <property>
+        <name>name</name>
+        <value>Initial Survey</value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>intro</name>
+        <value>Test 2 part survey with an optional form</value>
+        <type>String</type>
+    </property>
+    <property>
+        <name>frequencyIgnoreClinic</name>
+        <value>True</value>
+        <type>Boolean</type>
+    </property>
+    <node>
+        <name>Form1</name>
+        <primaryNodeType>cards:QuestionnaireRef</primaryNodeType>
+        <property>
+            <name>questionnaire</name>
+            <value>/Questionnaires/SmallTest1</value>
+            <type>Reference</type>
+        </property>
+        <property>
+            <name>estimate</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>frequency</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>optional</name>
+            <value>True</value>
+            <type>Boolean</type>
+        </property>
+        <property>
+            <name>order</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
+    </node>
+    <node>
+        <name>Form2</name>
+        <primaryNodeType>cards:QuestionnaireRef</primaryNodeType>
+        <property>
+            <name>questionnaire</name>
+            <value>/Questionnaires/SmallTest2</value>
+            <type>Reference</type>
+        </property>
+        <property>
+            <name>estimate</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>frequency</name>
+            <value>1</value>
+            <type>Long</type>
+        </property>
+        <property>
+            <name>order</name>
+            <value>2</value>
+            <type>Long</type>
+        </property>
+    </node>
+</node>


### PR DESCRIPTION
Specs: https://phenotips.atlassian.net/browse/CARDS-2908

To test:
* build this `cards` branch
* build `yourexperience` branch `omh_q` (https://github.com/data-team-uhn/yourexperience/pull/26)
* start `yourexperience`:
```
PROJECT_VERSION=1.3.0-SNAPSHOT ./start_cards.sh --dev -P cards4yourexp
```
* create a visit for any clinic other than CPES (all others have the optional Demographics questionnaire added at the end)
* as a patient, fill in the corresponding survey
  * test that you can submit without filling anything in Demographics
  * test that you can leave after completing all other questionnaires, return, and still fill in Demographics before submitting
 
Regression testing:
* check that nothing has changed for surveys without optional questionnaires - CPES on the `omh_q` branch, or test with the `main` branch of `yourexperience` where there are no optional questionnaires.