### PR TITLE
CARDS-2901: Improve pagination servlet filtering for empty arrays

### DIFF
--- a/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
@@ -386,13 +386,7 @@ public class PaginationServlet extends SlingJakartaSafeMethodsServlet
             final String[] fieldComparators = fieldParameters.get(FIELDCOMPARATORS);
 
             for (int i = 0; i < fieldNames.length; i++) {
-                if (StringUtils.isNotBlank(fieldNames[i])) {
-                    query.append(String.format(
-                        " and n.'%s'%s'%s'",
-                        this.sanitizeValue(fieldNames[i]),
-                        this.sanitizeComparator(fieldComparators[i]),
-                        this.sanitizeValue(fieldValues[i])));
-                }
+                addFieldConditionToQuery(query, fieldNames[i], fieldComparators[i], fieldValues[i]);
             }
         }
 
@@ -454,6 +448,27 @@ public class PaginationServlet extends SlingJakartaSafeMethodsServlet
         }
 
         return fieldParameters;
+    }
+
+    protected void addFieldConditionToQuery(final StringBuilder query, final String field, final String comparator,
+        final String value)
+    {
+        if (StringUtils.isNotBlank(field)) {
+            if ("<>".equals(comparator)) {
+                // `x <> y` does not work intuitively when y is an array as it is run on each array entry
+                // and does not match empty arrays. Convert to `not x = y`
+                query.append(String.format(
+                    " and not n.'%s'='%s'",
+                    this.sanitizeValue(field),
+                    this.sanitizeValue(value)));
+            } else {
+                query.append(String.format(
+                    " and n.'%s'%s'%s'",
+                    this.sanitizeValue(field),
+                    this.sanitizeComparator(comparator),
+                    this.sanitizeValue(value)));
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
- Swap "a <> b" filter comparator to "not a = b" to fix empty array filtering

Can test using the [CARDS-2814-2901-test](https://github.com/data-team-uhn/cards/tree/CARDS-2814-2901-test) branch. Creating a Computed Field Test questionnaire leads to a questionnaire with no status flags. This status flag-less questionnaire should be included when excluding a status flag from the FormView component.