### PR TITLE
[bugfix] Harden the slack-notifications module

### DIFF
--- a/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/ScheduledSlackNotification.java
+++ b/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/ScheduledSlackNotification.java
@@ -58,6 +58,11 @@ public class ScheduledSlackNotification
     protected void activate(Configuration config) throws Exception
     {
         LOGGER.info("ScheduledSlackNotifications activating");
+        if (StringUtils.isBlank(resolveFromEnvironment(config.endpoint()))) {
+            // Scheduling a job that can only ever fail would report the same failure every single night
+            LOGGER.warn("The {} notification has no endpoint configured, it will not be scheduled", config.name());
+            return;
+        }
         final String nightlyNotificationsSchedule = getSchedule(config.schedule());
 
         ScheduleOptions slackNotificationsOptions = this.scheduler.EXPR(nightlyNotificationsSchedule);
@@ -84,10 +89,21 @@ public class ScheduledSlackNotification
 
     private String getSchedule(final String config)
     {
-        String result = config;
-        if (result != null && result.startsWith("%ENV%")) {
-            result = System.getenv(config.substring("%ENV%".length()));
+        return StringUtils.defaultIfEmpty(resolveFromEnvironment(config), "0 0 0 * * ? *");
+    }
+
+    /*
+     * Reads a configuration value that names an environment variable rather than holding the value itself, which is
+     * how a secret such as a webhook address is kept out of the configuration files.
+     *
+     * @param config the configured value
+     * @return the value itself, or what the named environment variable holds
+     */
+    private String resolveFromEnvironment(final String config)
+    {
+        if (config != null && config.startsWith("%ENV%")) {
+            return System.getenv(config.substring("%ENV%".length()));
         }
-        return StringUtils.defaultIfEmpty(result, "0 0 0 * * ? *");
+        return config;
     }
 }

--- a/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/SlackNotificationsTask.java
+++ b/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/SlackNotificationsTask.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.uhndata.cards.httprequests.HttpRequests;
+import io.uhndata.cards.httprequests.HttpResponse;
 import io.uhndata.cards.slacknotifications.spi.SlackNotificationProducer;
 
 public class SlackNotificationsTask implements Runnable
@@ -79,17 +80,20 @@ public class SlackNotificationsTask implements Runnable
     public void run()
     {
         LOGGER.debug("Running SlackNotificationsTask");
-        List<List<JsonObject>> result = this.notifications.stream()
+        // Flattened, because a producer with nothing to say gives back an empty list rather than nothing at all:
+        // counting those as content made skipEmpty useless, posting an empty message on every run
+        List<JsonObject> result = this.notifications.stream()
             .filter(n -> this.include.isEmpty() || this.include.contains(n.getName()))
             .map(n -> n.prepareMessages(this.extraParameters))
             .filter(Objects::nonNull)
+            .flatMap(List::stream)
             .collect(Collectors.toList());
         LOGGER.debug("Got these results: {}", result);
         postToSlack(result);
         LOGGER.debug("Done SlackNotificationsTask");
     }
 
-    private void postToSlack(List<List<JsonObject>> messages)
+    private void postToSlack(List<JsonObject> messages)
     {
         if (messages.isEmpty() && this.skipEmpty) {
             return;
@@ -104,16 +108,22 @@ public class SlackNotificationsTask implements Runnable
                     .add(SlackNotificationProducer.COLOR, SlackNotificationProducer.INFO);
                 attachments.add(nothing);
             } else {
-                messages.forEach(innerList -> innerList.forEach(attachments::add));
+                messages.forEach(attachments::add);
             }
 
             if (StringUtils.isNotBlank(this.title)) {
                 slackApiReq.add("text", this.title);
             }
             slackApiReq.add("attachments", attachments);
-            HttpRequests.getPostResponse(this.endpoint, slackApiReq.build().toString(), "application/json");
+            final HttpResponse response =
+                HttpRequests.doHttpPost(this.endpoint, slackApiReq.build().toString(), "application/json");
+            if (response.getStatusCode() < 200 || response.getStatusCode() >= 300) {
+                // Slack was reached and refused the message, which no exception would have told us about
+                LOGGER.warn("Slack refused the notification with status {}: {}", response.getStatusCode(),
+                    response.getResponsePayload());
+            }
         } catch (IOException e) {
-            LOGGER.warn("Failed to send performance update to Slack");
+            LOGGER.warn("Failed to post the notification to Slack: {}", e.getMessage(), e);
         }
     }
 

--- a/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/internal/notifications/StatusReportNotification.java
+++ b/modules/slack-notifications/src/main/java/io/uhndata/cards/slacknotifications/internal/notifications/StatusReportNotification.java
@@ -20,9 +20,9 @@
 package io.uhndata.cards.slacknotifications.internal.notifications;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -30,8 +30,11 @@ import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 
+import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.uhndata.cards.slacknotifications.spi.SlackNotificationProducer;
 import io.uhndata.cards.status.api.StatusReportManager;
@@ -58,6 +61,8 @@ import io.uhndata.cards.status.spi.StatusReport;
 @Component(immediate = true)
 public class StatusReportNotification implements SlackNotificationProducer
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(StatusReportNotification.class);
+
     @Reference
     private StatusReportManager statusReportManager;
 
@@ -70,23 +75,15 @@ public class StatusReportNotification implements SlackNotificationProducer
     @Override
     public List<JsonObject> prepareMessages(final Map<String, String> extraParameters)
     {
-        StatusReport.Status targetStatus = StatusReport.Status.INFO;
-        String customTargetStatus = extraParameters.get("statusReport.targetStatusLevel");
-        if (customTargetStatus != null) {
-            targetStatus = StatusReport.Status.valueOf(customTargetStatus);
-        }
-        Set<String> tags = new HashSet<>();
-        String customTags = extraParameters.get("statusReport.includeTags");
-        if (customTags != null) {
-            Collections.addAll(tags, customTags.split(","));
-        }
         boolean unprivileged = Boolean.valueOf(extraParameters.get("statusReport.unprivileged"));
-        final List<StatusReport> reports = this.statusReportManager.getReports(unprivileged, targetStatus, tags);
+        final List<StatusReport> reports = this.statusReportManager.getReports(unprivileged,
+            getTargetStatus(extraParameters), getTags(extraParameters));
         final List<JsonObject> result = new ArrayList<>();
         for (StatusReport report : reports) {
             final JsonObjectBuilder json = Json.createObjectBuilder();
             json.add(TITLE, report.getName())
-                .add(TEXT, report.getText());
+                // A report with nothing more to say than its status has no body, and a null would break the builder
+                .add(TEXT, report.getText() == null ? "" : report.getText());
             switch (report.getStatus()) {
                 case SUCCESS:
                     json.add(COLOR, SUCCESS);
@@ -104,5 +101,46 @@ public class StatusReportNotification implements SlackNotificationProducer
             result.add(json.build());
         }
         return result.isEmpty() ? null : result;
+    }
+
+    /*
+     * The lowest status level to include. A configuration naming a level that does not exist falls back to the
+     * default; it used to throw, which cost the whole notification.
+     *
+     * @param extraParameters the configured extra parameters
+     * @return a status level, INFO unless another valid one was configured
+     */
+    private StatusReport.Status getTargetStatus(final Map<String, String> extraParameters)
+    {
+        final String configured = extraParameters.get("statusReport.targetStatusLevel");
+        if (configured == null) {
+            return StatusReport.Status.INFO;
+        }
+        try {
+            return StatusReport.Status.valueOf(configured.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("{} is not a known status level, reporting from INFO up instead", configured);
+            return StatusReport.Status.INFO;
+        }
+    }
+
+    /*
+     * Which status tags to include.
+     *
+     * @param extraParameters the configured extra parameters
+     * @return the tag names, an empty set for all of them
+     */
+    private Set<String> getTags(final Map<String, String> extraParameters)
+    {
+        final Set<String> tags = new HashSet<>();
+        final String configured = extraParameters.get("statusReport.includeTags");
+        if (configured != null) {
+            for (String tag : configured.split(",")) {
+                if (StringUtils.isNotBlank(tag)) {
+                    tags.add(tag.trim());
+                }
+            }
+        }
+        return tags;
     }
 }


### PR DESCRIPTION
- Don't schedule a task that has no endpoint
- Default to a midnight schedule when the envvar is not set
- Empty reports could still send an empty notification
- Log server errors
- Accept case-insensitive status levels