### PR TITLE
[bugfix] Harden the httprequests utility

### DIFF
--- a/modules/http-requests/src/main/java/io/uhndata/cards/httprequests/HttpRequests.java
+++ b/modules/http-requests/src/main/java/io/uhndata/cards/httprequests/HttpRequests.java
@@ -23,8 +23,11 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
+import org.apache.http.HttpEntity;
 import org.apache.http.StatusLine;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
@@ -33,6 +36,15 @@ import org.apache.http.impl.client.HttpClients;
 
 public final class HttpRequests
 {
+    /*
+     * How long to wait for a service to accept a connection, and how long to wait for it to answer once it has.
+     * Without these, a service that accepts a connection and then goes quiet holds up the caller forever, which for
+     * a scheduled job means it never runs again.
+     */
+    private static final int CONNECT_TIMEOUT_MS = 10000;
+
+    private static final int RESPONSE_TIMEOUT_MS = 30000;
+
     // Hide the utility class constructor
     private HttpRequests()
     {
@@ -40,33 +52,47 @@ public final class HttpRequests
 
     private static String readInputStream(InputStream stream) throws IOException
     {
-        final BufferedReader br = new BufferedReader(new InputStreamReader(stream, "utf-8"));
-        String responseLine = null;
-        final StringBuilder retVal = new StringBuilder();
-        while ((responseLine = br.readLine()) != null) {
-            retVal.append(responseLine.trim());
+        // Read the payload exactly as it was sent: trimming every line and joining them without a separator
+        // corrupts anything whose whitespace or line structure matters
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+            final StringBuilder retVal = new StringBuilder();
+            final char[] buffer = new char[4096];
+            int read = br.read(buffer);
+            while (read != -1) {
+                retVal.append(buffer, 0, read);
+                read = br.read(buffer);
+            }
+            return retVal.toString();
         }
-        return retVal.toString();
     }
 
     public static HttpResponse doHttpPost(final String url, final String data, final String contentType,
         final String payloadEncoding)
         throws IOException
     {
-        CloseableHttpClient client = HttpClients.createDefault();
-        HttpPost httpPost = new HttpPost(url);
-        StringEntity entity = new StringEntity(data, payloadEncoding);
-        httpPost.setEntity(entity);
+        final RequestConfig timeouts = RequestConfig.custom()
+            .setConnectTimeout(CONNECT_TIMEOUT_MS)
+            .setConnectionRequestTimeout(CONNECT_TIMEOUT_MS)
+            .setSocketTimeout(RESPONSE_TIMEOUT_MS)
+            .build();
+        final HttpPost httpPost = new HttpPost(url);
+        httpPost.setConfig(timeouts);
+        httpPost.setEntity(new StringEntity(data, payloadEncoding));
         httpPost.setHeader("Content-type", contentType);
-        CloseableHttpResponse response = client.execute(httpPost);
-        String responseString = readInputStream(response.getEntity().getContent());
-        StatusLine statusLine = response.getStatusLine();
-        HttpResponse httpResponse = new HttpResponse(-1, responseString);
-        if (statusLine != null) {
-            httpResponse.setStatusCode(statusLine.getStatusCode());
+        // Both the client and the response must be closed even when reading the response fails, or the connection
+        // is leaked
+        try (CloseableHttpClient client = HttpClients.createDefault();
+            CloseableHttpResponse response = client.execute(httpPost)) {
+            final HttpEntity entity = response.getEntity();
+            // A response may legitimately have no body at all, e.g. a 204
+            final String responseString = entity == null ? "" : readInputStream(entity.getContent());
+            final StatusLine statusLine = response.getStatusLine();
+            final HttpResponse httpResponse = new HttpResponse(-1, responseString);
+            if (statusLine != null) {
+                httpResponse.setStatusCode(statusLine.getStatusCode());
+            }
+            return httpResponse;
         }
-        client.close();
-        return httpResponse;
     }
 
     public static HttpResponse doHttpPost(final String url, final String data, final String contentType)


### PR DESCRIPTION
- Don't mangle the response by discarding newlines
- Avoid a resource leak by always closing the client and the response
- Return an empty string when there is no response body
- Avoid an infinite hang by setting timeouts for the requests