### PR TITLE
CARDS-2915: Fix wrapping warning caused by .token.html endpoint

### DIFF
--- a/modules/authentication/token/token-authentication-support/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
+++ b/modules/authentication/token/token-authentication-support/src/main/resources/SLING-INF/content/libs/cards/Subject/token.html.esp
@@ -15,10 +15,9 @@
 
 response.setContentType('text/plain');
 
-var Calendar = java.util.Calendar;
 
 var getOneHourExpiry = function() {
-    var result = Calendar.getInstance();
+    var result = java.util.Calendar.getInstance();
     result.setTimeInMillis(result.getTimeInMillis() + (1000*60*60));
     return result;
 }
@@ -27,13 +26,13 @@ var getExpiryByDays = function(days) {
     if (days < 1) {
         return getOneHourExpiry();
     } else {
-        var result = Calendar.getInstance();
+        var result = java.util.Calendar.getInstance();
         // Generate a new date at midnight
-        result.add(Calendar.DATE, days + 1);
-        result.set(Calendar.HOUR_OF_DAY, 0);
-        result.set(Calendar.MINUTE, 0);
-        result.set(Calendar.SECOND, 0);
-        result.set(Calendar.MILLISECOND, 0);
+        result.add(java.util.Calendar.DATE, days + 1);
+        result.set(java.util.Calendar.HOUR_OF_DAY, 0);
+        result.set(java.util.Calendar.MINUTE, 0);
+        result.set(java.util.Calendar.SECOND, 0);
+        result.set(java.util.Calendar.MILLISECOND, 0);
         return result;
     }
 }
@@ -72,8 +71,8 @@ if (daysParam !== null) {
             // Calculate when a standard token for this visit would expire for a standard survey
             var visitTime = time.getProperty("value").getDate();
             var validDays = config.getDaysRelativeToEventWhileSurveyIsValid(visitInformationForm);
-            visitTime.add(Calendar.DATE, validDays + 1);
-            var diff = java.time.temporal.ChronoUnit.DAYS.between(Calendar.getInstance().toInstant(), visitTime.toInstant());
+            visitTime.add(java.util.Calendar.DATE, validDays + 1);
+            var diff = java.time.temporal.ChronoUnit.DAYS.between(java.util.Calendar.getInstance().toInstant(), visitTime.toInstant());
             // Check if we are still within the standard visit expiry period
             if (diff >= 1) {
                 // There is at least one day left in the standard visit expiry period:


### PR DESCRIPTION
- Removing the casting of java.util.Calendar to a javascript object to fix the wrapping warning when an instance of Calendar (or a implementation thereof) is created

To make testing token lifespan easier, switch the test runmode from using `mvn:io.uhndata.cards/cards-jwt-token-authentication/${CARDS_VERSION}/slingosgifeature` to using `mvn:io.uhndata.cards/cards-stored-token-authentication/${CARDS_VERSION}/slingosgifeature` in `./start_cards.sh`. This way it is easier to validate when a token is set to expire using the token node stored in `jcr:system/cards:tokens/patient`.

To test, launch in runmode test.
- Create a visit information form for more than a month ago for the Date survey. Create a token for it and verify that the token expires in 2 weeks (per `manualTokenLifespanDays`).
- Create a visit for a day ago for the date survey and verify it is valid for 30 days (per `daysRelativeToEventWhileSurveyIsValid`)
- Manually create a token with `validForDays` and validate that the token is valid for that long eg. http://localhost:8080/Subjects/SamplePatient/24fe8589-69d5-4649-ad07-ea7b26b21601.token.html?validForDays=5