### PR TITLE
CARDS-2938: Accept out-of-range predefined answer options in number questions

### DIFF
--- a/modules/form-completion-status/src/main/java/io/uhndata/cards/formcompletionstatus/internal/MinMaxValueValidator.java
+++ b/modules/form-completion-status/src/main/java/io/uhndata/cards/formcompletionstatus/internal/MinMaxValueValidator.java
@@ -16,10 +16,12 @@
  */
 package io.uhndata.cards.formcompletionstatus.internal;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 import javax.jcr.Node;
+import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
 
 import org.apache.jackrabbit.oak.api.PropertyState;
@@ -30,7 +32,8 @@ import org.osgi.service.component.annotations.Component;
 import io.uhndata.cards.formcompletionstatus.spi.AnswerValidator;
 
 /**
- * An {@link MinMaxValueValidator} checks for each value if it is in the minValue ... maxValue range.
+ * An {@link MinMaxValueValidator} checks for each value if it is in the minValue ... maxValue range. Values matching a
+ * predefined answer option are accepted even if they fall outside that range.
  *
  * @version $Id$
  */
@@ -44,6 +47,8 @@ public class MinMaxValueValidator implements AnswerValidator
     private static final String MIN_VALUE_PROP = "minValue";
 
     private static final String DISABLE_MIN_MAX_ENFORCEMENT_PROP = "disableMinMaxValueEnforcement";
+
+    private static final String ANSWER_OPTION_NODETYPE = "cards:AnswerOption";
 
     private static final Set<String> SUPPORTED_TYPES = Set.of("long", "double", "decimal");
 
@@ -68,11 +73,15 @@ public class MinMaxValueValidator implements AnswerValidator
                 final double maxValue = question.hasProperty(MAX_VALUE_PROP)
                     ? question.getProperty(MAX_VALUE_PROP).getDouble() : Double.NaN;
 
+                final Set<Double> optionValues = getAnswerOptionValues(question);
+
                 final PropertyState answerProp = answer.getProperty(PROP_VALUE);
                 // if any value is out of range, set FLAG_INVALID to true
                 for (int i = 0; i < answerProp.count(); i++) {
                     final Double value = answerProp.getValue(Type.DOUBLE, i);
-                    if (value < minValue || value > maxValue) {
+                    // A predefined answer option (e.g. a "prefer not to answer" sentinel) is always accepted,
+                    // even if its value falls outside the configured range
+                    if ((value < minValue || value > maxValue) && !optionValues.contains(value)) {
                         flags.put(FLAG_INVALID, true);
                         break;
                     }
@@ -83,6 +92,35 @@ public class MinMaxValueValidator implements AnswerValidator
         } catch (final RepositoryException ex) {
             // If something goes wrong do nothing
         }
+    }
+
+    /**
+     * Collect the numeric values of all predefined answer options defined for the question. These are accepted even
+     * when they fall outside the configured range, since they represent deliberate choices offered to the user rather
+     * than free-form input.
+     *
+     * @param question the cards:Question node
+     * @return the set of answer option values, as doubles; may be empty, never {@code null}
+     */
+    private Set<Double> getAnswerOptionValues(final Node question)
+    {
+        final Set<Double> optionValues = new HashSet<>();
+        try {
+            final NodeIterator children = question.getNodes();
+            while (children.hasNext()) {
+                final Node child = children.nextNode();
+                if (child.isNodeType(ANSWER_OPTION_NODETYPE) && child.hasProperty(PROP_VALUE)) {
+                    try {
+                        optionValues.add(child.getProperty(PROP_VALUE).getDouble());
+                    } catch (final RepositoryException ex) {
+                        // A non-numeric option value cannot match a numeric answer, so it can be safely ignored
+                    }
+                }
+            }
+        } catch (final RepositoryException ex) {
+            // If something goes wrong, treat it as if there were no options
+        }
+        return optionValues;
     }
 
     private boolean isMinMaxValidationApplicable(final Node question)

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/NumberMinMaxTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/NumberMinMaxTest.xml
@@ -376,7 +376,7 @@ Expected values are between 0 and 10.</value>
 		</property>
 		<property>
 			<name>description</name>
-			<value>Enforced min/max with options whose values (-1, -2) are deliberately outside the range. The instruction should end with "or select one of the options". Because enforcement is on, typing an out-of-range value OR selecting "Not applicable" / "Unknown" is flagged in view mode and the backend marks the form INVALID on save. Compare with the not-enforced version below.</value>
+			<value>Enforced min/max with options whose values (-1, -2) are deliberately outside the range. The instruction should end with "or select one of the options". Because enforcement is on, typing an out-of-range value is flagged in view mode and the backend marks the form INVALID on save. However, selecting a predefined option ("Not applicable" / "Unknown") is always accepted: it is NOT flagged in view mode and does NOT mark the form invalid, even though its value falls outside the range. Compare with the not-enforced version below.</value>
 			<type>String</type>
 		</property>
 		<property>


### PR DESCRIPTION
#### Status:
DRAFT because it's published pre-testing

#### Testing:
- Start CARDS with --test
- Create a NumberMinMaxTest Form and test the questions with predefined values at the bottom