### PR TITLE
[misc:ui] Reuse LoadingOverlay for page-level loading indicators

### DIFF
--- a/modules/clinician-dashboard/src/main/frontend/src/clinician-dashboard/ClinicDashboard.jsx
+++ b/modules/clinician-dashboard/src/main/frontend/src/clinician-dashboard/ClinicDashboard.jsx
@@ -19,7 +19,6 @@
 import { useState, useEffect, useContext, useMemo } from "react";
 
 import {
-  CircularProgress,
   Grid,
   Typography,
   useMediaQuery
@@ -30,6 +29,7 @@ import { makeStyles } from 'tss-react/mui';
 
 import ClinicForms from "./ClinicForms";
 import ClinicVisits from "./ClinicVisits";
+import LoadingOverlay from "../components/LoadingOverlay";
 import { fetchWithReLogin, GlobalLoginContext } from "../login/ReLoginDialog.js";
 import { loadExtensions } from "../uiextension/extensionManager";
 
@@ -180,7 +180,7 @@ function ClinicDashboard(props) {
 
   if (defaultsLoading || extensionsLoading || !visitInfo) {
     return (
-      <Grid container justifyContent="center"><Grid><CircularProgress/></Grid></Grid>
+      <LoadingOverlay open={true} />
     );
   }
 

--- a/modules/clinician-dashboard/src/main/frontend/src/clinician-dashboard/Patient.jsx
+++ b/modules/clinician-dashboard/src/main/frontend/src/clinician-dashboard/Patient.jsx
@@ -25,7 +25,6 @@ import {
   Alert,
   AlertTitle,
   Box,
-  CircularProgress,
   Grid,
   Tooltip,
 } from "@mui/material";
@@ -33,6 +32,7 @@ import { DataGrid } from '@mui/x-data-grid';
 import { DateTime } from "luxon";
 import { useNavigate } from "react-router";
 
+import LoadingOverlay from "../components/LoadingOverlay";
 import ResourceErrorMessage from "../components/ResourceErrorMessage.jsx";
 import { fetchWithReLogin, GlobalLoginContext } from "../login/ReLoginDialog.js";
 import { FORM_ENTRY_CONTAINER_PROPS } from "../questionnaire/questionnaireConstants.jsx";
@@ -155,26 +155,14 @@ function Patient() {
   useEffect(formatVisits, [visits]);
 
   // --------------------------------------------------------------------------------------------------------------
-  // Message screens are displayed if the data isn't loaded yet or if there's an error
-
-  const displayMessageScreen = (message, type, icon) => (
-    <Grid container {...FORM_ENTRY_CONTAINER_PROPS}>
-      <Grid>
-        <Alert severity={type} icon={icon}>{message}</Alert>
-      </Grid>
-    </Grid>
-  );
+  // An error screen is shown if the data could not be fetched, a loading overlay while it is loading
 
   if (errorData) {
     return <ResourceErrorMessage {...errorData} />;
   }
 
   if (!patientData || !visits) {
-    return displayMessageScreen(
-      <AlertTitle>Loading...</AlertTitle>,
-      "info",
-      <CircularProgress size={24} />
-    );
+    return <LoadingOverlay open={true} />;
   }
 
   // ----------------------------------------------------------------------------------------------------------------

--- a/modules/clinician-dashboard/src/main/frontend/src/clinician-dashboard/Visit.jsx
+++ b/modules/clinician-dashboard/src/main/frontend/src/clinician-dashboard/Visit.jsx
@@ -25,10 +25,8 @@ import LockIcon from '@mui/icons-material/Lock';
 import WarningIcon from '@mui/icons-material/Warning';
 import {
   Alert,
-  AlertTitle,
   Avatar,
   Chip,
-  CircularProgress,
   Divider,
   Grid,
   List,
@@ -44,6 +42,7 @@ import { makeStyles } from 'tss-react/mui';
 
 import SurveyLinkButton from "./SurveyLinkButton";
 import FormattedText from "../components/FormattedText";
+import LoadingOverlay from "../components/LoadingOverlay";
 import ResourceErrorMessage from "../components/ResourceErrorMessage.jsx";
 import EditButton from "../dataHomepage/EditButton";
 import PrintButton from "../dataHomepage/PrintButton";
@@ -238,26 +237,14 @@ function Visit(props) {
 
 
   // --------------------------------------------------------------------------------------------------------------
-  // Message screens are displayed if the data isn't loaded yet or if there's an error
-
-  const displayMessageScreen = (message, type, icon) => (
-    <Grid container {...FORM_ENTRY_CONTAINER_PROPS}>
-      <Grid>
-        <Alert severity={type} icon={icon}>{message}</Alert>
-      </Grid>
-    </Grid>
-  );
+  // An error screen is shown if the data could not be fetched, a loading overlay while it is loading
 
   if (errorData) {
     return <ResourceErrorMessage {...errorData} />;
   }
 
   if (!questionnaireSetId || !questionnaireIds || !questionnaires || !visit) {
-    return displayMessageScreen(
-      <AlertTitle>Loading...</AlertTitle>,
-      "info",
-      <CircularProgress size={24} />
-    );
+    return <LoadingOverlay open={true} />;
   }
 
   // -----------------------------------------------------------------------------------------------------------

--- a/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
+++ b/modules/data-entry/src/main/frontend/src/dataHomepage/UserDashboard.jsx
@@ -20,7 +20,6 @@ import { useState, useEffect } from "react";
 
 import {
   Button,
-  CircularProgress,
   DialogActions,
   DialogContent,
   Grid,
@@ -29,6 +28,7 @@ import { MaterialReactTable } from "material-react-table";
 import { withStyles } from 'tss-react/mui';
 
 import dashboardStyles from "./dashboardStyles.jsx";
+import LoadingOverlay from "../components/LoadingOverlay";
 import NewItemButton from "../components/NewItemButton.jsx";
 import ResponsiveDialog from "../components/ResponsiveDialog"; // commons
 import { loadExtensions } from "../uiextension/extensionManager";
@@ -81,7 +81,7 @@ function UserDashboard(props) {
 
   if (loading) {
     return (
-      <Grid container justifyContent="center"><Grid><CircularProgress/></Grid></Grid>
+      <LoadingOverlay open={true} />
     );
   }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Form.jsx
@@ -28,7 +28,6 @@ import {
   Breadcrumbs,
   Button,
   Chip,
-  CircularProgress,
   Grid,
   IconButton,
   List,
@@ -519,7 +518,7 @@ function Form (props) {
   // If the data has not yet been fetched, return an in-progress symbol
   if (!data) {
     return (
-      <Grid container justifyContent="center"><Grid><CircularProgress/></Grid></Grid>
+      <LoadingOverlay open={true} />
     );
   }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/QuestionnairePreview.jsx
@@ -20,10 +20,7 @@
 import { useEffect, useState, useLayoutEffect } from "react";
 
 import CloseIcon from "@mui/icons-material/Close";
-import {
-  CircularProgress,
-  Grid
-} from "@mui/material";
+import { Grid } from "@mui/material";
 import { useNavigate, useLocation } from 'react-router';
 import { withStyles } from 'tss-react/mui';
 
@@ -33,6 +30,7 @@ import FormPagination from "./FormPagination";
 import formStyles from "./formStyles.jsx";
 import { FormUpdateProvider } from "./FormUpdateContext";
 import { FORM_ENTRY_CONTAINER_PROPS } from "./questionnaireConstants.jsx";
+import LoadingOverlay from "../components/LoadingOverlay";
 import MainActionButton from "../components/MainActionButton.jsx";
 import { usePageNameWriterContext } from "../themePage/Page.jsx";
 
@@ -68,7 +66,7 @@ function QuestionnairePreview (props) {
   // If the data has not yet been fetched, return an in-progress symbol
   if (!data) {
     return (
-      <Grid container justifyContent="center"><Grid><CircularProgress/></Grid></Grid>
+      <LoadingOverlay open={true} />
     );
   }
 

--- a/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/Subject.jsx
@@ -47,6 +47,7 @@ import { Link, useLocation, useNavigate } from 'react-router';
 import { withStyles } from 'tss-react/mui';
 
 import FormattedText from "../components/FormattedText";
+import LoadingOverlay from "../components/LoadingOverlay";
 import ResourceErrorMessage from "../components/ResourceErrorMessage.jsx";
 import { checkPropTypes } from "../propTypes";
 import { QUESTION_TYPES, SECTION_TYPES, ENTRY_TYPES } from "./FormEntry.jsx";
@@ -344,7 +345,7 @@ function SubjectHeader(props) {
 
   if (!subject) {
     return (
-      <Grid><CircularProgress className={classes.subjectLoading} /></Grid>
+      <LoadingOverlay open={true} />
     );
   }
 

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminConfigScreen.jsx
@@ -22,7 +22,6 @@ import {
   Alert,
   Button,
   CardActions,
-  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
@@ -35,6 +34,7 @@ import { makeStyles } from 'tss-react/mui';
 import { checkPropTypes } from "../propTypes";
 import AdminScreen from "./AdminScreen.jsx";
 import FormattedText from "../components/FormattedText.jsx";
+import LoadingOverlay from "../components/LoadingOverlay";
 import { fetchWithReLogin, GlobalLoginContext } from "../login/ReLoginDialog.js";
 
 const useStyles = makeStyles()(theme => ({
@@ -213,54 +213,54 @@ function AdminConfigScreen(props) {
   return (
     <AdminScreen title={title} className={classes.root}>
       { (configError || error) && <Alert severity="error">{configError || error}</Alert> }
-      { typeof(config) == 'undefined' ? <CircularProgress/> :
-        !config ? "" :
-          <form onSubmit={handleSubmit}>
-            { children }
-            <CardActions>
-              <Button
-                type="submit"
-                variant="contained"
-                disabled={!!configError || !hasChanges}
-              >
-                Save
-              </Button>
-              <Button
-                variant="outlined"
-                color="error"
-                disabled={configIsInitial}
-                onClick={() => setResetConfirmationPending(true)}
-              >
-                Reset to initial settings
-              </Button>
-            </CardActions>
+      <LoadingOverlay open={typeof config == 'undefined'} />
+      { config &&
+        <form onSubmit={handleSubmit}>
+          { children }
+          <CardActions>
+            <Button
+              type="submit"
+              variant="contained"
+              disabled={!!configError || !hasChanges}
+            >
+              Save
+            </Button>
+            <Button
+              variant="outlined"
+              color="error"
+              disabled={configIsInitial}
+              onClick={() => setResetConfirmationPending(true)}
+            >
+              Reset to initial settings
+            </Button>
+          </CardActions>
 
-            { /* Confirmation dialog for resetting the changes */ }
-            <Dialog className={classes.confirmationDialog} open={resetConfirmationPending}>
-              <DialogTitle>
-                Confirm configuration reset
-              </DialogTitle>
-              <DialogContent>
-                <FormattedText>
-                  This will revert **all** the changes made since opening this page
-                  **including the ones that you may have already saved**.
-                </FormattedText>
-                <FormattedText>
-                  If you wish to keep the saved changes and discard the unsaved ones,
-                  you can simply navigate away from this page, for example by clicking
-                  on the link to Administration at the top.
-                </FormattedText>
-                <FormattedText>
-                  **Are you sure you wish to proceed with resetting the configuration?**
-                </FormattedText>
-              </DialogContent>
-              <DialogActions>
-                <Button variant="contained" onClick={handleReset}>Yes, Reset</Button>
-                <Button variant="outlined" onClick={() => setResetConfirmationPending(false)}>No, Cancel</Button>
-                <Button onClick={() => navigate("/content.html/admin/")}>No, go to Administration</Button>
-              </DialogActions>
-            </Dialog>
-          </form>
+          { /* Confirmation dialog for resetting the changes */ }
+          <Dialog className={classes.confirmationDialog} open={resetConfirmationPending}>
+            <DialogTitle>
+              Confirm configuration reset
+            </DialogTitle>
+            <DialogContent>
+              <FormattedText>
+                This will revert **all** the changes made since opening this page
+                **including the ones that you may have already saved**.
+              </FormattedText>
+              <FormattedText>
+                If you wish to keep the saved changes and discard the unsaved ones,
+                you can simply navigate away from this page, for example by clicking
+                on the link to Administration at the top.
+              </FormattedText>
+              <FormattedText>
+                **Are you sure you wish to proceed with resetting the configuration?**
+              </FormattedText>
+            </DialogContent>
+            <DialogActions>
+              <Button variant="contained" onClick={handleReset}>Yes, Reset</Button>
+              <Button variant="outlined" onClick={() => setResetConfirmationPending(false)}>No, Cancel</Button>
+              <Button onClick={() => navigate("/content.html/admin/")}>No, go to Administration</Button>
+            </DialogActions>
+          </Dialog>
+        </form>
       }
     </AdminScreen>
   );

--- a/modules/homepage/src/main/frontend/src/adminDashboard/AdminDashboard.jsx
+++ b/modules/homepage/src/main/frontend/src/adminDashboard/AdminDashboard.jsx
@@ -19,7 +19,6 @@
 import { useState, useEffect } from "react";
 
 import {
-  CircularProgress,
   Grid,
   ListItemButton,
   ListItemIcon,
@@ -28,6 +27,7 @@ import {
 import { useNavigate } from "react-router";
 
 import AdminScreen from "./AdminScreen.jsx";
+import LoadingOverlay from "../components/LoadingOverlay";
 import { loadExtensions } from "../uiextension/extensionManager";
 
 
@@ -54,7 +54,7 @@ function AdminDashboard(props) {
 
   if (loading) {
     return (
-      <Grid container justifyContent="center"><Grid><CircularProgress/></Grid></Grid>
+      <LoadingOverlay open={true} />
     );
   }
 


### PR DESCRIPTION
The LoadingOverlay component (added in CARDS-2937 for the questionnaire designer) is now used in the other places that show a "the whole page is loading" spinner. Before, each of these rendered its own centered CircularProgress (or, in the clinician dashboard, an "Loading..." alert message screen). Switching them to the shared overlay makes the loading experience consistent across the app.

#### Affected components:
- homepage: AdminDashboard, AdminConfigScreen
- data-entry: UserDashboard, Form, QuestionnairePreview, Subject (page header only)
- clinician-dashboard: ClinicDashboard, Patient, Visit

#### Testing:
- Start cards with --test
- Login as admin
- Create some subjects and forms
- Throttle the network from the browser dev tools so the data fetches are slowed down  
- Navigate to:
  - UserDashboard
    - The created subject (clinician view)
    - The created form (clinican view)
  - Administration
    - Any administration config screen such as Patient Access
    - Clinic dashboard
    - Questionnaires > any questionnaire in form (preview) mode
    - Forms > the created form (admin view)
    - Subjects > the created subject (admin view)

#### Code review tip:
Review with whitespace changes ignored to see the meaningful changes in AdminConfigScreen which had an indentation shift.