### PR TITLE
CARDS-2939: Display numeric ranges as a single combined label

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/NumberQuestion.jsx
@@ -356,34 +356,22 @@ function NumberQuestion(props) {
 
   // Range error message
   let rangeErrorMessage = "The range is invalid: the lower limit must be less than or equal to the upper limit";
-  let rangeDisplayFormatter = function(label, idx) {
-    if (idx != 1) return '';
-    return (
-      <div>
-        <FormattedText color={!disableMinMaxValueEnforcement && pageActive && (minMaxError || rangeError) ? "error" : ""}>
-          { `${lowerRangeValue} &mdash; ${label}` }
-        </FormattedText>
-        { (typeof messageForValuesOutsideMinMax != "undefined" && minMaxError) ?
-          <Typography component="div" color="textSecondary" variant="caption">
-            { messageForValuesOutsideMinMax }
-          </Typography>
-          : (pageActive && (minMaxError || rangeError)) &&
-          <Typography component="div" color="error" variant="caption">
-            { rangeError ? rangeErrorMessage : minMaxError }
-          </Typography>
-        }
-      </div>
-    );
-  }
 
+  // A range is serialized as a single combined displayedValue (e.g. "5 — 10 mmHg") by NumberRangeLabelProcessor,
+  // so it is displayed like any other single value: one label, one error. A structural range error (lower > upper)
+  // takes precedence over an out-of-range limit, and the custom out-of-range message only stands in for the latter.
   let markdownFormatter = function(label, idx) {
-    const errorMessage = isMultivalued ? minMaxErrorByIndex[idx] : minMaxError;
+    const errorMessage = isRange
+      ? (rangeError ? rangeErrorMessage : minMaxError)
+      : (isMultivalued ? minMaxErrorByIndex[idx] : minMaxError);
+    const showCustomMessage = typeof messageForValuesOutsideMinMax != "undefined"
+      && (isRange ? minMaxError : errorMessage);
     return (
       <div>
         <FormattedText color={!disableMinMaxValueEnforcement && pageActive && errorMessage ? "error" : ""}>
           { label }
         </FormattedText>
-        { (typeof messageForValuesOutsideMinMax != "undefined" && errorMessage) ?
+        { showCustomMessage ?
           <Typography component="div" color="textSecondary" variant="caption">
             { messageForValuesOutsideMinMax }
           </Typography>
@@ -436,7 +424,7 @@ function NumberQuestion(props) {
 
   return (
     <Question
-      defaultDisplayFormatter={isRange ? rangeDisplayFormatter : markdownFormatter }
+      defaultDisplayFormatter={markdownFormatter}
       disableInstructions
       {...props}
     >

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/serialize/labels/NumberRangeLabelProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/serialize/labels/NumberRangeLabelProcessor.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.uhndata.cards.forms.serialize.labels;
+
+import java.util.function.Function;
+
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonValue;
+
+import org.osgi.service.component.annotations.Component;
+
+import io.uhndata.cards.serialize.spi.ResourceJsonProcessor;
+
+/**
+ * Gets the human-readable answer for numeric range questions. A range is stored as a two-valued property
+ * {@code [lower, upper]}, which the default label processor would turn into a two-element {@code displayedValue}
+ * array. Since a range is a single logical value, this processor overrides that with one combined label of the form
+ * {@code "lower - upper"} (using an em dash), appending the unit of measurement once when configured, e.g.
+ * {@code "5 - 10 mmHg"}.
+ *
+ * @version $Id$
+ */
+@Component(immediate = true)
+public class NumberRangeLabelProcessor extends SimpleAnswerLabelProcessor implements ResourceJsonProcessor
+{
+    /** Separator between the lower and upper limits, an em dash (U+2014) surrounded by spaces. */
+    private static final String RANGE_SEPARATOR = " — ";
+
+    @Override
+    public String getDescription()
+    {
+        return "Get the human readable answer for numeric range questions, combining the lower and upper limits into "
+            + "a single value, e.g. '5 — 10 mmHg' instead of the two separate values '5 mmHg' and '10 mmHg'.";
+    }
+
+    @Override
+    public void leave(Node node, JsonObjectBuilder json, Function<Node, JsonValue> serializeNode)
+    {
+        try {
+            if (isNumberAnswer(node) && node.hasProperty(PROP_VALUE)) {
+                final Node question = getQuestionNode(node);
+                if (isRange(question)) {
+                    addProperty(node, json, serializeNode);
+                }
+            }
+        } catch (RepositoryException e) {
+            // Really shouldn't happen
+        }
+    }
+
+    @Override
+    public JsonValue getAnswerLabel(final Node node, final Node question)
+    {
+        try {
+            final Property property = node.getProperty(PROP_VALUE);
+            // A well-formed range has exactly two values; anything else is left to the default handling.
+            if (property.isMultiple()) {
+                final Value[] values = property.getValues();
+                if (values.length == 2) {
+                    final StringBuilder label = new StringBuilder()
+                        .append(values[0].getString())
+                        .append(RANGE_SEPARATOR)
+                        .append(values[1].getString());
+                    if (question != null && question.hasProperty(PROP_UNITS)) {
+                        label.append(' ').append(question.getProperty(PROP_UNITS).getString());
+                    }
+                    return Json.createValue(label.toString());
+                }
+            }
+        } catch (final RepositoryException ex) {
+            // Really shouldn't happen
+        }
+        // Not a two-valued range: fall back to the default per-value label.
+        return super.getAnswerLabel(node, question);
+    }
+
+    private boolean isNumberAnswer(final Node node) throws RepositoryException
+    {
+        return node.isNodeType("cards:LongAnswer")
+            || node.isNodeType("cards:DoubleAnswer")
+            || node.isNodeType("cards:DecimalAnswer");
+    }
+
+    private boolean isRange(final Node question) throws RepositoryException
+    {
+        return question != null && question.hasProperty("isRange")
+            && question.getProperty("isRange").getBoolean();
+    }
+}

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/serialize/labels/NumberRangeLabelProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/serialize/labels/NumberRangeLabelProcessor.java
@@ -56,6 +56,16 @@ public class NumberRangeLabelProcessor extends SimpleAnswerLabelProcessor implem
     }
 
     @Override
+    public int getPriority()
+    {
+        // Label processors run in ascending priority order, each overwriting the displayedValue set by the previous
+        // one. This must run after the other processors that also produce a label for a number answer node: the base
+        // DefaultLabelProcessor (70) and AnswerOptionsLabelProcessor (75, which fires for any answer whose question
+        // has options). 76 puts it last, so the combined range label is the one that wins.
+        return 76;
+    }
+
+    @Override
     public void leave(Node node, JsonObjectBuilder json, Function<Node, JsonValue> serializeNode)
     {
         try {

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/RangeTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/RangeTest.xml
@@ -61,6 +61,11 @@
 			<type>String</type>
 		</property>
 		<property>
+			<name>unitOfMeasurement</name>
+			<value>bpm</value>
+			<type>String</type>
+		</property>
+		<property>
 			<name>isRange</name>
 			<value>True</value>
 			<type>Boolean</type>
@@ -153,6 +158,11 @@
 			<type>Double</type>
 		</property>
 		<property>
+			<name>unitOfMeasurement</name>
+			<value>%</value>
+			<type>String</type>
+		</property>
+		<property>
 			<name>isRange</name>
 			<value>True</value>
 			<type>Boolean</type>
@@ -195,6 +205,11 @@
 			<name>decimalScale</name>
 			<value>2</value>
 			<type>Long</type>
+		</property>
+		<property>
+			<name>unitOfMeasurement</name>
+			<value>mmol/L</value>
+			<type>String</type>
 		</property>
 		<property>
 			<name>isRange</name>


### PR DESCRIPTION
#### Specs:
https://phenotips.atlassian.net/browse/CARDS-2939

#### Changes:

**Backend**
- New `NumberRangeLabelProcessor`: for range number answers (`cards:LongAnswer` / `cards:DoubleAnswer` / `cards:DecimalAnswer` with  `isRange`), it replaces the two-item `displayedValue` list with one string `lower — upper`, adding the unit of measurement once at the end.

**Frontend**
- Removed the `rangeDisplayFormatter` workaround from `NumberQuestion.jsx`.
- Ranges now use the same `markdownFormatter` as other number answers, with a small addition so range validation messages (including "lower must be less than or equal to upper") still show.

#### Side effect - CSV exports:

With labels enabled, a range is now exported as a single human-readable value (`5 — 10 mmHg`) instead of a list (`5 mmHg; 10 mmHg`). Raw-value exports (labels off) are unchanged and still separate the two values with `;`.

#### Testing:
- Start cards with --test
- Create a RangeTest form, fill in some values (including out-of-range ones to test validation)
- Save and view -> check how the ranges (and their validation messages where applicable) are displayed in view mode
- Look at the form's .deep.json to see how the NumberRangeLabelProcessor generated the displayedValue
- Administration > Questionnaires > RangeTest > Export: check the `labels` export vs `values` export.