### PR TITLE
[misc] Fix Maven warning for legacy altDeploymentRepository format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -539,7 +539,7 @@
               <goal>deploy</goal>
             </goals>
             <configuration>
-              <altDeploymentRepository>localBuild::default::file://.mvnrepo</altDeploymentRepository>
+              <altDeploymentRepository>localBuild::file://.mvnrepo</altDeploymentRepository>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
This change eliminates maven build warning per each module 

`[WARNING] Using legacy syntax for alternative repository. Use "localBuild::file://.mvnrepo" instead.
`

In the modern maven v.3 the `default` layout is now assumed automatically