### PR TITLE
[CARDS-603:bugfix] link uuid-less parents by path so attachments don't disconnect the tree

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/questionnaireTreeModel.js
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/questionnaireTreeModel.js
@@ -183,7 +183,7 @@ function jcrFindEntries(jcrData, rootPath = (jcrData['@path'] || ''), nodes) {
     throw new Error("jcrFindEntries called with invalid jcrData");
   }
   const children = jcrGetChildren(jcrData);
-  const nodeParent = jcrData['jcr:uuid'];
+  const nodeParent = jcrGetUniqueId(jcrData);
 
   for (const child of children) {
     const uniqueNodeId = jcrGetUniqueId(child);


### PR DESCRIPTION
The issue was observed in the [RPS](https://github.com/data-team-uhn/rps) project when trying to open the ClinicianAssessment questionnaire in the Administration:

```
Unexpected Application Error!
There are disconnected nodes in the tree.
Error: There are disconnected nodes in the tree.
    at hasNoDisconnectedNodes (webpack-internal:///./src/questionnaireEditor/questionnaireTreeModel.js:277:11)
    at eval (webpack-internal:///./src/questionnaireEditor/QuestionnaireTreeContext.jsx:96:138)
    at Array.map (<anonymous>)
    at treeReducer (webpack-internal:///./src/questionnaireEditor/QuestionnaireTreeContext.jsx:96:121)
    at updateReducerImpl (webpack-internal:///./node_modules/react-dom/cjs/react-dom-client.development.js:8044:15)
    at updateReducer (webpack-internal:///./node_modules/react-dom/cjs/react-dom-client.development.js:7967:14)
    at Object.useReducer (webpack-internal:///./node_modules/react-dom/cjs/react-dom-client.development.js:26494:18)
    at exports.useReducer (webpack-internal:///./node_modules/react/cjs/react.development.js:1258:34)
    at QuestionnaireTreeProvider (webpack-internal:///./src/questionnaireEditor/QuestionnaireTreeContext.jsx:157:78)
    at Object.react_stack_bottom_frame (webpack-internal:///./node_modules/react-dom/cjs/react-dom-client.development.js:25903:20)
```

The crash is a bug introduced by #2044 via the CARDS-603 tree model, and it's triggered by file attachments in ClinicianAssessment (the 20 SVG pain-diagram images e.g. Ankle.svg, Back.svg, …) stored directly under the questionnaire as nt:file nodes, each with a jcr:content child of type nt:resource.

The bug is an inconsistency between how nodes are keyed versus how a node's parent id is assigned, in questionnaireTreeModel.js:

- Nodes are keyed by jcrGetUniqueId(node) → jcr:uuid if present, otherwise the node's @path
- But jcrFindEntries sets each child's parent to the raw jcrData['jcr:uuid'] not jcrGetUniqueId(jcrData).

So when a parent node has no jcr:uuid, the two disagree:

- An nt:file node (Ankle.svg) has no jcr:uuid, so it's stored in the map under its path.
- Its jcr:content child gets parent: undefined (the parent's non-existent uuid).
- hasNoDisconnectedNodes sees parent !== null && !nodes[undefined] → "There are disconnected nodes in the tree."