### PR TITLE
CARDS-2924: Improve question filtering for multi-valued answers and <> comparator

### DIFF
--- a/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
+++ b/modules/data-entry/src/main/java/io/uhndata/cards/PaginationServlet.java
@@ -905,28 +905,20 @@ public class PaginationServlet extends SlingJakartaSafeMethodsServlet
                     filter.source,
                     this.sanitizeValue(filter.value)));
         } else {
-            condition.append(" and");
-            if ("<>".equals(filter.comparator)) {
-                condition.append("(")
-                    .append(getValueComparisonString(filter))
-                    .append(
-                        String.format(
-                            " or %s.'value' IS NULL)",
-                            filter.source));
-            } else {
-                condition.append(getValueComparisonString(filter));
-            }
+            condition.append(getValueComparisonString(filter));
         }
         return condition.toString();
     }
 
     private String getValueComparisonString(Filter filter)
     {
+        boolean notEqual = "<>".equals(filter.comparator);
         return String.format(
-            " %s.'value'%s" + ("boolean".equals(filter.type) ? "%s"
+            " and %s%s.'value'%s" + ("boolean".equals(filter.type) ? "%s"
                 : StringUtils.isNotBlank(filter.value) ? "'%s'" : ""),
+            notEqual ? "not " : "",
             filter.source,
-            this.sanitizeComparator(filter.comparator),
+            this.sanitizeComparator(notEqual ? "=" : filter.comparator),
             this.sanitizeValue(filter.value));
     }
 


### PR DESCRIPTION
- Switches from `x<>y` to `not x=y` as that behaves much more intuitively

For testing, the visit information form's provider question is a good example of a multi-valued field to test filters on.
For example, set a provider to have the values `1` and `2`, filter by `provider <> 1` and verify that the form is not included