### PR TITLE
[bugfix] Harden the error tracking service

### DIFF
--- a/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLogger.java
+++ b/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLogger.java
@@ -21,7 +21,8 @@ package io.uhndata.cards.errortracking;
 
 public final class ErrorLogger
 {
-    private static ErrorLoggerService errorLoggerService;
+    /** Written by the service component as it starts and stops, read from arbitrary threads. */
+    private static volatile ErrorLoggerService errorLoggerService;
 
     // Hide the constructor
     private ErrorLogger()
@@ -31,6 +32,19 @@ public final class ErrorLogger
     static void setService(ErrorLoggerService service)
     {
         errorLoggerService = service;
+    }
+
+    /*
+     * Withdraws the service backing this facade, so that a stopped component, whose service references are gone,
+     * is not called any more. A component that was already replaced by a newer one withdraws nothing.
+     *
+     * @param service the service that is going away
+     */
+    static void unsetService(ErrorLoggerService service)
+    {
+        if (errorLoggerService == service) {
+            errorLoggerService = null;
+        }
     }
 
     /*

--- a/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLoggerImpl.java
+++ b/modules/error-tracking/src/main/java/io/uhndata/cards/errortracking/ErrorLoggerImpl.java
@@ -25,14 +25,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import org.apache.sling.api.resource.LoginException;
-import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,13 +52,18 @@ public final class ErrorLoggerImpl implements ErrorLoggerService
         ErrorLogger.setService(this);
     }
 
+    @Deactivate
+    protected void deactivate()
+    {
+        // Without this, the static facade would keep calling this component after it stopped, when its service
+        // references are already gone
+        ErrorLogger.unsetService(this);
+    }
+
     @Override
     public void logError(final Throwable loggedError)
     {
         try (ResourceResolver resolver = this.rrf.getServiceResourceResolver(null)) {
-            if (resolver == null) {
-                return;
-            }
             Resource eventsFolderResource = resolver.getResource(LOGGED_EVENTS_PATH);
             if (eventsFolderResource == null) {
                 return;
@@ -83,9 +87,10 @@ public final class ErrorLoggerImpl implements ErrorLoggerService
 
             // Commit these changes to JCR
             resolver.commit();
-        } catch (LoginException | PersistenceException e) {
+        } catch (Exception e) {
+            // The caller is already handling a failure; recording it must not raise a second one, so nothing
+            // escapes from here, not even a runtime exception
             LOGGER.error("logError failed.", e);
-            return;
         }
     }
 }


### PR DESCRIPTION
- Unplug the service from the static class when it gets deactivated to avoid using a dead service
- Catch and log a console error for every runtime exception instead of bubbling up to the code that tried to log an error
- Log a console error when the resource resolver is unavailable instead of silently ignoring the call to save an error