### PR TITLE
CARDS-2930: Polish the look of ErrorPage

### DIFF
--- a/modules/commons/src/main/frontend/src/components/ErrorPage.jsx
+++ b/modules/commons/src/main/frontend/src/components/ErrorPage.jsx
@@ -17,7 +17,7 @@
 //  under the License.
 //
 import NavigationIcon from '@mui/icons-material/Navigation';
-import { Fab, Grid, Paper, Typography } from '@mui/material';
+import { Divider, Fab, Grid, Paper, Stack, Typography } from '@mui/material';
 import { makeStyles } from 'tss-react/mui';
 
 import FormattedText from "./FormattedText";
@@ -27,8 +27,13 @@ const useStyles = makeStyles()(theme => ({
   paper: {
     display: 'flex',
     flexDirection: 'column',
-    alignItems: 'center',
+    alignItems: 'stretch',
     padding: theme.spacing(12, 3, 3),
+    maxWidth: 450,
+    margin: '0 auto',
+  },
+  logo: {
+    textAlign: 'left',
   },
   extendedIcon: {
     marginRight: theme.spacing(1),
@@ -37,6 +42,7 @@ const useStyles = makeStyles()(theme => ({
 
 export default function ErrorPage(props) {
   const {
+    disableAppName,
     errorCode,
     errorCodeColor,
     title,
@@ -45,32 +51,42 @@ export default function ErrorPage(props) {
     messageColor,
     buttonLink,
     buttonLabel,
-    textAlign="center",
+    textAlign="left",
     ...rest
   } = props;
   const { classes } = useStyles();
+
+  const appName = !disableAppName && document.querySelector('meta[name="title"]')?.content;
 
   return (
     <Paper className={classes.paper} elevation={0} {...rest}>
       <Grid
         container
         direction="column"
-        spacing={7}
+        spacing={6}
         textAlign={textAlign}
-        alignItems="center"
-        alignContent="center"
+        alignItems="stretch"
+        alignContent="stretch"
       >
-        <Logo maxWidth="360px" component={Grid}/>
+        <Logo component={Grid} className={classes.logo}/>
         <Grid>
-          {errorCode && <Typography variant="h1" color={errorCodeColor || "primary"}>
-            {errorCode}
-          </Typography> }
-          {title && <Typography variant="h1" color={titleColor || "primary"} gutterBottom>
-            {title}
-          </Typography> }
-          {message && <FormattedText variant="subtitle1" color={messageColor || "textSecondary"}>
-            {message}
-          </FormattedText> }
+          <Stack spacing={2}>
+            {appName && <>
+              <Typography variant="overline" component="h1" color="text.secondary" sx={{ fontWeight: 'bold' }}>
+                {appName}
+              </Typography>
+              <Divider />
+            </> }
+            {errorCode && <Typography variant="h3" component="h2" color={errorCodeColor || "secondary"}>
+              {errorCode}
+            </Typography> }
+            {title && <Typography variant="h4" color={titleColor || "secondary"} sx={{ fontWeight: 'bold' }}>
+              {title}
+            </Typography> }
+            {message && <FormattedText variant="subtitle1" color={messageColor || "textSecondary"}>
+              {message}
+            </FormattedText> }
+          </Stack>
         </Grid>
         { buttonLabel &&
             <Grid>

--- a/modules/commons/src/main/frontend/src/components/ErrorPage.jsx
+++ b/modules/commons/src/main/frontend/src/components/ErrorPage.jsx
@@ -72,15 +72,15 @@ export default function ErrorPage(props) {
         <Grid>
           <Stack spacing={2}>
             {appName && <>
-              <Typography variant="overline" component="h1" color="text.secondary" sx={{ fontWeight: 'bold' }}>
+              <Typography variant="overline" component="h1" color="textSecondary" sx={{ fontWeight: 'bold' }}>
                 {appName}
               </Typography>
               <Divider />
             </> }
-            {errorCode && <Typography variant="h3" component="h2" color={errorCodeColor || "secondary"}>
+            {errorCode && <Typography variant="h3" component="h2" color={errorCodeColor || "primary"}>
               {errorCode}
             </Typography> }
-            {title && <Typography variant="h4" color={titleColor || "secondary"} sx={{ fontWeight: 'bold' }}>
+            {title && <Typography variant="h4" color={titleColor || "primary"} sx={{ fontWeight: 'bold' }}>
               {title}
             </Typography> }
             {message && <FormattedText variant="subtitle1" color={messageColor || "textSecondary"}>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Footer.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Footer.jsx
@@ -35,10 +35,10 @@ async function getFooterExtensions() {
     );
 }
 
-const useStyles = makeStyles()(theme => ({
+const useStyles = makeStyles()((theme, { align }) => ({
   footer : {
     color: theme.palette.text.secondary,
-    justifyContent: "center",
+    justifyContent: { left: "flex-start", center: "center", right: "flex-end" }[align],
     minHeight: theme.spacing(2),
   },
   horizontal: {
@@ -51,14 +51,16 @@ const useStyles = makeStyles()(theme => ({
   },
   vertical: {
     display: "grid",
-    textAlign: "center",
+    padding: theme.spacing(0, 3),
+    textAlign: align,
   },
 }));
 
 export default function Footer (props) {
+  const { align = "center" } = props;
   let [ footerExtensions, setFooterExtensions ] = useState([]);
 
-  const { classes } = useStyles();
+  const { classes } = useStyles({ align });
 
   const isSmallScreen = useMediaQuery('(max-width:600px)');
 

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
@@ -252,6 +252,7 @@ function PatientIdentification(props) {
     let message = `${welcomeMessage || ""}\n\n### To fill out surveys, please follow the personalized link that was emailed to you.`;
     return (
       <ErrorPage
+        disableAppName
         sx={ theme => ({ maxWidth: theme.width.intro + "px !important" }) }
         title=""
         message={message}

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/index.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/index.jsx
@@ -86,7 +86,7 @@ function PatientPortalHomepage (props) {
       <PageStartWrapper extensionsName="PatientPortalPageStart">
         <Stack sx={ theme => ({ maxWidth: theme.width.intro, mx: "auto" }) }>
           <PatientIdentification onSuccess={onPatientIdentified} displayText={displayText} config={accessConfig}/>
-          <Footer />
+          <Footer align="left" />
         </Stack>
       </PageStartWrapper>
     );


### PR DESCRIPTION
### Specs:
https://phenotips.atlassian.net/browse/CARDS-2930

### Changes:
ErrorPage:
- Smaller message and error code font size
- Left-align the text for a more polished look
- Included AppName to give the user some context

Additional changes became necessary to components relying on ErrorPage:
- PatientIdentification renders ErrorPage to inform the patient user that they need a personalized link to complete surveys
  - Added `disableAppName` for backward compatibility
- With the ErrorPage content left-aligned, the centered footer looked out of place
  - Added an `align` prop to footer and set it to "left" on the patient identification page

### Preview:
<img width="1065" height="742" alt="image" src="https://github.com/user-attachments/assets/2ef5979d-e5fc-4c4c-b714-36a34b550a2f" />

<img width="932" height="815" alt="image" src="https://github.com/user-attachments/assets/c467c6e4-9645-4a09-b3da-cd05fd759d9d" />

<img width="827" height="808" alt="image" src="https://github.com/user-attachments/assets/f68f3a9a-f4c7-4395-b587-03ee11df9b52" />
