### PR TITLE
CARDS-2941: Display date intervals as a single combined label

### DIFF
--- a/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx
+++ b/modules/data-entry/src/main/frontend/src/questionnaire/DateQuestion.jsx
@@ -218,20 +218,9 @@ function DateQuestion(props) {
       </LocalizationProvider>);
   }
 
-  let rangeDisplayFormatter = function(label, idx) {
-    const initialValue = Array.from(existingAnswer?.[1]?.value || []);
-    let limits = initialValue.slice(0, 2);
-    if (idx > 0 || limits.length == 0) return '';
-    limits[0] = DateTimeUtilities.toPrecision(limits[0])?.toFormat(dateFormat);
-    // In case of invalid data (only one limit of the range is available)
-    if (limits.length == 1) {
-      limits.push("");
-    } else {
-      limits[1] = DateTimeUtilities.toPrecision(limits[1])?.toFormat(dateFormat);
-    }
-    return dateDisplayFormatter(limits.join(' - '), idx);
-  }
-
+  // Renders one formatted date label, with any validation error beneath it. Single dates and intervals are
+  // shown the same way: each answer already arrives as a ready-to-display label (an interval as a single
+  // combined "start — end" string), so the formatter only has to print it.
   let dateDisplayFormatter = function(label, idx) {
     return (
       <div>
@@ -270,7 +259,7 @@ function DateQuestion(props) {
 
   return (
     <Question
-      defaultDisplayFormatter={isRange? rangeDisplayFormatter : dateDisplayFormatter}
+      defaultDisplayFormatter={dateDisplayFormatter}
       compact={isRange}
       currentAnswers={isAnswerComplete() ? 1 : 0}
       {...props}

--- a/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/serialize/labels/DateRangeLabelProcessor.java
+++ b/modules/data-model/forms/impl/src/main/java/io/uhndata/cards/forms/serialize/labels/DateRangeLabelProcessor.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.uhndata.cards.forms.serialize.labels;
+
+import java.util.function.Function;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonValue;
+
+import org.osgi.service.component.annotations.Component;
+
+import io.uhndata.cards.serialize.spi.ResourceJsonProcessor;
+
+/**
+ * Gets the human-readable answer for date interval (range) questions. An interval is stored as a two-valued property
+ * {@code [start, end]}, which {@link DateLabelProcessor} would format into a two-element {@code displayedValue} array.
+ * Since an interval is a single logical value, this processor overrides that with one combined label of the form
+ * {@code "start - end"} (using an em dash), e.g. {@code "Jan 1, 2020 - Jan 5, 2020"}. The individual dates are
+ * formatted by reusing {@link DateLabelProcessor#getAnswerLabel(Node, Node)}, so the question's {@code dateFormat}
+ * (and the {@code yyyy} special case) are honored identically to single dates.
+ *
+ * @version $Id$
+ */
+@Component(immediate = true)
+public class DateRangeLabelProcessor extends DateLabelProcessor implements ResourceJsonProcessor
+{
+    /** The value of a question's {@code type} property that marks it as a date interval. */
+    private static final String INTERVAL_TYPE = "interval";
+
+    private static final String PROP_TYPE = "type";
+
+    /** Separator between the start and end dates, an em dash (U+2014) surrounded by spaces. */
+    private static final String RANGE_SEPARATOR = " — ";
+
+    @Override
+    public String getDescription()
+    {
+        return "Get the human readable answer for date interval questions, combining the start and end dates into a "
+            + "single value, e.g. 'Jan 1, 2020 — Jan 5, 2020' instead of the two separate dates.";
+    }
+
+    @Override
+    public int getPriority()
+    {
+        // Runs just after DateLabelProcessor (75), so its combined label overwrites the two-element array.
+        return 76;
+    }
+
+    @Override
+    public void leave(Node node, JsonObjectBuilder json, Function<Node, JsonValue> serializeNode)
+    {
+        try {
+            if (node.isNodeType("cards:DateAnswer") && isInterval(getQuestionNode(node))) {
+                addProperty(node, json, serializeNode);
+            }
+        } catch (RepositoryException e) {
+            // Really shouldn't happen
+        }
+    }
+
+    @Override
+    public JsonValue getAnswerLabel(final Node node, final Node question)
+    {
+        final JsonValue label = super.getAnswerLabel(node, question);
+        // A well-formed interval formats to exactly two dates; anything else is left to the default handling.
+        if (label != null && label.getValueType() == JsonValue.ValueType.ARRAY) {
+            final JsonArray dates = label.asJsonArray();
+            if (dates.size() == 2) {
+                return Json.createValue(dates.getString(0) + RANGE_SEPARATOR + dates.getString(1));
+            }
+        }
+        return label;
+    }
+
+    private boolean isInterval(final Node question) throws RepositoryException
+    {
+        return question != null && question.hasProperty(PROP_TYPE)
+            && INTERVAL_TYPE.equals(question.getProperty(PROP_TYPE).getString());
+    }
+}

--- a/test-resources/src/main/resources/SLING-INF/content/Questionnaires/DateFormatsTest.xml
+++ b/test-resources/src/main/resources/SLING-INF/content/Questionnaires/DateFormatsTest.xml
@@ -328,6 +328,45 @@
 		</property>
 	</node>
 	<node>
+		<name>absoluteyearmonthdayint</name>
+		<primaryNodeType>cards:Question</primaryNodeType>
+		<property>
+			<name>text</name>
+			<value>Full date interval with absolute lower and upper limits (`2022-08-02` - `2023-08-02`)</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dataType</name>
+			<value>date</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>dateFormat</name>
+			<value>yyyy-MM-dd</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>lowerLimit</name>
+			<value>2022-08-02</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>upperLimit</name>
+			<value>2023-08-02</value>
+			<type>String</type>
+		</property>
+		<property>
+			<name>maxAnswers</name>
+			<value>1</value>
+			<type>Long</type>
+		</property>
+		<property>
+			<name>type</name>
+			<value>interval</value>
+			<type>String</type>
+		</property>
+	</node>
+	<node>
 		<name>monthdayyearint</name>
 		<primaryNodeType>cards:Question</primaryNodeType>
 		<property>


### PR DESCRIPTION
#### Specs:
https://phenotips.atlassian.net/browse/CARDS-2941

#### Changes:

**Backend**
**Backend**
- New `DateRangeLabelProcessor` (extends `DateLabelProcessor`): for date answers where the question `type` is `interval`, it combines the two formatted dates into one `displayedValue` string `start — end`. It reuses `DateLabelProcessor`'s formatting, so `dateFormat` and the `yyyy` special case are honored exactly as for single dates.

**Frontend**
- Removed the `rangeDisplayFormatter` workaround from `DateQuestion.jsx`, including its duplicate client-side date re-formatting.
- Intervals now use the same `dateDisplayFormatter` as single dates.

**Test**
- Added a bounded full-date interval (`absoluteyearmonthdayint`) to
  `DateFormatsTest`, covering the interval + min/max validation case.

#### Side effect - CSV exports:

With labels enabled, an interval is now exported as a single human-readable value (`Jan 1, 2020 — Jan 5, 2020`) instead of a list (`Jan 1, 2020; Jan 5, 2020`). Raw-value exports (labels off) are unchanged.

#### Testing:
- Start cards with --test
- Create a DateFormatsTest form, fill in some values (including out-of-range ones to test validation)
- Save and view -> check how the ranges (and their validation messages where applicable) are displayed in view mode
- Look at the form's .deep.json to see how the DateRangeLabelProcessor generated the displayedValue
- Administration > Questionnaires > DateFormatsTest > Export: check the `labels` export vs `values` export.