### PR TITLE
CARDS-2938: Accept out-of-range predefined answer options in number questions with min/max [FRONTEND FIX]

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Answer.jsx
@@ -34,6 +34,24 @@ export const DESC_POS = 3;
 // Position used to read whether or not an answer is a "default" for questions that don’t yet have an existing answer, option is displayed as selected
 export const IS_DEFAULT_ANSWER_POS = 4;
 
+// Extract the predefined answer options of a question as normalized
+// [label, value, isDefaultOption, description, isDefaultAnswer] tuples.
+// When `defaults` is supplied (already in that shape) it is returned as-is;
+// otherwise the options are read from the child cards:AnswerOption nodes.
+export const getAnswerOptions = (questionDefinition, defaults) => {
+  if (defaults) {
+    return defaults;
+  }
+  return Object.values(questionDefinition || {})
+    // Keep only answer options
+    // FIXME Must deal with nested options, do this recursively
+    .filter(value => value['jcr:primaryType'] == 'cards:AnswerOption')
+    // Sort by default order
+    .sort((option1, option2) => (option1.defaultOrder - option2.defaultOrder))
+    // Only extract the labels, internal values and description from the node
+    .map(value => [value.label || value.value, value.value, true, value.description, value.isDefault]);
+};
+
 // Holds answers and automatically generates hidden inputs
 // for form submission
 function Answer (props) {

--- a/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/MultipleChoice.jsx
@@ -40,7 +40,14 @@ import PropTypes from "prop-types";
 import { withStyles } from 'tss-react/mui';
 
 import { checkPropTypes } from "../propTypes";
-import Answer, { LABEL_POS, VALUE_POS, DESC_POS, IS_DEFAULT_OPTION_POS, IS_DEFAULT_ANSWER_POS } from "./Answer";
+import Answer, {
+  LABEL_POS,
+  VALUE_POS,
+  DESC_POS,
+  IS_DEFAULT_OPTION_POS,
+  IS_DEFAULT_ANSWER_POS,
+  getAnswerOptions
+} from "./Answer";
 import AnswerInstructions from "./AnswerInstructions.jsx";
 import { useFormReaderContext } from "./FormContext";
 import { useFormUpdateReaderContext, useFormUpdateWriterContext } from "./FormUpdateContext";
@@ -93,14 +100,7 @@ function MultipleChoice(props) {
   // pageActive and answerNodeType should be passed to the Answer component, so we make sure to include them in the `rest` variable above
   let { instanceId, pageActive, answerNodeType } = props;
 
-  let defaults = props.defaults || Object.values(props.questionDefinition)
-    // Keep only answer options
-    // FIXME Must deal with nested options, do this recursively
-    .filter(value => value['jcr:primaryType'] == 'cards:AnswerOption')
-    // Sort by default order
-    .sort((option1, option2) => (option1.defaultOrder - option2.defaultOrder))
-    // Only extract the labels, internal values and description from the node
-    .map(value => [value.label || value.value, value.value, true, value.description, value.isDefault]);
+  let defaults = getAnswerOptions(props.questionDefinition, props.defaults);
   // Locate an option referring to the "none of the above", if it exists
   let naOption = naValue || Object.values(props.questionDefinition)
     .find((value) => value['notApplicable'])?.["value"];

--- a/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
@@ -31,7 +31,7 @@ import { NumericFormat } from 'react-number-format';
 import { makeStyles } from 'tss-react/mui';
 
 import { checkPropTypes } from "../propTypes";
-import Answer from "./Answer";
+import Answer, { VALUE_POS, getAnswerOptions } from "./Answer";
 import AnswerComponentManager from "./AnswerComponentManager";
 import AnswerInstructions from "./AnswerInstructions";
 import { useFormReaderContext } from "./FormContext";
@@ -196,21 +196,14 @@ function NumberQuestion(props) {
   // A single numeric default for this question's own slider and range inputs.
   const defaultValue = numericDefaultValues.length ? numericDefaultValues[0] : null;
 
-  // The numeric values of the predefined answer options, gathered both from the `defaults` prop and from the child
-  // cards:AnswerOption nodes of the question definition. A value matching one of these is always accepted, even when
+  // The numeric values of the predefined answer options. A value matching one of these is always accepted, even when
   // it falls outside [minValue, maxValue], mirroring the backend MinMaxValueValidator.
   const answerOptionValues = useMemo(() => {
     const values = new Set();
-    (props.defaults || []).forEach(option => {
-      const rawValue = option?.[1];
+    getAnswerOptions(props.questionDefinition, props.defaults).forEach(option => {
+      const rawValue = option[VALUE_POS];
       if (rawValue != null && rawValue !== "" && !Number.isNaN(Number(rawValue))) {
         values.add(Number(rawValue));
-      }
-    });
-    Object.values(props.questionDefinition).forEach(option => {
-      if (option?.['jcr:primaryType'] === 'cards:AnswerOption'
-          && option.value != null && option.value !== "" && !Number.isNaN(Number(option.value))) {
-        values.add(Number(option.value));
       }
     });
     return values;
@@ -366,7 +359,7 @@ function NumberQuestion(props) {
   // * minValue  = 0
   // * displayMode = slider
   let minMaxMessage = "";
-  let hasAnswerOptions = !!(props.defaults || Object.values(props.questionDefinition).some(value => value['jcr:primaryType'] == 'cards:AnswerOption'));
+  let hasAnswerOptions = getAnswerOptions(props.questionDefinition, props.defaults).length > 0;
   if ((typeof minValue !== "undefined" || typeof maxValue !== "undefined") && !isSlider && !disableValueInstructions) {
     if (typeof messageForValuesOutsideMinMax !== "undefined") {
       minMaxMessage = messageForValuesOutsideMinMax;

--- a/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
@@ -196,6 +196,26 @@ function NumberQuestion(props) {
   // A single numeric default for this question's own slider and range inputs.
   const defaultValue = numericDefaultValues.length ? numericDefaultValues[0] : null;
 
+  // The numeric values of the predefined answer options, gathered both from the `defaults` prop and from the child
+  // cards:AnswerOption nodes of the question definition. A value matching one of these is always accepted, even when
+  // it falls outside [minValue, maxValue], mirroring the backend MinMaxValueValidator.
+  const answerOptionValues = useMemo(() => {
+    const values = new Set();
+    (props.defaults || []).forEach(option => {
+      const rawValue = option?.[1];
+      if (rawValue != null && rawValue !== "" && !Number.isNaN(Number(rawValue))) {
+        values.add(Number(rawValue));
+      }
+    });
+    Object.values(props.questionDefinition).forEach(option => {
+      if (option?.['jcr:primaryType'] === 'cards:AnswerOption'
+          && option.value != null && option.value !== "" && !Number.isNaN(Number(option.value))) {
+        values.add(Number(option.value));
+      }
+    });
+    return values;
+  }, [props.defaults, props.questionDefinition]);
+
   const [ minMaxError, setMinMaxError ] = useState(null);
   const [ minMaxErrorByIndex, setMinMaxErrorByIndex ] = useState({});
 
@@ -257,6 +277,12 @@ function NumberQuestion(props) {
       if (WHITESPACE_ONLY_PATTERN.test(text) || Number.isNaN(value)) {
         return `The value${pluralSuffix} must be numeric`;
       }
+    }
+
+    // A value matching a predefined answer option is always accepted, even when it falls outside [minValue, maxValue].
+    // This mirrors the backend MinMaxValueValidator, so the two sides agree on which values are valid.
+    if (answerOptionValues.has(value)) {
+      return null;
     }
 
     // For a range with both limits defined, show a single "between" message when the value falls outside them


### PR DESCRIPTION
PR #2387 updated the backend validator to not add an INVALID flag to answer values out of the min/maxValue interval if those values correspond to predefined options.

This PR applies the same rule on the frontend in NumberQuestion: predefined values coming from AnswerOptions or defaults are exempt from frontend validation and flagging.

To facilitate this without duplicating the AnswerOption extraction logic, the cards:AnswerOption parsing was moved out of MultipleChoice and into a helper in Answer.jsx, so it can be imported and reused by NumberQuestion.

Testing:
* Start CARDS with --test
* Create a NumberMinMaxTest Form and test the two questions with predefined options BEFORE the last one (_Long, list + input, enforced min and max, with options_ and _Long, list + input, min and max not enforced, with options_)
* Test other MultipleChoice questions for any regressions from the refactoring