### PR TITLE
[WIP] Allow accepting JWT tokens from other CARDs instances

### DIFF
--- a/modules/authentication/token/jwt-token-authentication/pom.xml
+++ b/modules/authentication/token/jwt-token-authentication/pom.xml
@@ -98,6 +98,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.19.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>osgi.cmpn</artifactId>
     </dependency>

--- a/modules/authentication/token/jwt-token-authentication/pom.xml
+++ b/modules/authentication/token/jwt-token-authentication/pom.xml
@@ -30,6 +30,12 @@
   <packaging>bundle</packaging>
   <name>CARDS - JWT Token Authentications</name>
 
+  <properties>
+    <!-- Module-aggregate (BUNDLE-scoped) minimum instruction coverage enforced by jacoco:check under -Ptests.
+         Actual is ~57%; this floor sits just under that, with headroom. Raise it as coverage grows. -->
+    <coverage.instructionRatio>0.50</coverage.instructionRatio>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
@@ -119,6 +125,30 @@
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt-api</artifactId>
       <version>0.13.0</version>
+    </dependency>
+
+    <!-- TEST -->
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>0.13.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>0.13.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/modules/authentication/token/jwt-token-authentication/pom.xml
+++ b/modules/authentication/token/jwt-token-authentication/pom.xml
@@ -84,6 +84,10 @@
       <artifactId>jcr</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.api</artifactId>
     </dependency>
@@ -149,6 +153,12 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+      <version>2.0.18</version>
     </dependency>
   </dependencies>
 </project>

--- a/modules/authentication/token/jwt-token-authentication/src/main/features/feature.json
+++ b/modules/authentication/token/jwt-token-authentication/src/main/features/feature.json
@@ -43,7 +43,9 @@
       "service.ranking:Integer": 300,
       "scripts": [
         "create path (rep:Unstructured) /jcr:system/cards:jwt/JWTSigningKey \n set ACL for everyone \n   deny jcr:all on /jcr:system/cards:jwt/JWTSigningKey \n end",
-        "create service user cards-jwt-token-manager \n set ACL for cards-jwt-token-manager \n allow jcr:all on /jcr:system/cards:jwt/JWTSigningKey \n     allow jcr:read on / \n end"
+        "create service user cards-jwt-token-manager \n set ACL for cards-jwt-token-manager \n allow jcr:all on /jcr:system/cards:jwt/JWTSigningKey \n     allow jcr:read on / \n end",
+        "create path (rep:Unstructured) /jcr:system/cards:jwt/JWTRSA256Key \n set ACL for everyone \n   deny jcr:all on /jcr:system/cards:jwt/JWTRSA256Key \n end",
+        "create service user cards-jwt-token-manager \n set ACL for cards-jwt-token-manager \n allow jcr:all on /jcr:system/cards:jwt/JWTRSA256Key \n     allow jcr:read on / \n end"
       ]
     },
     "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~cards-jwt-token-authentication": {

--- a/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenImpl.java
+++ b/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenImpl.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.api.security.authentication.token.TokenCredentials;
 import org.apache.jackrabbit.oak.spi.security.authentication.token.TokenInfo;
 
@@ -48,6 +49,10 @@ public class CardsJwtTokenImpl implements CardsToken
 
     /** The expiration time of the token. */
     private final Calendar expirationTime;
+
+    /** Our own internal ID */
+    public static final String SELF_ID =
+        StringUtils.defaultIfEmpty(System.getenv("CARDS_HOST_AND_PORT"), "localhost:8080");
 
     /**
      * Public attributes stored in the token, that, once successfully authenticated, will also be exposed as session

--- a/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenImpl.java
+++ b/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenImpl.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.api.security.authentication.token.TokenCredentials;
 import org.apache.jackrabbit.oak.spi.security.authentication.token.TokenInfo;
 
@@ -40,10 +39,6 @@ public class CardsJwtTokenImpl implements CardsToken
 {
     /** The name of the parent node where tokens for a user are stored. */
     public static final String SYSTEM_NODE_NAME = "jcr:system";
-
-    /** The ID of this CARDS instance, used to determine the `iss` field when minting tokens. */
-    public static final String SELF_ID =
-        StringUtils.defaultIfEmpty(System.getenv("CARDS_HOST_AND_PORT"), "localhost:8080");
 
     /** The login token string. */
     private final String loginToken;

--- a/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenImpl.java
+++ b/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenImpl.java
@@ -41,6 +41,10 @@ public class CardsJwtTokenImpl implements CardsToken
     /** The name of the parent node where tokens for a user are stored. */
     public static final String SYSTEM_NODE_NAME = "jcr:system";
 
+    /** The ID of this CARDS instance, used to determine the `iss` field when minting tokens. */
+    public static final String SELF_ID =
+        StringUtils.defaultIfEmpty(System.getenv("CARDS_HOST_AND_PORT"), "localhost:8080");
+
     /** The login token string. */
     private final String loginToken;
 
@@ -49,10 +53,6 @@ public class CardsJwtTokenImpl implements CardsToken
 
     /** The expiration time of the token. */
     private final Calendar expirationTime;
-
-    /** Our own internal ID */
-    public static final String SELF_ID =
-        StringUtils.defaultIfEmpty(System.getenv("CARDS_HOST_AND_PORT"), "localhost:8080");
 
     /**
      * Public attributes stored in the token, that, once successfully authenticated, will also be exposed as session

--- a/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
+++ b/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
@@ -23,10 +23,10 @@ import java.security.PublicKey;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Calendar;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import javax.crypto.SecretKey;
 import javax.jcr.Node;
 
 import org.apache.sling.api.resource.LoginException;
@@ -41,14 +41,13 @@ import org.slf4j.LoggerFactory;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ClaimsMutator.AudienceCollection;
-import io.jsonwebtoken.JweHeader;
-import io.jsonwebtoken.JwsHeader;
 import io.jsonwebtoken.Jwt;
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.security.Keys;
 import io.uhndata.cards.auth.token.TokenManager;
 
 /**
@@ -65,7 +64,12 @@ public class CardsJwtTokenManagerImpl implements TokenManager
     /** JCR property containing a verification key. */
     public static final String VERIFY_PROP = "verify";
 
+    /** JCR path to the node where we keep our signing/verification keys. */
+    public static final String KEY_PATH = "/jcr:system/cards:jwt/JWTRSA256Key";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(CardsJwtTokenManagerImpl.class);
+
+    private final SecretKey symmetricKey;
 
     private final PrivateKey signingKey;
 
@@ -82,13 +86,14 @@ public class CardsJwtTokenManagerImpl implements TokenManager
         this.selfID = CardsJwtTokenImpl.SELF_ID.replaceAll("\\P{Alnum}", "");
         PrivateKey result = null;
         PublicKey verification = null;
+        SecretKey symmetric = null;
         try (ResourceResolver resolver = rrf.getServiceResourceResolver(null)) {
-            String resourcePath = "/jcr:system/cards:jwt/JWTSigningKey";
-            Resource res = resolver.resolve(resourcePath);
+            Resource res = resolver.resolve(CardsJwtTokenManagerImpl.KEY_PATH);
             Node keyNode = res.adaptTo(Node.class);
             if (keyNode == null) {
-                LOGGER.error("Failed to load JWT Signing key: node {} could not be read", resourcePath);
-                throw new ExceptionInInitializerError(resourcePath);
+                LOGGER.error("Failed to load JWT Signing key: node {} could not be read",
+                    CardsJwtTokenManagerImpl.KEY_PATH);
+                throw new ExceptionInInitializerError(CardsJwtTokenManagerImpl.KEY_PATH);
             }
 
             if (keyNode.hasProperty(CardsJwtTokenManagerImpl.SIGNING_KEY_PROP)
@@ -115,6 +120,14 @@ public class CardsJwtTokenManagerImpl implements TokenManager
                 result = newPair.getPrivate();
                 verification = newPair.getPublic();
             }
+
+            // For backwards compatibility: attempt to load (but not generate) a symmetric key, if it exists
+            res = resolver.resolve("/jcr:system/cards:jwt/JWTSigningKey");
+            keyNode = res.adaptTo(Node.class);
+            if (keyNode != null && keyNode.hasProperty(CardsJwtTokenManagerImpl.SIGNING_KEY_PROP)) {
+                symmetric = Keys.hmacShaKeyFor(Decoders.BASE64.decode(keyNode.getProperty(
+                    CardsJwtTokenManagerImpl.SIGNING_KEY_PROP).getString()));
+            }
         } catch (LoginException e) {
             LOGGER.error("Service access not granted: {}", e.getMessage());
         } catch (Exception e) {
@@ -122,6 +135,7 @@ public class CardsJwtTokenManagerImpl implements TokenManager
         }
         this.signingKey = result;
         this.verificationKey = verification;
+        this.symmetricKey = symmetric;
     }
 
     @Override
@@ -129,12 +143,18 @@ public class CardsJwtTokenManagerImpl implements TokenManager
         final Map<String, String> extraData)
     {
         // Assume our own audience if none is given
-        Set<String> audience = new HashSet<String>();
-        audience.add(this.selfID);
-        return create(userId, expiration, extraData, audience);
+        return create(userId, expiration, extraData, Set.of(this.selfID));
     }
 
-    // Override of the above create that allows for multiple audiences to be set
+    /**
+     * Create a JWT with the given specifications.
+     *
+     * @param userId The user ID to assign as a subject
+     * @param expiration An expiration time for the JWT
+     * @param extraData Additional data to include in the JWT payload
+     * @param audiences A set of audiences that the JWT is meant for
+     * @return A CardsJwtTokenImpl corresponding to a newly minted JWT with the given parameters.
+     */
     public CardsJwtTokenImpl create(final String userId, final Calendar expiration,
         final Map<String, String> extraData, Set<String> audiences)
     {
@@ -169,7 +189,8 @@ public class CardsJwtTokenManagerImpl implements TokenManager
         try {
             PublicKey ourVerificationKey = this.verificationKey;
             Jwt<?, ?> jwt = Jwts.parser()
-                .keyLocator(new CardsJwtVerificationLocatorImpl(this.verificationKey, this.rrf, this.selfID))
+                .keyLocator(new CardsJwtVerificationLocatorImpl(this.verificationKey, this.symmetricKey, this.rrf,
+                    this.selfID))
                 .build()
                 .parseSignedClaims(loginToken);
 
@@ -177,9 +198,13 @@ public class CardsJwtTokenManagerImpl implements TokenManager
             Object payload = jwt.getPayload();
             if (payload instanceof Claims) {
                 Claims claims = (Claims) payload;
-                String keyID = jwt.getHeader() instanceof JwsHeader ? ((JwsHeader) jwt.getHeader()).getKeyId()
-                    : ((JweHeader) jwt.getHeader()).getKeyId();
-                // Double-check that we're the intended audience for this JWT
+                String keyID = CardsJwtVerificationLocatorImpl.getKey(jwt.getHeader());
+                if (keyID == null) {
+                    // We were signed using a symmetric key (no `kid` present): we accept for backwards compatability
+                    return new CardsJwtTokenImpl(jwt, loginToken);
+                }
+
+                // If we're signed using an asymmetric key, double-check that we're the intended audience for this JWT
                 if (claims.getAudience() == null) {
                     // No audience found, reject
                     throw new JwtException("The given JWT is missing an `aud` claim.");

--- a/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
+++ b/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
@@ -16,10 +16,15 @@
  */
 package io.uhndata.cards.auth.token.jwt.impl;
 
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
 import java.util.Calendar;
 import java.util.Map;
 
-import javax.crypto.SecretKey;
 import javax.jcr.Node;
 
 import org.apache.sling.api.resource.LoginException;
@@ -37,7 +42,6 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.io.Encoders;
-import io.jsonwebtoken.security.Keys;
 import io.uhndata.cards.auth.token.TokenManager;
 
 /**
@@ -50,12 +54,15 @@ public class CardsJwtTokenManagerImpl implements TokenManager
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(CardsJwtTokenManagerImpl.class);
 
-    private final SecretKey key;
+    private final PrivateKey signingKey;
+
+    private final PublicKey verificationKey;
 
     @Activate
     public CardsJwtTokenManagerImpl(@Reference ResourceResolverFactory rrf)
     {
-        SecretKey result = null;
+        PrivateKey result = null;
+        PublicKey verification = null;
         try (ResourceResolver resolver = rrf.getServiceResourceResolver(null)) {
             String resourcePath = "/jcr:system/cards:jwt/JWTSigningKey";
             Resource res = resolver.resolve(resourcePath);
@@ -64,26 +71,38 @@ public class CardsJwtTokenManagerImpl implements TokenManager
                 LOGGER.error("Failed to load JWT Signing key: node {} could not be read", resourcePath);
                 throw new ExceptionInInitializerError(resourcePath);
             }
-            if (keyNode.hasProperty("key")) {
-                result = Keys.hmacShaKeyFor(Decoders.BASE64.decode(keyNode.getProperty("key").getString()));
+            if (keyNode.hasProperty("key") && keyNode.hasProperty("verify")) {
+                // Private key is PKCS-encoded
+                byte[] privBytes = Decoders.BASE64.decode(keyNode.getProperty("key").getString());
+                result = KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(privBytes));
+
+                // Public key is X.509-encoded
+                byte[] pubBytes = Decoders.BASE64.decode(keyNode.getProperty("verify").getString());
+                verification = KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(pubBytes));
             } else {
-                result = Jwts.SIG.HS512.key().build();
-                String secretString = Encoders.BASE64.encode(result.getEncoded());
+                KeyPair newPair = Jwts.SIG.RS256.keyPair().build();
+                String secretString = Encoders.BASE64.encode(newPair.getPrivate().getEncoded());
+                String signingString = Encoders.BASE64.encode(newPair.getPublic().getEncoded());
                 keyNode.setProperty("key", secretString);
+                keyNode.setProperty("verify", signingString);
                 resolver.commit();
+
+                result = newPair.getPrivate();
+                verification = newPair.getPublic();
             }
         } catch (LoginException e) {
             LOGGER.error("Service access not granted: {}", e.getMessage());
         } catch (Exception e) {
             LOGGER.error("Failed to load JWT Signing key from node: {}", e.getMessage(), e);
         }
-        this.key = result;
+        this.signingKey = result;
+        this.verificationKey = verification;
     }
 
     @Override
     public CardsJwtTokenImpl create(final String userId, final Calendar expiration, final Map<String, String> extraData)
     {
-        if (this.key == null) {
+        if (this.signingKey == null || this.verificationKey == null) {
             // Should not happen
             return null;
         }
@@ -91,7 +110,7 @@ public class CardsJwtTokenManagerImpl implements TokenManager
             .subject(userId)
             .expiration(expiration.getTime())
             .claims(extraData)
-            .signWith(this.key)
+            .signWith(this.signingKey)
             .compact();
         return new CardsJwtTokenImpl(jws, userId, expiration, extraData);
     }
@@ -99,11 +118,11 @@ public class CardsJwtTokenManagerImpl implements TokenManager
     @Override
     public CardsJwtTokenImpl parse(final String loginToken)
     {
-        if (loginToken == null || this.key == null) {
+        if (loginToken == null || this.verificationKey == null) {
             return null;
         }
         try {
-            Jwt<?, ?> jwt = Jwts.parser().verifyWith(this.key).build().parseSignedClaims(loginToken);
+            Jwt<?, ?> jwt = Jwts.parser().verifyWith(this.verificationKey).build().parseSignedClaims(loginToken);
             return new CardsJwtTokenImpl(jwt, loginToken);
         } catch (JwtException e) {
             // Not a JWT token

--- a/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
+++ b/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
@@ -16,7 +16,6 @@
  */
 package io.uhndata.cards.auth.token.jwt.impl;
 
-import java.security.Key;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.PrivateKey;
@@ -36,23 +35,18 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Header;
+import io.jsonwebtoken.ClaimsMutator.AudienceCollection;
 import io.jsonwebtoken.JweHeader;
 import io.jsonwebtoken.JwsHeader;
 import io.jsonwebtoken.Jwt;
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.Locator;
-import io.jsonwebtoken.ClaimsMutator.AudienceCollection;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.io.Encoders;
 import io.uhndata.cards.auth.token.TokenManager;
@@ -65,11 +59,19 @@ import io.uhndata.cards.auth.token.TokenManager;
 @Component(immediate = true, property = "service.ranking:Integer=50", service = { TokenManager.class })
 public class CardsJwtTokenManagerImpl implements TokenManager
 {
+    /** JCR property containing our signing key. */
+    public static final String SIGNING_KEY_PROP = "key";
+
+    /** JCR property containing a verification key. */
+    public static final String VERIFY_PROP = "verify";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(CardsJwtTokenManagerImpl.class);
 
     private final PrivateKey signingKey;
 
     private final PublicKey verificationKey;
+
+    private final String selfID;
 
     private ResourceResolverFactory rrf;
 
@@ -77,6 +79,7 @@ public class CardsJwtTokenManagerImpl implements TokenManager
     public CardsJwtTokenManagerImpl(@Reference ResourceResolverFactory rrf)
     {
         this.rrf = rrf;
+        this.selfID = CardsJwtTokenImpl.SELF_ID.replaceAll("\\P{Alnum}", "");
         PrivateKey result = null;
         PublicKey verification = null;
         try (ResourceResolver resolver = rrf.getServiceResourceResolver(null)) {
@@ -87,20 +90,26 @@ public class CardsJwtTokenManagerImpl implements TokenManager
                 LOGGER.error("Failed to load JWT Signing key: node {} could not be read", resourcePath);
                 throw new ExceptionInInitializerError(resourcePath);
             }
-            if (keyNode.hasProperty("key") && keyNode.hasProperty("verify")) {
+
+            if (keyNode.hasProperty(CardsJwtTokenManagerImpl.SIGNING_KEY_PROP)
+                && keyNode.hasProperty(CardsJwtTokenManagerImpl.VERIFY_PROP)) {
                 // Private key is PKCS-encoded
-                byte[] privBytes = Decoders.BASE64.decode(keyNode.getProperty("key").getString());
+                byte[] privBytes = Decoders.BASE64.decode(
+                    keyNode.getProperty(CardsJwtTokenManagerImpl.SIGNING_KEY_PROP).getString()
+                );
                 result = KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(privBytes));
 
                 // Public key is X.509-encoded
-                byte[] pubBytes = Decoders.BASE64.decode(keyNode.getProperty("verify").getString());
+                byte[] pubBytes = Decoders.BASE64.decode(keyNode.getProperty(
+                    CardsJwtTokenManagerImpl.VERIFY_PROP).getString()
+                );
                 verification = KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(pubBytes));
             } else {
                 KeyPair newPair = Jwts.SIG.RS256.keyPair().build();
                 String secretString = Encoders.BASE64.encode(newPair.getPrivate().getEncoded());
                 String signingString = Encoders.BASE64.encode(newPair.getPublic().getEncoded());
-                keyNode.setProperty("key", secretString);
-                keyNode.setProperty("verify", signingString);
+                keyNode.setProperty(CardsJwtTokenManagerImpl.SIGNING_KEY_PROP, secretString);
+                keyNode.setProperty(CardsJwtTokenManagerImpl.VERIFY_PROP, signingString);
                 resolver.commit();
 
                 result = newPair.getPrivate();
@@ -116,24 +125,25 @@ public class CardsJwtTokenManagerImpl implements TokenManager
     }
 
     @Override
-    public CardsJwtTokenImpl create(final String userId, final Calendar expiration, final Map<String, String> extraData)
+    public CardsJwtTokenImpl create(final String userId, final Calendar expiration,
+        final Map<String, String> extraData)
     {
         // Assume our own audience if none is given
-        HashSet<String> audience = new HashSet<String>();
-        audience.add(CardsJwtTokenImpl.SELF_ID);
+        Set<String> audience = new HashSet<String>();
+        audience.add(this.selfID);
         return create(userId, expiration, extraData, audience);
     }
 
     // Override of the above create that allows for multiple audiences to be set
-    public CardsJwtTokenImpl create(final String userId, final Calendar expiration, final Map<String, String> extraData,
-            Set<String> audiences)
+    public CardsJwtTokenImpl create(final String userId, final Calendar expiration,
+        final Map<String, String> extraData, Set<String> audiences)
     {
         if (this.signingKey == null || this.verificationKey == null) {
             // Should not happen
             return null;
         }
         AudienceCollection<JwtBuilder> audBuilder = Jwts.builder()
-                .issuer(CardsJwtTokenImpl.SELF_ID)
+                .issuer(this.selfID)
                 .audience();
 
         for (String aud : audiences) {
@@ -144,34 +154,10 @@ public class CardsJwtTokenManagerImpl implements TokenManager
             .subject(userId)
             .expiration(expiration.getTime())
             .claims(extraData)
-            .header().keyId(CardsJwtTokenImpl.SELF_ID).and()
+            .header().keyId(this.selfID).and()
             .signWith(this.signingKey)
             .compact();
         return new CardsJwtTokenImpl(jws, userId, expiration, extraData);
-    }
-
-    private PublicKey lookupPeerKey(final String keyID)
-    {
-        try (ResourceResolver resolver = this.rrf.getServiceResourceResolver(null)) {
-            String resourcePath = "/jcr:system/cards:jwt/" + keyID;
-            Resource res = resolver.resolve(resourcePath);
-            Node keyNode = res.adaptTo(Node.class);
-            if (keyNode == null) {
-                LOGGER.error("Failed to load JWT Verification key for peer {}: node {} could not be read", keyID, resourcePath);
-                throw new ExceptionInInitializerError(resourcePath);
-            }
-            if (!keyNode.hasProperty("verify")) {
-                LOGGER.error("Failed to load JWT Verification key for peer {}: node {} has no property 'verify'", keyID, resourcePath);
-                throw new ExceptionInInitializerError(resourcePath);
-            }
-            byte[] pubBytes = Decoders.BASE64.decode(keyNode.getProperty("verify").getString());
-            return KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(pubBytes));
-        } catch (LoginException e) {
-            LOGGER.error("Service access not granted: {}", e.getMessage());
-        } catch (Exception e) {
-            LOGGER.error("Failed to load JWT validation key from node: {}", e.getMessage());
-        }
-        return null;
     }
 
     @Override
@@ -182,31 +168,29 @@ public class CardsJwtTokenManagerImpl implements TokenManager
         }
         try {
             PublicKey ourVerificationKey = this.verificationKey;
-            Jwt<?, ?> jwt = Jwts.parser().keyLocator(new Locator<Key>() {
-                @Override
-                public Key locate(Header header)
-                {
-                    String keyID = header instanceof JwsHeader ? ((JwsHeader) header).getKeyId() : ((JweHeader) header).getKeyId();
-                    if (keyID == null) {
-                        return null;
-                    }
+            Jwt<?, ?> jwt = Jwts.parser()
+                .keyLocator(new CardsJwtVerificationLocatorImpl(this.verificationKey, this.rrf, this.selfID))
+                .build()
+                .parseSignedClaims(loginToken);
 
-                    return keyID.equals(CardsJwtTokenImpl.SELF_ID) ? ourVerificationKey : lookupPeerKey(key_id);
-                }
-            }).build().parseSignedClaims(loginToken);
+            // Double check claims in the payload:
             Object payload = jwt.getPayload();
             if (payload instanceof Claims) {
                 Claims claims = (Claims) payload;
+                String keyID = jwt.getHeader() instanceof JwsHeader ? ((JwsHeader) jwt.getHeader()).getKeyId()
+                    : ((JweHeader) jwt.getHeader()).getKeyId();
                 // Double-check that we're the intended audience for this JWT
                 if (claims.getAudience() == null) {
-                    // No audience found, but the token was from a verified source -- assume we're OK
-                    return new CardsJwtTokenImpl(jwt, loginToken);
-                } else if (claims.getAudience().contains(CardsJwtTokenImpl.SELF_ID)) {
+                    // No audience found, reject
+                    throw new JwtException("The given JWT is missing an `aud` claim.");
+                } else if (!claims.getAudience().contains(this.selfID)) {
+                    throw new JwtException("Our server (" + this.selfID
+                        + ")) is not in the list of JWT audiences for the given JWT.");
+                } else if (!claims.getIssuer().equals(keyID)) {
+                    throw new JwtException("The given JWT's issuer does not match the KeyID passed in its header.");
+                } else {
                     // Audience found, and we're in it -- OK
                     return new CardsJwtTokenImpl(jwt, loginToken);
-                } else {
-                    LOGGER.error("JWT validation failed: Our server ({}) is not in the list of JWT audiences for the given JWT.",
-                        CardsJwtTokenImpl.SELF_ID);
                 }
             }
         } catch (JwtException e) {

--- a/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
+++ b/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
@@ -16,6 +16,7 @@
  */
 package io.uhndata.cards.auth.token.jwt.impl;
 
+import java.security.Key;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.PrivateKey;
@@ -23,6 +24,7 @@ import java.security.PublicKey;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Calendar;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -34,15 +36,22 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.FieldOption;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.JweHeader;
+import io.jsonwebtoken.JwsHeader;
 import io.jsonwebtoken.Jwt;
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.Locator;
 import io.jsonwebtoken.ClaimsMutator.AudienceCollection;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.io.Encoders;
@@ -62,9 +71,12 @@ public class CardsJwtTokenManagerImpl implements TokenManager
 
     private final PublicKey verificationKey;
 
+    private ResourceResolverFactory rrf;
+
     @Activate
     public CardsJwtTokenManagerImpl(@Reference ResourceResolverFactory rrf)
     {
+        this.rrf = rrf;
         PrivateKey result = null;
         PublicKey verification = null;
         try (ResourceResolver resolver = rrf.getServiceResourceResolver(null)) {
@@ -104,22 +116,12 @@ public class CardsJwtTokenManagerImpl implements TokenManager
     }
 
     @Override
-    public CardsJwtTokenImpl create(final String userId, final Calendar expiration,
-            final Map<String, String> extraData)
+    public CardsJwtTokenImpl create(final String userId, final Calendar expiration, final Map<String, String> extraData)
     {
-        if (this.signingKey == null || this.verificationKey == null) {
-            // Should not happen
-            return null;
-        }
-        String jws = Jwts.builder()
-            .issuer(CardsJwtTokenImpl.SELF_ID)
-            .audience().add(CardsJwtTokenImpl.SELF_ID).and() // Assume, for now, we're making tokens for ourselves
-            .subject(userId)
-            .expiration(expiration.getTime())
-            .claims(extraData)
-            .signWith(this.signingKey)
-            .compact();
-        return new CardsJwtTokenImpl(jws, userId, expiration, extraData);
+        // Assume our own audience if none is given
+        HashSet<String> audience = new HashSet<String>();
+        audience.add(CardsJwtTokenImpl.SELF_ID);
+        return create(userId, expiration, extraData, audience);
     }
 
     // Override of the above create that allows for multiple audiences to be set
@@ -142,9 +144,34 @@ public class CardsJwtTokenManagerImpl implements TokenManager
             .subject(userId)
             .expiration(expiration.getTime())
             .claims(extraData)
+            .header().keyId(CardsJwtTokenImpl.SELF_ID).and()
             .signWith(this.signingKey)
             .compact();
         return new CardsJwtTokenImpl(jws, userId, expiration, extraData);
+    }
+
+    private PublicKey lookupPeerKey(final String keyID)
+    {
+        try (ResourceResolver resolver = this.rrf.getServiceResourceResolver(null)) {
+            String resourcePath = "/jcr:system/cards:jwt/" + keyID;
+            Resource res = resolver.resolve(resourcePath);
+            Node keyNode = res.adaptTo(Node.class);
+            if (keyNode == null) {
+                LOGGER.error("Failed to load JWT Verification key for peer {}: node {} could not be read", keyID, resourcePath);
+                throw new ExceptionInInitializerError(resourcePath);
+            }
+            if (!keyNode.hasProperty("verify")) {
+                LOGGER.error("Failed to load JWT Verification key for peer {}: node {} has no property 'verify'", keyID, resourcePath);
+                throw new ExceptionInInitializerError(resourcePath);
+            }
+            byte[] pubBytes = Decoders.BASE64.decode(keyNode.getProperty("verify").getString());
+            return KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(pubBytes));
+        } catch (LoginException e) {
+            LOGGER.error("Service access not granted: {}", e.getMessage());
+        } catch (Exception e) {
+            LOGGER.error("Failed to load JWT validation key from node: {}", e.getMessage());
+        }
+        return null;
     }
 
     @Override
@@ -154,26 +181,36 @@ public class CardsJwtTokenManagerImpl implements TokenManager
             return null;
         }
         try {
-            // TODO: check with every verification key
-            Jwt<?, ?> jwt = Jwts.parser().verifyWith(this.verificationKey).build().parseSignedClaims(loginToken);
+            PublicKey ourVerificationKey = this.verificationKey;
+            Jwt<?, ?> jwt = Jwts.parser().keyLocator(new Locator<Key>() {
+                @Override
+                public Key locate(Header header)
+                {
+                    String keyID = header instanceof JwsHeader ? ((JwsHeader) header).getKeyId() : ((JweHeader) header).getKeyId();
+                    if (keyID == null) {
+                        return null;
+                    }
+
+                    return keyID.equals(CardsJwtTokenImpl.SELF_ID) ? ourVerificationKey : lookupPeerKey(key_id);
+                }
+            }).build().parseSignedClaims(loginToken);
             Object payload = jwt.getPayload();
             if (payload instanceof Claims) {
                 Claims claims = (Claims) payload;
                 // Double-check that we're the intended audience for this JWT
                 if (claims.getAudience() == null) {
-                    // No audience found, but the token was from a verified source -- assume we're
-                    // OK
+                    // No audience found, but the token was from a verified source -- assume we're OK
                     return new CardsJwtTokenImpl(jwt, loginToken);
                 } else if (claims.getAudience().contains(CardsJwtTokenImpl.SELF_ID)) {
                     // Audience found, and we're in it -- OK
                     return new CardsJwtTokenImpl(jwt, loginToken);
                 } else {
-                    LOGGER.error("Our server ({}) is not in the list of JWT audiences for the given JWT.");
+                    LOGGER.error("JWT validation failed: Our server ({}) is not in the list of JWT audiences for the given JWT.",
+                        CardsJwtTokenImpl.SELF_ID);
                 }
             }
         } catch (JwtException e) {
-            // Not a JWT token
-            LOGGER.error("A non-JWT token was passed to JWTTokenManager");
+            LOGGER.error("JWT validation failed: {}", e.getMessage());
         }
         return null;
     }

--- a/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
+++ b/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
@@ -177,13 +177,7 @@ public class CardsJwtTokenManagerImpl implements TokenManager
             return null;
         }
 
-        try
-        {
-            return DigestUtils.sha256Hex(Encoders.BASE64.encode(publicKey.getEncoded()));
-        } catch (Exception e) {
-            // TODO: Better exception handling
-            return null;
-        }
+        return DigestUtils.sha256Hex(Encoders.BASE64.encode(publicKey.getEncoded()));
     }
 
     /**

--- a/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
+++ b/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
@@ -30,6 +30,7 @@ import javax.crypto.SecretKey;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -65,6 +66,9 @@ public class CardsJwtTokenManagerImpl implements TokenManager
     /** JCR property containing a verification key. */
     public static final String VERIFY_PROP = "verify";
 
+    /** JCR property containing a peer's expected 'issuer' ID. */
+    public static final String ISSUER_PROP = "iss";
+
     /** JCR path to the node where we keep our signing/verification keys. */
     public static final String KEY_PATH = "/jcr:system/cards:jwt/JWTRSA256Key";
 
@@ -76,6 +80,8 @@ public class CardsJwtTokenManagerImpl implements TokenManager
 
     private final PublicKey verificationKey;
 
+    private final String selfAud;
+
     private final String selfID;
 
     private ResourceResolverFactory rrf;
@@ -84,7 +90,7 @@ public class CardsJwtTokenManagerImpl implements TokenManager
     public CardsJwtTokenManagerImpl(@Reference ResourceResolverFactory rrf)
     {
         this.rrf = rrf;
-        this.selfID = CardsJwtTokenImpl.SELF_ID.replaceAll("\\P{Alnum}", "");
+        this.selfAud = CardsJwtTokenImpl.SELF_ID.replaceAll("\\P{Alnum}", "");
         PrivateKey result = null;
         PublicKey verification = null;
         SecretKey symmetric = null;
@@ -107,10 +113,10 @@ public class CardsJwtTokenManagerImpl implements TokenManager
                     new X509EncodedKeySpec(readKey(keyNode, CardsJwtTokenManagerImpl.VERIFY_PROP)));
             } else {
                 KeyPair newPair = Jwts.SIG.RS256.keyPair().build();
-                String secretString = Encoders.BASE64.encode(newPair.getPrivate().getEncoded());
-                String signingString = Encoders.BASE64.encode(newPair.getPublic().getEncoded());
-                keyNode.setProperty(CardsJwtTokenManagerImpl.SIGNING_KEY_PROP, secretString);
-                keyNode.setProperty(CardsJwtTokenManagerImpl.VERIFY_PROP, signingString);
+                keyNode.setProperty(CardsJwtTokenManagerImpl.SIGNING_KEY_PROP,
+                    Encoders.BASE64.encode(newPair.getPrivate().getEncoded()));
+                keyNode.setProperty(CardsJwtTokenManagerImpl.VERIFY_PROP,
+                    Encoders.BASE64.encode(newPair.getPublic().getEncoded()));
                 resolver.commit();
 
                 result = newPair.getPrivate();
@@ -119,7 +125,7 @@ public class CardsJwtTokenManagerImpl implements TokenManager
 
             // For backwards compatibility: attempt to load (but not generate) a symmetric key, if it exists
             res = resolver.resolve("/jcr:system/cards:jwt/JWTSigningKey");
-            keyNode = res.adaptTo(Node.class);
+            keyNode = res == null ? null : res.adaptTo(Node.class);
             if (keyNode != null && keyNode.hasProperty(CardsJwtTokenManagerImpl.SIGNING_KEY_PROP)) {
                 symmetric = Keys.hmacShaKeyFor(Decoders.BASE64.decode(keyNode.getProperty(
                     CardsJwtTokenManagerImpl.SIGNING_KEY_PROP).getString()));
@@ -132,6 +138,7 @@ public class CardsJwtTokenManagerImpl implements TokenManager
         this.signingKey = result;
         this.verificationKey = verification;
         this.symmetricKey = symmetric;
+        this.selfID = getFingerprint(verification);
     }
 
     /**
@@ -153,7 +160,30 @@ public class CardsJwtTokenManagerImpl implements TokenManager
         final Map<String, String> extraData)
     {
         // Assume our own audience if none is given
-        return create(userId, expiration, extraData, Set.of(this.selfID));
+        return create(userId, expiration, extraData, Set.of(this.selfAud));
+    }
+
+    /**
+     * Obtain a fingerprint from the given public key.
+     *
+     * @param publicKey The key to obtain a fingerprint for
+     * @return A string hash that should uniquely identify the given public key
+     */
+    public static String getFingerprint(final PublicKey publicKey)
+    {
+        // Obtain a fingerprint from a key
+        if (publicKey == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return DigestUtils.sha256Hex(Encoders.BASE64.encode(publicKey.getEncoded()));
+        } catch (Exception e) {
+            // TODO: Better exception handling
+            return null;
+        }
     }
 
     /**
@@ -173,7 +203,7 @@ public class CardsJwtTokenManagerImpl implements TokenManager
             return null;
         }
         AudienceCollection<JwtBuilder> audBuilder = Jwts.builder()
-                .issuer(this.selfID)
+                .issuer(this.selfAud)
                 .audience();
 
         for (String aud : audiences) {
@@ -190,6 +220,38 @@ public class CardsJwtTokenManagerImpl implements TokenManager
         return new CardsJwtTokenImpl(jws, userId, expiration, extraData);
     }
 
+    private boolean areClaimsValid(Jwt<?, ?> jwt, CardsJwtVerificationLocatorImpl locator) throws JwtException,
+        RepositoryException
+    {
+        // Double check claims in the payload:
+        Object payload = jwt.getPayload();
+        if (payload instanceof Claims) {
+            Claims claims = (Claims) payload;
+            String keyID = CardsJwtVerificationLocatorImpl.getKey(jwt.getHeader());
+            if (keyID == null) {
+                // We were signed using a symmetric key (no `kid` present): we accept for backwards compatability
+                return true;
+            }
+
+            String issuer = keyID.equals(this.selfID) ? this.selfAud : locator.lookupPeerDetails(keyID)
+                .getProperty(CardsJwtTokenManagerImpl.ISSUER_PROP).getString();
+
+            // If we're signed using an asymmetric key, double-check that we're the intended audience for this JWT
+            if (claims.getAudience() == null) {
+                // No audience found, reject
+                throw new JwtException("The given JWT is missing an `aud` claim.");
+            } else if (!claims.getAudience().contains(this.selfAud)) {
+                throw new JwtException("Our server (" + this.selfAud
+                    + ")) is not in the list of JWT audiences for the given JWT.");
+            } else if (!claims.getIssuer().equals(issuer)) {
+                throw new JwtException("The given JWT's issuer does not match the expected issuer.");
+            }
+            return true;
+        } else {
+            throw new JwtException("The given JWT's payload is in an unknown format.");
+        }
+    }
+
     @Override
     public CardsJwtTokenImpl parse(final String loginToken)
     {
@@ -197,37 +259,21 @@ public class CardsJwtTokenManagerImpl implements TokenManager
             return null;
         }
         try {
+            CardsJwtVerificationLocatorImpl locator = new CardsJwtVerificationLocatorImpl(this.verificationKey,
+                this.symmetricKey, this.rrf, this.selfID);
+
             Jwt<?, ?> jwt = Jwts.parser()
-                .keyLocator(new CardsJwtVerificationLocatorImpl(this.verificationKey, this.symmetricKey, this.rrf,
-                    this.selfID))
+                .keyLocator(locator)
                 .build()
                 .parseSignedClaims(loginToken);
 
             // Double check claims in the payload:
-            Object payload = jwt.getPayload();
-            if (payload instanceof Claims) {
-                Claims claims = (Claims) payload;
-                String keyID = CardsJwtVerificationLocatorImpl.getKey(jwt.getHeader());
-                if (keyID == null) {
-                    // We were signed using a symmetric key (no `kid` present): we accept for backwards compatability
-                    return new CardsJwtTokenImpl(jwt, loginToken);
-                }
-
-                // If we're signed using an asymmetric key, double-check that we're the intended audience for this JWT
-                if (claims.getAudience() == null) {
-                    // No audience found, reject
-                    throw new JwtException("The given JWT is missing an `aud` claim.");
-                } else if (!claims.getAudience().contains(this.selfID)) {
-                    throw new JwtException("Our server (" + this.selfID
-                        + ")) is not in the list of JWT audiences for the given JWT.");
-                } else if (!claims.getIssuer().equals(keyID)) {
-                    throw new JwtException("The given JWT's issuer does not match the KeyID passed in its header.");
-                } else {
-                    // Audience found, and we're in it -- OK
-                    return new CardsJwtTokenImpl(jwt, loginToken);
-                }
+            if (areClaimsValid(jwt, locator)) {
+                return new CardsJwtTokenImpl(jwt, loginToken);
             }
         } catch (JwtException e) {
+            LOGGER.error("JWT validation failed: {}", e.getMessage());
+        } catch (RepositoryException e) {
             LOGGER.error("JWT validation failed: {}", e.getMessage());
         }
         return null;

--- a/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
+++ b/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
@@ -31,6 +31,7 @@ import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -72,6 +73,10 @@ public class CardsJwtTokenManagerImpl implements TokenManager
     /** JCR path to the node where we keep our signing/verification keys. */
     public static final String KEY_PATH = "/jcr:system/cards:jwt/JWTRSA256Key";
 
+    /** The ID of this CARDS instance, used to determine the `iss` field when minting tokens. */
+    public static final String SELF_ID =
+        StringUtils.defaultIfEmpty(System.getenv("CARDS_HOST_AND_PORT"), "localhost:8080");
+
     private static final Logger LOGGER = LoggerFactory.getLogger(CardsJwtTokenManagerImpl.class);
 
     private final SecretKey symmetricKey;
@@ -90,32 +95,32 @@ public class CardsJwtTokenManagerImpl implements TokenManager
     public CardsJwtTokenManagerImpl(@Reference ResourceResolverFactory rrf)
     {
         this.rrf = rrf;
-        this.selfAud = CardsJwtTokenImpl.SELF_ID.replaceAll("\\P{Alnum}", "");
+        this.selfAud = SELF_ID.replaceAll("\\P{Alnum}", "");
         PrivateKey result = null;
         PublicKey verification = null;
         SecretKey symmetric = null;
         try (ResourceResolver resolver = rrf.getServiceResourceResolver(null)) {
-            Resource res = resolver.resolve(CardsJwtTokenManagerImpl.KEY_PATH);
+            Resource res = resolver.resolve(KEY_PATH);
             Node keyNode = res.adaptTo(Node.class);
             if (keyNode == null) {
                 LOGGER.error("Failed to load JWT Signing key: node {} could not be read",
-                    CardsJwtTokenManagerImpl.KEY_PATH);
-                throw new ExceptionInInitializerError(CardsJwtTokenManagerImpl.KEY_PATH);
+                    KEY_PATH);
+                throw new ExceptionInInitializerError(KEY_PATH);
             }
 
-            if (keyNode.hasProperty(CardsJwtTokenManagerImpl.SIGNING_KEY_PROP)
-                && keyNode.hasProperty(CardsJwtTokenManagerImpl.VERIFY_PROP)) {
+            if (keyNode.hasProperty(SIGNING_KEY_PROP)
+                && keyNode.hasProperty(VERIFY_PROP)) {
                 // Private key is PKCS-encoded
                 result = KeyFactory.getInstance("RSA").generatePrivate(
-                    new PKCS8EncodedKeySpec(readKey(keyNode, CardsJwtTokenManagerImpl.SIGNING_KEY_PROP)));
+                    new PKCS8EncodedKeySpec(readKey(keyNode, SIGNING_KEY_PROP)));
                 // Public key is X.509-encoded
                 verification = KeyFactory.getInstance("RSA").generatePublic(
-                    new X509EncodedKeySpec(readKey(keyNode, CardsJwtTokenManagerImpl.VERIFY_PROP)));
+                    new X509EncodedKeySpec(readKey(keyNode, VERIFY_PROP)));
             } else {
                 KeyPair newPair = Jwts.SIG.RS256.keyPair().build();
-                keyNode.setProperty(CardsJwtTokenManagerImpl.SIGNING_KEY_PROP,
+                keyNode.setProperty(SIGNING_KEY_PROP,
                     Encoders.BASE64.encode(newPair.getPrivate().getEncoded()));
-                keyNode.setProperty(CardsJwtTokenManagerImpl.VERIFY_PROP,
+                keyNode.setProperty(VERIFY_PROP,
                     Encoders.BASE64.encode(newPair.getPublic().getEncoded()));
                 resolver.commit();
 
@@ -126,9 +131,9 @@ public class CardsJwtTokenManagerImpl implements TokenManager
             // For backwards compatibility: attempt to load (but not generate) a symmetric key, if it exists
             res = resolver.resolve("/jcr:system/cards:jwt/JWTSigningKey");
             keyNode = res == null ? null : res.adaptTo(Node.class);
-            if (keyNode != null && keyNode.hasProperty(CardsJwtTokenManagerImpl.SIGNING_KEY_PROP)) {
+            if (keyNode != null && keyNode.hasProperty(SIGNING_KEY_PROP)) {
                 symmetric = Keys.hmacShaKeyFor(Decoders.BASE64.decode(keyNode.getProperty(
-                    CardsJwtTokenManagerImpl.SIGNING_KEY_PROP).getString()));
+                    SIGNING_KEY_PROP).getString()));
             }
         } catch (LoginException e) {
             LOGGER.error("Service access not granted: {}", e.getMessage());
@@ -171,7 +176,6 @@ public class CardsJwtTokenManagerImpl implements TokenManager
      */
     public static String getFingerprint(final PublicKey publicKey)
     {
-        // Obtain a fingerprint from a key
         if (publicKey == null)
         {
             return null;
@@ -214,6 +218,15 @@ public class CardsJwtTokenManagerImpl implements TokenManager
         return new CardsJwtTokenImpl(jws, userId, expiration, extraData);
     }
 
+    /**
+     * Validate JWT claims against expected issuer/audience/key constraints.
+     *
+     * @param jwt the parsed JWT to validate
+     * @param locator verification locator containing expected key and audience information
+     * @return {@code true} if all required claims are valid, {@code false} otherwise
+     * @throws JwtException if the JWT claims are malformed or invalid
+     * @throws RepositoryException if verification requires repository access that fails
+     */
     private boolean areClaimsValid(Jwt<?, ?> jwt, CardsJwtVerificationLocatorImpl locator) throws JwtException,
         RepositoryException
     {
@@ -228,7 +241,7 @@ public class CardsJwtTokenManagerImpl implements TokenManager
             }
 
             String issuer = keyID.equals(this.selfID) ? this.selfAud : locator.lookupPeerDetails(keyID)
-                .getProperty(CardsJwtTokenManagerImpl.ISSUER_PROP).getString();
+                .getProperty(ISSUER_PROP).getString();
 
             // If we're signed using an asymmetric key, double-check that we're the intended audience for this JWT
             if (claims.getAudience() == null) {

--- a/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
+++ b/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
@@ -197,7 +197,6 @@ public class CardsJwtTokenManagerImpl implements TokenManager
             return null;
         }
         try {
-            PublicKey ourVerificationKey = this.verificationKey;
             Jwt<?, ?> jwt = Jwts.parser()
                 .keyLocator(new CardsJwtVerificationLocatorImpl(this.verificationKey, this.symmetricKey, this.rrf,
                     this.selfID))

--- a/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
+++ b/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
@@ -85,11 +85,15 @@ public class CardsJwtTokenManagerImpl implements TokenManager
 
     private final PublicKey verificationKey;
 
+    /** Our own audience, used in the Jwt `aud` field to verify that this token is meant for us. */
     private final String selfAud;
 
+    /** Our own fingerprint, used to identify tokens that are signed by us. */
     private final String selfID;
 
-    private ResourceResolverFactory rrf;
+    private final CardsJwtVerificationLocatorImpl locator;
+
+    private final ResourceResolverFactory rrf;
 
     @Activate
     public CardsJwtTokenManagerImpl(@Reference ResourceResolverFactory rrf)
@@ -144,6 +148,8 @@ public class CardsJwtTokenManagerImpl implements TokenManager
         this.verificationKey = verification;
         this.symmetricKey = symmetric;
         this.selfID = getFingerprint(verification);
+        this.locator = new CardsJwtVerificationLocatorImpl(this.verificationKey, this.symmetricKey, this.rrf,
+            this.selfID);
     }
 
     /**
@@ -201,8 +207,9 @@ public class CardsJwtTokenManagerImpl implements TokenManager
             return null;
         }
         AudienceCollection<JwtBuilder> audBuilder = Jwts.builder()
-                .issuer(this.selfAud)
-                .audience();
+            .claims(extraData)
+            .issuer(this.selfAud)
+            .audience();
 
         for (String aud : audiences) {
             audBuilder.add(aud);
@@ -211,7 +218,6 @@ public class CardsJwtTokenManagerImpl implements TokenManager
         String jws = audBuilder.and()
             .subject(userId)
             .expiration(expiration.getTime())
-            .claims(extraData)
             .header().keyId(this.selfID).and()
             .signWith(this.signingKey)
             .compact();
@@ -222,12 +228,11 @@ public class CardsJwtTokenManagerImpl implements TokenManager
      * Validate JWT claims against expected issuer/audience/key constraints.
      *
      * @param jwt the parsed JWT to validate
-     * @param locator verification locator containing expected key and audience information
      * @return {@code true} if all required claims are valid, {@code false} otherwise
      * @throws JwtException if the JWT claims are malformed or invalid
      * @throws RepositoryException if verification requires repository access that fails
      */
-    private boolean areClaimsValid(Jwt<?, ?> jwt, CardsJwtVerificationLocatorImpl locator) throws JwtException,
+    private boolean areClaimsValid(Jwt<?, ?> jwt) throws JwtException,
         RepositoryException
     {
         // Double check claims in the payload:
@@ -240,7 +245,7 @@ public class CardsJwtTokenManagerImpl implements TokenManager
                 return true;
             }
 
-            String issuer = keyID.equals(this.selfID) ? this.selfAud : locator.lookupPeerDetails(keyID)
+            String issuer = keyID.equals(this.selfID) ? this.selfAud : this.locator.lookupPeerDetails(keyID)
                 .getProperty(ISSUER_PROP).getString();
 
             // If we're signed using an asymmetric key, double-check that we're the intended audience for this JWT
@@ -249,8 +254,8 @@ public class CardsJwtTokenManagerImpl implements TokenManager
                 throw new JwtException("The given JWT is missing an `aud` claim.");
             } else if (!claims.getAudience().contains(this.selfAud)) {
                 throw new JwtException("Our server (" + this.selfAud
-                    + ")) is not in the list of JWT audiences for the given JWT.");
-            } else if (!claims.getIssuer().equals(issuer)) {
+                    + ") is not in the list of JWT audiences for the given JWT.");
+            } else if (!issuer.equals(claims.getIssuer())) {
                 throw new JwtException("The given JWT's issuer does not match the expected issuer.");
             }
             return true;
@@ -266,16 +271,13 @@ public class CardsJwtTokenManagerImpl implements TokenManager
             return null;
         }
         try {
-            CardsJwtVerificationLocatorImpl locator = new CardsJwtVerificationLocatorImpl(this.verificationKey,
-                this.symmetricKey, this.rrf, this.selfID);
-
             Jwt<?, ?> jwt = Jwts.parser()
-                .keyLocator(locator)
+                .keyLocator(this.locator)
                 .build()
                 .parseSignedClaims(loginToken);
 
             // Double check claims in the payload:
-            if (areClaimsValid(jwt, locator)) {
+            if (areClaimsValid(jwt)) {
                 return new CardsJwtTokenImpl(jwt, loginToken);
             }
         } catch (JwtException e) {

--- a/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
+++ b/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import javax.crypto.SecretKey;
 import javax.jcr.Node;
+import javax.jcr.RepositoryException;
 
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
@@ -99,16 +100,11 @@ public class CardsJwtTokenManagerImpl implements TokenManager
             if (keyNode.hasProperty(CardsJwtTokenManagerImpl.SIGNING_KEY_PROP)
                 && keyNode.hasProperty(CardsJwtTokenManagerImpl.VERIFY_PROP)) {
                 // Private key is PKCS-encoded
-                byte[] privBytes = Decoders.BASE64.decode(
-                    keyNode.getProperty(CardsJwtTokenManagerImpl.SIGNING_KEY_PROP).getString()
-                );
-                result = KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(privBytes));
-
+                result = KeyFactory.getInstance("RSA").generatePrivate(
+                    new PKCS8EncodedKeySpec(readKey(keyNode, CardsJwtTokenManagerImpl.SIGNING_KEY_PROP)));
                 // Public key is X.509-encoded
-                byte[] pubBytes = Decoders.BASE64.decode(keyNode.getProperty(
-                    CardsJwtTokenManagerImpl.VERIFY_PROP).getString()
-                );
-                verification = KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(pubBytes));
+                verification = KeyFactory.getInstance("RSA").generatePublic(
+                    new X509EncodedKeySpec(readKey(keyNode, CardsJwtTokenManagerImpl.VERIFY_PROP)));
             } else {
                 KeyPair newPair = Jwts.SIG.RS256.keyPair().build();
                 String secretString = Encoders.BASE64.encode(newPair.getPrivate().getEncoded());
@@ -136,6 +132,20 @@ public class CardsJwtTokenManagerImpl implements TokenManager
         this.signingKey = result;
         this.verificationKey = verification;
         this.symmetricKey = symmetric;
+    }
+
+    /**
+     * Read a BASE64-encoded key from the given property of the given node.
+     *
+     * @param keyNode The node to extract a key from
+     * @param propName The property containing the key
+     * @return A byte array from the BASE64-encoded key
+     */
+    private byte[] readKey(Node keyNode, String propName) throws RepositoryException
+    {
+        return Decoders.BASE64.decode(
+            keyNode.getProperty(propName).getString()
+        );
     }
 
     @Override

--- a/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
+++ b/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImpl.java
@@ -24,6 +24,7 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Calendar;
 import java.util.Map;
+import java.util.Set;
 
 import javax.jcr.Node;
 
@@ -37,9 +38,12 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwt;
+import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.ClaimsMutator.AudienceCollection;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.io.Encoders;
 import io.uhndata.cards.auth.token.TokenManager;
@@ -100,13 +104,41 @@ public class CardsJwtTokenManagerImpl implements TokenManager
     }
 
     @Override
-    public CardsJwtTokenImpl create(final String userId, final Calendar expiration, final Map<String, String> extraData)
+    public CardsJwtTokenImpl create(final String userId, final Calendar expiration,
+            final Map<String, String> extraData)
     {
         if (this.signingKey == null || this.verificationKey == null) {
             // Should not happen
             return null;
         }
         String jws = Jwts.builder()
+            .issuer(CardsJwtTokenImpl.SELF_ID)
+            .audience().add(CardsJwtTokenImpl.SELF_ID).and() // Assume, for now, we're making tokens for ourselves
+            .subject(userId)
+            .expiration(expiration.getTime())
+            .claims(extraData)
+            .signWith(this.signingKey)
+            .compact();
+        return new CardsJwtTokenImpl(jws, userId, expiration, extraData);
+    }
+
+    // Override of the above create that allows for multiple audiences to be set
+    public CardsJwtTokenImpl create(final String userId, final Calendar expiration, final Map<String, String> extraData,
+            Set<String> audiences)
+    {
+        if (this.signingKey == null || this.verificationKey == null) {
+            // Should not happen
+            return null;
+        }
+        AudienceCollection<JwtBuilder> audBuilder = Jwts.builder()
+                .issuer(CardsJwtTokenImpl.SELF_ID)
+                .audience();
+
+        for (String aud : audiences) {
+            audBuilder.add(aud);
+        }
+
+        String jws = audBuilder.and()
             .subject(userId)
             .expiration(expiration.getTime())
             .claims(extraData)
@@ -122,10 +154,26 @@ public class CardsJwtTokenManagerImpl implements TokenManager
             return null;
         }
         try {
+            // TODO: check with every verification key
             Jwt<?, ?> jwt = Jwts.parser().verifyWith(this.verificationKey).build().parseSignedClaims(loginToken);
-            return new CardsJwtTokenImpl(jwt, loginToken);
+            Object payload = jwt.getPayload();
+            if (payload instanceof Claims) {
+                Claims claims = (Claims) payload;
+                // Double-check that we're the intended audience for this JWT
+                if (claims.getAudience() == null) {
+                    // No audience found, but the token was from a verified source -- assume we're
+                    // OK
+                    return new CardsJwtTokenImpl(jwt, loginToken);
+                } else if (claims.getAudience().contains(CardsJwtTokenImpl.SELF_ID)) {
+                    // Audience found, and we're in it -- OK
+                    return new CardsJwtTokenImpl(jwt, loginToken);
+                } else {
+                    LOGGER.error("Our server ({}) is not in the list of JWT audiences for the given JWT.");
+                }
+            }
         } catch (JwtException e) {
             // Not a JWT token
+            LOGGER.error("A non-JWT token was passed to JWTTokenManager");
         }
         return null;
     }

--- a/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtVerificationLocatorImpl.java
+++ b/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtVerificationLocatorImpl.java
@@ -20,7 +20,9 @@ import java.security.Key;
 import java.security.KeyFactory;
 import java.security.PublicKey;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.regex.Pattern;
 
+import javax.crypto.SecretKey;
 import javax.jcr.Node;
 
 import org.apache.sling.api.resource.LoginException;
@@ -44,13 +46,17 @@ public class CardsJwtVerificationLocatorImpl implements Locator<Key>
 {
     private final PublicKey verificationKey;
 
+    private final SecretKey symmetricKey;
+
     private final ResourceResolverFactory rrf;
 
     private final String selfID;
 
-    public CardsJwtVerificationLocatorImpl(PublicKey verificationKey, ResourceResolverFactory resolver, String selfID)
+    public CardsJwtVerificationLocatorImpl(PublicKey verificationKey, SecretKey symmetricKey,
+        ResourceResolverFactory resolver, String selfID)
     {
         this.verificationKey = verificationKey;
+        this.symmetricKey = symmetricKey;
         this.rrf = resolver;
         this.selfID = selfID;
     }
@@ -60,9 +66,10 @@ public class CardsJwtVerificationLocatorImpl implements Locator<Key>
      */
     private PublicKey lookupPeerKey(final String keyID)
     {
+        Pattern pattern = Pattern.compile("\\P{Alnum}");
         try (ResourceResolver resolver = this.rrf.getServiceResourceResolver(null)) {
             // Ensure the keyID is sanitized, disallow usage and return nothing if not
-            if (keyID.indexOf("\\P{Alnum}") >= 0) {
+            if (pattern.matcher(keyID).find()) {
                 throw new JwtException(String.format("Unsafe peer key: {}", keyID));
             }
 
@@ -93,14 +100,30 @@ public class CardsJwtVerificationLocatorImpl implements Locator<Key>
         }
     }
 
+    /**
+     * Extracts the `kid` header from a given JWT Header.
+     *
+     * @param header The JWT Header
+     * @return the `kid` header, or {@code null} if the given header does not correspond to a JwsHeader/JweHeader
+     */
+    public static String getKey(Header header)
+    {
+        if (header instanceof JwsHeader) {
+            return ((JwsHeader) header).getKeyId();
+        } else if (header instanceof JweHeader) {
+            return ((JweHeader) header).getKeyId();
+        }
+        return null;
+    }
+
     @Override
     public Key locate(Header header)
     {
-        final String keyID = header instanceof JwsHeader ? ((JwsHeader) header).getKeyId()
-            : ((JweHeader) header).getKeyId();
+        final String keyID = getKey(header);
 
         if (keyID == null) {
-            return null;
+            // This might instead be a symmetric key -- use the symmetric key
+            return this.symmetricKey;
         }
 
         return keyID.equals(this.selfID) ? this.verificationKey : lookupPeerKey(keyID);

--- a/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtVerificationLocatorImpl.java
+++ b/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtVerificationLocatorImpl.java
@@ -94,6 +94,12 @@ public class CardsJwtVerificationLocatorImpl implements Locator<Key>
         }
     }
 
+    /**
+     * Extracts the public key from a given JCR Node representing a peer.
+     *
+     * @param keyNode The JCR node representing a peer's keys
+     * @return The peer's PublicKey
+     */
     private PublicKey getPublicKey(Node keyNode) throws JwtException
     {
         try {
@@ -121,7 +127,7 @@ public class CardsJwtVerificationLocatorImpl implements Locator<Key>
      * Extracts the `kid` header from a given JWT Header.
      *
      * @param header The JWT Header
-     * @return the `kid` header, or {@code null} if the given header does not correspond to a JwsHeader/JweHeader
+     * @return The `kid` header, or {@code null} if the given header does not correspond to a JwsHeader/JweHeader
      */
     public static String getKey(Header header)
     {

--- a/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtVerificationLocatorImpl.java
+++ b/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtVerificationLocatorImpl.java
@@ -16,6 +16,7 @@
  */
 package io.uhndata.cards.auth.token.jwt.impl;
 
+import java.security.GeneralSecurityException;
 import java.security.Key;
 import java.security.KeyFactory;
 import java.security.PublicKey;
@@ -24,6 +25,7 @@ import java.util.regex.Pattern;
 
 import javax.crypto.SecretKey;
 import javax.jcr.Node;
+import javax.jcr.RepositoryException;
 
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
@@ -62,9 +64,12 @@ public class CardsJwtVerificationLocatorImpl implements Locator<Key>
     }
 
     /**
-     * In an instance where the JWT does not belong to us, look up the peer key in `/jcr:system/cards:jwt/`.
+     * In an instance where the JWT does not belong to us, look up info about them in `/jcr:system/cards:jwt/`.
+     *
+     * @param keyID The ID under which to find the key
+     * @return A node corresponding to the peer's details, or null if we do not have it
      */
-    private PublicKey lookupPeerKey(final String keyID)
+    public Node lookupPeerDetails(final String keyID)
     {
         Pattern pattern = Pattern.compile("\\P{Alnum}");
         try (ResourceResolver resolver = this.rrf.getServiceResourceResolver(null)) {
@@ -76,27 +81,39 @@ public class CardsJwtVerificationLocatorImpl implements Locator<Key>
             // Grab the appropriate key node, if it exists
             String resourcePath = "/jcr:system/cards:jwt/" + keyID;
             Resource res = resolver.resolve(resourcePath);
-            Node keyNode = res.adaptTo(Node.class);
+            Node keyNode = res == null ? null : res.adaptTo(Node.class);
             if (keyNode == null) {
                 throw new JwtException(
                     String.format("Failed to load JWT Verification key for peer %s: node %s could not be read",
                         keyID, resourcePath)
                 );
             }
+            return keyNode;
+        } catch (LoginException e) {
+            throw new JwtException(String.format("Service access not granted: %s", e.getMessage()));
+        }
+    }
+
+    private PublicKey getPublicKey(Node keyNode) throws JwtException
+    {
+        try {
             if (!keyNode.hasProperty(CardsJwtTokenManagerImpl.VERIFY_PROP)) {
                 throw new JwtException(
-                    String.format("Failed to load JWT Verification key for peer %s: node %s could not be read",
-                        keyID, resourcePath)
+                    String.format("Failed to load JWT Verification key: node %s missing %s property",
+                        keyNode.getIdentifier(), CardsJwtTokenManagerImpl.VERIFY_PROP)
                 );
             }
+
             byte[] pubBytes = Decoders.BASE64.decode(
                 keyNode.getProperty(CardsJwtTokenManagerImpl.VERIFY_PROP).getString()
             );
             return KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(pubBytes));
-        } catch (LoginException e) {
-            throw new JwtException(String.format("Service access not granted: %s", e.getMessage()));
-        } catch (Exception e) {
-            throw new JwtException(String.format("Failed to load JWT validation key from node: %s", e.getMessage()));
+        } catch (GeneralSecurityException e) {
+            // Should not happen, this is to catch java.security.NoSuchAlgorithmException
+            // or java.security.spec.InvalidKeySpecException, but KeyFactory should be able to load RSA
+            throw new JwtException(String.format("Failed to load decryption algorithm: %s", e.getMessage()));
+        } catch (RepositoryException e) {
+            throw new JwtException(String.format("Failed to load JWT Verification key: %s", e.getMessage()));
         }
     }
 
@@ -126,6 +143,6 @@ public class CardsJwtVerificationLocatorImpl implements Locator<Key>
             return this.symmetricKey;
         }
 
-        return keyID.equals(this.selfID) ? this.verificationKey : lookupPeerKey(keyID);
+        return keyID.equals(this.selfID) ? this.verificationKey : getPublicKey(lookupPeerDetails(keyID));
     }
 }

--- a/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtVerificationLocatorImpl.java
+++ b/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtVerificationLocatorImpl.java
@@ -70,7 +70,7 @@ public class CardsJwtVerificationLocatorImpl implements Locator<Key>
         try (ResourceResolver resolver = this.rrf.getServiceResourceResolver(null)) {
             // Ensure the keyID is sanitized, disallow usage and return nothing if not
             if (pattern.matcher(keyID).find()) {
-                throw new JwtException(String.format("Unsafe peer key: {}", keyID));
+                throw new JwtException(String.format("Unsafe peer key: %s", keyID));
             }
 
             // Grab the appropriate key node, if it exists
@@ -94,9 +94,9 @@ public class CardsJwtVerificationLocatorImpl implements Locator<Key>
             );
             return KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(pubBytes));
         } catch (LoginException e) {
-            throw new JwtException(String.format("Service access not granted: {}", e.getMessage()));
+            throw new JwtException(String.format("Service access not granted: %s", e.getMessage()));
         } catch (Exception e) {
-            throw new JwtException(String.format("Failed to load JWT validation key from node: {}", e.getMessage()));
+            throw new JwtException(String.format("Failed to load JWT validation key from node: %s", e.getMessage()));
         }
     }
 

--- a/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtVerificationLocatorImpl.java
+++ b/modules/authentication/token/jwt-token-authentication/src/main/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtVerificationLocatorImpl.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.auth.token.jwt.impl;
+
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.X509EncodedKeySpec;
+
+import javax.jcr.Node;
+
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.JweHeader;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Locator;
+import io.jsonwebtoken.io.Decoders;
+
+/**
+ * Implementation of a {@link Locator} for JWT validation key lookup.
+ *
+ * @version $Id$
+ */
+public class CardsJwtVerificationLocatorImpl implements Locator<Key>
+{
+    private final PublicKey verificationKey;
+
+    private final ResourceResolverFactory rrf;
+
+    private final String selfID;
+
+    public CardsJwtVerificationLocatorImpl(PublicKey verificationKey, ResourceResolverFactory resolver, String selfID)
+    {
+        this.verificationKey = verificationKey;
+        this.rrf = resolver;
+        this.selfID = selfID;
+    }
+
+    /**
+     * In an instance where the JWT does not belong to us, look up the peer key in `/jcr:system/cards:jwt/`.
+     */
+    private PublicKey lookupPeerKey(final String keyID)
+    {
+        try (ResourceResolver resolver = this.rrf.getServiceResourceResolver(null)) {
+            // Ensure the keyID is sanitized, disallow usage and return nothing if not
+            if (keyID.indexOf("\\P{Alnum}") >= 0) {
+                throw new JwtException(String.format("Unsafe peer key: {}", keyID));
+            }
+
+            // Grab the appropriate key node, if it exists
+            String resourcePath = "/jcr:system/cards:jwt/" + keyID;
+            Resource res = resolver.resolve(resourcePath);
+            Node keyNode = res.adaptTo(Node.class);
+            if (keyNode == null) {
+                throw new JwtException(
+                    String.format("Failed to load JWT Verification key for peer %s: node %s could not be read",
+                        keyID, resourcePath)
+                );
+            }
+            if (!keyNode.hasProperty(CardsJwtTokenManagerImpl.VERIFY_PROP)) {
+                throw new JwtException(
+                    String.format("Failed to load JWT Verification key for peer %s: node %s could not be read",
+                        keyID, resourcePath)
+                );
+            }
+            byte[] pubBytes = Decoders.BASE64.decode(
+                keyNode.getProperty(CardsJwtTokenManagerImpl.VERIFY_PROP).getString()
+            );
+            return KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(pubBytes));
+        } catch (LoginException e) {
+            throw new JwtException(String.format("Service access not granted: {}", e.getMessage()));
+        } catch (Exception e) {
+            throw new JwtException(String.format("Failed to load JWT validation key from node: {}", e.getMessage()));
+        }
+    }
+
+    @Override
+    public Key locate(Header header)
+    {
+        final String keyID = header instanceof JwsHeader ? ((JwsHeader) header).getKeyId()
+            : ((JweHeader) header).getKeyId();
+
+        if (keyID == null) {
+            return null;
+        }
+
+        return keyID.equals(this.selfID) ? this.verificationKey : lookupPeerKey(keyID);
+    }
+}

--- a/modules/authentication/token/jwt-token-authentication/src/test/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImplTest.java
+++ b/modules/authentication/token/jwt-token-authentication/src/test/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImplTest.java
@@ -47,19 +47,15 @@ import static org.mockito.Mockito.when;
  * {@code TokenManager}.
  *
  * <p>
- * These pin the current behaviour of self-issued, symmetric (HMAC) tokens so
- * that future changes to
- * {@code parse()} -- such as adding support for tokens issued by trusted
- * external providers -- can be made without
- * regressing the existing patient-portal flow, where a token minted by
- * {@code create()} must round-trip back through
+ * These check the behaviour of self-issued, asymmetric RS256 tokens,
+ * where a token minted by {@code create()} must round-trip back through
  * {@code parse()} and yield the same user and session subject.
  * </p>
  *
  * <p>
- * On activation the manager reads its HMAC signing key from
- * {@code /jcr:system/cards:jwt/JWTSigningKey}; here that
- * lookup is mocked to return a freshly generated, valid HS512 key, so no
+ * On activation the manager reads its RSA256 signing key from
+ * {@code /jcr:system/cards:jwt/JWTRSA256Key}; here that
+ * lookup is mocked to return a freshly generated, valid RSA256 key, so no
  * repository is needed.
  * </p>
  */
@@ -191,12 +187,23 @@ public class CardsJwtTokenManagerImplTest
     }
 
     @Test
-    public void parseRejectsTokenSignedWithForeignKey()
+    public void parseRejectsTokenSignedWithUnknownKey()
     {
-        // A well-formed token signed with some other key must be rejected: verification
-        // uses this instance's own
-        // secret. This is exactly the boundary that cross-provider support would later
-        // have to open up deliberately.
+        // A well-formed token signed with some an asymmetric key NOT in our list of accepted providers must be
+        // rejected
+        final String foreign = Jwts.builder()
+                .subject("attacker")
+                .expiration(new Date(System.currentTimeMillis() + 3_600_000L))
+                .header().keyId("attacker").and()
+                .signWith(Jwts.SIG.RS256.keyPair().build().getPrivate())
+                .compact();
+        Assert.assertNull("A token signed with a different key must not parse", this.manager.parse(foreign));
+    }
+
+    @Test
+    public void parseRejectsTokenSignedWithUnknownSymmetricKey()
+    {
+        // A well-formed token signed with some other symmetric key must be rejected
         final String foreign = Jwts.builder()
                 .subject("attacker")
                 .expiration(new Date(System.currentTimeMillis() + 3_600_000L))

--- a/modules/authentication/token/jwt-token-authentication/src/test/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImplTest.java
+++ b/modules/authentication/token/jwt-token-authentication/src/test/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImplTest.java
@@ -16,11 +16,11 @@
  */
 package io.uhndata.cards.auth.token.jwt.impl;
 
+import java.security.KeyPair;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;
 
-import javax.crypto.SecretKey;
 import javax.jcr.Node;
 import javax.jcr.Property;
 
@@ -74,19 +74,25 @@ public class CardsJwtTokenManagerImplTest
     @Mock
     private Property keyProperty;
 
+    @Mock
+    private Property verifyProperty;
+
     private CardsJwtTokenManagerImpl manager;
 
     @Before
     public void setUp() throws Exception
     {
-        // Generate a real, valid HS512 secret and expose it exactly as the component reads it from the repository.
-        final SecretKey key = Jwts.SIG.HS512.key().build();
+        // Generate a RS256 keypair and expose it exactly as the component reads it from the repository.
+        final KeyPair keypair = Jwts.SIG.RS256.keyPair().build();
         when(this.resolverFactory.getServiceResourceResolver(any())).thenReturn(this.resolver);
         when(this.resolver.resolve(KEY_PATH)).thenReturn(this.keyResource);
         when(this.keyResource.adaptTo(Node.class)).thenReturn(this.keyNode);
         when(this.keyNode.hasProperty("key")).thenReturn(true);
         when(this.keyNode.getProperty("key")).thenReturn(this.keyProperty);
-        when(this.keyProperty.getString()).thenReturn(Encoders.BASE64.encode(key.getEncoded()));
+        when(this.keyNode.hasProperty("verify")).thenReturn(true);
+        when(this.keyNode.getProperty("verify")).thenReturn(this.verifyProperty);
+        when(this.keyProperty.getString()).thenReturn(Encoders.BASE64.encode(keypair.getPrivate().getEncoded()));
+        when(this.verifyProperty.getString()).thenReturn(Encoders.BASE64.encode(keypair.getPublic().getEncoded()));
 
         // Activate the component via its @Activate constructor.
         this.manager = new CardsJwtTokenManagerImpl(this.resolverFactory);
@@ -140,7 +146,7 @@ public class CardsJwtTokenManagerImplTest
         final String foreign = Jwts.builder()
             .subject("attacker")
             .expiration(new Date(System.currentTimeMillis() + 3_600_000L))
-            .signWith(Jwts.SIG.HS512.key().build())
+            .signWith(Jwts.SIG.RS256.keyPair().build().getPrivate())
             .compact();
         Assert.assertNull("A token signed with a different key must not parse", this.manager.parse(foreign));
     }

--- a/modules/authentication/token/jwt-token-authentication/src/test/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImplTest.java
+++ b/modules/authentication/token/jwt-token-authentication/src/test/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImplTest.java
@@ -73,9 +73,11 @@ public class CardsJwtTokenManagerImplTest
 
     private static final String KEY_PATH = "/jcr:system/cards:jwt/JWTRSA256Key";
 
+    private static final String SELF_ID = "localhost8080";
+
     private static final String PEER_ID = "localhost8081";
 
-    private static final String PEER_KEY_PATH = "/jcr:system/cards:jwt/" + PEER_ID;
+    private static final String PEER_KEY_PATH_PREFIX = "/jcr:system/cards:jwt/";
 
     @Mock
     private ResourceResolverFactory resolverFactory;
@@ -96,6 +98,9 @@ public class CardsJwtTokenManagerImplTest
     private Property verifyProperty;
 
     @Mock
+    private Property issuerProperty;
+
+    @Mock
     private Resource peerResource;
 
     @Mock
@@ -104,9 +109,14 @@ public class CardsJwtTokenManagerImplTest
     @Mock
     private Property peerVerifyProperty;
 
+    @Mock
+    private Property peerIssuerProperty;
+
     private CardsJwtTokenManagerImpl manager;
 
     private KeyPair peerPair;
+
+    private String peerFingerprint;
 
     @Before
     public void setUp() throws Exception
@@ -125,12 +135,15 @@ public class CardsJwtTokenManagerImplTest
         when(this.verifyProperty.getString()).thenReturn(Encoders.BASE64.encode(keyPair.getPublic().getEncoded()));
 
         this.peerPair = Jwts.SIG.RS256.keyPair().build();
-        when(this.resolver.resolve(PEER_KEY_PATH)).thenReturn(this.peerResource);
+        this.peerFingerprint = CardsJwtTokenManagerImpl.getFingerprint(this.peerPair.getPublic());
+        when(this.resolver.resolve(PEER_KEY_PATH_PREFIX + this.peerFingerprint)).thenReturn(this.peerResource);
         when(this.peerResource.adaptTo(Node.class)).thenReturn(this.peerNode);
         when(this.peerNode.hasProperty("verify")).thenReturn(true);
         when(this.peerNode.getProperty("verify")).thenReturn(this.peerVerifyProperty);
+        when(this.peerNode.getProperty("iss")).thenReturn(this.peerIssuerProperty);
         when(this.peerVerifyProperty.getString()).thenReturn(
             Encoders.BASE64.encode(this.peerPair.getPublic().getEncoded()));
+        when(this.peerIssuerProperty.getString()).thenReturn(PEER_ID);
 
         // Activate the component via its @Activate constructor.
         this.manager = new CardsJwtTokenManagerImpl(this.resolverFactory);
@@ -220,7 +233,7 @@ public class CardsJwtTokenManagerImplTest
             .issuer("localhost8081")
             .audience().add(selfID).and()
             .expiration(oneHourFromNow().getTime())
-            .header().keyId("localhost8081").and()
+            .header().keyId(this.peerFingerprint).and()
             .signWith(this.peerPair.getPrivate())
             .compact();
         Assert.assertNotNull("A foreign, trusted issued token must parse back", this.manager.parse(foreign));

--- a/modules/authentication/token/jwt-token-authentication/src/test/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImplTest.java
+++ b/modules/authentication/token/jwt-token-authentication/src/test/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImplTest.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.uhndata.cards.auth.token.jwt.impl;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Map;
+
+import javax.crypto.SecretKey;
+import javax.jcr.Node;
+import javax.jcr.Property;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Encoders;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link CardsJwtTokenManagerImpl}, the JWT-backed {@code TokenManager}.
+ *
+ * <p>These pin the current behaviour of self-issued, symmetric (HMAC) tokens so that future changes to
+ * {@code parse()} -- such as adding support for tokens issued by trusted external providers -- can be made without
+ * regressing the existing patient-portal flow, where a token minted by {@code create()} must round-trip back through
+ * {@code parse()} and yield the same user and session subject.</p>
+ *
+ * <p>On activation the manager reads its HMAC signing key from {@code /jcr:system/cards:jwt/JWTSigningKey}; here that
+ * lookup is mocked to return a freshly generated, valid HS512 key, so no repository is needed.</p>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CardsJwtTokenManagerImplTest
+{
+    /** The public claim used by the patient portal to carry the visit/subject path. */
+    private static final String SESSION_SUBJECT = "cards:sessionSubject";
+
+    private static final String KEY_PATH = "/jcr:system/cards:jwt/JWTSigningKey";
+
+    @Mock
+    private ResourceResolverFactory resolverFactory;
+
+    @Mock
+    private ResourceResolver resolver;
+
+    @Mock
+    private Resource keyResource;
+
+    @Mock
+    private Node keyNode;
+
+    @Mock
+    private Property keyProperty;
+
+    private CardsJwtTokenManagerImpl manager;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        // Generate a real, valid HS512 secret and expose it exactly as the component reads it from the repository.
+        final SecretKey key = Jwts.SIG.HS512.key().build();
+        when(this.resolverFactory.getServiceResourceResolver(any())).thenReturn(this.resolver);
+        when(this.resolver.resolve(KEY_PATH)).thenReturn(this.keyResource);
+        when(this.keyResource.adaptTo(Node.class)).thenReturn(this.keyNode);
+        when(this.keyNode.hasProperty("key")).thenReturn(true);
+        when(this.keyNode.getProperty("key")).thenReturn(this.keyProperty);
+        when(this.keyProperty.getString()).thenReturn(Encoders.BASE64.encode(key.getEncoded()));
+
+        // Activate the component via its @Activate constructor.
+        this.manager = new CardsJwtTokenManagerImpl(this.resolverFactory);
+    }
+
+    @Test
+    public void createThenParseRoundTripsUserIdAndSubject()
+    {
+        final CardsJwtTokenImpl created =
+            this.manager.create("guest-patient", oneHourFromNow(), Map.of(SESSION_SUBJECT, "/Subjects/v1"));
+        final String token = created.getToken();
+
+        // A JWT is three base64url segments separated by dots (the same check the auth handler applies).
+        Assert.assertTrue("Issued token is not a well-formed JWT",
+            token.matches("^[\\w-_]+\\.[\\w-_]+\\.[\\w-_]+$"));
+
+        final CardsJwtTokenImpl parsed = this.manager.parse(token);
+        Assert.assertNotNull("A freshly issued token must parse back", parsed);
+        Assert.assertEquals("guest-patient", parsed.getUserId());
+        Assert.assertEquals("/Subjects/v1", parsed.getPublicAttributes().get(SESSION_SUBJECT));
+    }
+
+    @Test
+    public void parseRejectsNull()
+    {
+        Assert.assertNull(this.manager.parse(null));
+    }
+
+    @Test
+    public void parseRejectsMalformedToken()
+    {
+        Assert.assertNull(this.manager.parse("garbage"));
+        Assert.assertNull(this.manager.parse("this.is.not-a-real-jwt"));
+    }
+
+    @Test
+    public void parseRejectsExpiredToken()
+    {
+        final Calendar past = Calendar.getInstance();
+        past.add(Calendar.HOUR_OF_DAY, -1);
+        final String expired =
+            this.manager.create("guest-patient", past, Map.of(SESSION_SUBJECT, "/Subjects/v1")).getToken();
+        Assert.assertNull("An expired token must not parse", this.manager.parse(expired));
+    }
+
+    @Test
+    public void parseRejectsTokenSignedWithForeignKey()
+    {
+        // A well-formed token signed with some other key must be rejected: verification uses this instance's own
+        // secret. This is exactly the boundary that cross-provider support would later have to open up deliberately.
+        final String foreign = Jwts.builder()
+            .subject("attacker")
+            .expiration(new Date(System.currentTimeMillis() + 3_600_000L))
+            .signWith(Jwts.SIG.HS512.key().build())
+            .compact();
+        Assert.assertNull("A token signed with a different key must not parse", this.manager.parse(foreign));
+    }
+
+    private static Calendar oneHourFromNow()
+    {
+        final Calendar c = Calendar.getInstance();
+        c.add(Calendar.HOUR_OF_DAY, 1);
+        return c;
+    }
+}

--- a/modules/authentication/token/jwt-token-authentication/src/test/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImplTest.java
+++ b/modules/authentication/token/jwt-token-authentication/src/test/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImplTest.java
@@ -227,7 +227,7 @@ public class CardsJwtTokenManagerImplTest
     public void createForeignKeyThenAccept()
     {
         // Test using a second set of keys that we've accepted
-        String selfID = CardsJwtTokenImpl.SELF_ID.replaceAll("\\P{Alnum}", "");
+        String selfID = CardsJwtTokenManagerImpl.SELF_ID.replaceAll("\\P{Alnum}", "");
 
         final String foreign = Jwts.builder()
             .issuer("localhost8081")

--- a/modules/authentication/token/jwt-token-authentication/src/test/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImplTest.java
+++ b/modules/authentication/token/jwt-token-authentication/src/test/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImplTest.java
@@ -71,7 +71,7 @@ public class CardsJwtTokenManagerImplTest
      */
     private static final String SESSION_SUBJECT = "cards:sessionSubject";
 
-    private static final String KEY_PATH = "/jcr:system/cards:jwt/JWTSigningKey";
+    private static final String KEY_PATH = "/jcr:system/cards:jwt/JWTRSA256Key";
 
     private static final String PEER_ID = "localhost8081";
 
@@ -213,7 +213,7 @@ public class CardsJwtTokenManagerImplTest
     @Test
     public void createForeignKeyThenAccept()
     {
-        // Test using a second set of keys
+        // Test using a second set of keys that we've accepted
         String selfID = CardsJwtTokenImpl.SELF_ID.replaceAll("\\P{Alnum}", "");
 
         final String foreign = Jwts.builder()

--- a/modules/authentication/token/jwt-token-authentication/src/test/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImplTest.java
+++ b/modules/authentication/token/jwt-token-authentication/src/test/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImplTest.java
@@ -21,6 +21,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import javax.jcr.Node;
 import javax.jcr.Property;
@@ -72,6 +73,10 @@ public class CardsJwtTokenManagerImplTest
 
     private static final String KEY_PATH = "/jcr:system/cards:jwt/JWTSigningKey";
 
+    private static final String PEER_ID = "localhost8081";
+
+    private static final String PEER_KEY_PATH = "/jcr:system/cards:jwt/" + PEER_ID;
+
     @Mock
     private ResourceResolverFactory resolverFactory;
 
@@ -90,14 +95,25 @@ public class CardsJwtTokenManagerImplTest
     @Mock
     private Property verifyProperty;
 
+    @Mock
+    private Resource peerResource;
+
+    @Mock
+    private Node peerNode;
+
+    @Mock
+    private Property peerVerifyProperty;
+
     private CardsJwtTokenManagerImpl manager;
+
+    private KeyPair peerPair;
 
     @Before
     public void setUp() throws Exception
     {
         // Generate a RS256 keypair and expose it exactly as the component reads it from
         // the repository.
-        final KeyPair keypair = Jwts.SIG.RS256.keyPair().build();
+        final KeyPair keyPair = Jwts.SIG.RS256.keyPair().build();
         when(this.resolverFactory.getServiceResourceResolver(any())).thenReturn(this.resolver);
         when(this.resolver.resolve(KEY_PATH)).thenReturn(this.keyResource);
         when(this.keyResource.adaptTo(Node.class)).thenReturn(this.keyNode);
@@ -105,8 +121,16 @@ public class CardsJwtTokenManagerImplTest
         when(this.keyNode.getProperty("key")).thenReturn(this.keyProperty);
         when(this.keyNode.hasProperty("verify")).thenReturn(true);
         when(this.keyNode.getProperty("verify")).thenReturn(this.verifyProperty);
-        when(this.keyProperty.getString()).thenReturn(Encoders.BASE64.encode(keypair.getPrivate().getEncoded()));
-        when(this.verifyProperty.getString()).thenReturn(Encoders.BASE64.encode(keypair.getPublic().getEncoded()));
+        when(this.keyProperty.getString()).thenReturn(Encoders.BASE64.encode(keyPair.getPrivate().getEncoded()));
+        when(this.verifyProperty.getString()).thenReturn(Encoders.BASE64.encode(keyPair.getPublic().getEncoded()));
+
+        this.peerPair = Jwts.SIG.RS256.keyPair().build();
+        when(this.resolver.resolve(PEER_KEY_PATH)).thenReturn(this.peerResource);
+        when(this.peerResource.adaptTo(Node.class)).thenReturn(this.peerNode);
+        when(this.peerNode.hasProperty("verify")).thenReturn(true);
+        when(this.peerNode.getProperty("verify")).thenReturn(this.peerVerifyProperty);
+        when(this.peerVerifyProperty.getString()).thenReturn(
+            Encoders.BASE64.encode(this.peerPair.getPublic().getEncoded()));
 
         // Activate the component via its @Activate constructor.
         this.manager = new CardsJwtTokenManagerImpl(this.resolverFactory);
@@ -172,7 +196,7 @@ public class CardsJwtTokenManagerImplTest
     public void createThenParseRejectsInvalidAudience()
     {
         // Create a real token, but exclude ourselves from the audience, and then make sure we fail to parse
-        HashSet<String> fakeAudience = new HashSet<String>();
+        Set<String> fakeAudience = new HashSet<String>();
         fakeAudience.add("not_you");
         final CardsJwtTokenImpl created = this.manager.create("guest-patient", oneHourFromNow(),
                 Map.of(SESSION_SUBJECT, "/Subjects/v1"), fakeAudience);
@@ -184,6 +208,22 @@ public class CardsJwtTokenManagerImplTest
                 token.matches("^[\\w-_]+\\.[\\w-_]+\\.[\\w-_]+$"));
         Assert.assertNull("A token signed with an audience that does not include us must not parse",
                 this.manager.parse(token));
+    }
+
+    @Test
+    public void createForeignKeyThenAccept()
+    {
+        // Test using a second set of keys
+        String selfID = CardsJwtTokenImpl.SELF_ID.replaceAll("\\P{Alnum}", "");
+
+        final String foreign = Jwts.builder()
+            .issuer("localhost8081")
+            .audience().add(selfID).and()
+            .expiration(oneHourFromNow().getTime())
+            .header().keyId("localhost8081").and()
+            .signWith(this.peerPair.getPrivate())
+            .compact();
+        Assert.assertNotNull("A foreign, trusted issued token must parse back", this.manager.parse(foreign));
     }
 
     private static Calendar oneHourFromNow()

--- a/modules/authentication/token/jwt-token-authentication/src/test/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImplTest.java
+++ b/modules/authentication/token/jwt-token-authentication/src/test/java/io/uhndata/cards/auth/token/jwt/impl/CardsJwtTokenManagerImplTest.java
@@ -19,6 +19,7 @@ package io.uhndata.cards.auth.token.jwt.impl;
 import java.security.KeyPair;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Map;
 
 import javax.jcr.Node;
@@ -41,20 +42,32 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 /**
- * Tests for {@link CardsJwtTokenManagerImpl}, the JWT-backed {@code TokenManager}.
+ * Tests for {@link CardsJwtTokenManagerImpl}, the JWT-backed
+ * {@code TokenManager}.
  *
- * <p>These pin the current behaviour of self-issued, symmetric (HMAC) tokens so that future changes to
- * {@code parse()} -- such as adding support for tokens issued by trusted external providers -- can be made without
- * regressing the existing patient-portal flow, where a token minted by {@code create()} must round-trip back through
- * {@code parse()} and yield the same user and session subject.</p>
+ * <p>
+ * These pin the current behaviour of self-issued, symmetric (HMAC) tokens so
+ * that future changes to
+ * {@code parse()} -- such as adding support for tokens issued by trusted
+ * external providers -- can be made without
+ * regressing the existing patient-portal flow, where a token minted by
+ * {@code create()} must round-trip back through
+ * {@code parse()} and yield the same user and session subject.
+ * </p>
  *
- * <p>On activation the manager reads its HMAC signing key from {@code /jcr:system/cards:jwt/JWTSigningKey}; here that
- * lookup is mocked to return a freshly generated, valid HS512 key, so no repository is needed.</p>
+ * <p>
+ * On activation the manager reads its HMAC signing key from
+ * {@code /jcr:system/cards:jwt/JWTSigningKey}; here that
+ * lookup is mocked to return a freshly generated, valid HS512 key, so no
+ * repository is needed.
+ * </p>
  */
 @RunWith(MockitoJUnitRunner.class)
 public class CardsJwtTokenManagerImplTest
 {
-    /** The public claim used by the patient portal to carry the visit/subject path. */
+    /**
+     * The public claim used by the patient portal to carry the visit/subject path.
+     */
     private static final String SESSION_SUBJECT = "cards:sessionSubject";
 
     private static final String KEY_PATH = "/jcr:system/cards:jwt/JWTSigningKey";
@@ -82,7 +95,8 @@ public class CardsJwtTokenManagerImplTest
     @Before
     public void setUp() throws Exception
     {
-        // Generate a RS256 keypair and expose it exactly as the component reads it from the repository.
+        // Generate a RS256 keypair and expose it exactly as the component reads it from
+        // the repository.
         final KeyPair keypair = Jwts.SIG.RS256.keyPair().build();
         when(this.resolverFactory.getServiceResourceResolver(any())).thenReturn(this.resolver);
         when(this.resolver.resolve(KEY_PATH)).thenReturn(this.keyResource);
@@ -101,13 +115,14 @@ public class CardsJwtTokenManagerImplTest
     @Test
     public void createThenParseRoundTripsUserIdAndSubject()
     {
-        final CardsJwtTokenImpl created =
-            this.manager.create("guest-patient", oneHourFromNow(), Map.of(SESSION_SUBJECT, "/Subjects/v1"));
+        final CardsJwtTokenImpl created = this.manager.create("guest-patient", oneHourFromNow(),
+                Map.of(SESSION_SUBJECT, "/Subjects/v1"));
         final String token = created.getToken();
 
-        // A JWT is three base64url segments separated by dots (the same check the auth handler applies).
+        // A JWT is three base64url segments separated by dots (the same check the auth
+        // handler applies).
         Assert.assertTrue("Issued token is not a well-formed JWT",
-            token.matches("^[\\w-_]+\\.[\\w-_]+\\.[\\w-_]+$"));
+                token.matches("^[\\w-_]+\\.[\\w-_]+\\.[\\w-_]+$"));
 
         final CardsJwtTokenImpl parsed = this.manager.parse(token);
         Assert.assertNotNull("A freshly issued token must parse back", parsed);
@@ -133,22 +148,42 @@ public class CardsJwtTokenManagerImplTest
     {
         final Calendar past = Calendar.getInstance();
         past.add(Calendar.HOUR_OF_DAY, -1);
-        final String expired =
-            this.manager.create("guest-patient", past, Map.of(SESSION_SUBJECT, "/Subjects/v1")).getToken();
+        final String expired = this.manager.create("guest-patient", past, Map.of(SESSION_SUBJECT, "/Subjects/v1"))
+                .getToken();
         Assert.assertNull("An expired token must not parse", this.manager.parse(expired));
     }
 
     @Test
     public void parseRejectsTokenSignedWithForeignKey()
     {
-        // A well-formed token signed with some other key must be rejected: verification uses this instance's own
-        // secret. This is exactly the boundary that cross-provider support would later have to open up deliberately.
+        // A well-formed token signed with some other key must be rejected: verification
+        // uses this instance's own
+        // secret. This is exactly the boundary that cross-provider support would later
+        // have to open up deliberately.
         final String foreign = Jwts.builder()
-            .subject("attacker")
-            .expiration(new Date(System.currentTimeMillis() + 3_600_000L))
-            .signWith(Jwts.SIG.RS256.keyPair().build().getPrivate())
-            .compact();
+                .subject("attacker")
+                .expiration(new Date(System.currentTimeMillis() + 3_600_000L))
+                .signWith(Jwts.SIG.RS256.keyPair().build().getPrivate())
+                .compact();
         Assert.assertNull("A token signed with a different key must not parse", this.manager.parse(foreign));
+    }
+
+    @Test
+    public void createThenParseRejectsInvalidAudience()
+    {
+        // Create a real token, but exclude ourselves from the audience, and then make sure we fail to parse
+        HashSet<String> fakeAudience = new HashSet<String>();
+        fakeAudience.add("not_you");
+        final CardsJwtTokenImpl created = this.manager.create("guest-patient", oneHourFromNow(),
+                Map.of(SESSION_SUBJECT, "/Subjects/v1"), fakeAudience);
+        final String token = created.getToken();
+
+        // A JWT is three base64url segments separated by dots (the same check the auth
+        // handler applies).
+        Assert.assertTrue("Issued token is not a well-formed JWT",
+                token.matches("^[\\w-_]+\\.[\\w-_]+\\.[\\w-_]+$"));
+        Assert.assertNull("A token signed with an audience that does not include us must not parse",
+                this.manager.parse(token));
     }
 
     private static Calendar oneHourFromNow()


### PR DESCRIPTION
# Description
For the hub-and-spoke principle that we're hoping to use, it'll be convenient for us to pass JWT tokens between CARDS instances (for example, to pass updates on a form from one instance to another). This PR introduces a few things that allow this:
1. **Switching from symmetric to asymmetric encryption**, so that we can pass the ability for CARDS instances to verify one another without needing them to be able to create new tokens for each other. The current CARDS implementation uses symmetric encryption, where the same key is used for encryption & decryption, which opens up a vulnerability where if you can decode it, you could also fake requests coming from another CARDS instance.
2. **Allowing you to store peer tokens**, trusting or distrusting their JWTs as needed. This allows each site to selectively choose which peers they trust, which is a key part of federation (although slightly annoying in practice because we've had issues in CanDIG where people retained out of date keys).

# To Test
- Start up two cards instances:
  1. On one, add: `audBuilder.add("localhost8081");` to `CardsJwtTokenManagerImpl:152` and start via `./start_cards.sh --dev --test`
  2. On the other, `export CARDS_HOST_AND_PORT=localhost:8081` and then run `./start_cards.sh --dev --test -p 8081`
- Create a new patient/visit for each

You'll notice, under `/bin/browser.html`, that the JWTSigningKey has been moved to a node named `JWTRSA256Key` replaced with an asymmetric key:
<img width="1139" height="677" alt="image" src="https://github.com/user-attachments/assets/6ecbdf1a-129e-4448-893a-15c52559ecf0" />

You'll also notice, after creating a Survey for the new patient and logging in as that patient, that the structure of the JWT in the `cards_auth_token` has changed
<img width="1770" height="832" alt="image" src="https://github.com/user-attachments/assets/8f4450d7-18cf-4e47-9895-59d5386716c0" />


You can then create a new Node `/jcr:system/cards:jwt/localhost8080` (EDIT: you now need to use the hex representation of the _hash_ of the public key as the node name) to the second instance, with property "verify" equal to the "verify" token from the first instance. If you login to the second instance as a Visit subject, and then replace the `cards_auth_token` cookie with its value from the first instance, it will not crash when you refresh the page.

This code is technically backwards compatible with running instances of Cards, retaining the ability to decode tokens under the previous encryption scheme. However, it will no longer mint new Tokens using the old symmetric key.

# Future work
- **Automatically providing/downloading peer tokens given just their URL** is a feature that is enabled in CanDIG via the OIDC protocol, but I haven't implemented it here. Normally this involves Keycloak providing an OIDC endpoint for us to read all the public key, etc for.
- **Dev-only endpoint for minting tokens?** I should probably have a dev endpoint just to mint/test the JWTs rather than co-opting the Survey link.