### PR TITLE
CARDS-603: refactor to share reorder logic between ReorderForm and ReorderDraft, and fix reorder UX issues

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/QuestionnaireTreeContext.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/QuestionnaireTreeContext.jsx
@@ -29,6 +29,7 @@ import {
   setSubtreeAtPath,
   stateValidators,
 } from "./questionnaireTreeModel";
+import { getMoveValidity, isValidIndex } from "./reorderModel";
 import { GlobalLoginContext } from "../login/ReLoginDialog.js";
 
 // React context
@@ -189,56 +190,14 @@ export function QuestionnaireTreeProvider(props) {
     // Add tree as an optional parameter to allow moves in between without resetting tree in context
     // Otherwise uses the latest tree via ref to avoid stale closure
     const nodes = tree || nodesRef.current;
-    const reorderValidators = {
-      sourceNodeExists: (reorderSourceId, newParentId, newPosition) => {
-        return nodes[reorderSourceId] ? true : 'Source node does not exist.';
-      },
-      newParentExists: (reorderSourceId, newParentId, newPosition) => {
-        return nodes[newParentId] ? true : 'New parent node does not exist.';
-      },
-      notMovingToSelfOrDescendant: (reorderSourceId, newParentId, newPosition) => {
-        let currentNodeId = newParentId;
-
-        while (currentNodeId) {
-          if (currentNodeId === reorderSourceId) {
-            return 'Cannot move to self or a descendant.';
-          }
-          currentNodeId = nodes[currentNodeId]?.parent; // Move up to the parent
-        }
-        return true;
-      },
-      isValidNewPosition: (reorderSourceId, newParentId, newPosition) => {
-        // newPosition is either the literal 'last' (Sling :order keyword) or a 0-based index
-        // within the new parent's children.
-        if (newPosition === 'last') {
-          return true;
-        }
-        const newParentNode = nodes[newParentId];
-        const childrenCount = newParentNode.children.length;
-        if (newPosition < 0 || newPosition > childrenCount) {
-          return 'Invalid new position.';
-        }
-        return true;
-      },
-      newParentHasChildWithSameName: (reorderSourceId, newParentId, newPosition) => {
-        const sourceNode = nodes[reorderSourceId];
-        const newParentNode = nodes[newParentId];
-        const newParentChildren = newParentNode.children.map(id => nodes[id]?.name);
-        const sourceNodeName = sourceNode.name;
-        const isNewParent = sourceNode.parent !== newParentId;
-        if (isNewParent && newParentChildren.includes(sourceNodeName)) {
-          return 'New parent node already has a child with the same name.';
-        }
-        return true;
-      },
-    };
-    // Check if any validators return strings, indicating an error
-    const validation = Object.values(reorderValidators)
-      .map(validator => validator(reorderSourceId, newParentId, newPosition));
-    const isNotValid = validation.some(result => typeof result === 'string');
-    if (isNotValid) {
-      const validationErrors = validation.filter(result => typeof result === 'string').join('\n');
-      throw new Error("Invalid reorder operation ".concat(validationErrors));
+    // Structural legality (source/parent exist, not into self or a descendant, no name clash)
+    // is checked first; it also guarantees both nodes exist before the position is range-checked.
+    const validity = getMoveValidity(nodes, reorderSourceId, newParentId);
+    if (!validity.valid) {
+      throw new Error("Invalid reorder operation: ".concat(validity.message));
+    }
+    if (!isValidIndex(nodes, newParentId, newPosition)) {
+      throw new Error("Invalid reorder operation: Invalid new position.");
     }
 
     const reorderSourceParentId = nodes[reorderSourceId].parent;

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReorderDraft.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReorderDraft.jsx
@@ -44,13 +44,19 @@ import {
   Typography,
 } from '@mui/material';
 import { alpha } from '@mui/material/styles';
-import _ from "lodash";
 import { DateTime } from 'luxon';
 import { useBlocker } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
 
 import { ENTRY_TITLE_FIELD_SPEC, jcrGetConditionalTitle } from './entryDisplay';
 import { useQuestionnaireTreeContext } from './QuestionnaireTreeContext';
+import {
+  applyMove,
+  getMoveValidity,
+  isNoOpMove,
+  resolveTargetIndex,
+  MOVE_INVALID,
+} from './reorderModel';
 import { getEntryChildIds } from './treeQueries';
 import ErrorDialog from '../components/ErrorDialog';
 import MainActionButton from "../components/MainActionButton";
@@ -179,41 +185,22 @@ const reorderReducer = (state, action) => {
 
       const { reorderTargetId, insert } = action.payload;
       const reorderSourceId = state.inputs.reorderSourceId;
-      // Determine source and target parent
-      const sourceParent = state.draftTree[reorderSourceId].parent;
-      // If insert then target parent is target node
+      // An "insert" placeholder appends into the target node itself; otherwise the source lands
+      // just before the target sibling, inside that sibling's parent.
       const targetParent = insert ? reorderTargetId : state.draftTree[reorderTargetId].parent;
-      // Determine new position of source node in targetParent
-      const getTargetPosition = (sourceParent, targetParent, reorderTargetId, insert) => {
-        const targetParentChildren = state.draftTree[targetParent].children;
-        let targetIndex = insert ? (targetParentChildren?.length || 0) : targetParentChildren.indexOf(reorderTargetId);
-
-        const sourceIndex = state.draftTree[sourceParent].children.indexOf(state.inputs.reorderSourceId);
-        if ((sourceParent == targetParent) && (sourceIndex < targetIndex)) {
-          targetIndex = targetIndex - 1;
-        }
-        return targetIndex;
-      };
-      const reorderTargetIndex = getTargetPosition(sourceParent, targetParent, reorderTargetId, insert);
+      const slot = insert ? { type: 'last' } : { type: 'before', refId: reorderTargetId };
+      const reorderTargetIndex = resolveTargetIndex(state.draftTree, reorderSourceId, targetParent, slot);
       // Define move and clear inputs
       const move = { reorderSourceId, reorderTargetId, reorderTargetIndex, reorderNewParentId: targetParent, insert };
       const newMoves = [...state.moves, move];
       const newInputs = { reorderSourceId: null, reorderTargetId: null };
 
-      // Reflect move in the draft tree
-      const newDraftTree = _.cloneDeep(state.draftTree);
-
-      const sourceNode = newDraftTree[reorderSourceId];
-      const sourceParentNode = newDraftTree[sourceParent];
-
-      // Remove source node
-      const sourceParentChildren = sourceParentNode.children.filter(childId => childId != reorderSourceId);
-      newDraftTree[sourceParent].children = sourceParentChildren;
-      // Insert source node into target parent
-      const targetParentNode = newDraftTree[targetParent];
-      targetParentNode.children.splice(reorderTargetIndex, 0, reorderSourceId); //splice is in place
-
-      sourceNode.parent = targetParent;
+      // Reflect the move in the draft tree so the list re-renders in its new order.
+      const newDraftTree = applyMove(state.draftTree, {
+        sourceId: reorderSourceId,
+        targetParentId: targetParent,
+        index: reorderTargetIndex,
+      });
       return { ...state, moves: newMoves, inputs: newInputs, draftTree: newDraftTree };
     }
     case 'RESET_MOVES':
@@ -445,40 +432,30 @@ const TargetPlaceholderDivider = (props) => {
   const isInvalidTarget = useCallback(
     (nodeId) => {
       if (!sourceIsSelected) return INVALID_REASONS['NO_SOURCE'];
-      // Check is not source
-      if (reorderSourceId === nodeId) return INVALID_REASONS['CIRCULAR'];
-      // Check is not descendent of source
-      if (getDescendents(reorderSourceId, reorderState.draftTree).includes(nodeId)) return INVALID_REASONS['DESCENDENT'];
+      const draftTree = reorderState.draftTree;
+      // The placeholder either inserts into nodeId (as its last child) or sits just before
+      // nodeId (inside nodeId's parent).
+      const targetParentId = insert ? nodeId : draftTree[nodeId].parent;
 
-      // Check is not next sibling of source
-      const node = reorderState.draftTree[nodeId];
-      if (insert) {
-        // Check that source is not the last child of this node
-        const sourceIsLastChild = (node.children.length > 0) &&
-          (node.children[node.children.length - 1] === reorderSourceId);
-        if (sourceIsLastChild) return INVALID_REASONS['LAST_CHILD'];
-      } else {
-        const nodeParent = reorderState.draftTree[nodeId].parent;
-        const sourceParent = reorderState.draftTree[reorderSourceId].parent;
-        const sourceIndex = reorderState.draftTree[sourceParent].children.indexOf(reorderSourceId);
-        const targetIndex = reorderState.draftTree[nodeParent].children.indexOf(nodeId);
-
-        const isSameParent = sourceParent === nodeParent;
-        if (isSameParent && (sourceIndex === targetIndex - 1)) return INVALID_REASONS['SAME_PARENT'];
+      // Structural legality: into itself, into a descendant, or a name clash in a new parent.
+      const validity = getMoveValidity(draftTree, reorderSourceId, targetParentId);
+      if (!validity.valid) {
+        if (validity.code === MOVE_INVALID.SELF) return INVALID_REASONS['CIRCULAR'];
+        if (validity.code === MOVE_INVALID.DESCENDANT) return INVALID_REASONS['DESCENDENT'];
+        if (validity.code === MOVE_INVALID.NAME_COLLISION) return INVALID_REASONS['EXISTING_CHILD'];
+        return INVALID_REASONS['NO_SOURCE'];
       }
 
-      // Check if containing parent of this target placeholder has no existing children with the same name as reorder source
-      const sourceName = reorderState.draftTree[reorderSourceId].name;
-      const sourceParentId = reorderState.draftTree[reorderSourceId].parent;
-      const nodeParentId = insert ? nodeId : reorderState.draftTree[nodeId].parent;
-      if (nodeParentId !== sourceParentId) {
-        const nodeParentChildren = reorderState.draftTree[nodeParentId].children.map(id => reorderState.draftTree[id]);
-        const sameNameExists = nodeParentChildren.some(child => child.name === sourceName);
-        if (sameNameExists) return INVALID_REASONS['EXISTING_CHILD'];
+      // A move that leaves the source in its current slot is a no-op: already the last child for
+      // an insert, or dropping onto its own next-sibling divider otherwise.
+      const slot = insert ? { type: 'last' } : { type: 'before', refId: nodeId };
+      const index = resolveTargetIndex(draftTree, reorderSourceId, targetParentId, slot);
+      if (isNoOpMove(draftTree, reorderSourceId, targetParentId, index)) {
+        return insert ? INVALID_REASONS['LAST_CHILD'] : INVALID_REASONS['SAME_PARENT'];
       }
 
       return '';
-    }, [reorderSourceId, reorderState.draftTree, sourceIsSelected]);
+    }, [reorderSourceId, reorderState.draftTree, sourceIsSelected, insert]);
 
   // Click handler
   const handleClickReorderTargetSelect = () => {
@@ -611,11 +588,6 @@ const ReorderConditionalSubheader = (props) => {
   );
 }
 
-
-function getDescendents(id, nodes) {
-  const node = nodes[id];
-  return [id, ...node.children.flatMap(childId => getDescendents(childId, nodes))];
-}
 
 function RecursiveDragList(props) {
   const { nodeId, level = 0, } = props;

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReorderForm.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReorderForm.jsx
@@ -177,6 +177,30 @@ export default function ReorderForm(props) {
     });
   }, [nodes, newParent]);
 
+  // Which position radios are selectable, computed once and shared by the radio render and the
+  // effect that clears a selection once it stops being valid. A radio is disabled when there is
+  // no new parent, or when picking it wouldn't actually move the source:
+  //  - First/Last: the source already sits in that slot (no-op).
+  //  - After...: every offered reference position is a no-op (e.g. moving the last of two
+  //    children — "after the first" is its current spot, "after itself" is excluded).
+  // An empty target parent has only a single slot, so only First stays enabled there.
+  const positionRadioDisabled = useMemo(() => {
+    const canEvaluate = !!nodes[reorderSource] && !!newParent && !!nodes[newParent];
+    const noNewParent = !newParent;
+    const newParentHasNoEntryChildren = canEvaluate && getEntryChildIds(nodes, newParent).length === 0;
+    const isNoOp = (slot) =>
+      isNoOpMove(nodes, reorderSource, newParent, resolveTargetIndex(nodes, reorderSource, newParent, slot));
+    const firstIsNoOp = canEvaluate && isNoOp({ type: 'first' });
+    const lastIsNoOp = canEvaluate && isNoOp({ type: 'last' });
+    const afterHasViableTarget = canEvaluate
+      && getEntryChildIds(nodes, newParent).some(refId => !isNoOp({ type: 'after', refId }));
+    return {
+      first: noNewParent || firstIsNoOp,
+      other: noNewParent || newParentHasNoEntryChildren || !afterHasViableTarget,
+      last: noNewParent || newParentHasNoEntryChildren || lastIsNoOp,
+    };
+  }, [nodes, reorderSource, newParent]);
+
 
   useEffect(() => {
     if (Object.keys(nodes).length === 0) {
@@ -204,14 +228,22 @@ export default function ReorderForm(props) {
 
   useEffect(() => {
     setNewPositionSelection([]);
-    // If newParent has no entry-type children (conditionals excluded), default positionRadio
-    // to 'first'
-    const newParentHasNoEntryChildren = !!newParent && getEntryChildIds(nodes, newParent).length === 0;
-
+    if (!newParent) return;
+    // If the target parent has no entry-type children (conditionals excluded), First is the only
+    // slot, so default to it.
+    const newParentHasNoEntryChildren = getEntryChildIds(nodes, newParent).length === 0;
     if (newParentHasNoEntryChildren) {
       reorderDispatch({ type: 'SET_POSITIONRADIO', payload: 'first' });
+      return;
     }
-  }, [newParent]);
+    // Otherwise, if the current choice is no longer selectable (e.g. "After..." lost all viable
+    // targets after a parent change), drop it so a stale, unusable selection and its dropdown
+    // can't linger — falling back to First when that one is still valid.
+    const current = reorderState.inputs.positionRadio;
+    if (current && positionRadioDisabled[current]) {
+      reorderDispatch({ type: 'SET_POSITIONRADIO', payload: positionRadioDisabled.first ? '' : 'first' });
+    }
+  }, [newParent, nodes, positionRadioDisabled, reorderState.inputs.positionRadio]);
 
   const selectReorderSourceContent = (
     <>
@@ -332,47 +364,19 @@ export default function ReorderForm(props) {
           value={reorderState.inputs.positionRadio}
           onChange={(e) => reorderDispatch({ type: 'SET_POSITIONRADIO', payload: e.target.value })}
         >
-          {(() => {
-            const noNewParent = !newParent
-            const newParentHasNoEntryChildren = getEntryChildIds(nodes, newParent).length === 0
-            // First/Last are no-ops only when the source would land back in its current slot.
-            // isNoOpMove already returns false across different parents, so no same-parent guard
-            // is needed here. It works in the full-children index space (the space :order uses),
-            // so it stays consistent with the submit-time noNewTarget guard below.
-            const canEvaluate = !!nodes[reorderSource] && !!nodes[newParent];
-            const firstIsNoOp = canEvaluate
-              && isNoOpMove(nodes, reorderSource, newParent, resolveTargetIndex(nodes, reorderSource, newParent, { type: 'first' }));
-            const lastIsNoOp = canEvaluate
-              && isNoOpMove(nodes, reorderSource, newParent, resolveTargetIndex(nodes, reorderSource, newParent, { type: 'last' }));
-            // "After..." is only useful if some reference position yields a real move. Within the
-            // same parent every "after" slot can be a no-op (e.g. moving the last of two children:
-            // "after the first" is its current spot, "after itself" is excluded), so disable it
-            // when no offered position would actually move the source.
-            const afterHasViableTarget = canEvaluate && getEntryChildIds(nodes, newParent).some(refId =>
-              !isNoOpMove(nodes, reorderSource, newParent, resolveTargetIndex(nodes, reorderSource, newParent, { type: 'after', refId })));
-            return (
-              [ { value: 'first', label: 'First' },
-                { value: 'other', label: 'After...' },
-                { value: 'last', label: 'Last' },
-              ].map(({ value, label }) =>
-                <FormControlLabel
-                  key={value}
-                  value={value}
-                  label={label}
-                  disabled={[
-                    noNewParent,
-                    // An empty target parent has a single slot, so keep First (which the
-                    // effect auto-selects) enabled and disable After.../Last.
-                    (newParentHasNoEntryChildren && value !== 'first'),
-                    (value === 'first' && firstIsNoOp),
-                    (value === 'last' && lastIsNoOp),
-                    (value === 'other' && !afterHasViableTarget)
-                  ].includes(true)}
-                  control={<Radio />}
-                />
-              )
-            )
-          })()}
+          {[
+            { value: 'first', label: 'First' },
+            { value: 'other', label: 'After...' },
+            { value: 'last', label: 'Last' },
+          ].map(({ value, label }) =>
+            <FormControlLabel
+              key={value}
+              value={value}
+              label={label}
+              disabled={positionRadioDisabled[value]}
+              control={<Radio />}
+            />
+          )}
         </RadioGroup>
         { reorderState.inputs.positionRadio === 'other' &&
           <QuestionnaireAutocomplete

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReorderForm.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReorderForm.jsx
@@ -185,9 +185,15 @@ export default function ReorderForm(props) {
       resolveTargetIndex(nodes, reorderSource, newParent, { type: 'after', refId: option.id })),
   [nodes, reorderSource, newParent]);
 
+  // A different target parent must not already contain a child with the same node name (JCR
+  // siblings need unique names). Detected up front so the radios and Move stay disabled and we can
+  // warn inline, rather than letting reorderNode throw on submit.
+  const nameCollision = !!nodes[reorderSource] && !!nodes[newParent]
+    && getMoveValidity(nodes, reorderSource, newParent).code === MOVE_INVALID.NAME_COLLISION;
+
   // Which position radios are selectable, computed once and shared by the radio render and the
   // effect that clears a selection once it stops being valid. A radio is disabled when there is
-  // no new parent, or when picking it wouldn't actually move the source:
+  // no new parent, a name collision blocks the whole move, or picking it wouldn't move the source:
   //  - First/Last: the source already sits in that slot (no-op).
   //  - After...: every offered reference position is a no-op (e.g. moving the last of two
   //    children — "after the first" is its current spot, "after itself" is excluded).
@@ -203,11 +209,11 @@ export default function ReorderForm(props) {
     const afterHasViableTarget = canEvaluate
       && getEntryChildIds(nodes, newParent).some(refId => !isNoOp({ type: 'after', refId }));
     return {
-      first: noNewParent || firstIsNoOp,
-      other: noNewParent || newParentHasNoEntryChildren || !afterHasViableTarget,
-      last: noNewParent || newParentHasNoEntryChildren || lastIsNoOp,
+      first: noNewParent || nameCollision || firstIsNoOp,
+      other: noNewParent || nameCollision || newParentHasNoEntryChildren || !afterHasViableTarget,
+      last: noNewParent || nameCollision || newParentHasNoEntryChildren || lastIsNoOp,
     };
-  }, [nodes, reorderSource, newParent]);
+  }, [nodes, reorderSource, newParent, nameCollision]);
 
 
   useEffect(() => {
@@ -361,6 +367,11 @@ export default function ReorderForm(props) {
           id="newParent"
           disabled={!reorderSource}
         />
+        {nameCollision &&
+          <Typography variant="caption" color="error" sx={{ display: 'block', mt: 0.5 }}>
+            This destination already contains an item with the same name. Choose a different destination.
+          </Typography>
+        }
       </Grid>
 
       <Grid size={3}>
@@ -434,7 +445,7 @@ export default function ReorderForm(props) {
   const slingPosition = (!invalidPosition && newParent) ? computeSlingPosition() : null;
 
   const noNewTarget = slingPosition !== null && isNoOpMove(nodes, reorderSource, newParent, slingPosition);
-  const disableSubmit = isLoadingOrError || noReorderSource || noNewTarget || invalidPosition;
+  const disableSubmit = isLoadingOrError || noReorderSource || noNewTarget || invalidPosition || nameCollision;
 
   const handleError = (e) => {
     console.warn('Reorder error', e);
@@ -451,13 +462,19 @@ export default function ReorderForm(props) {
   };
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (!reorderSource || !newParent || invalidPosition) {
+    if (disableSubmit) {
       return;
     }
     reorderDispatch({ type: 'SET_LOADING' });
-    treeContext.actions.reorderNode(reorderSource, newParent, slingPosition)
-      .then(handleSuccess)
-      .catch(handleError);
+    // reorderNode validates synchronously and can throw before it returns a promise, so a
+    // try/catch is needed alongside .catch() for the async (server) failure path.
+    try {
+      treeContext.actions.reorderNode(reorderSource, newParent, slingPosition)
+        .then(handleSuccess)
+        .catch(handleError);
+    } catch (err) {
+      handleError(err);
+    }
   };
 
   return (

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReorderForm.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReorderForm.jsx
@@ -32,7 +32,13 @@ import {
 } from '@mui/material';
 
 import { useQuestionnaireTreeContext } from './QuestionnaireTreeContext';
-import { getEntryChildIds, isDescendant } from './treeQueries';
+import {
+  getMoveValidity,
+  isNoOpMove,
+  resolveTargetIndex,
+  MOVE_INVALID,
+} from './reorderModel';
+import { getEntryChildIds } from './treeQueries';
 import { ENTRY_TYPES } from '../questionnaire/FormEntry';
 import QuestionnaireAutocomplete from '../questionnaire/QuestionnaireAutocomplete';
 import { getOrdinalString, stripCardsNamespace } from '../questionnaire/QuestionnaireUtilities';
@@ -150,12 +156,10 @@ export default function ReorderForm(props) {
   }, [nodes, reorderSource]);
 
   const getParentOptionDisabled = useCallback((option) => {
-    // Exclude current node (can't reassign node as parent to itself)
-    // Exclude children of current node (can't reassign parent to child)
-    const isReorderSource = reorderSource === option.value;
-    const isDescendantOfReorderSource = isDescendant(nodes, reorderSource, option.value);
-    const disabled = isReorderSource || isDescendantOfReorderSource;
-    return disabled;
+    // Exclude the source itself and any of its descendants — neither can be its parent.
+    // Name collisions are intentionally not pre-checked here; they surface on submit, as before.
+    const { code } = getMoveValidity(nodes, reorderSource, option.value);
+    return code === MOVE_INVALID.SELF || code === MOVE_INVALID.DESCENDANT;
   }, [nodes, reorderSource]);
 
   const positionOptions = useMemo(() => {
@@ -331,13 +335,15 @@ export default function ReorderForm(props) {
           {(() => {
             const noNewParent = !newParent
             const newParentHasNoEntryChildren = getEntryChildIds(nodes, newParent).length === 0
-            // First/Last are no-ops only when staying in the same parent; moving into a
-            // different parent, First/Last are always valid (different) destinations.
-            const isSameParent = nodes[reorderSource]?.parent === newParent;
-            const filteredChildren = getEntryChildIds(nodes, nodes[reorderSource]?.parent);
-            const originalPositionIndex = filteredChildren.indexOf(reorderSource);
-            const originalPositionIsFirst = originalPositionIndex === 0;
-            const originalPositionIsLast = originalPositionIndex === filteredChildren.length - 1;
+            // First/Last are no-ops only when the source would land back in its current slot.
+            // isNoOpMove already returns false across different parents, so no same-parent guard
+            // is needed here. It works in the full-children index space (the space :order uses),
+            // so it stays consistent with the submit-time noNewTarget guard below.
+            const canEvaluate = !!nodes[reorderSource] && !!nodes[newParent];
+            const firstIsNoOp = canEvaluate
+              && isNoOpMove(nodes, reorderSource, newParent, resolveTargetIndex(nodes, reorderSource, newParent, { type: 'first' }));
+            const lastIsNoOp = canEvaluate
+              && isNoOpMove(nodes, reorderSource, newParent, resolveTargetIndex(nodes, reorderSource, newParent, { type: 'last' }));
             return (
               [ { value: 'first', label: 'First' },
                 { value: 'other', label: 'After...' },
@@ -352,8 +358,8 @@ export default function ReorderForm(props) {
                     // An empty target parent has a single slot, so keep First (which the
                     // effect auto-selects) enabled and disable After.../Last.
                     (newParentHasNoEntryChildren && value !== 'first'),
-                    (value === 'first' && isSameParent && originalPositionIsFirst),
-                    (value === 'last' && isSameParent && originalPositionIsLast)
+                    (value === 'first' && firstIsNoOp),
+                    (value === 'last' && lastIsNoOp)
                   ].includes(true)}
                   control={<Radio />}
                 />
@@ -391,33 +397,24 @@ export default function ReorderForm(props) {
 
   const isLoadingOrError = ['loading', 'error'].includes(reorderState.status);
   const noReorderSource = !reorderSource;
-  const sameNewParent = !noReorderSource && nodes[reorderSource]?.parent === newParent;
   const invalidPosition = newPosition === null || newPosition === "";
 
-  // Compute the actual Sling :order value to send.
-  // For 'other' (After...), newPosition is a 0-based filtered-children index of the reference node.
-  // We need position = refAllIndex + 1 (place after reference), adjusted when the source sits
-  // before that slot in the same parent (removing source shifts subsequent indices down by 1).
+  // Resolve the Sling :order value to send, from the selected radio:
+  //  - First/Last become the 0 / 'last' slot; resolveTargetIndex returns 'last' verbatim.
+  //  - 'other' (After...) places the source after the entry child at the selected index.
+  // resolveTargetIndex handles the same-parent shift (removing the source moves later siblings up).
   const computeSlingPosition = () => {
-    if (reorderState.inputs.positionRadio !== 'other') return newPosition;
-    const allChildren = nodes[newParent].children;
-    const filteredChildren = getEntryChildIds(nodes, newParent);
-    const referenceNodeId = filteredChildren[newPosition];
+    if (!nodes[reorderSource] || !newParent) return null;
+    const radio = reorderState.inputs.positionRadio;
+    if (radio === 'first') return resolveTargetIndex(nodes, reorderSource, newParent, { type: 'first' });
+    if (radio === 'last') return resolveTargetIndex(nodes, reorderSource, newParent, { type: 'last' });
+    const referenceNodeId = getEntryChildIds(nodes, newParent)[newPosition];
     if (!referenceNodeId) return null;
-    const refAllIndex = allChildren.indexOf(referenceNodeId);
-    let slingPos = refAllIndex + 1;
-    if (nodes[reorderSource]?.parent === newParent) {
-      const sourceAllIndex = allChildren.indexOf(reorderSource);
-      if (sourceAllIndex < slingPos) {
-        slingPos -= 1;
-      }
-    }
-    return slingPos;
+    return resolveTargetIndex(nodes, reorderSource, newParent, { type: 'after', refId: referenceNodeId });
   };
   const slingPosition = (!invalidPosition && newParent) ? computeSlingPosition() : null;
 
-  const noNewTarget = sameNewParent && slingPosition !== null
-    && slingPosition === nodes[newParent]?.children.indexOf(reorderSource);
+  const noNewTarget = slingPosition !== null && isNoOpMove(nodes, reorderSource, newParent, slingPosition);
   const disableSubmit = isLoadingOrError || noReorderSource || noNewTarget || invalidPosition;
 
   const handleError = (e) => {

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReorderForm.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReorderForm.jsx
@@ -168,6 +168,7 @@ export default function ReorderForm(props) {
       const node = nodes[id];
       return ({
         value: index,
+        id: id,
         name: node.name,
         text: node.title,
         path: node.path,
@@ -176,6 +177,13 @@ export default function ReorderForm(props) {
       });
     });
   }, [nodes, newParent]);
+
+  // Disable any "After..." reference whose slot wouldn't move the item: the item itself, and
+  // (within the same parent) its current predecessor — placing it after either leaves it put.
+  const getPositionOptionDisabled = useCallback((option) =>
+    isNoOpMove(nodes, reorderSource, newParent,
+      resolveTargetIndex(nodes, reorderSource, newParent, { type: 'after', refId: option.id })),
+  [nodes, reorderSource, newParent]);
 
   // Which position radios are selectable, computed once and shared by the radio render and the
   // effect that clears a selection once it stops being valid. A radio is disabled when there is
@@ -383,7 +391,7 @@ export default function ReorderForm(props) {
             showSelection={false}
             multiple={false}
             entities={positionOptions}
-            getOptionDisabled={(option) => option.path === nodes[reorderSource]?.path}
+            getOptionDisabled={getPositionOptionDisabled}
             selection={newPositionSelection}
             onSelectionChanged={setNewPositionSelection}
             placeholderText="... other questionnaire entry"

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReorderForm.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReorderForm.jsx
@@ -344,6 +344,12 @@ export default function ReorderForm(props) {
               && isNoOpMove(nodes, reorderSource, newParent, resolveTargetIndex(nodes, reorderSource, newParent, { type: 'first' }));
             const lastIsNoOp = canEvaluate
               && isNoOpMove(nodes, reorderSource, newParent, resolveTargetIndex(nodes, reorderSource, newParent, { type: 'last' }));
+            // "After..." is only useful if some reference position yields a real move. Within the
+            // same parent every "after" slot can be a no-op (e.g. moving the last of two children:
+            // "after the first" is its current spot, "after itself" is excluded), so disable it
+            // when no offered position would actually move the source.
+            const afterHasViableTarget = canEvaluate && getEntryChildIds(nodes, newParent).some(refId =>
+              !isNoOpMove(nodes, reorderSource, newParent, resolveTargetIndex(nodes, reorderSource, newParent, { type: 'after', refId })));
             return (
               [ { value: 'first', label: 'First' },
                 { value: 'other', label: 'After...' },
@@ -359,7 +365,8 @@ export default function ReorderForm(props) {
                     // effect auto-selects) enabled and disable After.../Last.
                     (newParentHasNoEntryChildren && value !== 'first'),
                     (value === 'first' && firstIsNoOp),
-                    (value === 'last' && lastIsNoOp)
+                    (value === 'last' && lastIsNoOp),
+                    (value === 'other' && !afterHasViableTarget)
                   ].includes(true)}
                   control={<Radio />}
                 />

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/reorderModel.js
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/reorderModel.js
@@ -1,0 +1,186 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+// The reorder domain model: pure functions shared by the two reorder UIs (ReorderForm and
+// ReorderDraft) and by the tree context's reorderNode action. They answer the three questions
+// every reorder needs, against the flat node map produced by the tree model (see jcrToNode):
+//   - is a move legal?            getMoveValidity
+//   - where does the item land?   resolveTargetIndex
+//   - is the move a no-op?        isNoOpMove
+//   - apply it to a node map      applyMove
+// Index math is done against a parent's FULL children array (conditionals included), the same
+// space Sling's :order uses; entry-type filtering is a display concern handled by the callers.
+// Nothing here touches React.
+
+import { isDescendant } from "./treeQueries";
+
+/**
+ * Reason codes returned by getMoveValidity. Callers decide how to present each one (disable an
+ * option, draw an invalid placeholder, throw on submit), so the codes live in one place.
+ * @enum {string}
+ */
+export const MOVE_INVALID = {
+  NO_SOURCE: 'NO_SOURCE',
+  NO_PARENT: 'NO_PARENT',
+  SELF: 'SELF',
+  DESCENDANT: 'DESCENDANT',
+  NAME_COLLISION: 'NAME_COLLISION',
+};
+
+const MOVE_INVALID_MESSAGES = {
+  [MOVE_INVALID.NO_SOURCE]: 'Source node does not exist.',
+  [MOVE_INVALID.NO_PARENT]: 'New parent node does not exist.',
+  [MOVE_INVALID.SELF]: 'Cannot move an item into itself.',
+  [MOVE_INVALID.DESCENDANT]: 'Cannot move an item into one of its own descendants.',
+  [MOVE_INVALID.NAME_COLLISION]: 'New parent node already has a child with the same name.',
+};
+
+/**
+ * Checks whether moving `sourceId` under `targetParentId` is structurally legal, independent of
+ * the exact slot it lands in. This is the single home for the self / descendant / name-collision
+ * rules that the reorder UIs and reorderNode all need. Position validity (index in range) and
+ * no-op detection are separate concerns — see isValidIndex and isNoOpMove.
+ *
+ * @param {Object} nodes - The flat node map from the tree.
+ * @param {string} sourceId - The ID of the node being moved.
+ * @param {string} targetParentId - The ID of the parent the node would move under.
+ * @returns {{valid: boolean, code: (string|null), message: (string|null)}} - `valid` is true when
+ *   the move is allowed; otherwise `code` is a MOVE_INVALID code and `message` a human-readable string.
+ */
+export function getMoveValidity(nodes, sourceId, targetParentId) {
+  const invalid = (code) => ({ valid: false, code, message: MOVE_INVALID_MESSAGES[code] });
+
+  if (!nodes[sourceId]) return invalid(MOVE_INVALID.NO_SOURCE);
+  if (!nodes[targetParentId]) return invalid(MOVE_INVALID.NO_PARENT);
+  // Moving a node under itself, or under any of its own descendants, would detach the subtree.
+  // isDescendant walks down from the source and returns true for the source itself too, so the
+  // explicit self check below is only there to give the clearer "into itself" message.
+  if (targetParentId === sourceId) return invalid(MOVE_INVALID.SELF);
+  if (isDescendant(nodes, sourceId, targetParentId)) return invalid(MOVE_INVALID.DESCENDANT);
+
+  // Two siblings cannot share a name in JCR. Only relevant when changing parent: staying put
+  // keeps the existing (already unique) name.
+  const isChangingParent = nodes[sourceId].parent !== targetParentId;
+  if (isChangingParent) {
+    const sourceName = nodes[sourceId].name;
+    const collides = nodes[targetParentId].children.some(id => nodes[id]?.name === sourceName);
+    if (collides) return invalid(MOVE_INVALID.NAME_COLLISION);
+  }
+
+  return { valid: true, code: null, message: null };
+}
+
+/**
+ * Resolves the 0-based index (or the literal 'last') at which `sourceId` should land in
+ * `targetParentId`. The index is expressed against the target parent's FULL children array AFTER
+ * the source has been removed, so it can be handed straight to a splice (applyMove) or to Sling's
+ * :order. 'last' is returned verbatim for an append, matching Sling's keyword and avoiding any
+ * reliance on an out-of-range index resolving to last.
+ *
+ * @param {Object} nodes - The flat node map from the tree.
+ * @param {string} sourceId - The ID of the node being moved.
+ * @param {string} targetParentId - The ID of the parent the node moves under.
+ * @param {{type: ('first'|'last'|'before'|'after'), refId?: string}} slot - Where to place it:
+ *   'first'/'last' need no reference; 'before'/'after' are relative to the sibling `refId`.
+ * @returns {(number|'last')} - The post-removal insertion index, or 'last' to append.
+ */
+export function resolveTargetIndex(nodes, sourceId, targetParentId, slot) {
+  if (slot.type === 'first') return 0;
+  if (slot.type === 'last') return 'last';
+
+  const children = nodes[targetParentId].children;
+  const refIndex = children.indexOf(slot.refId);
+  // 'before' takes the reference's slot; 'after' takes the one past it.
+  let index = slot.type === 'after' ? refIndex + 1 : refIndex;
+
+  // Moving within the same parent, removing the source first shifts every later sibling down by
+  // one, so a destination past the source's old slot must compensate.
+  if (nodes[sourceId].parent === targetParentId) {
+    const sourceIndex = children.indexOf(sourceId);
+    if (sourceIndex < index) index -= 1;
+  }
+  return index;
+}
+
+/**
+ * Checks whether the resolved destination is where the source already sits — i.e. the move would
+ * change nothing. Only possible when staying within the same parent. Unifies the "already first",
+ * "already last" and "dropped onto its own next-sibling slot" cases the UIs each guard against.
+ *
+ * @param {Object} nodes - The flat node map from the tree.
+ * @param {string} sourceId - The ID of the node being moved.
+ * @param {string} targetParentId - The ID of the parent the node would move under.
+ * @param {(number|'last')} resolvedIndex - The destination from resolveTargetIndex.
+ * @returns {boolean} - True when the source would end up in its current position.
+ */
+export function isNoOpMove(nodes, sourceId, targetParentId, resolvedIndex) {
+  if (nodes[sourceId].parent !== targetParentId) return false;
+  const children = nodes[targetParentId].children;
+  const currentIndex = children.indexOf(sourceId);
+  // Removing the source then re-inserting it at its own index reconstructs the original order.
+  const finalIndex = resolvedIndex === 'last' ? children.length - 1 : resolvedIndex;
+  return finalIndex === currentIndex;
+}
+
+/**
+ * Checks that an index is a placeable position in `targetParentId`: either the 'last' keyword, or
+ * an integer from 0 up to and including the current child count (the slot just past the end).
+ *
+ * @param {Object} nodes - The flat node map from the tree.
+ * @param {string} targetParentId - The ID of the parent the node moves under.
+ * @param {(number|'last')} index - The index to validate.
+ * @returns {boolean} - True when the index is valid.
+ */
+export function isValidIndex(nodes, targetParentId, index) {
+  if (index === 'last') return true;
+  if (!Number.isInteger(index)) return false;
+  const childrenCount = nodes[targetParentId].children.length;
+  return index >= 0 && index <= childrenCount;
+}
+
+/**
+ * Immutably applies a move to a flat node map: detaches the source from its current parent and
+ * inserts it into the target parent at `index` (or appends it for 'last'), updating the source's
+ * parent pointer. Only the touched nodes are cloned; untouched nodes are shared. Mirrors what the
+ * server does, so the reorder UIs can reflect a move without a reload.
+ *
+ * @param {Object} nodes - The flat node map from the tree.
+ * @param {{sourceId: string, targetParentId: string, index: (number|'last')}} move - The move.
+ * @returns {Object} - A new node map with the move applied.
+ */
+export function applyMove(nodes, { sourceId, targetParentId, index }) {
+  const sourceParentId = nodes[sourceId].parent;
+  const next = { ...nodes };
+
+  // Detach from the current parent first. When source and target share a parent, this updated
+  // (source-free) children array is the one we splice into below — so `index`, computed against
+  // the post-removal array by resolveTargetIndex, lines up.
+  next[sourceParentId] = {
+    ...next[sourceParentId],
+    children: next[sourceParentId].children.filter(id => id !== sourceId),
+  };
+
+  const targetChildren = [...next[targetParentId].children];
+  const at = index === 'last' ? targetChildren.length : index;
+  targetChildren.splice(at, 0, sourceId);
+  next[targetParentId] = { ...next[targetParentId], children: targetChildren };
+  next[sourceId] = { ...next[sourceId], parent: targetParentId };
+
+  return next;
+}


### PR DESCRIPTION
**Summary of changes:**

1. **Refactor: one shared module for reorder logic**
   The same rules ("is this move allowed", "what index does the item land at", "is this a no-op") were implemented separately and slightly inconsistently across three places: `ReorderForm`,  `ReorderDraft`, and `reorderNode` in the tree context).
  This adds a single pure module, `reorderModel.js` reused by all 3. No behaviour change is in the refactoring part of this PR.

2. **ReorderForm UX issues**
  - **Name clash**: moving an item into a parent that already has a child with the same name used to fail silently and throw an uncaught error in the console. Now it shows an inline message, disables the position radios, and keeps MOVE disabled (matching ReorderDraft, which already blocked this).
  - **"After..." with no useful target**: when no offered position would actually move the item (e.g. the last of two children), "After..." is now disabled instead of staying selectable while MOVE never enables.
  - **No-op positions**: the "After..." dropdown now disables positions that wouldn't move the item (the item itself and its prev neighbour).
  - **Stale selection**: when a parent change makes the chosen position invalid, the selection (and its dropdown) is now cleared.

**Testing**
- `ReorderForm` (the "Move item" dialog in the EDIT tab):
  - Move within the same parent: First / After... / Last, and check the original position is shown and no-op options are disabled.
  - Move into a different parent.
  - Attempt to move into a parent that already has an item with the same name
      - Check warning, radios and Move disabled, no console error.
  - Move into an empty section
      - Check that it defaults to First.

- `ReorderDraft` (the drag-and-drop REORDER tab):
  - Drag items within and across sections, including to the bottom of a section.
  - Queue several moves, then SAVE.
  - Also try leaving with unsaved moves.
  - Confirm invalid drop targets (into itself, into a descendant, name clash) are still blocked.

- Both:
  - Try a variety of moves involving sections with conditionals, to confirm correct position computation
  - Confirm the data is not stale when switching between EDIT and REORDER tabs

**This is a LOW RISK PR because it involves new code with a very small set of target users, and there is a workaround if this functionality is broken (/bin/browser).**