### PR TITLE
CARDS-2931: Patient Portal - improve the look of the Unsubscribe page

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
@@ -113,7 +113,7 @@ function Unsubscribe (props) {
       })
       .catch(error => {
         // error now has access to a custom backend error data
-        let errMsg = "Cannot unsubscribe: ";
+        const errMsg = "Cannot unsubscribe: ";
         setError(errMsg + (error.error || error));
       });
   }, [patient, authToken]);
@@ -127,20 +127,20 @@ function Unsubscribe (props) {
     );
   }
 
-  let unsubscribe = (value) => {
-    let request_data = new FormData();
+  const unsubscribe = (value) => {
+    const request_data = new FormData();
     request_data.append("unsubscribe", value);
     patient && request_data.append("patient", patient);
     fetch("/Survey.unsubscribe", { method: 'POST', body: request_data })
       .then( (response) => response.ok ? response.json() : Promise.reject(response) )
       .then( json => json.status == "success" ? (setConfirmed(json.unsubscribed), setAlreadyUnsubscribed(null)) : Promise.reject(json.error))
       .catch((response) => {
-        let errMsg = "Unsubscribing failed";
+        const errMsg = "Unsubscribing failed";
         setError(errMsg + (response.status ? ` with error code ${response.status}: ${response.statusText}` : response));
       });
   }
 
-  let appName = document.querySelector('meta[name="title"]')?.content;
+  const appName = document.querySelector('meta[name="title"]')?.content;
 
   return (
     <Paper className={classes.paper} elevation={0}>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
@@ -23,7 +23,8 @@ import {
   AlertTitle,
   Button,
   Grid,
-  Paper
+  Paper,
+  Typography
 } from '@mui/material';
 import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
 import { createRoot } from 'react-dom/client';
@@ -132,6 +133,11 @@ function Unsubscribe (props) {
         spacing={7}
       >
         <Logo component={Grid} />
+        { appName &&
+          <Grid>
+            <Typography variant="h6" component="h1" gutterBottom>{appName}</Typography>
+          </Grid>
+        }
         <Grid>
           { error && <Alert severity="error">
             <AlertTitle>An error occurred</AlertTitle>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
@@ -140,6 +140,10 @@ function Unsubscribe (props) {
       });
   }
 
+  const returnToSurvey = () => {
+    window.location = "/Survey.html/" + (authToken ? `?auth_token=${authToken}` : "");
+  };
+
   const appName = document.querySelector('meta[name="title"]')?.content;
 
   return (
@@ -162,21 +166,23 @@ function Unsubscribe (props) {
           </Grid>
         }
         <Grid>
-          { error && <Alert severity="error">
-            <AlertTitle>An error occurred</AlertTitle>
-            {error}
-          </Alert>
-          }
-          { alreadyUnsubscribed ?
+          { error ?
             <>
+              <Alert severity="error">
+                <AlertTitle>An error occurred</AlertTitle>
+                {error}
+              </Alert>
+              {authToken && <SubmitButton onClick={returnToSurvey}>
+                Return to survey
+              </SubmitButton>}
+            </> : alreadyUnsubscribed ? <>
               <StatusMessage>
                 { `You are already unsubscribed from all ${appName} emails.`}
               </StatusMessage>
               <SubmitButton variant="outlined" onClick={() => unsubscribe(0)}>
                 Resubscribe
               </SubmitButton>
-            </>
-            : confirmed !== null ?
+            </> : confirmed !== null ?
               <>
                 <Alert severity="success">
                   You have been {confirmed ? "unsubscribed from" : "resubscribed to"} {appName}.

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
@@ -52,8 +52,7 @@ const useStyles = makeStyles()(theme => ({
     },
   },
   submit : {
-    marginTop: theme.spacing(5),
-    float: 'right',
+    marginTop: theme.spacing(4),
   }
 }));
 
@@ -132,7 +131,7 @@ function Unsubscribe (props) {
         container
         direction="column"
         alignItems="stretch"
-        spacing={7}
+        spacing={4}
       >
         <Logo component={Grid} />
         { appName &&
@@ -157,6 +156,7 @@ function Unsubscribe (props) {
               <Button
                 type="submit"
                 variant="contained"
+                color="secondary"
                 className={classes.submit}
                 onClick={() => unsubscribe(0)}
               >
@@ -171,6 +171,7 @@ function Unsubscribe (props) {
                 <Button
                   type="submit"
                   variant="contained"
+                  color="secondary"
                   className={classes.submit}
                   onClick={() => unsubscribe(1-confirmed)}
                 >
@@ -183,6 +184,7 @@ function Unsubscribe (props) {
                 <Button
                   type="submit"
                   variant="contained"
+                  color="secondary"
                   className={classes.submit}
                   onClick={() => unsubscribe(1)}
                 >

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
@@ -51,10 +51,27 @@ const useStyles = makeStyles()(theme => ({
       width: "calc(100% - 16px)",
     },
   },
-  submit : {
-    marginTop: theme.spacing(4),
-  }
 }));
+
+// The two informational lines shown before the subscribe / unsubscribe action.
+// The bold headline is passed as children; the resubscribe hint is always the same.
+const StatusMessage = ({ children }) => (
+  <div>
+    <Typography variant="subtitle1" color="secondary" sx={{ fontWeight: "bold" }}>
+      { children }
+    </Typography>
+    <Typography variant="subtitle1" color="textSecondary">
+      You can resubscribe any time using this link.
+    </Typography>
+  </div>
+);
+
+// Submit-style action button; all variants share the same type, color and top margin.
+const SubmitButton = ({ variant = "contained", onClick, children }) => (
+  <Button type="submit" variant={variant} color="secondary" onClick={onClick} sx={{ mt: 4 }}>
+    { children }
+  </Button>
+);
 
 function Unsubscribe (props) {
   // Current user and associated subject
@@ -152,58 +169,30 @@ function Unsubscribe (props) {
           }
           { alreadyUnsubscribed ?
             <>
-              <div>
-                <Typography variant="subtitle1" color="secondary" sx={{ fontWeight: "bold" }}>
-                  { `You are already unsubscribed from all ${appName} emails.`}
-                </Typography>
-                <Typography variant="subtitle1" color="textSecondary">
-                  You can resubscribe any time using this link.
-                </Typography>
-              </div>
-              <Button
-                type="submit"
-                variant="outlined"
-                color="secondary"
-                className={classes.submit}
-                onClick={() => unsubscribe(0)}
-              >
+              <StatusMessage>
+                { `You are already unsubscribed from all ${appName} emails.`}
+              </StatusMessage>
+              <SubmitButton variant="outlined" onClick={() => unsubscribe(0)}>
                 Resubscribe
-              </Button>
+              </SubmitButton>
             </>
             : confirmed !== null ?
               <>
                 <Alert severity="success">
                   You have been {confirmed ? "unsubscribed from" : "resubscribed to"} {appName}.
                 </Alert>
-                <Button
-                  type="submit"
-                  variant="contained"
-                  color="secondary"
-                  className={classes.submit}
-                  onClick={() => unsubscribe(1-confirmed)}
-                >
+                <SubmitButton onClick={() => unsubscribe(1 - confirmed)}>
                   {confirmed ? "Resubscribe" : "Unsubscribe"}
-                </Button>
+                </SubmitButton>
               </>
               :
               <>
-                <div>
-                  <Typography variant="subtitle1" color="secondary" sx={{ fontWeight: "bold" }}>
-                    { `This will unsubscribe you from all ${appName} emails.`}
-                  </Typography>
-                  <Typography variant="subtitle1" color="textSecondary">
-                    You can resubscribe any time using this link.
-                  </Typography>
-                </div>
-                <Button
-                  type="submit"
-                  variant="contained"
-                  color="secondary"
-                  className={classes.submit}
-                  onClick={() => unsubscribe(1)}
-                >
+                <StatusMessage>
+                  { `This will unsubscribe you from all ${appName} emails.`}
+                </StatusMessage>
+                <SubmitButton onClick={() => unsubscribe(1)}>
                   Unsubscribe
-                </Button>
+                </SubmitButton>
               </>
           }
         </Grid>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
@@ -57,7 +57,7 @@ const useStyles = makeStyles()(theme => ({
 // The bold headline is passed as children; the resubscribe hint is always the same.
 const StatusMessage = ({ children }) => (
   <div>
-    <Typography variant="subtitle1" color="secondary" sx={{ fontWeight: "bold" }}>
+    <Typography variant="subtitle1" color="primary" sx={{ fontWeight: "bold" }}>
       { children }
     </Typography>
     <Typography variant="subtitle1" color="textSecondary">
@@ -68,7 +68,7 @@ const StatusMessage = ({ children }) => (
 
 // Submit-style action button; all variants share the same type, color and top margin.
 const SubmitButton = ({ variant = "contained", onClick, children }) => (
-  <Button type="submit" variant={variant} color="secondary" onClick={onClick} sx={{ mt: 4 }}>
+  <Button type="submit" variant={variant} color="primary" onClick={onClick} sx={{ mt: 4 }}>
     { children }
   </Button>
 );

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
@@ -22,8 +22,10 @@ import {
   Alert,
   AlertTitle,
   Button,
+  Divider,
   Grid,
   Paper,
+  Stack,
   Typography
 } from '@mui/material';
 import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
@@ -135,7 +137,12 @@ function Unsubscribe (props) {
         <Logo component={Grid} />
         { appName &&
           <Grid>
-            <Typography variant="h6" component="h1" gutterBottom>{appName}</Typography>
+            <Stack spacing={2}>
+              <Typography variant="overline" component="h1" color="textSecondary" sx={{ fontWeight: "bold" }}>
+                { appName }
+              </Typography>
+              <Divider />
+            </Stack>
           </Grid>
         }
         <Grid>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
@@ -61,7 +61,7 @@ const StatusMessage = ({ children }) => (
       { children }
     </Typography>
     <Typography variant="subtitle1" color="textSecondary">
-      You can resubscribe any time using this link.
+      You can unsubscribe or resubscribe any time using this link.
     </Typography>
   </div>
 );

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
@@ -152,10 +152,17 @@ function Unsubscribe (props) {
           }
           { alreadyUnsubscribed ?
             <>
-              <Alert icon={false} severity="info">{ `You are already unsubscribed from ${appName}.` }</Alert>
+              <div>
+                <Typography variant="subtitle1" color="secondary" sx={{ fontWeight: "bold" }}>
+                  { `You are already unsubscribed from all ${appName} emails.`}
+                </Typography>
+                <Typography variant="subtitle1" color="textSecondary">
+                  You can resubscribe any time using this link.
+                </Typography>
+              </div>
               <Button
                 type="submit"
-                variant="contained"
+                variant="outlined"
                 color="secondary"
                 className={classes.submit}
                 onClick={() => unsubscribe(0)}
@@ -180,7 +187,14 @@ function Unsubscribe (props) {
               </>
               :
               <>
-                <Alert icon={false} severity="info">{`This will unsubscribe you from all ${appName} emails.`}</Alert>
+                <div>
+                  <Typography variant="subtitle1" color="secondary" sx={{ fontWeight: "bold" }}>
+                    { `This will unsubscribe you from all ${appName} emails.`}
+                  </Typography>
+                  <Typography variant="subtitle1" color="textSecondary">
+                    You can resubscribe any time using this link.
+                  </Typography>
+                </div>
                 <Button
                   type="submit"
                   variant="contained"


### PR DESCRIPTION
### Specs:
https://phenotips.atlassian.net/browse/CARDS-2931

Also fixes https://phenotips.atlassian.net/browse/CARDS-2920  (_Don't show the Unsubscribe button on the Patient Portal Unsubscribe page if it's known that the Patient information form is missing_)

### Summary of changes:
* Added the app name under the logo to give the user some context styles similarly to #2374 
*  Left-aligned layout
* Spacing adjustments for more balance
* Replaced the info Alerts with text since no action has been taken yet.
* Made the buttons secondary color for a more consistent color scheme on the small page
* Made the Resubscribe action secondary when the user just landed on the page but they're already unsubscribed, since it's unlikely that resubscribing is the user's intention when they follow the Unsubscribe link

### Preview:

<img width="787" height="632" alt="image" src="https://github.com/user-attachments/assets/9c6caa1a-b452-43f5-89ff-032877c61d3b" />

<img width="805" height="582" alt="image" src="https://github.com/user-attachments/assets/a9d266de-7bf2-4c79-8a47-924ac0b90321" />

<img width="782" height="547" alt="image" src="https://github.com/user-attachments/assets/6fedb809-321d-424d-935a-1b0f31df753c" />

<img width="831" height="640" alt="image" src="https://github.com/user-attachments/assets/ac202170-5ed8-4e91-8a26-c764c8a9f87a" />

