### PR TITLE
CARDS-2929: Patient Portal - use the theme to define the content width instead of hard-coding it in style objects

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
@@ -48,9 +48,8 @@ import ResponsiveDialog from "../components/ResponsiveDialog.jsx";
 
 const useStyles = makeStyles()(theme => ({
   form : {
-    maxWidth: "500px",
     margin: "auto",
-    padding: theme.spacing(2),
+    padding: theme.spacing(3),
   },
   description : {
     "& > *" : {
@@ -253,7 +252,7 @@ function PatientIdentification(props) {
     let message = `${welcomeMessage || ""}\n\n### To fill out surveys, please follow the personalized link that was emailed to you.`;
     return (
       <ErrorPage
-        sx={{ maxWidth: 500, margin: "0 auto" }}
+        sx={ theme => ({ maxWidth: theme.width.intro + "px !important" }) }
         title=""
         message={message}
         messageColor="textPrimary"

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -66,7 +66,7 @@ const useStyles = makeStyles()(theme => ({
   screen : {
     alignItems: "flex-start",
     margin: "auto",
-    maxWidth: "780px",
+    maxWidth: theme.width.main,
     width: "100%",
     "& > .mainItem" : {
       paddingLeft: 0,
@@ -105,7 +105,7 @@ const useStyles = makeStyles()(theme => ({
     justify: "space-between",
     flexWrap: "nowrap",
     "& form" : {
-      maxWidth: "780px",
+      maxWidth: theme.width.main,
       margin: "auto",
     },
   },

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Unsubscribe.jsx
@@ -29,9 +29,9 @@ import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
 import { createRoot } from 'react-dom/client';
 import { makeStyles } from 'tss-react/mui';
 
+import { portalTheme } from "./portalTheme.jsx";
 import ErrorPage from "../components/ErrorPage.jsx";
 import Logo from "../components/Logo.jsx";
-import { appTheme } from "../themePalette.jsx";
 
 const useStyles = makeStyles()(theme => ({
   paper: {
@@ -40,11 +40,11 @@ const useStyles = makeStyles()(theme => ({
     alignItems: 'stretch',
     padding: theme.spacing(12, 0, 3),
     margin: "0 auto",
-    width: 500,
-    // Magic number 532 = 500 (width on wider screens) + 16px on each side
-    [theme.breakpoints.down(532)]: {
+    width: theme.width.compact,
+    // Magic number = content width + 16px on each side
+    [theme.breakpoints.down(theme.width.compact + 32)]: {
       // 8px on each side are the `body` padding
-      // subtract 16 more to achieve smooth transition when resizing the window to under 532px wide
+      // subtract 16 more to achieve smooth transition when resizing the window below the content width
       width: "calc(100% - 16px)",
     },
   },
@@ -187,7 +187,7 @@ const root = createRoot(document.querySelector('#patient-portal-unsubscribe-cont
 root.render(
   <StrictMode>
     <StyledEngineProvider injectFirst>
-      <ThemeProvider theme={appTheme}>
+      <ThemeProvider theme={portalTheme}>
         <Unsubscribe />
       </ThemeProvider>
     </StyledEngineProvider>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/index.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/index.jsx
@@ -20,6 +20,7 @@ import { StrictMode, useState, useEffect } from "react";
 
 import createCache from "@emotion/cache";
 import { CacheProvider } from "@emotion/react";
+import { Stack } from '@mui/material';
 import { ThemeProvider } from '@mui/material/styles';
 import { createRoot } from 'react-dom/client';
 import { createBrowserRouter, RouterProvider, Navigate } from "react-router";
@@ -81,12 +82,14 @@ function PatientPortalHomepage (props) {
   }
 
   if (!subject) {
-    return (<>
+    return (
       <PageStartWrapper extensionsName="PatientPortalPageStart">
-        <PatientIdentification onSuccess={onPatientIdentified} displayText={displayText} config={accessConfig}/>
-        <Footer />
+        <Stack sx={ theme => ({ maxWidth: theme.width.intro, mx: "auto" }) }>
+          <PatientIdentification onSuccess={onPatientIdentified} displayText={displayText} config={accessConfig}/>
+          <Footer />
+        </Stack>
       </PageStartWrapper>
-    </>);
+    );
   }
 
   return (

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/portalTheme.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/portalTheme.jsx
@@ -37,6 +37,7 @@ const portalTheme = createTheme({
     },
   },
   width: {
+    compact: 500,
     intro: 540,
     main: 780,
   },

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/portalTheme.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/portalTheme.jsx
@@ -36,6 +36,10 @@ const portalTheme = createTheme({
       fontSize: "1rem",
     },
   },
+  width: {
+    intro: 540,
+    main: 780,
+  },
 });
 
 export { portalTheme };


### PR DESCRIPTION
No visible changes other than the patient identification page content being a few pixels wider (both in the case where the patient is advised to use their personalized link to fill out surveys, and where they must confirm their identity with dob and mrn/hc). Test all screens, including surveys screens, for regressions.