### PR TITLE
[WIP] Improve the patient portal header, footer and identification screens

### DIFF
--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Footer.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Footer.jsx
@@ -20,10 +20,9 @@ import { useState, useEffect } from "react";
 
 import {
   Link,
+  Stack,
   Toolbar,
 } from "@mui/material";
-import useMediaQuery from '@mui/material/useMediaQuery';
-import classNames from "classnames";
 import { makeStyles } from 'tss-react/mui';
 
 import { loadExtensions } from "../uiextension/extensionManager";
@@ -38,21 +37,16 @@ async function getFooterExtensions() {
 const useStyles = makeStyles()((theme, { align }) => ({
   footer : {
     color: theme.palette.text.secondary,
-    justifyContent: { left: "flex-start", center: "center", right: "flex-end" }[align],
     minHeight: theme.spacing(2),
   },
-  horizontal: {
-    "& > * + *:before" : {
-      content: '"·"',
-      display: "inline-block",
-      margin: theme.spacing(0, 1),
-      opacity: 0.5,
-    },
+  items : {
+    width: "100%",
+    alignItems: "center",
+    justifyContent: { left: "flex-start", center: "center", right: "flex-end" }[align],
   },
-  vertical: {
-    display: "grid",
-    padding: theme.spacing(0, 3),
-    textAlign: align,
+  separator : {
+    opacity: 0.5,
+    userSelect: "none",
   },
 }));
 
@@ -62,8 +56,6 @@ export default function Footer (props) {
 
   const { classes } = useStyles({ align });
 
-  const isSmallScreen = useMediaQuery('(max-width:600px)');
-
   useEffect(() => {
     getFooterExtensions()
       .then(extensions => setFooterExtensions(extensions))
@@ -71,15 +63,20 @@ export default function Footer (props) {
   }, []);
 
   return (
-    <Toolbar
-      className={classNames(classes.footer, isSmallScreen ? classes.vertical : classes.horizontal)}
-    >
-      {
-        footerExtensions.map((extension, index) => {
-          let Extension = extension["cards:extensionRender"];
-          return <Extension key={index} extension={extension} />
-        })
-      }
+    <Toolbar className={classes.footer}>
+      <Stack
+        direction="row"
+        spacing={1}
+        className={classes.items}
+        divider={<span aria-hidden="true" className={classes.separator}>·</span>}
+      >
+        {
+          footerExtensions.map((extension, index) => {
+            let Extension = extension["cards:extensionRender"];
+            return <Extension key={index} extension={extension} />
+          })
+        }
+      </Stack>
     </Toolbar>
   );
 }

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/Header.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/Header.jsx
@@ -20,7 +20,6 @@ import { useContext } from "react";
 
 import {
   AppBar,
-  Breadcrumbs,
   Collapse,
   Fade,
   LinearProgress,
@@ -46,57 +45,83 @@ const useStyles = makeStyles()(theme => ({
     color: theme.palette.text.primary,
     boxShadow: "none",
   },
-  toolbar : {
-    maxWidth: "780px",
+  utility : {
+    maxWidth: theme.width.main,
     margin: "auto",
     display: "flex",
+    justifyContent: "flex-end",
+    paddingRight: theme.spacing(2),
+    [theme.breakpoints.up('sm')]: {
+      paddingRight: theme.spacing(3),
+    },
+  },
+  userMenu : {
+    display: "flex",
+    alignItems: "center",
+    gap: theme.spacing(1.5),
+    minWidth: 0,
+    maxWidth: "100%",
+    marginRight: theme.spacing(-1.5),
+    padding: theme.spacing(0.5, 1.5),
+    background: theme.palette.action.selected,
+    borderBottomLeftRadius: theme.spacing(1),
+    borderBottomRightRadius: theme.spacing(1),
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.body2.fontSize,
+  },
+  toolbar : {
+    maxWidth: theme.width.main,
+    margin: "auto",
+    display: "flex",
+    alignItems: "center",
     justifyContent: "space-between",
+    gap: theme.spacing(2),
     background: theme.palette.background.paper,
     paddingTop: theme.spacing(1),
     paddingBottom: theme.spacing(1),
-    "& > .cards-patientPortal-surveyTitle" : {
-      "@media (max-width: 500px)" : {
-        display: "none",
-      },
-    },
   },
-  withAffiliation : {
-    display: "block",
-    "& > .cards-patientPortal-surveyTitle" : {
-      textAlign: "center",
-      margin: "-4rem 140px 0",
-    },
-    "& > .MuiBreadcrumbs-root" : {
-      width: "fit-content",
-      margin: "auto",
-    }
+  brand : {
+    display: "flex",
+    alignItems: "center",
+    gap: theme.spacing(1.5),
+    minWidth: 0,
+    maxWidth: "50%",
   },
   logo : {
-    maxWidth: "780px !important",
+    flexShrink: 0,
     "& > img" : {
-      "@media (max-width: 500px)" : {
+      [`@media (max-width: ${theme.width.compact}px)`] : {
         maxHeight: theme.spacing(4),
       }
     }
   },
-  sideMenu : {
-    float: "right",
-    textAlign: "right",
-    width: "160px",
-    "& .MuiBreadcrumbs-ol": {
-      display: "block",
-    },
-    "& .MuiBreadcrumbs-separator": {
+  bar : {
+    alignSelf: "center",
+    flexShrink: 0,
+    width: "1px",
+    height: theme.spacing(4),
+    backgroundColor: theme.palette.divider,
+  },
+  surveyTitle : {
+    minWidth: 0,
+    fontWeight: "bold",
+    lineHeight: 1.2,
+  },
+  affiliation : {
+    flexShrink: 0,
+    maxWidth: "160px",
+    [`@media (max-width: ${theme.width.compact}px)`] : {
       display: "none",
     },
-    "& .MuiBreadcrumbs-li:not(:last-child)": {
-      marginBottom: theme.spacing(1),
-    }
   },
   greeting: {
-    "@media (max-width: 500px)" : {
-      display: "none",
-    },
+    minWidth: 0,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  signout: {
+    flexShrink: 0,
   },
   fullSize : {
     paddingTop: theme.spacing(5),
@@ -124,6 +149,8 @@ function Header (props) {
 
   const contentOffset = useContext(PageStartContext);
 
+  const affiliationLogo = document.querySelector('meta[name="affiliationLogoLight"]')?.content;
+
   let subtitleBar = subtitle ?
     <Toolbar variant="dense" className={classes.toolbar}>
       <Typography variant="h6" color="textPrimary">{ subtitle }</Typography>
@@ -131,42 +158,49 @@ function Header (props) {
     </Toolbar>
     : <></>;
 
-  const withAffiliation = !!(document.querySelector('meta[name="affiliationLogoLight"]')?.content);
-
-  let toolbarClassNames = [classes.toolbar];
-  if (withAffiliation) toolbarClassNames.push(classes.withAffiliation);
-
   return (
     <>
       <AppBar position="sticky" className={classes.appbar} id="patient-portal-header" style={{ top: contentOffset }}>
         <Collapse in={!subtitle || !(scrollTrigger)}>
-          <Toolbar variant="dense" className={toolbarClassNames.join(' ')}>
-            <Logo className={classes.logo} maxWidth="160px" />
-            { title &&
-              <Typography
-                variant="overline"
-                color="textPrimary"
-                component="div"
-                className="cards-patientPortal-surveyTitle"
-              >
-                { title }
-              </Typography>}
-            { (greeting || withSignout) &&
-            <Breadcrumbs separator="·" className={!withAffiliation ? classes.sideMenu : undefined}>
-              { greeting && <span className={classes.greeting}>{ greeting }</span>}
-              { withSignout &&
-                <Link
-                  href="/system/sling/logout"
-                  underline="hover"
-                  onClick={(event) => {
-                    event.preventDefault();
-                    window.location = "/system/sling/logout?resource=" + encodeURIComponent(window.location.pathname);
-                  }}
-                >
-                  Sign out
-                </Link>
+          { (greeting || withSignout) &&
+            <div className={classes.utility}>
+              <div className={classes.userMenu}>
+                { greeting && <span className={classes.greeting}>{ greeting }</span> }
+                { withSignout &&
+                  <Link
+                    className={classes.signout}
+                    href="/system/sling/logout"
+                    underline="hover"
+                    onClick={(event) => {
+                      event.preventDefault();
+                      window.location = "/system/sling/logout?resource=" + encodeURIComponent(window.location.pathname);
+                    }}
+                  >
+                    Sign out
+                  </Link>
+                }
+              </div>
+            </div>
+          }
+          <Toolbar variant="dense" className={classes.toolbar}>
+            <div className={classes.brand}>
+              <Logo disableAffiliation className={classes.logo} maxWidth="160px" />
+              { title &&
+                <>
+                  <span className={classes.bar} />
+                  <Typography
+                    variant="overline"
+                    color="textSecondary"
+                    component="div"
+                    className={`cards-patientPortal-surveyTitle ${classes.surveyTitle}`}
+                  >
+                    { title }
+                  </Typography>
+                </>
               }
-            </Breadcrumbs>
+            </div>
+            { affiliationLogo &&
+              <img src={affiliationLogo} alt="" className={classes.affiliation} />
             }
           </Toolbar>
         </Collapse>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/MRNHelper.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/MRNHelper.jsx
@@ -1,0 +1,87 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+// A "Where can I find my MRN?" hint for the patient identification form: a link
+// shown under the MRN input that opens a dialog explaining where to find the MRN.
+//
+// This component is currently DORMANT: it is not rendered anywhere. The dialog
+// content is institution specific (UHN) and the screenshots are out of date. To
+// reuse it, update the screenshots and copy for the target institution, then drop
+// <MRNHelper /> in place of the MRN input's FormHelperText in PatientIdentification.
+// To make it opt-in per deployment, expose it as a PatientPortal UI extension,
+// following the pattern used by the page footer (see Footer.jsx).
+//
+import { useState } from 'react';
+
+import {
+  DialogContent,
+  FormHelperText,
+  Link,
+  Typography,
+} from '@mui/material';
+import { makeStyles } from 'tss-react/mui';
+
+import ResponsiveDialog from "../components/ResponsiveDialog.jsx";
+
+const useStyles = makeStyles()(theme => ({
+  mrnHelperImage: {
+    maxWidth: '100%',
+  },
+  mrnHelperLink: {
+    cursor: 'pointer',
+  },
+}));
+
+function MRNHelper(props) {
+  const [ open, setOpen ] = useState(false);
+
+  const { classes } = useStyles();
+
+  return (<>
+    <FormHelperText id="mrn_helper">
+      <Link
+        variant="caption"
+        underline="hover"
+        onClick={() => setOpen(true)}
+        className={classes.mrnHelperLink}
+      >
+        Where can I find my MRN?
+      </Link>
+    </FormHelperText>
+
+    <ResponsiveDialog
+      title="Where can I find my MRN?"
+      withCloseButton
+      open={open}
+      onClose={() => setOpen(false)}
+    >
+      <DialogContent>
+        <Typography component="p">
+          1. Check the top right-hand corner of your Patient Itinerary.
+        </Typography>
+        <img src="/libs/cards/resources/media/patient-portal/mrn_helper_1.png" alt="MRN location within the Appointment Itinerary" className={classes.mrnHelperImage} />
+        <Typography component="p">
+          2. Check your account page on the myUHN PatientPortal.
+        </Typography>
+        <img src="/libs/cards/resources/media/patient-portal/mrn_helper_2.png" alt="MRN location within the Patient Portal side bar" className={classes.mrnHelperImage} />
+      </DialogContent>
+    </ResponsiveDialog>
+  </>);
+}
+
+export default MRNHelper;

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
@@ -22,9 +22,7 @@ import AppointmentIcon from '@mui/icons-material/Event';
 import {
   Button,
   CircularProgress,
-  DialogContent,
   FormControl,
-  FormHelperText,
   Grid,
   Input,
   InputLabel,
@@ -44,7 +42,6 @@ import DateTimeUtilities from "../components/DateTimeUtilities";
 import ErrorPage from "../components/ErrorPage.jsx";
 import FormattedText from "../components/FormattedText.jsx";
 import Logo from "../components/Logo.jsx";
-import ResponsiveDialog from "../components/ResponsiveDialog.jsx";
 
 const useStyles = makeStyles()(theme => ({
   form : {
@@ -79,12 +76,6 @@ const useStyles = makeStyles()(theme => ({
   },
   dateLabel : {
     paddingTop: theme.spacing(1),
-  },
-  mrnHelperImage: {
-    maxWidth: '100%',
-  },
-  mrnHelperLink: {
-    cursor: 'pointer',
   },
   appointmentEntry: {
     "& .MuiButton-root" : {
@@ -127,8 +118,6 @@ function PatientIdentification(props) {
   const [ touCleared, setTouCleared ] = useState();
   // Whether the Terms of Use dialog can be displayed after patient identification
   const [ showTou, setShowTou ] = useState(false);
-
-  const [ mrnHelperOpen, setMrnHelperOpen ] = useState(false);
 
   const dateFormat = DateTimeUtilities.defaultDateFormat;
   const views = DateTimeUtilities.getPickerViews(dateFormat);
@@ -277,26 +266,6 @@ function PatientIdentification(props) {
       }}
     />
 
-    {/* MRN hint dialog*/}
-
-    <ResponsiveDialog
-      title="Where can I find my MRN?"
-      withCloseButton
-      open={mrnHelperOpen}
-      onClose={() => setMrnHelperOpen(false)}
-    >
-      <DialogContent>
-        <Typography component="p">
-          1. Check the top right-hand corner of your Patient Itinerary.
-        </Typography>
-        <img src="/libs/cards/resources/media/patient-portal/mrn_helper_1.png" alt="MRN location within the Appointment Itinerary" className={classes.mrnHelperImage} />
-        <Typography component="p">
-          2. Check your account page on the myUHN PatientPortal.
-        </Typography>
-        <img src="/libs/cards/resources/media/patient-portal/mrn_helper_2.png" alt="MRN location within the Patient Portal side bar" className={classes.mrnHelperImage} />
-      </DialogContent>
-    </ResponsiveDialog>
-
     {/* Patient identification form */}
 
     <form className={classes.form} onSubmit={onSubmit} >
@@ -370,16 +339,6 @@ function PatientIdentification(props) {
                     <FormControl variant="standard" margin="normal" fullWidth>
                       <InputLabel htmlFor="j_mrn" shrink={true}>MRN</InputLabel>
                       <Input id="j_mrn" name="j_mrn" autoComplete="off" type="number" placeholder="1234567" className={classes.mrnInput} onChange={event => setMrn(event.target.value)}/>
-                      <FormHelperText id="mrn_helper">
-                        <Link
-                          variant="caption"
-                          underline="hover"
-                          onClick={() => setMrnHelperOpen(true)}
-                          className={classes.mrnHelperLink}
-                        >
-                          Where can I find my MRN?
-                        </Link>
-                      </FormHelperText>
                     </FormControl>
                   </Grid>
                   <Grid alignSelf="center">or</Grid>

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
@@ -92,9 +92,6 @@ const useStyles = makeStyles()(theme => ({
       textTransform: "none",
     },
   },
-  submit : {
-    float: 'right',
-  }
 }));
 
 // The patient is already authenticated via the token.
@@ -398,7 +395,6 @@ function PatientIdentification(props) {
                 <Button
                   type="submit"
                   variant="contained"
-                  className={classes.submit}
                 >
                   Continue
                 </Button>
@@ -448,7 +444,6 @@ function PatientIdentification(props) {
                   <Grid>
                     <Button
                       variant="contained"
-                      className={classes.submit}
                       onClick={() => window.location = "/system/sling/logout"}
                     >
                       Close

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/PatientIdentification.jsx
@@ -315,14 +315,7 @@ function PatientIdentification(props) {
                       variant: 'standard',
                       autoFocus: true,
                       fullWidth: true,
-                      className: classes.textField,
                       helperText: null,
-                      onBlur: (event) => {
-                        if (dob?.invalid) {
-                          setError(true);
-                          setErrorMessage("Invalid date" + (dob.invalid.explanation ? ": " + dob.invalid.explanation : ""));
-                        }
-                      },
                       inputProps: {
                         placeholder: `${dateFormat}, for example ${DateTime.fromISO("1970-12-31").toFormat(dateFormat)}`
                       },

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/QuestionnaireSet.jsx
@@ -592,7 +592,7 @@ function QuestionnaireSet(props) {
     <>
       <Header
         key="header"
-        greeting={username}
+        greeting={!!(config?.PIIAuthRequired) && username}
         withSignout={!!(config?.PIIAuthRequired)}
         progress={0}
       />

--- a/modules/patient-portal/src/main/frontend/src/patient-portal/portalTheme.jsx
+++ b/modules/patient-portal/src/main/frontend/src/patient-portal/portalTheme.jsx
@@ -36,6 +36,18 @@ const portalTheme = createTheme({
       fontSize: "1rem",
     },
   },
+  components: {
+    MuiStack: {
+      defaultProps: {
+        useFlexGap: true,
+      },
+      styleOverrides: {
+        root: {
+          flexWrap: "wrap",
+        },
+      },
+    },
+  },
   width: {
     compact: 500,
     intro: 540,


### PR DESCRIPTION
## Status: [WORK IN PROGRESS]
This branch was prepared for RPS demo and isn't meant for merging at this time, but can still be reviewed.

Needs more testing on projects with different Affiliation and PatientAccess settings than RPS, especially Your Experience.

Also needs a Jira ticket and properly tagged commits.

## Summary

UI improvements across the patient portal's shared chrome and the patient identification screen. Layout and styling only — no changes to the authentication flow, survey logic, or stored data.

## Footer

- Reimplemented as a single wrapping row `Stack` inside the `Toolbar`, with the middle dot as the `Stack` divider. On narrow screens the items   wrap onto more lines instead of switching to a separate vertical layout.
- Enabled `useFlexGap` (via `MuiStack` default props) and `flexWrap: wrap`  (via style overrides) for all `Stack`s in `portalTheme`, so this behavior is defined once rather than per component. Verified this does not affect the other stacks rendered in the patient portal.

## Header

- Survey name now sits next to the app logo, separated by a light vertical bar (shown only when a name is present). It is bold, muted, and wraps to the left half of the header instead of stretching across the row.
- The affiliation logo is rendered on the right at its original branding size, and is hidden below 500px so the brand and name have room on narrow  screens.
- The user greeting and Sign out moved to a small pill at the top right, styled to look like it hangs from the top. The name truncates with an ellipsis instead of disappearing, and Sign out is never truncated.
- On the message screen, the greeting now shows only when PII identification is required, matching when Sign out is shown.
- Replaced the hardcoded 780px and 500px widths with the theme values   (`width.main` and `width.compact`), and removed the old block-layout overrides that centered everything between the two logos.

## Patient identification

- Left-aligned the "Continue" and "Close" buttons.
- Moved the "Where can I find my MRN?" hint into its own `MRNHelper` component. It is dormant (not rendered): its dialog content is specific to UHN and the screenshots are out of date. The file documents how to refresh and reuse it, or expose it as an opt-in UI extension per deployment.
- Removed dead code in the date of birth field: an `onBlur` handler that referenced a nonexistent setter and showed a long, technical message, plus a `className` pointing at a missing style. Invalid dates are still blocked on submit.