### PR TITLE
[misc] Remove IE-only flag "X-UA-Compatible"

### DIFF
--- a/modules/authentication/saml/fetch-requires-saml-login/src/main/resources/SLING-INF/content/fetch_requires_saml_login.html
+++ b/modules/authentication/saml/fetch-requires-saml-login/src/main/resources/SLING-INF/content/fetch_requires_saml_login.html
@@ -20,7 +20,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>

--- a/modules/authentication/token/token-authentication-support/src/main/resources/SLING-INF/content/libs/cards/TokenExpired/html.html
+++ b/modules/authentication/token/token-authentication-support/src/main/resources/SLING-INF/content/libs/cards/TokenExpired/html.html
@@ -22,7 +22,6 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="referrer" content="no-referrer"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <sly data-sly-use.config="/libs/cards/conf/Version">

--- a/modules/commons/src/main/resources/SLING-INF/content/apps/sling/servlet/errorhandler/default.esp
+++ b/modules/commons/src/main/resources/SLING-INF/content/apps/sling/servlet/errorhandler/default.esp
@@ -67,7 +67,6 @@ if ("application/json".equals(request.getHeader("Accept"))) {
 <html>
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="referrer" content="no-referrer">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="version" content="${Packages.org.apache.commons.text.StringEscapeUtils.escapeXml11(version)}">

--- a/modules/commons/src/main/resources/SLING-INF/content/libs/sling/servlet/errorhandler/404.html
+++ b/modules/commons/src/main/resources/SLING-INF/content/libs/sling/servlet/errorhandler/404.html
@@ -22,7 +22,6 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="referrer" content="no-referrer">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <sly data-sly-use.config="/libs/cards/conf/Version">

--- a/modules/data-model/items/api/src/main/resources/SLING-INF/content/libs/cards/Item/header.html
+++ b/modules/data-model/items/api/src/main/resources/SLING-INF/content/libs/cards/Item/header.html
@@ -20,7 +20,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="referrer" content="no-referrer">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <sly data-sly-use.config="/libs/cards/conf/Version">


### PR DESCRIPTION
Internet Explorer is not supported anymore, so this flag, which tells it which of the past IE versions to use for rendering, should no longer have any impact.