### PR TITLE
CARDS-2937: Add loading indicators to the questionnaire designer (initial load and view switching)

### DIFF
--- a/modules/commons/src/main/frontend/src/components/LoadingOverlay.jsx
+++ b/modules/commons/src/main/frontend/src/components/LoadingOverlay.jsx
@@ -1,0 +1,75 @@
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
+
+import {
+  Backdrop,
+  CircularProgress,
+  Typography
+} from "@mui/material";
+import { alpha } from '@mui/material/styles';
+import PropTypes from "prop-types";
+
+import { checkPropTypes } from "../propTypes";
+
+// A full-screen loading overlay: a dimmed backdrop with a centered spinner, shown while a page
+// or a long-running action is working and the UI should not be interacted with. The backdrop is
+// offset past the left navigation drawer on md+ screens so the navigation stays reachable.
+//
+// Props:
+// open: Boolean controlling whether the overlay is shown
+// message: Optional string shown under the spinner (e.g. "Reordering entries")
+// progress: Optional number 0-100. When given, the spinner is determinate and shows this value;
+//   otherwise it spins indeterminately.
+//
+// Sample usage:
+// <LoadingOverlay open={saving} message="Saving changes" progress={percent} />
+
+const LoadingOverlay = (props) => {
+  checkPropTypes(LoadingOverlay, props);
+  const { open, message, progress } = props;
+  const isDeterminate = typeof progress === "number";
+
+  return (
+    <Backdrop
+      open={open}
+      sx={(theme) => ({
+        flexDirection: "column",
+        rowGap: 2,
+        color: theme.palette.text.primary,
+        backgroundColor: alpha(theme.palette.background.paper, .7),
+        marginLeft: { md: "260px" },
+        zIndex: theme.zIndex.drawer + 1
+      })}
+    >
+      { message && <Typography variant="h6">{message}</Typography> }
+      <CircularProgress
+        variant={isDeterminate ? "determinate" : "indeterminate"}
+        value={progress}
+      />
+    </Backdrop>
+  );
+};
+
+LoadingOverlay.propTypes = {
+  open: PropTypes.bool.isRequired,
+  message: PropTypes.string,
+  progress: PropTypes.number,
+};
+
+export default LoadingOverlay;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -25,7 +25,6 @@ import DoneIcon from "@mui/icons-material/Done";
 import EditIcon from '@mui/icons-material/Edit';
 import MoreIcon from '@mui/icons-material/MoreVert';
 import {
-  Backdrop,
   Breadcrumbs,
   Button,
   Chip,
@@ -38,7 +37,6 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
-import { alpha } from '@mui/material/styles';
 import { DateTime } from "luxon";
 import { Link, useNavigate, useBlocker } from "react-router";
 import { withStyles } from 'tss-react/mui';
@@ -56,6 +54,7 @@ import { getTextHierarchy, getHierarchyAsList } from "./SubjectIdentifier";
 import { SelectorDialog, parseToArray } from "./SubjectSelector";
 import ErrorDialog from "../components/ErrorDialog";
 import FormattedText from "../components/FormattedText.jsx";
+import LoadingOverlay from "../components/LoadingOverlay";
 import MainActionButton from "../components/MainActionButton.jsx";
 import ResourceErrorMessage from "../components/ResourceErrorMessage.jsx";
 import DeleteButton from "../dataHomepage/DeleteButton";
@@ -762,18 +761,7 @@ function Form (props) {
                 disableRedirect
               />
             }
-            {fetchInProgress &&
-              <Backdrop
-                open={fetchInProgress}
-                sx={(theme) => ({
-                  backgroundColor: alpha(theme.palette.background.paper, .5),
-                  marginLeft: { md : "260px" },
-                  zIndex: theme.zIndex.drawer + 1
-                })}
-              >
-                <CircularProgress />
-              </Backdrop>
-            }
+            <LoadingOverlay open={fetchInProgress} />
             {changedSubject &&
               <>
                 <input type="hidden" name={`${data["@path"]}/subject`} value={changedSubject["@path"]} />

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
@@ -17,12 +17,19 @@
 //  under the License.
 //
 
-import { useEffect, useState, useMemo } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from "react";
 
 import EditIcon from '@mui/icons-material/Edit';
 import PreviewIcon from '@mui/icons-material/FindInPage';
 import MoreIcon from '@mui/icons-material/MoreVert';
 import {
+  Backdrop,
   Button,
   CircularProgress,
   Divider,
@@ -38,6 +45,7 @@ import {
   Typography,
   useScrollTrigger,
 } from "@mui/material";
+import { alpha } from '@mui/material/styles';
 import _ from "lodash";
 import { DateTime } from "luxon";
 import PropTypes from "prop-types";
@@ -72,6 +80,9 @@ import { getAncestorPath } from "../questionnaireEditor/treeQueries";
 import { usePageNameWriterContext } from "../themePage/Page.jsx";
 
 export const QUESTIONNAIRE_ITEM_NAMES = ENTRY_TYPES.map(type => stripCardsNamespace(type));
+
+// Stable reference so the memoized edit-tab element below isn't invalidated every render.
+const MAIN_ACTION_MENU_PROPS = { isMainAction: true };
 
 let Questionnaire = (props) => {
   let location = useLocation();
@@ -161,10 +172,48 @@ let QuestionnaireComponent = (props) => {
   let navigate = useNavigate();
   let isEdit = location.pathname.endsWith(".edit");
   let isReorder = location.pathname.endsWith(".reorder");
-  // Derive the active tab from the URL rather than holding it in separate state. This keeps
+  // Derive the active view from the URL rather than holding it in separate state. This keeps
   // the Reorder tab mounted when its navigation guard blocks a tab switch: the guard blocks
-  // the URL change, the derived tab stays on "reorder", and no out-of-sync state lingers.
-  const editTab = isReorder ? 'reorder' : 'edit';
+  // the URL change, the derived view stays on "reorder", and no out-of-sync state lingers.
+  const view = isReorder ? 'reorder' : (isEdit ? 'edit' : 'preview');
+  // The heavy tab content is rendered from `renderedView`, which lags `view` during a switch.
+  // Mounting a tab's subtree blocks for a while on a big questionnaire. The view comes from
+  // react-router's location (a synchronous external store React can't defer), so we bridge the
+  // change into our own state inside a transition: React then renders the next view in the
+  // background, keeps the current one on screen, and `isSwitchingView` (pending) drives the
+  // progress bar. Rendering stays interruptible, so the page doesn't lock up mid-switch.
+  // This runs in a layout effect (before paint) rather than a passive one, so the pending
+  // backdrop appears on the same frame as the click instead of one paint later.
+  const [renderedView, setRenderedView] = useState(view);
+  const [isSwitchingView, startTransition] = useTransition();
+  useLayoutEffect(() => {
+    if (view !== renderedView) startTransition(() => setRenderedView(view));
+  }, [view, renderedView]);
+
+  // Memoize each view's element so a location-change re-render of this component doesn't
+  // reconcile the (large) current view again before the switch transition starts — that
+  // extra reconcile is what delayed the backdrop when leaving the Edit tab. The element only
+  // rebuilds when its own inputs change; context-driven updates still reach the subtree.
+  const previewContent = useMemo(() => (
+    <QuestionnairePreview
+      data={data}
+      title={questionnaireTitle}
+      contentOffset={props.contentOffset}
+    />
+  ), [data, questionnaireTitle, props.contentOffset]);
+  const editContent = useMemo(() => (
+    <QuestionnaireContents
+      key={treeContext.state.revision}
+      disableDelete
+      data={data}
+      classes={classes}
+      menuProps={MAIN_ACTION_MENU_PROPS}
+    />
+  ), [treeContext.state.revision, data, classes]);
+  const reorderContent = useMemo(() => (
+    <ReorderDraft key={treeContext.state.timestamp} />
+  ), [treeContext.state.timestamp]);
+
   let pageNameWriter = usePageNameWriterContext();
 
   // First, fetch the questionnaire data
@@ -273,7 +322,8 @@ let QuestionnaireComponent = (props) => {
           error={error}
         />
         :
-        data?.["jcr:primaryType"] === "cards:Questionnaire" &&
+        data?.["jcr:primaryType"] === "cards:Questionnaire"
+          ?
           <Grid container className={classes.formContainer} {...FORM_ENTRY_CONTAINER_PROPS}>
             <QuestionnaireResourceHeader
               title={questionnaireTitle}
@@ -284,17 +334,24 @@ let QuestionnaireComponent = (props) => {
               showLocation={isEdit}
             />
             <Grid>
-              { !(isEdit || isReorder)
-                ?
-                <QuestionnairePreview
-                  data={data}
-                  title={questionnaireTitle}
-                  contentOffset={props.contentOffset}
-                />
+              { isSwitchingView &&
+                <Backdrop
+                  open={isSwitchingView}
+                  sx={(theme) => ({
+                    backgroundColor: alpha(theme.palette.background.paper, .5),
+                    marginLeft: { md : "260px" },
+                    zIndex: theme.zIndex.drawer + 1
+                  })}
+                >
+                  <CircularProgress />
+                </Backdrop>
+              }
+              { renderedView === 'preview'
+                ? previewContent
                 :
                 <>
                   <Tabs
-                    value={editTab}
+                    value={renderedView}
                     onChange={(event, newValue) => {
                       navigate(questionnaireUrl + `.${newValue}`);
                     }}
@@ -303,21 +360,16 @@ let QuestionnaireComponent = (props) => {
                     <Tab label="Reorder" value="reorder" />
                   </Tabs>
                   <Divider />
-                  { editTab == "edit" &&
-                    <QuestionnaireContents
-                      key={treeContext.state.revision}
-                      disableDelete
-                      data={data}
-                      classes={classes}
-                      menuProps={{ isMainAction: true }}
-                    />
-                  }
-                  { editTab == "reorder" &&
-                    <ReorderDraft key={treeContext.state.timestamp} />
-                  }
+                  { renderedView == "edit" && editContent }
+                  { renderedView == "reorder" && reorderContent }
                 </>
               }
             </Grid>
+          </Grid>
+          :
+          // Initial load: the questionnaire data is still being fetched (or first-rendered).
+          <Grid container justifyContent="center" sx={{ p: 4 }}>
+            <CircularProgress />
           </Grid>
       }
     </QuestionnaireProvider>

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Questionnaire.jsx
@@ -29,7 +29,6 @@ import EditIcon from '@mui/icons-material/Edit';
 import PreviewIcon from '@mui/icons-material/FindInPage';
 import MoreIcon from '@mui/icons-material/MoreVert';
 import {
-  Backdrop,
   Button,
   CircularProgress,
   Divider,
@@ -45,7 +44,6 @@ import {
   Typography,
   useScrollTrigger,
 } from "@mui/material";
-import { alpha } from '@mui/material/styles';
 import _ from "lodash";
 import { DateTime } from "luxon";
 import PropTypes from "prop-types";
@@ -59,6 +57,7 @@ import { QuestionnaireProvider, useQuestionnaireInViewContext } from "./Question
 import QuestionnairePreview from "./QuestionnairePreview";
 import { stripCardsNamespace } from "./QuestionnaireUtilities";
 import ResourceHeader from "./ResourceHeader";
+import LoadingOverlay from "../components/LoadingOverlay";
 import ResourceErrorMessage from "../components/ResourceErrorMessage.jsx";
 import DeleteButton from "../dataHomepage/DeleteButton";
 import ExportButton from "../dataHomepage/ExportButton";
@@ -334,18 +333,7 @@ let QuestionnaireComponent = (props) => {
               showLocation={isEdit}
             />
             <Grid>
-              { isSwitchingView &&
-                <Backdrop
-                  open={isSwitchingView}
-                  sx={(theme) => ({
-                    backgroundColor: alpha(theme.palette.background.paper, .5),
-                    marginLeft: { md : "260px" },
-                    zIndex: theme.zIndex.drawer + 1
-                  })}
-                >
-                  <CircularProgress />
-                </Backdrop>
-              }
+              <LoadingOverlay open={isSwitchingView} />
               { renderedView === 'preview'
                 ? previewContent
                 :
@@ -368,9 +356,7 @@ let QuestionnaireComponent = (props) => {
           </Grid>
           :
           // Initial load: the questionnaire data is still being fetched (or first-rendered).
-          <Grid container justifyContent="center" sx={{ p: 4 }}>
-            <CircularProgress />
-          </Grid>
+          <LoadingOverlay open={true}/>
       }
     </QuestionnaireProvider>
   );

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReorderDraft.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReorderDraft.jsx
@@ -306,7 +306,7 @@ const ReorderSubmitModal = (props) => {
       <Snackbar
         open={reorderState.status === 'success'}
         autoHideDuration={2000}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
         onClose={() => reorderDispatch({ type: 'SET_IDLE' })}
       >
         <Alert

--- a/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReorderDraft.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaireEditor/ReorderDraft.jsx
@@ -32,7 +32,6 @@ import {
   Divider,
   Icon,
   IconButton,
-  LinearProgress,
   List,
   ListItem,
   ListItemAvatar,
@@ -59,6 +58,7 @@ import {
 } from './reorderModel';
 import { getEntryChildIds } from './treeQueries';
 import ErrorDialog from '../components/ErrorDialog';
+import LoadingOverlay from '../components/LoadingOverlay';
 import MainActionButton from "../components/MainActionButton";
 import { QUESTIONNAIRE_TYPES, SECTION_TYPES, CONDITIONAL_TYPES } from '../questionnaire/FormEntry';
 import { useQuestionnaireInViewContext } from '../questionnaire/QuestionnaireContext';
@@ -297,18 +297,11 @@ const ReorderSubmitModal = (props) => {
         disabled={moves.length === 0}
         inProgress={reorderState.status === 'loading'}
       />
-      <Dialog
-        maxWidth="lg"
-        open={['loading'].includes(reorderState.status)}
-      >
-        <DialogTitle>Reordering entries</DialogTitle>
-        <DialogContent>
-          <LinearProgress
-            variant="determinate"
-            value={progressValue}
-          />
-        </DialogContent>
-      </Dialog>
+      <LoadingOverlay
+        open={reorderState.status === 'loading'}
+        message="Reordering entries..."
+        progress={progressValue}
+      />
 
       <Snackbar
         open={reorderState.status === 'success'}


### PR DESCRIPTION
#### Specs:
https://phenotips.atlassian.net/browse/CARDS-2937

#### Visible changes:
- Initial load: show a spinner while the questionnaire data is being fetched.
- View switch: while the next view is being rendered, show a dimmed backdrop with a spinner (matching the one used in Form.jsx), which also makes clear the page shouldn't be clicked mid-switch.
- REORDER tab -> SAVE: display the backdrop with the "Reordering entries..." and a determinate CircularProgress instead of a Dialog & LinearProgress.
- [MISC unrelated change] REORDER tab -> SAVE: moved the "Success" snackbar message to the bottom right, closer to the triggering button.

#### Refactoring:
- Created a reusable component LoadingOverlay to avoid code duplication between Form and Questionnaire.

#### Testing:
Very large questionnaires recommended, such as ClinicianAssessment in the RPS project.

#### Important note:
There is no speed improvement. With large questionnaires everything will be painfully slow. But at least now we get to look at a spinner for 10 seconds instead of a frozen screen.

#### Preview:

<img width="990" height="970" alt="image" src="https://github.com/user-attachments/assets/df5c0827-4127-4153-8e19-f1aef3235cfa" />

<img width="1000" height="1101" alt="image" src="https://github.com/user-attachments/assets/dafc679d-dd7a-4ac1-9179-80c900d5ba01" />
