### PR TITLE
Tighten broad org.apache.commons.codec.binary exclusion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -770,7 +770,8 @@
                       <!--module name="IllegalCatch"/-->
 
                       <module name="IllegalImport">
-                        <property name="illegalPkgs" value="sun,groovy,org.apache.commons.lang,org.apache.commons.codec.binary,antlr" />
+                        <property name="illegalPkgs" value="sun,groovy,org.apache.commons.lang,antlr" />
+                        <property name="illegalClasses" value="org.apache.commons.codec.binary.StringUtils" />
                       </module>
 
                       <module name="IllegalInstantiation">
@@ -1228,7 +1229,8 @@
                       <!--module name="IllegalCatch"/-->
 
                       <module name="IllegalImport">
-                        <property name="illegalPkgs" value="sun,groovy,org.apache.commons.lang,org.apache.commons.codec.binary,antlr" />
+                        <property name="illegalPkgs" value="sun,groovy,org.apache.commons.lang,antlr" />
+                        <property name="illegalClasses" value="org.apache.commons.codec.binary.StringUtils" />
                       </module>
 
                       <module name="IllegalInstantiation">


### PR DESCRIPTION
Currently the exclusion on `org.apache.commons.codec.binary` is too broad, as it excludes the entire package, when the purpose of it (according to @sdumitriu ) was to exclude the `StringUtils` class within that package. This tightens the exclusion to just the one class.

# To test
In any class, add a:
```
import org.apache.commons.codec.binary.StringUtils;

...

LOGGER.error(StringUtils.newStringUtf16(StringUtils.getBytesUtf16("Test")));
```

anywhere, and it should still fail `mvn verify`. Conversely, adding:
```
import org.apache.commons.codec.binary.Hex;

LOGGER.error(Hex.encodeHexString(Hex.decodeHex("Test")));
```

will no longer crash out a `mvn verify` run.