### PR TITLE
CARDS-603: Rubustness improvement - use "last" instead of -1 for ordering questionnaire items

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/QuestionnaireTreeContext.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/QuestionnaireTreeContext.jsx
@@ -208,10 +208,14 @@ export function QuestionnaireTreeProvider(props) {
         return true;
       },
       isValidNewPosition: (reorderSourceId, newParentId, newPosition) => {
-        // Return error if newPosition is not a valid index
+        // newPosition is either the literal 'last' (Sling :order keyword) or a 0-based index
+        // within the new parent's children.
+        if (newPosition === 'last') {
+          return true;
+        }
         const newParentNode = nodes[newParentId];
         const childrenCount = newParentNode.children.length;
-        if (newPosition < -1 || newPosition > childrenCount) {
+        if (newPosition < 0 || newPosition > childrenCount) {
           return 'Invalid new position.';
         }
         return true;

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReorderForm.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReorderForm.jsx
@@ -66,7 +66,8 @@ const reorderReducer = (state, action) => {
       return { ...state, inputs: { ...state.inputs, newParent: action.payload } };
     case 'SET_POSITIONRADIO': {
       const positionRadio = action.payload;
-      const newPosition = positionRadio === 'first' ? 0 : positionRadio === 'last' ? -1 : null;
+      // 'last' is sent verbatim as Sling's :order keyword
+      const newPosition = positionRadio === 'first' ? 0 : positionRadio === 'last' ? 'last' : null;
       return {
         ...state,
         inputs: {

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/questionnaireApi.js
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/questionnaireApi.js
@@ -74,7 +74,7 @@ export const jcrActions = {
   // :order=before siblingNodeName || index
   moveEntryNested: (globalLoginDisplay, { reorderSourceNode, newParentNode, newPosition }) => {
     const reorderForm = new FormData();
-    // :order is a 0-based index, or -1 to place last
+    // :order is a 0-based index, or the literal 'last' to place last
     const order = newPosition;
     const dest = newParentNode.path.concat('/');
     const path = reorderSourceNode.path;


### PR DESCRIPTION
When reordering a questionnaire item to the last position in its parent, the code used to send -1 as the Sling :order value. However, relying on an out-of-range index (e.g. -1) to resolve to last is fragile and breaks if that fallback ever changes in Sling. This replaces the -1 assumption with Sling's documented 'last' keyword, which :order supports natively.