### PR TITLE
[CARDS-2940] Add loading indicators to more administration sections

### DIFF
--- a/modules/google-apis/src/main/frontend/src/GoogleApiKeyAdminPage.jsx
+++ b/modules/google-apis/src/main/frontend/src/GoogleApiKeyAdminPage.jsx
@@ -22,7 +22,9 @@ import { useState, useEffect, useContext } from "react";
 import {
   Alert,
   Button,
+  CircularProgress,
   Grid,
+  InputAdornment,
   TextField,
 } from "@mui/material";
 
@@ -35,6 +37,7 @@ const APIKEY_SERVLET_URL = "/.googleApiKey";
 export default function GoogleApiKeyAdminPage() {
   const [ googleApiKey, setGoogleApiKey ] = useState("");
   const [ hasChanges, setHasChanges ] = useState(false);
+  const [ loading, setLoading ] = useState(true);
   const [ error, setError ] = useState();
 
   const globalLoginDisplay = useContext(GlobalLoginContext);
@@ -50,7 +53,8 @@ export default function GoogleApiKeyAdminPage() {
       })
       .catch((error) => {
         setError("Error fetching GoogleApiKey node: " + error);
-      });
+      })
+      .finally(() => setLoading(false));
   }, []);
 
   // function to create / edit node
@@ -91,12 +95,21 @@ export default function GoogleApiKeyAdminPage() {
                 value={googleApiKey}
                 label="Google API key"
                 fullWidth
+                disabled={loading}
+                slotProps={{
+                  input: {
+                    endAdornment: loading &&
+                      <InputAdornment position="end">
+                        <CircularProgress size={20} />
+                      </InputAdornment>,
+                  },
+                }}
               />
             </Grid>
             <Grid size={2}>
               <Button
                 variant="contained"
-                disabled={!hasChanges}
+                disabled={!hasChanges || loading}
                 onClick={updateKey}
               >
                 Submit

--- a/modules/principals/src/main/frontend/src/Userboard/Groups/GroupsManager.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Groups/GroupsManager.jsx
@@ -158,7 +158,7 @@ let GroupUsersTable = (props) => {
 
 function GroupsManager(props) {
   checkPropTypes(GroupsManager, props);
-  const { classes, groups, users, reload } = props;
+  const { classes, groups, users, loading, reload } = props;
 
   let [ currentGroupUsers, setCurrentGroupUsers ] = useState([]);
   let [ currentGroupName, setCurrentGroupName ] = useState("");
@@ -252,6 +252,7 @@ function GroupsManager(props) {
           enableSorting={false}
           enableToolbarInternalActions={false}
           initialState={{ showGlobalFilter: true }}
+          state={{ isLoading: loading }}
           muiTableHeadCellProps={{
             sx: (theme) => ({
               background: theme.palette.grey['200'],
@@ -314,6 +315,7 @@ function GroupsManager(props) {
 GroupsManager.propTypes = {
   groups: PropTypes.array,
   users: PropTypes.array,
+  loading: PropTypes.bool,
   reload: PropTypes.func.isRequired
 }
 

--- a/modules/principals/src/main/frontend/src/Userboard/PrincipalsContainer.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/PrincipalsContainer.jsx
@@ -27,6 +27,7 @@ import { fetchWithReLogin, GlobalLoginContext } from "../login/ReLoginDialog.js"
 export default function PrincipalsContainer(props) {
   const [ users, setUsers ] = useState([]);
   const [ groups, setGroups ] = useState([]);
+  const [ loading, setLoading ] = useState(true);
   const globalLoginDisplay = useContext(GlobalLoginContext);
 
   let handleLoadGroups = () => {
@@ -39,6 +40,7 @@ export default function PrincipalsContainer(props) {
       .then((data) => setGroups(data.rows))
       .catch((error) => console.log(error?.statusText ?? error))
       .finally(() => {
+        setLoading(false);
         // This event is needed in cases we do not want to collapse details panel after reload
         let reloadedEvent = new CustomEvent('principals-reloaded', {
           bubbles: true,
@@ -49,6 +51,7 @@ export default function PrincipalsContainer(props) {
   }
 
   let handleLoadUsers = () => {
+    setLoading(true);
     fetchWithReLogin(globalLoginDisplay, "/home/users.json",
       {
         method: 'GET',
@@ -74,8 +77,8 @@ export default function PrincipalsContainer(props) {
 
   return (
     <div>
-      { props.isUserListPage ? <UsersManager users={users} groups={groups} reload={handleLoadUsers}/>
-        : <GroupsManager users={users} groups={groups} reload={handleLoadUsers}/> }
+      { props.isUserListPage ? <UsersManager users={users} groups={groups} loading={loading} reload={handleLoadUsers}/>
+        : <GroupsManager users={users} groups={groups} loading={loading} reload={handleLoadUsers}/> }
     </div>
   );
 }

--- a/modules/principals/src/main/frontend/src/Userboard/Users/UsersManager.jsx
+++ b/modules/principals/src/main/frontend/src/Userboard/Users/UsersManager.jsx
@@ -38,7 +38,7 @@ const USER_URL = "/system/userManager/user/";
 
 function UsersManager(props) {
   checkPropTypes(UsersManager, props);
-  const { classes, groups, users, reload } = props;
+  const { classes, groups, users, loading, reload } = props;
 
   let [ currentUserName, setCurrentUserName ] = useState("");
   let [ deployCreateUser, setDeployCreateUser ] = useState(false);
@@ -92,6 +92,7 @@ function UsersManager(props) {
           enableSorting={false}
           enableToolbarInternalActions={false}
           initialState={{ showGlobalFilter: true }}
+          state={{ isLoading: loading }}
           muiTableHeadCellProps={{
             sx: (theme) => ({
               background: theme.palette.grey['200'],
@@ -188,6 +189,7 @@ function UsersManager(props) {
 UsersManager.propTypes = {
   users: PropTypes.array,
   groups: PropTypes.array,
+  loading: PropTypes.bool,
   reload: PropTypes.func.isRequired
 }
 

--- a/modules/vocabularies/src/main/frontend/src/BioportalApiKey.jsx
+++ b/modules/vocabularies/src/main/frontend/src/BioportalApiKey.jsx
@@ -22,6 +22,7 @@ import { useEffect, useContext, useState } from "react";
 import SettingsIcon from '@mui/icons-material/Settings';
 import {
   Button,
+  CircularProgress,
   Grid,
   Dialog,
   DialogTitle,
@@ -75,6 +76,8 @@ export function BioPortalApiKey(props) {
   /* User input api key */
   const [customApiKey, setCustomApiKey] = useState('');
   const [displayPopup, setDisplayPopup] = useState(false);
+  /* Whether the currently configured key is still being fetched */
+  const [loading, setLoading] = useState(true);
 
   // function to create / edit node
   function addNewKey() {
@@ -98,8 +101,10 @@ export function BioPortalApiKey(props) {
       (apiKey) => {
         updateKey(apiKey);
         setCustomApiKey(apiKey);
+        setLoading(false);
       }, () => {
         updateKey(false);
+        setLoading(false);
       });
   }, [bioPortalApiKey]);
 
@@ -136,7 +141,13 @@ export function BioPortalApiKey(props) {
         </Typography>
       </Grid>
 
-      { !bioPortalApiKey && <>
+      { loading &&
+        <Grid className={classes.noKeyInfo}>
+          <CircularProgress size={20} />
+        </Grid>
+      }
+
+      { !loading && !bioPortalApiKey && <>
         <Grid className={classes.noKeyInfo}>
           <Typography>Your system does not have a <a href="https://www.bioontology.org/wiki/BioPortal_Help#Getting_an_API_key" target="_blank" rel="noreferrer">Bioportal API Key</a> configured.</Typography>
           {/* eslint-disable-next-line @stylistic/max-len */}


### PR DESCRIPTION
#### Specs:
https://phenotips.atlassian.net/browse/CARDS-2940

#### Changes:
- **Google API key** (`GoogleApiKeyAdminPage`): while loading, the key field is disabled and shows a small spinner in its end adornment, and the Submit button is disabled. This keeps the user from overwriting the key before it is fetched.

- **Users and Groups** (`PrincipalsContainer`, `UsersManager`, `GroupsManager`): the container already loads users and then groups; it now tracks a loading flag (true until both requests finish) and passes it to the two managers, which show the MaterialReactTable built-in loading state (in-table skeleton rows).

- **Vocabularies > Bioportal API key** (`BioportalApiKey`):  this is not listed in the ticket, but it has a similar problem Google API key, so it is fixed here as the natural next step. While the configured key is being fetched, a spinner is shown instead of the "no API key configured" message and the empty input, so the user is not prompted to enter a key before we know whether one already exists.