### PR TITLE
CARDS-2933: The sling.js script is not accessible before logging in

### DIFF
--- a/distribution/src/main/features/core/base-configuration.json
+++ b/distribution/src/main/features/core/base-configuration.json
@@ -49,6 +49,7 @@
                 "-/favicon.ico",
                 "-/libs",
                 "-/apps",
+                "-/system/sling.js",
                 "-/system/sling/info"
             ]
         }


### PR DESCRIPTION
To test: open the login page, open the JS console, check that there are no errors about sling.js.

Also, before logging in, check that `http://localhost:8080/system/sling.js` can be opened.