### PR TITLE
CARDS-2927: Add optional title and intro to the login page

### DIFF
--- a/modules/commons/src/main/frontend/src/components/Logo.jsx
+++ b/modules/commons/src/main/frontend/src/components/Logo.jsx
@@ -36,6 +36,7 @@ const useStyles = makeStyles()(theme => ({
   },
   doubleLogo : {
     display: "flex",
+    gap: theme.spacing(4),
     justifyContent: "space-between",
     alignItems: "center",
     flexWrap: "wrap-reverse",
@@ -43,7 +44,7 @@ const useStyles = makeStyles()(theme => ({
     "& > img" : {
       width: `calc(50% - ${theme.spacing(4)})`,
       minWidth: "100px",
-      margin: theme.spacing(1, 2),
+      margin: theme.spacing(1, 0),
     },
   },
 }));

--- a/modules/data-model/items/api/src/main/resources/SLING-INF/content/libs/cards/Item/header.html
+++ b/modules/data-model/items/api/src/main/resources/SLING-INF/content/libs/cards/Item/header.html
@@ -38,6 +38,14 @@
         <meta name="appVersion" content="${config['AppVersion']}">
       </sly>
     </sly>
+    <sly data-sly-use.config="/libs/cards/conf/LoginPage">
+      <sly data-sly-test="${config.loginTitle}">
+        <meta name="loginTitle" content="${config['loginTitle']}">
+      </sly>
+      <sly data-sly-test="${config.loginDescription}">
+        <meta name="loginDescription" content="${config['loginDescription']}">
+      </sly>
+    </sly>
     <sly data-sly-use.config="/libs/cards/conf/ThemeColor">
       <sly data-sly-repeat="${config.valueMap.entrySet.iterator}">
         <meta name="${item.key}" content="${item.value}">

--- a/modules/login/src/main/frontend/src/login/LoginForm.js
+++ b/modules/login/src/main/frontend/src/login/LoginForm.js
@@ -217,7 +217,7 @@ function LoginForm(props) {
                   }
                 />
               </FormControl>
-              <Grid container justifyContent="center" alignItems="center" spacing={2} className={classes.actions}>
+              <Grid container justifyContent="flex-start" alignItems="center" spacing={2} className={classes.actions}>
                 {  (!singleStepEntry) &&
                   <Grid>
                     <Button

--- a/modules/login/src/main/frontend/src/login/MainLoginContainer.js
+++ b/modules/login/src/main/frontend/src/login/MainLoginContainer.js
@@ -23,6 +23,7 @@ import { withStyles } from 'tss-react/mui';
 
 import LoginForm from './LoginForm';
 import RegistrationForm from './RegistrationForm';
+import FormattedText from '../components/FormattedText';
 import Logo from "../components/Logo";
 import styles from "../styling/styles";
 
@@ -32,6 +33,8 @@ function MainLoginContainer(props) {
 
   const isLongForm = !!window.location.pathname.startsWith("/login");
   const title = document.querySelector('meta[name="title"]').content;
+  const loginTitle = document.querySelector('meta[name="loginTitle"]')?.content;
+  const loginDescription = document.querySelector('meta[name="loginDescription"]')?.content;
   const paperClassName = `${classes.paper} ${selfContained ? classes.selfContained : ''}`.trim();
 
   return (
@@ -44,6 +47,16 @@ function MainLoginContainer(props) {
         alignContent="center"
       >
         <Logo maxWidth="200px" component={Grid}/>
+        { isLongForm && (loginTitle || loginDescription) &&
+          <Grid className={classes.appIntro}>
+            { loginTitle &&
+              <Typography variant="h6" component="h1" gutterBottom>{loginTitle}</Typography>
+            }
+            { loginDescription &&
+              <FormattedText variant="body2" color="textSecondary">{loginDescription}</FormattedText>
+            }
+          </Grid>
+        }
         <Grid>
           { signInShown ?
             <LoginForm handleLogin={handleLogin} redirectOnLogin={redirectOnLogin}/>

--- a/modules/login/src/main/frontend/src/login/MainLoginContainer.js
+++ b/modules/login/src/main/frontend/src/login/MainLoginContainer.js
@@ -43,10 +43,10 @@ function MainLoginContainer(props) {
         container
         direction="column"
         spacing={3}
-        alignItems="center"
-        alignContent="center"
+        alignItems="stretch"
+        alignContent="stretch"
       >
-        <Logo maxWidth="200px" component={Grid}/>
+        <Logo component={Grid} />
         { isLongForm && (loginTitle || loginDescription) &&
           <Grid className={classes.appIntro}>
             { loginTitle &&

--- a/modules/login/src/main/frontend/src/styling/styles.js
+++ b/modules/login/src/main/frontend/src/styling/styles.js
@@ -63,6 +63,10 @@ const styles = theme => ({
       display: "inline-block",
     },
   },
+  appIntro: {
+    textAlign: "center",
+    maxWidth: "450px",
+  },
   closeButton: {
     float: 'right',
     marginLeft: theme.spacing(2),

--- a/modules/login/src/main/frontend/src/styling/styles.js
+++ b/modules/login/src/main/frontend/src/styling/styles.js
@@ -18,19 +18,16 @@
 //
 const styles = theme => ({
   main: {
-    width: 'auto',
-    display: 'block', // Fix IE 11 issue.
-    [theme.breakpoints.up(400 + theme.spacing(6))]: {
-      width: 400,
-      marginLeft: 'auto',
-      marginRight: 'auto',
-    },
+    width: '100%',
   },
   paper: {
     display: 'flex',
     flexDirection: 'column',
-    alignItems: 'center',
+    alignItems: 'stretch',
     padding: theme.spacing(2, 3, 3),
+    maxWidth: "450px",
+    marginLeft: "auto",
+    marginRight: "auto",
   },
   selfContained: {
     // Extra top margin so the login box and logo stay visible below up to two
@@ -42,7 +39,7 @@ const styles = theme => ({
   form: {
     width: '100%', // Fix IE 11 issue.
     marginTop: theme.spacing(1),
-    textAlign: "center",
+    textAlign: "left",
   },
   formAction: {
     float: 'right',
@@ -58,14 +55,9 @@ const styles = theme => ({
   },
   appInfo: {
     marginTop: theme.spacing(6),
-    textAlign: "center",
     "& ol, li": {
       display: "inline-block",
     },
-  },
-  appIntro: {
-    textAlign: "center",
-    maxWidth: "450px",
   },
   closeButton: {
     float: 'right',

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/LandingPage.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/LandingPage.jsx
@@ -61,6 +61,7 @@ function LandingPage(props) {
   const [ isOpen, setIsOpen ] = useState(true);
 
   const appInfo = document.querySelector('meta[name="title"]').content;
+  const loginTitle = document.querySelector('meta[name="loginTitle"]')?.content;
 
   const USER_TYPE_PARAM = "usertype";
   const USER_TYPE_HCP = "hcp";
@@ -86,6 +87,11 @@ function LandingPage(props) {
       <DialogContent className={classes.paper}>
         <Grid container direction="column" spacing={2} alignItems="center" alignContent="center">
           <Logo component={Grid} className={classes.logo} maxWidth="200px" />
+          { loginTitle &&
+            <Grid>
+              <Typography variant="h6" component="h1">{loginTitle}</Typography>
+            </Grid>
+          }
           <Grid>
             <Typography variant="h6">I am a...</Typography>
           </Grid>

--- a/modules/utils/src/main/resources/SLING-INF/content/libs/cards/conf/LoginPage.json
+++ b/modules/utils/src/main/resources/SLING-INF/content/libs/cards/conf/LoginPage.json
@@ -1,0 +1,5 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "loginTitle": "",
+  "loginDescription": ""
+}


### PR DESCRIPTION
Also made the login form left-aligned instead of centered so the (possibly long) description would look better. With this layout change, the login screen is also more consistent with the patient portal identification and welcome screens.

To test:
- start plain cards and edit login title and description in /bin/browser, then sign out to see the updated login screen
<img width="370" height="392" alt="image" src="https://github.com/user-attachments/assets/d285dcb1-9374-4155-bd56-fe0b29066495" />

- start the rps project, branch `rename-rps-login https://github.com/data-team-uhn/rps/pull/59
- in both: while logged in, sign out in a separate tab then attempt some internal navigation to reveal the modal login dialog, which should NOT contain the new title and description
- also in both: check that the new layout looks polished, both with 1 logo and 2.